### PR TITLE
Add CHAT_AGENT_WRITE_ONLY env-var to suppress SQL execution

### DIFF
--- a/samples/chat_with_data_agent/agent.py
+++ b/samples/chat_with_data_agent/agent.py
@@ -32,6 +32,27 @@ BIGQUERY_MCP_ENDPOINT = "https://bigquery.googleapis.com/mcp"
 DATAPLEX_MCP_ENDPOINT = "https://dataplex.googleapis.com/mcp"
 CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 
+# Write-only mode (opt-in via env var). When CHAT_AGENT_WRITE_ONLY is truthy,
+# `execute_sql_readonly` is hidden from the BigQuery toolset and the agent
+# instruction is augmented to direct the model to emit SQL in a fenced block
+# instead of executing it. Useful for offline eval where you want to isolate
+# planning quality from BigQuery MCP execution; not recommended for end-user
+# chat where actual query results are expected.
+WRITE_ONLY_MODE = os.environ.get("CHAT_AGENT_WRITE_ONLY", "").lower() in (
+    "1", "true", "yes", "on"
+)
+_WRITE_ONLY_GUIDELINES = (
+    "\n\n## Write-only mode (CHAT_AGENT_WRITE_ONLY=1 is set):\n"
+    "- The `execute_sql_readonly` tool is **not available** in this build.\n"
+    "- When you would normally run a query, instead emit the complete SQL\n"
+    "  inside a fenced ```sql block in your text response and stop.\n"
+    "- Always use fully-qualified BigQuery table names in the form\n"
+    "  `project.dataset.table` so the table is unambiguously identified.\n"
+    "- Do not apologise for not executing — that is the intended behaviour.\n"
+    "- You may still use BigQuery schema/list tools (e.g. `get_table_info`,\n"
+    "  `list_table_ids`) to inspect tables before writing the SQL.\n"
+)
+
 # Credentials object stays in module scope; the httpx event hook below calls
 # .refresh() on it lazily before each MCP request so the Bearer token never
 # goes stale mid-session.
@@ -99,6 +120,8 @@ def load_instruction(project_id: str) -> str:
         " discovery sub-agent and explore/query data using BigQuery and"
         " Dataplex OneMCP tools."
     )
+  if WRITE_ONLY_MODE:
+    content += _WRITE_ONLY_GUIDELINES
   return content + f"\n\nUse Consumer Project ID: {project_id} for billing or running queries"
 
 
@@ -107,6 +130,12 @@ bigquery_mcp_toolset = McpToolset(
         url=BIGQUERY_MCP_ENDPOINT,
         headers=static_headers,
         httpx_client_factory=make_mcp_http_client,
+    ),
+    # In write-only mode, suppress execute_sql_readonly so the agent must emit
+    # SQL as text instead of running it. No-op otherwise.
+    tool_filter=(
+        (lambda tool, ctx=None: tool.name != "execute_sql_readonly")
+        if WRITE_ONLY_MODE else None
     ),
 )
 


### PR DESCRIPTION
**Depends on #35** (auth-refresh fix). This PR's diff *against `dev`* will include both commits until #35 merges; please review only the head commit (`Add CHAT_AGENT_WRITE_ONLY env-var…`).

---

Adds an opt-in mode for offline evaluation where you want to measure the
agent's planning quality (table choice, query shape) without depending on
BigQuery MCP execution actually succeeding. Default behaviour is unchanged.

When the env var `CHAT_AGENT_WRITE_ONLY` is set to a truthy value
("1", "true", "yes", "on"):
  1. The BigQuery toolset filters out `execute_sql_readonly` via
     `tool_filter`, so the model cannot call it.
  2. The instruction loaded from SKILL.md is augmented with a guideline
     telling the model to emit the SQL inside a fenced ```sql block instead
     of attempting to run it. The augmentation is injected at runtime in
     `load_instruction()` so SKILL.md itself stays unchanged for the
     default case.

When the env var is unset (the default), `tool_filter` is None and the
instruction is loaded verbatim — zero behaviour change for end users.

Useful for: scoring agent SQL output via similarity to a known-good
golden query (Jaccard, exact match, etc.); reproducing model-only
failures decoupled from MCP/BigQuery state; running eval harnesses on
environments where the BigQuery MCP endpoint is unreachable.

Verified on dataplex-demo / concord-demo-overlay:
- Unset (default): tool_filter is None, instruction has no extra section.
- CHAT_AGENT_WRITE_ONLY=1: tool_filter wired up, instruction contains
  the directive. Agent emits SQL in fenced blocks across 11/20 questions
  in a re-run of the local eval, mean Jaccard 0.142 vs golden, two
  questions reaching Jaccard ≥ 0.50.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

