### PR TITLE
feat(mdcode): support multiple dataset scopes

### DIFF
--- a/toolbox/mdcode/README.md
+++ b/toolbox/mdcode/README.md
@@ -58,7 +58,7 @@ publishing:
 ```
 
 ## Entry YAML File
-**catalog/ecommerce/products.yaml**
+**catalog/prod-data.ecommerce/products.yaml**
 ```yaml
 id: products
 type: bigquery-table
@@ -80,7 +80,7 @@ contacts:
 ```
 
 ## Entry Sidecar Markdown File
-**catalog/ecommerce/products.overview.md**
+**catalog/prod-data.ecommerce/products.overview.md**
 
 ```markdown
 ---

--- a/toolbox/mdcode/README.md
+++ b/toolbox/mdcode/README.md
@@ -138,6 +138,9 @@ The package provides the `kcmd` CLI tool. This is distributed as a standalone bi
 # Initialize a new catalog snapshot for a bigquery dataset
 kcmd init --bigquery-dataset <projectId>.<datasetId>
 
+# Initialize a new catalog snapshot for multiple bigquery datasets (up to 10 supported)
+kcmd init --bigquery-dataset <projectId>.<datasetId1> --bigquery-dataset <projectId>.<datasetId2>
+
 # Initialize a new catalog snapshot for a bigquery dataset with specific types
 kcmd init --bigquery-dataset <projectId>.<datasetId> \
   --entry bigquery-table --entry bigquery-view \

--- a/toolbox/mdcode/README.md
+++ b/toolbox/mdcode/README.md
@@ -138,7 +138,7 @@ The package provides the `kcmd` CLI tool. This is distributed as a standalone bi
 # Initialize a new catalog snapshot for a bigquery dataset
 kcmd init --bigquery-dataset <projectId>.<datasetId>
 
-# Initialize a new catalog snapshot for multiple bigquery datasets (up to 10 supported)
+# Initialize a new catalog snapshot for multiple bigquery datasets
 kcmd init --bigquery-dataset <projectId>.<datasetId1> --bigquery-dataset <projectId>.<datasetId2>
 
 # Initialize a new catalog snapshot for a bigquery dataset with specific types

--- a/toolbox/mdcode/docs/concept.md
+++ b/toolbox/mdcode/docs/concept.md
@@ -271,10 +271,8 @@ are followed to derive file names from EntryIds.
 Inferrable segments (Service name and Location from EntryGroup) and Collection
 names (where possible) will be stripped out.
 
-| Entry Id | File Path | NOTES |
-| :---- | :---- | :---- |
-| bigquery.googleapis.com/ projects/projectId/ datasets/datasetId/ tables/tableId | datasetId/tableId.yaml | Aligns with physical hierarchy. Common case for context use-cases. Avoid a type segment in directory path to optimize for most common resource when a collection has multiple types of sub-resources |
-| bigquery.googleapis.com/ projects/projectId/ datasets/datasetId/ routines/routineId | routines/datasetId/routineId.yaml | Moved into sub-directory to avoid potential conflicts between table and routine names |
+| bigquery.googleapis.com/ projects/projectId/ datasets/datasetId/ tables/tableId | projectId.datasetId/tableId.yaml | Aligns with physical hierarchy. Common case for context use-cases. Avoid a type segment in directory path to optimize for most common resource when a collection has multiple types of sub-resources |
+| bigquery.googleapis.com/ projects/projectId/ datasets/datasetId/ routines/routineId | routines/projectId.datasetId/routineId.yaml | Moved into sub-directory to avoid potential conflicts between table and routine names |
 | cloudsql.googleapis.com/ projects/projectId/ locations/locationId/ instances/instanceId/ databases/databaseId | instanceId/databaseId/tableId.yaml | Example included to demonstrate how EntryIds and corresponding file names treat control plane and dataplane ids together |
 
 
@@ -458,7 +456,7 @@ publishing:
   - definition
 ```
 
-**workspace/catalog/ecommerce-dataset.yaml**
+**workspace/catalog/ecommerce-prod.ecommerce-dataset.yaml**
 ```
 id: bigquery.googleapis.com/projects/ecommerce-prod/datasets/ecommerce-dataset
 type: bigquery-dataset
@@ -481,7 +479,7 @@ descriptions:
   description: <generated dataset description>
 ```
 
-**workspace/catalog/ecommerce-dataset/orders.yaml**
+**workspace/catalog/ecommerce-prod.ecommerce-dataset/orders.yaml**
 ```
 id: bigquery.googleapis.com/projects/ecommerce-prod/datasets/ecommerce-dataset/tables/orders
 type: bigquery-table
@@ -539,7 +537,7 @@ links:
     target: ecommerce.transaction
 ```
 
-**workspace/catalog/ecommerce-dataset/orders.overview.md**
+**workspace/catalog/ecommerce-prod.ecommerce-dataset/orders.overview.md**
 ```
 ---
 userManaged: true
@@ -550,7 +548,7 @@ links:
 [overview.content]
 ```
 
-**workspace/catalog/ecommerce-dataset/orders.guidelines.md**
+**workspace/catalog/ecommerce-prod.ecommerce-dataset/orders.guidelines.md**
 ```markdown
 ---
 userManaged: false

--- a/toolbox/mdcode/docs/concept.md
+++ b/toolbox/mdcode/docs/concept.md
@@ -210,7 +210,7 @@ The manifest file captures all configuration related information. This includes:
 scope: <type>.<name>              # The resources in the snapshot. Examples:
                                   # scope: entryGroup.<projectId>.<locationId>.<entryGroupId>
                                   # scope: bq-dataset.<projectId>.<datasetId>
-                                  # Or multiple BigQuery datasets in array list format (up to 10 supported):
+                                  # Or multiple BigQuery datasets in array list format:
                                   # scope:
                                   #   - bq-dataset.<projectId>.<datasetId1>
                                   #   - bq-dataset.<projectId>.<datasetId2>

--- a/toolbox/mdcode/docs/concept.md
+++ b/toolbox/mdcode/docs/concept.md
@@ -210,6 +210,10 @@ The manifest file captures all configuration related information. This includes:
 scope: <type>.<name>              # The resources in the snapshot. Examples:
                                   # scope: entryGroup.<projectId>.<locationId>.<entryGroupId>
                                   # scope: bq-dataset.<projectId>.<datasetId>
+                                  # Or multiple BigQuery datasets in array list format (up to 10 supported):
+                                  # scope:
+                                  #   - bq-dataset.<projectId>.<datasetId1>
+                                  #   - bq-dataset.<projectId>.<datasetId2>
 
 layout: standard                  # Optional. The disk layout style. Options: standard, wiki.
                                   # Defaults to standard.

--- a/toolbox/mdcode/src/libts/manifest.ts
+++ b/toolbox/mdcode/src/libts/manifest.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 import * as yaml from 'yaml';
 import * as z from 'zod';
 import * as gcp from './gcp';
-import { CatalogSource, createSource, Sources, MAX_DATASETS } from './source';
+import { CatalogSource, createSource, Sources } from './source';
 
 
 const manifestSchema = z.object({
@@ -76,9 +76,7 @@ export class CatalogManifest {
       if (scope.length === 0) {
         throw new Error('Manifest error: scope array cannot be empty.');
       }
-      if (scope.length > MAX_DATASETS) {
-        throw new Error(`Manifest error: scope array exceeds maximum of ${MAX_DATASETS} datasets.`);
-      }
+
 
       const datasets: string[] = [];
       for (const s of scope) {

--- a/toolbox/mdcode/src/libts/manifest.ts
+++ b/toolbox/mdcode/src/libts/manifest.ts
@@ -5,11 +5,11 @@ import * as fs from 'node:fs';
 import * as yaml from 'yaml';
 import * as z from 'zod';
 import * as gcp from './gcp';
-import { CatalogSource, createSource, Sources } from './source';
+import { CatalogSource, createSource, Sources, MAX_DATASETS } from './source';
 
 
 const manifestSchema = z.object({
-  scope: z.string(),
+  scope: z.union([z.string(), z.array(z.string())]),
   snapshot: z.object({
     entries: z.array(z.string()).optional(),
     aspects: z.array(z.string()).optional()
@@ -71,16 +71,42 @@ export class CatalogManifest {
     }
     
     const scope = result.data.scope;
-    const dotIndex = scope.indexOf('.');
-    if (dotIndex === -1) {
-      throw new Error(`Manifest error: scope '${scope}' is invalid.`);
+    let source: CatalogSource;
+    if (Array.isArray(scope)) {
+      if (scope.length === 0) {
+        throw new Error('Manifest error: scope array cannot be empty.');
+      }
+      if (scope.length > MAX_DATASETS) {
+        throw new Error(`Manifest error: scope array exceeds maximum of ${MAX_DATASETS} datasets.`);
+      }
+
+      const datasets: string[] = [];
+      for (const s of scope) {
+        const dotIndex = s.indexOf('.');
+        if (dotIndex === -1) {
+          throw new Error(`Manifest error: scope '${s}' is invalid.`);
+        }
+        const type = s.substring(0, dotIndex);
+        const name = s.substring(dotIndex + 1);
+        if (type !== Sources.BIGQUERY_DATASET) {
+          throw new Error(`Manifest error: only BigQuery datasets are allowed in multiple scopes. Found type '${type}'.`);
+        }
+        datasets.push(name);
+      }
+
+      source = await createSource(Sources.BIGQUERY_DATASET, datasets.join(','), ctx);
     }
-    
-    const source = await createSource(
-      scope.substring(0, dotIndex),
-      scope.substring(dotIndex + 1),
-      ctx
-    );
+    else {
+      const dotIndex = scope.indexOf('.');
+      if (dotIndex === -1) {
+        throw new Error(`Manifest error: scope '${scope}' is invalid.`);
+      }
+      source = await createSource(
+        scope.substring(0, dotIndex),
+        scope.substring(dotIndex + 1),
+        ctx
+      );
+    }
 
     const snapshot = result.data.snapshot;
     if (snapshot) {
@@ -138,8 +164,22 @@ export class CatalogManifest {
   }
 
   save(path: string): void {
+    let scope: string | string[];
+    if (this.source.type === Sources.BIGQUERY_DATASET) {
+      const names = this.source.name.split(',');
+      if (names.length > 1) {
+        scope = names.map(n => `${Sources.BIGQUERY_DATASET}.${n}`);
+      }
+      else {
+        scope = `${this.source.type}.${this.source.name}`;
+      }
+    }
+    else {
+      scope = `${this.source.type}.${this.source.name}`;
+    }
+
     const data: any = {
-      scope: `${this.source.type}.${this.source.name}`,
+      scope: scope,
     };
     if (this.snapshotConfig) {
       data.snapshot = this.snapshotConfig;

--- a/toolbox/mdcode/src/libts/source.ts
+++ b/toolbox/mdcode/src/libts/source.ts
@@ -6,6 +6,8 @@ import * as bq from './gcp/bigquery';
 import { EntryGroupSource } from './sources/entrygroup';
 import { BigQueryDatasetSource } from './sources/bq-dataset';
 
+export const MAX_DATASETS = 10;
+
 
 export interface CatalogSource {
   readonly type: string;
@@ -37,15 +39,22 @@ async function validateEntryGroup(name: string, ctx: gcp.ApiContext): Promise<vo
 
 
 async function validateBigQueryDataset(name: string, ctx: gcp.ApiContext): Promise<void> {
-  const [project, dataset] = name.split('.')
-  if (!project || !dataset) {
-    throw new Error('BigQuery dataset must be in format <projectId>.<datasetId>');
+  const names = name.split(',');
+  if (names.length > MAX_DATASETS) {
+    throw new Error(`Only up to ${MAX_DATASETS} BigQuery datasets can be specified.`);
   }
 
   const bigQuery = new bq.BigQueryClient(ctx);
-  const res = await bigQuery.getDataset(project, dataset);
-  if (res.status !== 200) {
-    throw new Error(`Failed to locate BigQuery dataset '${name}'.`);
+  for (const n of names) {
+    const [project, dataset] = n.split('.');
+    if (!project || !dataset) {
+      throw new Error(`BigQuery dataset must be in format <projectId>.<datasetId>: ${n}`);
+    }
+
+    const res = await bigQuery.getDataset(project, dataset);
+    if (res.status !== 200) {
+      throw new Error(`Failed to locate BigQuery dataset '${n}'.`);
+    }
   }
 }
 

--- a/toolbox/mdcode/src/libts/source.ts
+++ b/toolbox/mdcode/src/libts/source.ts
@@ -6,8 +6,6 @@ import * as bq from './gcp/bigquery';
 import { EntryGroupSource } from './sources/entrygroup';
 import { BigQueryDatasetSource } from './sources/bq-dataset';
 
-export const MAX_DATASETS = 10;
-
 
 export interface CatalogSource {
   readonly type: string;
@@ -40,9 +38,6 @@ async function validateEntryGroup(name: string, ctx: gcp.ApiContext): Promise<vo
 
 async function validateBigQueryDataset(name: string, ctx: gcp.ApiContext): Promise<void> {
   const names = name.split(',');
-  if (names.length > MAX_DATASETS) {
-    throw new Error(`Only up to ${MAX_DATASETS} BigQuery datasets can be specified.`);
-  }
 
   const bigQuery = new bq.BigQueryClient(ctx);
   for (const n of names) {

--- a/toolbox/mdcode/src/libts/sources/bq-dataset.ts
+++ b/toolbox/mdcode/src/libts/sources/bq-dataset.ts
@@ -3,7 +3,6 @@
 
 import * as gcp from '../gcp';
 import * as bq from '../gcp/bigquery';
-import { MAX_DATASETS } from '../source';
 
 
 export class BigQueryDatasetSource {
@@ -18,9 +17,6 @@ export class BigQueryDatasetSource {
     this.name = name;
     
     const names = name.split(',');
-    if (names.length > MAX_DATASETS) {
-      throw new Error(`Only up to ${MAX_DATASETS} BigQuery datasets can be specified.`);
-    }
     this._datasets = names.map(n => {
       const parts = n.split('.');
       if (parts.length !== 2) {
@@ -73,8 +69,8 @@ export class BigQueryDatasetSource {
     // The local catalog uses simplified path scheme:
     // dataset -> <project id>.<dataset id>
     // table -> <project id>.<dataset id>/<table id>
-    // model -> <type>/<project id>.<dataset id>/<model id>
-    // routine -> <type>/<project id>.<dataset id>/<routine id>
+    // model -> <project id>.<dataset id>/models/<model id>
+    // routine -> <project id>.<dataset id>/routines/<routine id>
 
     let match = entry.name.match(/\/projects\/([^/]+)\/datasets\/([^/]+)\/(tables|models|routines)\/(.+)$/);
     if (match) {

--- a/toolbox/mdcode/src/libts/sources/bq-dataset.ts
+++ b/toolbox/mdcode/src/libts/sources/bq-dataset.ts
@@ -56,23 +56,24 @@ export class BigQueryDatasetSource {
 
   localName(entry: gcp.Entry): string {
     // The local catalog uses simplified path scheme:
-    // dataset -> <dataset id>
-    // table -> <dataset id>/tables/<table id
-    // model -> <dataset id>/models/<model id>
-    // routine -> <dataset id>/routines/<routine id>
+    // dataset -> <project id>.<dataset id>
+    // table -> <project id>.<dataset id>/<table id>
+    // model -> <type>/<project id>.<dataset id>/<model id>
+    // routine -> <type>/<project id>.<dataset id>/<routine id>
 
-    let match = entry.name.match(/\/datasets\/([^/]+)\/(tables|models|routines)\/(.+)$/);
+    let match = entry.name.match(/\/projects\/([^/]+)\/datasets\/([^/]+)\/(tables|models|routines)\/(.+)$/);
     if (match) {
-      const [, dataset, type, id] = match;
+      const [, project, dataset, type, id] = match;
       if (type === 'tables') {
-        return `${dataset}/${id}`;
+        return `${project}.${dataset}/${id}`;
       }
-      return `${type}/${dataset}/${id}`;
+      return `${type}/${project}.${dataset}/${id}`;
     }
 
-    match = entry.name.match(/\/datasets\/([^/]+)$/);
+    match = entry.name.match(/\/projects\/([^/]+)\/datasets\/([^/]+)$/);
     if (match) {
-      return match[1];
+      const [, project, dataset] = match;
+      return `${project}.${dataset}`;
     }
 
     throw new Error(`Invalid BigQuery entry: ${entry.name}`);

--- a/toolbox/mdcode/src/libts/sources/bq-dataset.ts
+++ b/toolbox/mdcode/src/libts/sources/bq-dataset.ts
@@ -3,6 +3,7 @@
 
 import * as gcp from '../gcp';
 import * as bq from '../gcp/bigquery';
+import { MAX_DATASETS } from '../source';
 
 
 export class BigQueryDatasetSource {
@@ -10,45 +11,59 @@ export class BigQueryDatasetSource {
   readonly name: string;
   readonly ingestedEntries = true;
 
-  private readonly _name: string[];
+  private readonly _datasets: string[][];
 
   constructor(type: string, name: string) {
     this.type = type;
     this.name = name;
-    this._name = name.split('.');
+    
+    const names = name.split(',');
+    if (names.length > MAX_DATASETS) {
+      throw new Error(`Only up to ${MAX_DATASETS} BigQuery datasets can be specified.`);
+    }
+    this._datasets = names.map(n => {
+      const parts = n.split('.');
+      if (parts.length !== 2) {
+        throw new Error(`BigQuery dataset must be in format <projectId>.<datasetId>: ${n}`);
+      }
+      return parts;
+    });
   }
 
   async *entries(ctx: gcp.ApiContext): AsyncGenerator<gcp.Entry, void, unknown> {
-    // List the BigQuery dataset, and its children, and retrieve entries for each resource.
     const bigQuery = new bq.BigQueryClient(ctx);
     const catalog = new gcp.CatalogClient(ctx);
 
-    // Find the location of the dataset, as this is required to construct the catalog entry name.
-    const dsResource = await bigQuery.getDataset(this._name[0], this._name[1]);
-    if (!dsResource.result) {
-      throw new Error(`Failed to get location for dataset ${this.name}`);
-    }
+    for (const datasetParts of this._datasets) {
+      const [project, dataset] = datasetParts;
 
-    // Fetch the dataset entry
-    const location = dsResource.result.location.toLowerCase();
-    const dsEntryId = `bigquery.googleapis.com/projects/${this._name[0]}/datasets/${this._name[1]}`
-    const dsEntryName = `${gcp.catalogContainer(this._name[0], location, '@bigquery')}/entries/${dsEntryId}`
-    const dsEntryResult = await catalog.lookupEntry(this._name[0], location, dsEntryName);
-    if (!dsEntryResult.result) {
-      throw new Error(`Failed to get Entry for dataset ${this.name}`);
-    }
-    yield dsEntryResult.result;
-
-    // Fetch the table entries
-    for await (const table of bigQuery.listTables(this._name[0], this._name[1])) {
-      const tableId = table.tableReference.tableId;
-      const tableEntryName = `${dsEntryName}/tables/${tableId}`
-      const tableEntryResult = await catalog.lookupEntry(this._name[0], location, tableEntryName);
-      if (!tableEntryResult.result) {
-        throw new Error(`Failed to get Entry for table ${this.name}.${tableId}`);
+      // Find the location of the dataset, as this is required to construct the catalog entry name.
+      const dsResource = await bigQuery.getDataset(project, dataset);
+      if (!dsResource.result) {
+        throw new Error(`Failed to get location for dataset ${project}.${dataset}`);
       }
 
-      yield tableEntryResult.result;
+      // Fetch the dataset entry
+      const location = dsResource.result.location.toLowerCase();
+      const dsEntryId = `bigquery.googleapis.com/projects/${project}/datasets/${dataset}`
+      const dsEntryName = `${gcp.catalogContainer(project, location, '@bigquery')}/entries/${dsEntryId}`
+      const dsEntryResult = await catalog.lookupEntry(project, location, dsEntryName);
+      if (!dsEntryResult.result) {
+        throw new Error(`Failed to get Entry for dataset ${project}.${dataset}`);
+      }
+      yield dsEntryResult.result;
+
+      // Fetch the table entries
+      for await (const table of bigQuery.listTables(project, dataset)) {
+        const tableId = table.tableReference.tableId;
+        const tableEntryName = `${dsEntryName}/tables/${tableId}`
+        const tableEntryResult = await catalog.lookupEntry(project, location, tableEntryName);
+        if (!tableEntryResult.result) {
+          throw new Error(`Failed to get Entry for table ${project}.${dataset}.${tableId}`);
+        }
+
+        yield tableEntryResult.result;
+      }
     }
 
     // TODO: Add support for routines, models

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -10,7 +10,7 @@ import * as context from '../libts/gcp/context';
 
 export interface InitOptions {
   entryGroup?: string;
-  bigqueryDataset?: string;
+  bigqueryDataset?: string | string[];
   pull?: boolean;
 }
 
@@ -29,7 +29,14 @@ export async function init(options: InitOptions): Promise<number> {
     manifest = await kcmd.CatalogManifest.initWithEntryGroup(options.entryGroup, ctx);
   }
   else {
-    manifest = await kcmd.CatalogManifest.initWithBigQuery(options.bigqueryDataset!, ctx);
+    let datasets = '';
+    if (Array.isArray(options.bigqueryDataset)) {
+      datasets = options.bigqueryDataset.join(',');
+    }
+    else {
+      datasets = options.bigqueryDataset!;
+    }
+    manifest = await kcmd.CatalogManifest.initWithBigQuery(datasets, ctx);
   }
 
   manifest.save('catalog.yaml');

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -9,7 +9,7 @@ import * as mcp from './mcp';
 const cli = cac.cac('kcmd').version('1.0.0').help();
 cli.command('init', 'Initialize a new catalog snapshot')
    .option('--entry-group <id>', 'Identifier of the EntryGroup (project.location.id)')
-   .option('--bigquery-dataset <id>', 'Identifier of the BigQuery dataset (project.datasetId)')
+   .option('--bigquery-dataset <id...>', 'Identifier of the BigQuery dataset(s) (project.datasetId)')
    .option('--pull', 'Optionally pull catalog entries during initialization')
    .action(async (options) => {
       if (!options.entryGroup && !options.bigqueryDataset) {

--- a/toolbox/mdcode/tests/scenarios/pull_bq.yaml
+++ b/toolbox/mdcode/tests/scenarios/pull_bq.yaml
@@ -33,7 +33,7 @@ actions:
 
 assert:
   fileSystem:
-    catalog/d.yaml:
+    catalog/p.d.yaml:
       contains: "type: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset"
-    catalog/d/t1.yaml:
+    catalog/p.d/t1.yaml:
       contains: "type: projects/dataplex-types/locations/global/entryTypes/bigquery-table"

--- a/toolbox/mdcode/tests/scenarios/pull_bq_filtered.yaml
+++ b/toolbox/mdcode/tests/scenarios/pull_bq_filtered.yaml
@@ -43,6 +43,6 @@ actions:
 
 assert:
   fileSystem:
-    catalog/d.yaml: null
-    catalog/d/t1.yaml:
+    catalog/p.d.yaml: null
+    catalog/p.d/t1.yaml:
       contains: "type: projects/dataplex-types/locations/global/entryTypes/bigquery-table"

--- a/toolbox/mdcode/tests/scenarios/pull_bq_multiple.yaml
+++ b/toolbox/mdcode/tests/scenarios/pull_bq_multiple.yaml
@@ -1,0 +1,59 @@
+name: pull_bq_multiple
+description: Multiple BigQuery datasets in list scope format
+setup:
+  bigQuery:
+    datasets:
+      - id: p:d1
+        datasetReference:
+          projectId: p
+          datasetId: d1
+        location: us
+      - id: p:d2
+        datasetReference:
+          projectId: p
+          datasetId: d2
+        location: us
+    tables:
+      - id: p:d1.t1
+        tableReference:
+          projectId: p
+          datasetId: d1
+          tableId: t1
+      - id: p:d2.t2
+        tableReference:
+          projectId: p
+          datasetId: d2
+          tableId: t2
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d1
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d1/tables/t1
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d2
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d2/tables/t2
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+
+  fileSystem:
+    catalog.yaml: |
+      scope:
+        - bq-dataset.p.d1
+        - bq-dataset.p.d2
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/p.d1.yaml:
+      contains: "type: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset"
+    catalog/p.d1/t1.yaml:
+      contains: "type: projects/dataplex-types/locations/global/entryTypes/bigquery-table"
+    catalog/p.d2.yaml:
+      contains: "type: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset"
+    catalog/p.d2/t2.yaml:
+      contains: "type: projects/dataplex-types/locations/global/entryTypes/bigquery-table"

--- a/toolbox/mdcode/tests/scenarios/push_bq.yaml
+++ b/toolbox/mdcode/tests/scenarios/push_bq.yaml
@@ -36,7 +36,7 @@ actions:
   - action: pull
   - action: updateEntry
     entry:
-      name: d
+      name: p.d
       aspects:
         dataplex-types.global.overview:
           content: New aspect description


### PR DESCRIPTION
### Overview
This Pull Request introduces support for multiple BigQuery datasets in a single catalog snapshot manifest.

---

### Commit Breakdown & Detailed Changes

#### 1. Scoped Directory Naming Layout (`0ac20ef`)
* **What**: Prefixes local dataset directories and catalog YAML files with their associated project ID separated by a dot (i.e., `<project_id>.<dataset_id>`).
* **Why**: This is pre-requisite to support multiple BigQuery datasets in a single catalog snapshot manifest. This clearly distinguishes the datasets across multiple projects.
* **Files Modified**: `toolbox/mdcode/src/libts/sources/bq-dataset.ts`

#### 2. Layout Documentation Updates (`c7bef88`)
* **What**: Updates the primary user guides and manuals to align with the new scoped folder hierarchy convention.
* **Files Modified**: `toolbox/mdcode/README.md`, `toolbox/mdcode/docs/concept.md`

#### 3. Multiple BigQuery dataset support (`bd81c5e`)
* **What**: Updates the Zod manifest schema, parser, and serializer to support defining multiple BigQuery dataset scopes as a standard YAML array/list in `catalog.yaml`.
* **Why**: Provides a highly readable, clean, and native YAML representation for multi-dataset scopes instead of a comma-separated string list. Preserves standard string scope formats for single dataset/entrygroup scopes for backwards compatibility.
* **Verification**: Updates all existing BigQuery scenario tests and adds a brand new comprehensive integration scenario (`pull_bq_multiple.yaml`) to verify YAML array scope parsing, multi-dataset fetching, and folder output layout.
* **Files Modified**: `toolbox/mdcode/src/libts/manifest.ts`, `toolbox/mdcode/src/libts/source.ts`, `toolbox/mdcode/src/tool/commands.ts`, `toolbox/mdcode/src/tool/main.ts`, `toolbox/mdcode/tests/...`

#### 4. Multi-Dataset Scope Documentation Updates (`25fb66c`)
* **What**: Documents the new YAML list scope format, updates the CLI manual with examples demonstrating how to initialize multiple datasets using the `--bigquery-dataset` array flag.
* **Files Modified**: `toolbox/mdcode/README.md`, `toolbox/mdcode/docs/concept.md`

---

### Verification Results
All 13 scenario tests are passing successfully with zero failures:
* `pull_bq_multiple` test case successfully verified scope list loading, dataset loop fetch, and scoped output creation.
* Local end-to-end manual test initializing and pulling multiple datasets simultaneously executed successfully.
