### PR TITLE
Document OKF demo in demo README

### DIFF
--- a/toolbox/mdcode/demo/README.md
+++ b/toolbox/mdcode/demo/README.md
@@ -117,3 +117,55 @@ cat catalog/index.md
 ```bash
 bun cleanup.ts
 ```
+
+## OKF Wiki
+
+This demo demonstrates publishing an [Open Knowledge Format](https://github.com/google/okf)
+wiki bundle (a directory of markdown files with YAML frontmatter) into a
+Knowledge Catalog EntryGroup via the Documents Layout. The bundle in
+`okf/catalog/` is a GA4 sample with indexes, references, a dataset, and a
+table — 17 markdown files in total. The Documents Layout maps each `.md`
+file to an entry whose name is derived from the file path, with the
+markdown body stored on the `dataplex-types.global.overview` aspect.
+
+**Setup**
+
+* Creates an empty Dataplex EntryGroup (`okf_ga4`).
+* Creates a `catalog.yaml` manifest pointing at the EntryGroup.
+* The `catalog/` directory is already populated with the GA4 markdown bundle.
+
+```bash
+bun setup.ts
+cat catalog.yaml
+ls -R catalog
+```
+
+**Publish Metadata Snapshot**
+
+* Push the bundled markdown to Knowledge Catalog. Entry names mirror the
+  file path (e.g. `references/metrics/event_count.md` &rarr; entry
+  `references/metrics/event_count`). Custom `type:` values in frontmatter
+  that aren't valid Dataplex type refs fall back to
+  `dataplex-types.global.generic`.
+
+```bash
+../../dist/kcmd push
+```
+
+**Modify Metadata Snapshot**
+
+* Edit any markdown file under `catalog/` directly &mdash; both frontmatter
+  fields (`title`, `description`, `tags`) and the markdown body &mdash; then
+  push again.
+
+```bash
+../../dist/kcmd push
+```
+
+**Cleanup**
+
+* Deletes the Dataplex EntryGroup
+
+```bash
+bun cleanup.ts
+```

--- a/toolbox/mdcode/demo/README.md
+++ b/toolbox/mdcode/demo/README.md
@@ -124,7 +124,7 @@ This demo demonstrates publishing an [Open Knowledge Format](https://github.com/
 wiki bundle (a directory of markdown files with YAML frontmatter) into a
 Knowledge Catalog EntryGroup via the Documents Layout. The bundle in
 `okf/catalog/` is a GA4 sample with indexes, references, a dataset, and a
-table — 17 markdown files in total. The Documents Layout maps each `.md`
+table, 17 markdown files in total. The Documents Layout maps each `.md`
 file to an entry whose name is derived from the file path, with the
 markdown body stored on the `dataplex-types.global.overview` aspect.
 
@@ -154,9 +154,9 @@ ls -R catalog
 
 **Modify Metadata Snapshot**
 
-* Edit any markdown file under `catalog/` directly &mdash; both frontmatter
-  fields (`title`, `description`, `tags`) and the markdown body &mdash; then
-  push again.
+* Edit any markdown file under `catalog/` directly. Both frontmatter
+  fields (`title`, `description`, `tags`) and the markdown body can be
+  changed, then push again.
 
 ```bash
 ../../dist/kcmd push


### PR DESCRIPTION
## Summary

Adds an "OKF Wiki" section to `toolbox/mdcode/demo/README.md`, documenting the OKF demo added in #19. The section mirrors the existing BigQuery and Knowledge Base sections and covers:

- **Setup** — creates the `okf_ga4` EntryGroup and `catalog.yaml` manifest. Notes that `catalog/` ships pre-populated with the 17-file GA4 markdown bundle (no `pull` step needed).
- **Publish** — `kcmd push`. Calls out that entry names are derived from file paths (e.g. `references/metrics/event_count.md` &rarr; entry `references/metrics/event_count`) and that custom `type:` values in frontmatter that aren't valid Dataplex type refs fall back to `dataplex-types.global.generic`.
- **Modify** — edit markdown directly (no `update.ts` script, unlike the other two demos).
- **Cleanup** — `bun cleanup.ts` deletes the EntryGroup.

## Test plan

- [x] README renders cleanly on GitHub.
- [x] Commands in the section match the actual `okf/setup.ts`, `okf/cleanup.ts`, and `okf/catalog/` layout on `main`.
