### PR TITLE
fix(mdcode): fix BigQuery dataset location casing and snapshot pull overwrite issue

### DIFF
--- a/toolbox/mdcode/src/libts/snapshot.ts
+++ b/toolbox/mdcode/src/libts/snapshot.ts
@@ -213,10 +213,9 @@ export class CatalogSnapshot {
   // This is only meant to be used within the syncing process (as part of pull operations).
   async _storeEntry(name: string, entry: dataplex.Entry): Promise<void> {
     let entryPath = this._index.get(name);
-    if (entryPath && fs.existsSync(entryPath)) {
-       throw new Error(`Entry '${name}' already exists`);
+    if (!entryPath) {
+      entryPath = path.resolve(this.basePath, 'catalog', name + '.yaml');
     }
-    entryPath = path.resolve(this.basePath, 'catalog', name + '.yaml');
 
     await fs.promises.mkdir(path.dirname(entryPath), { recursive: true });
     await fs.promises.writeFile(entryPath, yaml.stringify(toLocalEntry(entry)));

--- a/toolbox/mdcode/src/libts/sources/bq-dataset.ts
+++ b/toolbox/mdcode/src/libts/sources/bq-dataset.ts
@@ -30,7 +30,7 @@ export class BigQueryDatasetSource {
     }
 
     // Fetch the dataset entry
-    const location = dsResource.result.location;
+    const location = dsResource.result.location.toLowerCase();
     const dsEntryId = `bigquery.googleapis.com/projects/${this._name[0]}/datasets/${this._name[1]}`
     const dsEntryName = `${gcp.catalogContainer(this._name[0], location, '@bigquery')}/entries/${dsEntryId}`
     const dsEntryResult = await catalog.lookupEntry(this._name[0], location, dsEntryName);


### PR DESCRIPTION
### Description
This PR resolves two separate blocker issues encountered when executing the `kcmd` Metadata-as-Code workflow locally for BigQuery datasets:

#### 1. BigQuery Location Casing Mismatch Fix
* **Problem**: The BigQuery API returns the dataset location in uppercase (e.g., `"US"`). However, the Dataplex / Knowledge Catalog API endpoints are case-sensitive and expect region/location identifiers in request URL paths to be lowercase (e.g., `"us"`). Because of this mismatch, construction of lookup request URLs (e.g. `https://dataplex.googleapis.com/v1/projects/<project_id>/locations/US:lookupEntry`) failed with a `403: Location US is not found / PERMISSION_DENIED` error.
* **Solution**: Modified `src/libts/sources/bq-dataset.ts` to automatically convert the retrieved BigQuery dataset location to lowercase (converting `"US"` -> `"us"`) before constructing lookup and entry URLs.

#### 2. Snapshot Pull Overwrite Bug Fix
* **Problem**: When running `kcmd pull` inside a workspace where local metadata snapshot files were already present from a previous pull, the tool threw an `'already exists'` error and aborted the sync, preventing any snapshot updates or refreshes.
* **Solution**: Updated `src/libts/snapshot.ts`'s `_storeEntry` method to overwrite and update existing local metadata snapshot files with the latest remote metadata retrieved from the catalog, rather than throwing an error and halting.

---

### Verification Results
Verified both fixes successfully using the end-to-end local `kcmd` workflow against the bigquery dataset:
1. **Initialization**: `kcmd init --bigquery-dataset <project_id>.<dataset_id> --pull` completed successfully without `403` errors and fetched the entry.
2. **Subsequent Pull**: `kcmd pull` successfully updated the local snapshot and aspects without throwing `'already exists'` errors.
3. **Push**: Modifying an aspect (e.g., updating `description`) and executing `kcmd push` successfully updated the remote catalog entry.
