### PR TITLE
docs: update phased delivery plan for metadata as code

### DIFF
--- a/toolbox/mdcode/docs/plan.md
+++ b/toolbox/mdcode/docs/plan.md
@@ -23,7 +23,7 @@ Establish the local file structure and enable basic bi-directional metadata sync
         *   Implement test cases for snapshot creation and directory layout for BigQuery datasets and EntryGroups.
         *   Implement test cases for basic push operations and publishing configuration filtering.
 
-## Phase 2: Enhanced Representation & Basic Sync
+## Phase 2: Enhanced Representation & State Management
 Optimize the file format for human and agent editing. Implement layout support, multi-dataset scope, entry links, and lakehouse assets. Establish basic sync and state management.
 
 *   **Key Features & Work:**
@@ -32,7 +32,7 @@ Optimize the file format for human and agent editing. Implement layout support, 
         *   Support multi-dataset configuration for BigQuery, enabling sync of multiple datasets.
         *   Support `lakehouse` `entryGroup` in `catalog.yaml` to enable Dataplex Lakehouse asset sync.
         *   Support `EntryLinks` for catalog entries.
-        *   **Basic Sync and State Management**:
+        *   **Sync and State Management**:
             *   Store checksums of local state in a separate metadata file (e.g., `.catalog.state`).
             *   Use checksums to detect local modifications and remote drift.
             *   Treat missing local files as intent to delete corresponding remote catalog entries.
@@ -48,13 +48,13 @@ Optimize the file format for human and agent editing. Implement layout support, 
         *   Implement test cases for multi-dataset BigQuery pulling and pushing.
         *   Implement test cases for Dataplex Lakehouse asset syncing.
         *   Implement test cases for entry links.
-        *   **Basic Sync Testing**:
+        *   **Sync and State Management Testing**:
             *   Implement test cases for checksum calculation and drift detection.
             *   Implement test cases for intent to delete behavior.
             *   Implement test cases for sync conflict resolution, `--force` override, and `--dry-run` behavior.
 
-## Phase 3: Validation & Advanced Sync
-Ensure data integrity, dynamic validation, type aliases, creation of remote resources, overlay sync, and enterprise-grade advanced synchronization.
+## Phase 3: Validation & Overlay Support
+Ensure data integrity, dynamic validation, type aliases, creation of remote resources, overlay support.
 
 *   **Key Features & Work:**
     *   **Validation & Aliases**:
@@ -64,19 +64,14 @@ Ensure data integrity, dynamic validation, type aliases, creation of remote reso
     *   **Overlay & Target Management**:
         *   Support Dataplex Entry Group creation if they do not exist on the remote catalog.
         *   Support pushing BigQuery metadata to a different overlay Entry Group in Dataplex rather than the source dataset directly.
-    *   **Advanced Sync and State Management**:
-        *   **State File Resiliency & Atomic Writes**: Implement atomic file updates using temporary files and OS-level renames, combined with automatic backups (`.catalog_state.json.bak`) to prevent state file corruption.
-        *   **State Scalability & Parallelization**: Evaluate transitioning state storage to a transactional database (e.g., embedded SQLite) to support row-level concurrency and high-scale parallel operations.
-        *   **Fine-Grained Change Isolation & Automatic Merging**: Isolate unpushed changes via publish-scoped dirty checks, and implement three-way aspect merging to automatically resolve non-overlapping conflicts.
     *   **CLI (TS-based)**:
-        *   Update `push` and `pull` to support atomic transactions, batched scale operations, aspect-level updates, aliases, and overlay entry groups.
+        *   Update `push` and `pull` to support aliases, and overlay entry groups.
     *   **Testing**:
+        *   Comprehensive test suite for different scenarios.
         *   Implement test cases for type aliases.
         *   Implement test cases for dynamic schema fetching and schema validation.
         *   Implement test cases for creating Entry Groups and pushing to overlay Entry Groups.
-        *   Implement test cases for atomic writes, OS-level renames, and backup recovery.
-        *   Test scale scalability, bulk parallel operations, and transactional state concurrency.
-        *   Implement test cases for publish-scoped dirty checks and three-way aspect merging.
+        *   Implement test cases for aspect-level change detection and incremental push updates.
 
 ## Phase 4: MCP Tools & Ecosystem Integrations
 Expose Metadata as Code via MCP, integrate with workflow engines, and support Python and other language ecosystems.

--- a/toolbox/mdcode/docs/plan.md
+++ b/toolbox/mdcode/docs/plan.md
@@ -24,13 +24,12 @@ Establish the local file structure and enable basic bi-directional metadata sync
         *   Implement test cases for basic push operations and publishing configuration filtering.
 
 ## Phase 2: Enhanced Representation & State Management
-Optimize the file format for human and agent editing. Implement layout support, multi-dataset scope, entry links, and lakehouse assets. Establish basic sync and state management.
+Optimize the file format for human and agent editing. Implement layout support, multi-dataset scope, and entry links. Establish sync and state management.
 
 *   **Key Features & Work:**
     *   **Library (TS)**:
         *   Support `standard` and `wiki` layouts.
         *   Support multi-dataset configuration for BigQuery, enabling sync of multiple datasets.
-        *   Support `lakehouse` `entryGroup` in `catalog.yaml` to enable Dataplex Lakehouse asset sync.
         *   Support `EntryLinks` for catalog entries.
         *   **Sync and State Management**:
             *   Store checksums of local state in a separate metadata file (e.g., `.catalog.state`).
@@ -38,7 +37,7 @@ Optimize the file format for human and agent editing. Implement layout support, 
             *   Treat missing local files as intent to delete corresponding remote catalog entries.
             *   Fail fast on remote modifications to prevent overwriting newer changes.
     *   **CLI (TS-based)**:
-        *   Update `pull` and `push` operations to support sidecars, multi-dataset BQ, entry links, and lakehouse assets.
+        *   Update `pull` and `push` operations to support sidecars, multi-dataset BQ and entry links.
         *   Add `kcmd status` to check for local modifications and remote drift.
         *   Update `kcmd push` to use checksums and report sync conflicts.
         *   Support a force override (`--force`) flag to bypass drift checks.
@@ -46,7 +45,6 @@ Optimize the file format for human and agent editing. Implement layout support, 
     *   **Testing**:
         *   Implement test cases for Standard layout (YAML + sidecars) and Documents layout (Markdown + frontmatter) format mapping.
         *   Implement test cases for multi-dataset BigQuery pulling and pushing.
-        *   Implement test cases for Dataplex Lakehouse asset syncing.
         *   Implement test cases for entry links.
         *   **Sync and State Management Testing**:
             *   Implement test cases for checksum calculation and drift detection.
@@ -64,6 +62,7 @@ Ensure data integrity, dynamic validation, type aliases, creation of remote reso
     *   **Overlay & Target Management**:
         *   Support Dataplex Entry Group creation if they do not exist on the remote catalog.
         *   Support pushing BigQuery metadata to a different overlay Entry Group in Dataplex rather than the source dataset directly.
+    *   Support `lakehouse` `entryGroup` in `catalog.yaml` to enable Dataplex Lakehouse asset sync.
     *   **CLI (TS-based)**:
         *   Update `push` and `pull` to support aliases, and overlay entry groups.
     *   **Testing**:

--- a/toolbox/mdcode/docs/plan.md
+++ b/toolbox/mdcode/docs/plan.md
@@ -1,47 +1,79 @@
 # Phased Delivery Plan
 
-This document outlines the phased delivery plan for building the Metadata as Code foundation. 
+This document outlines the phased delivery plan for building the Metadata as Code foundation.
 
-## Phase 1: MVP - Read-Only Snapshot & Consumption
-Establish the local file structure by pulling metadata using the TypeScript library, and enable reading that snapshot via MCP. Support early distribution.
-
-*   **Key Features & Work:**
-    *   **Library (TS)**: Fetch metadata for a BigQuery dataset or Dataplex EntryGroup; create local directory structure mirroring the resource hierarchy; generate main YAML file per entry (Standard layout); paginated pull; ADC authentication.
-    *   **CLI (TS-based)**: Implement `kcmd init` and a basic read-only `kcmd pull`.
-    *   **MCP (TS-based)**: Implement an MCP server with tools: `list-entries` and `lookup-entry` (reading from the local snapshot).
-    *   **Distribution**: Support installation from source repository or local package for early access.
-    *   **Testing**: Implement test cases for snapshot creation and directory layout for BigQuery datasets and EntryGroups.
-
-## Phase 2: MVP - Basic Push (Publish)
-Complete the bi-directional sync by enabling local modifications to be pushed back to the catalog using the TypeScript library.
+## Phase 1: Core Sync (Pull & Push)
+Establish the local file structure and enable basic bi-directional metadata synchronization using the TypeScript library.
 
 *   **Key Features & Work:**
-    *   **Library (TS)**: Read local YAML files and reconstruct API payloads; push updates individually per entry; support parsing and filtering via `publishing` configuration in `catalog.yaml`.
-    *   **CLI (TS-based)**: Implement a basic `kcmd push`.
-    *   **Distribution**: Update early access packages with push capability.
-    *   **Testing**: Implement test cases for basic push operation and publishing configuration filtering.
+    *   **Library (TS)**:
+        *   Fetch metadata for a BigQuery dataset or Dataplex EntryGroup.
+        *   Create local directory structure mirroring the resource hierarchy.
+        *   Generate main YAML file per entry (Standard layout).
+        *   Implement paginated pull.
+        *   Implement ADC authentication.
+        *   Read local YAML files and reconstruct API payloads.
+        *   Push updates individually per entry.
+        *   Support parsing and filtering via `publishing` configuration in `catalog.yaml`.
+    *   **CLI (TS-based)**:
+        *   Implement `kcmd init`, `kcmd pull`, and `kcmd push` commands.
+    *   **Distribution**:
+        *   Support installation from source repository or local package for early access.
+    *   **Testing**:
+        *   Implement test cases for snapshot creation and directory layout for BigQuery datasets and EntryGroups.
+        *   Implement test cases for basic push operations and publishing configuration filtering.
 
-## Phase 3: Enhanced Representation
-Optimize the file format for human and agent editing. Update interfaces to support the new formats and layout options.
-
-*   **Key Features & Work:**
-    *   **Library (TS)**: Support `kb` scope type alongside `bq-dataset` and `entryGroup` in `catalog.yaml`; implement the `CatalogLayout` abstraction (`layout.ts`) and its concrete layouts (`StandardLayout` and `DocumentsLayout`); refactor `CatalogSnapshot` to delegate filesystem list, read, and write operations to the active layout strategy (automatically instantiated based on the scope); support type aliases in `catalog.yaml`, including built-in aliases for built-in types.
-    *   **CLI (TS-based)**: Update `pull` and `push` operations to handle sidecars, aliases, and different layout scopes correctly.
-    *   **MCP (TS-based)**: Ensure `list-entries` and `lookup-entry` tools correctly handle layouts (by delegating via `CatalogSnapshot` to `CatalogLayout` strategy).
-    *   **Testing**: Implement test cases for format mapping, including Standard layout (YAML + sidecars) and Documents layout (Markdown + frontmatter), and validate that `CatalogSnapshot` interacts correctly with both layouts based on the active scope type. Implement test cases for aliases.
-
-## Phase 4: Robust Sync and State Management
-Ensure data integrity and efficient updates.
-
-*   **Key Features & Work:**
-    *   **Library (TS)**: Store checksums of local state in a separate file; use checksums to detect changes; treat missing files as intent to delete; fail fast on remote modification; fetch type definitions dynamically for validation.
-    *   **CLI (TS-based)**: Add `kcmd status` to check for local modifications; update `kcmd push` to use checksums and report conflicts; support **force override** flag; implement `--dry-run` option for `pull` and `push` commands.
-    *   **Testing**: Implement test cases for checksum validation, intent to delete, validation against dynamic schema, and `--dry-run` behavior.
-
-## Phase 5: Future / Other
-Other workstreams to consider.
+## Phase 2: Enhanced Representation
+Optimize the file format for human and agent editing. Implement layout and aliases support, multi-dataset scope, entry links, overlay push target creation, and lakehouse assets.
 
 *   **Key Features & Work:**
-    *   **Library (TS)**: Support for EntryLinks
-    *   **Python Library**: Implement the equivalent library in Python to support Python-based agents and workflows.
-    *   **MCP (TS-based)**: Implement `pull` and `push` tools in the MCP server.
+    *   **Library (TS)**:
+        *   Support `standard` and `wiki` layouts.
+        *   Support multi-dataset configuration for BigQuery, enabling sync of multiple datasets.
+        *   Support `lakehouse` `entryGroup` in `catalog.yaml` to enable Dataplex Lakehouse asset sync.
+        *   Support `EntryLinks` for catalog entries.
+        *   Support Dataplex Entry Group creation if they do not exist on the remote catalog.
+        *   Support pushing BigQuery metadata to a different overlay Entry Group in Dataplex rather than the source dataset directly.
+        *   Support type aliases in `catalog.yaml`.
+    *   **CLI (TS-based)**:
+        *   Update `pull` and `push` operations to support sidecars, aliases, multi-dataset BQ, overlay entry groups, entry links, and lakehouse assets.
+    *   **Testing**:
+        *   Implement test cases for Standard layout (YAML + sidecars) and Documents layout (Markdown + frontmatter) format mapping.
+        *   Implement test cases for multi-dataset BigQuery pulling and pushing.
+        *   Implement test cases for Dataplex Lakehouse asset syncing.
+        *   Implement test cases for entry links.
+        *   Implement test cases for creating Entry Groups and pushing to overlay Entry Groups.
+        *   Implement test cases for type aliases.
+
+## Phase 3: Robust Sync and State Management
+Ensure data integrity, validation, and efficient sync updates.
+
+*   **Key Features & Work:**
+    *   **Validation**:
+        *   Fetch type definitions dynamically for client-side schema validation.
+    *   **Sync and State Management**:
+        *   Store checksums of local state in a separate metadata file.
+        *   Use checksums to detect local modifications and remote drift.
+        *   Treat missing local files as intent to delete corresponding remote catalog entries.
+        *   Fail fast on remote modifications to prevent overwriting newer changes.
+    *   **CLI (TS-based)**:
+        *   Add `kcmd status` to check for local modifications and remote drift.
+        *   Update `kcmd push` to use checksums and report sync conflicts.
+        *   Support a force override (`--force`) flag to bypass drift checks.
+        *   Implement a dry-run (`--dry-run`) option for `pull` and `push` commands.
+    *   **Testing**:
+        *   Implement test cases for dynamic schema fetching and client-side validation.
+        *   Implement test cases for checksum calculation and drift detection.
+        *   Implement test cases for intent to delete behavior.
+        *   Implement test cases for sync conflict resolution, force override, and `--dry-run` behavior.
+
+## Phase 4: MCP Tools & Ecosystem Integrations
+Expose Metadata as Code via MCP, integrate with workflow engines, and support Python and other language ecosystems.
+
+*   **Key Features & Work:**
+    *   **MCP Tools (TS-based)**:
+        *   Implement an MCP server exposing tools: `list-entries`, `lookup-entry`, `pull`, and `push` directly to agents.
+    *   **Python Library**:
+        *   Implement equivalent Python-based library to support Python-based workflows and agents.
+        *   Maintain parity with TypeScript library for YAML structures, layouts, and checksum state management to ensure cross-language compatibility.
+    *   **Dataform and other products Integration**

--- a/toolbox/mdcode/docs/plan.md
+++ b/toolbox/mdcode/docs/plan.md
@@ -23,8 +23,8 @@ Establish the local file structure and enable basic bi-directional metadata sync
         *   Implement test cases for snapshot creation and directory layout for BigQuery datasets and EntryGroups.
         *   Implement test cases for basic push operations and publishing configuration filtering.
 
-## Phase 2: Enhanced Representation
-Optimize the file format for human and agent editing. Implement layout and aliases support, multi-dataset scope, entry links, overlay push target creation, and lakehouse assets.
+## Phase 2: Enhanced Representation & Basic Sync
+Optimize the file format for human and agent editing. Implement layout support, multi-dataset scope, entry links, and lakehouse assets. Establish basic sync and state management.
 
 *   **Key Features & Work:**
     *   **Library (TS)**:
@@ -32,40 +32,51 @@ Optimize the file format for human and agent editing. Implement layout and alias
         *   Support multi-dataset configuration for BigQuery, enabling sync of multiple datasets.
         *   Support `lakehouse` `entryGroup` in `catalog.yaml` to enable Dataplex Lakehouse asset sync.
         *   Support `EntryLinks` for catalog entries.
-        *   Support Dataplex Entry Group creation if they do not exist on the remote catalog.
-        *   Support pushing BigQuery metadata to a different overlay Entry Group in Dataplex rather than the source dataset directly.
-        *   Support type aliases in `catalog.yaml`.
+        *   **Basic Sync and State Management**:
+            *   Store checksums of local state in a separate metadata file (e.g., `.catalog.state`).
+            *   Use checksums to detect local modifications and remote drift.
+            *   Treat missing local files as intent to delete corresponding remote catalog entries.
+            *   Fail fast on remote modifications to prevent overwriting newer changes.
     *   **CLI (TS-based)**:
-        *   Update `pull` and `push` operations to support sidecars, aliases, multi-dataset BQ, overlay entry groups, entry links, and lakehouse assets.
-    *   **Testing**:
-        *   Implement test cases for Standard layout (YAML + sidecars) and Documents layout (Markdown + frontmatter) format mapping.
-        *   Implement test cases for multi-dataset BigQuery pulling and pushing.
-        *   Implement test cases for Dataplex Lakehouse asset syncing.
-        *   Implement test cases for entry links.
-        *   Implement test cases for creating Entry Groups and pushing to overlay Entry Groups.
-        *   Implement test cases for type aliases.
-
-## Phase 3: Robust Sync and State Management
-Ensure data integrity, validation, and efficient sync updates.
-
-*   **Key Features & Work:**
-    *   **Validation**:
-        *   Fetch type definitions dynamically for client-side schema validation.
-    *   **Sync and State Management**:
-        *   Store checksums of local state in a separate metadata file.
-        *   Use checksums to detect local modifications and remote drift.
-        *   Treat missing local files as intent to delete corresponding remote catalog entries.
-        *   Fail fast on remote modifications to prevent overwriting newer changes.
-    *   **CLI (TS-based)**:
+        *   Update `pull` and `push` operations to support sidecars, multi-dataset BQ, entry links, and lakehouse assets.
         *   Add `kcmd status` to check for local modifications and remote drift.
         *   Update `kcmd push` to use checksums and report sync conflicts.
         *   Support a force override (`--force`) flag to bypass drift checks.
         *   Implement a dry-run (`--dry-run`) option for `pull` and `push` commands.
     *   **Testing**:
-        *   Implement test cases for dynamic schema fetching and client-side validation.
-        *   Implement test cases for checksum calculation and drift detection.
-        *   Implement test cases for intent to delete behavior.
-        *   Implement test cases for sync conflict resolution, force override, and `--dry-run` behavior.
+        *   Implement test cases for Standard layout (YAML + sidecars) and Documents layout (Markdown + frontmatter) format mapping.
+        *   Implement test cases for multi-dataset BigQuery pulling and pushing.
+        *   Implement test cases for Dataplex Lakehouse asset syncing.
+        *   Implement test cases for entry links.
+        *   **Basic Sync Testing**:
+            *   Implement test cases for checksum calculation and drift detection.
+            *   Implement test cases for intent to delete behavior.
+            *   Implement test cases for sync conflict resolution, `--force` override, and `--dry-run` behavior.
+
+## Phase 3: Validation & Advanced Sync
+Ensure data integrity, dynamic validation, type aliases, creation of remote resources, overlay sync, and enterprise-grade advanced synchronization.
+
+*   **Key Features & Work:**
+    *   **Validation & Aliases**:
+        *   Support type aliases in `catalog.yaml`.
+        *   Fetch type definitions dynamically from Catalog service for client-side schema validation.
+        *   Perform client-side schema validation against dynamic schemas prior to push operations.
+    *   **Overlay & Target Management**:
+        *   Support Dataplex Entry Group creation if they do not exist on the remote catalog.
+        *   Support pushing BigQuery metadata to a different overlay Entry Group in Dataplex rather than the source dataset directly.
+    *   **Advanced Sync and State Management**:
+        *   **State File Resiliency & Atomic Writes**: Implement atomic file updates using temporary files and OS-level renames, combined with automatic backups (`.catalog_state.json.bak`) to prevent state file corruption.
+        *   **State Scalability & Parallelization**: Evaluate transitioning state storage to a transactional database (e.g., embedded SQLite) to support row-level concurrency and high-scale parallel operations.
+        *   **Fine-Grained Change Isolation & Automatic Merging**: Isolate unpushed changes via publish-scoped dirty checks, and implement three-way aspect merging to automatically resolve non-overlapping conflicts.
+    *   **CLI (TS-based)**:
+        *   Update `push` and `pull` to support atomic transactions, batched scale operations, aspect-level updates, aliases, and overlay entry groups.
+    *   **Testing**:
+        *   Implement test cases for type aliases.
+        *   Implement test cases for dynamic schema fetching and schema validation.
+        *   Implement test cases for creating Entry Groups and pushing to overlay Entry Groups.
+        *   Implement test cases for atomic writes, OS-level renames, and backup recovery.
+        *   Test scale scalability, bulk parallel operations, and transactional state concurrency.
+        *   Implement test cases for publish-scoped dirty checks and three-way aspect merging.
 
 ## Phase 4: MCP Tools & Ecosystem Integrations
 Expose Metadata as Code via MCP, integrate with workflow engines, and support Python and other language ecosystems.
@@ -76,4 +87,5 @@ Expose Metadata as Code via MCP, integrate with workflow engines, and support Py
     *   **Python Library**:
         *   Implement equivalent Python-based library to support Python-based workflows and agents.
         *   Maintain parity with TypeScript library for YAML structures, layouts, and checksum state management to ensure cross-language compatibility.
-    *   **Dataform and other products Integration**
+    *   **Dataform and other products Integration**:
+        *   Develop native adapters or plugins to sync metadata directly from Dataform, DBT, or other data orchestration systems.


### PR DESCRIPTION
### Description
This PR updates the phased delivery plan for the Metadata as Code foundation to align with new design decisions, layout strategies, and integration scopes. 