### PR TITLE
Add agents/ folder with enrichment and mdcode

### DIFF
--- a/agents/enrichment/README.md
+++ b/agents/enrichment/README.md
@@ -1,0 +1,381 @@
+<!-- disableFinding(HTML_OPEN) -->
+<!-- disableFinding(HTML_BROKEN) -->
+<!-- disableFinding(LINE_OVER_80) -->
+<!-- disableFinding(LIST_NO_LINE) -->
+<!-- disableFinding(HEADING_REPEAT_H1) -->
+<!-- disableFinding(WHITESPACE_LINES) -->
+<!-- disableFinding(WHITESPACE_TRAILING) -->
+
+# Knowledge Catalog Enrichment Agent
+
+A command-line agent that generates **Metadata as Code** (mdcode) for Knowledge
+Catalog (Dataplex). It extracts information from source material and produces the
+YAML + Markdown artifacts that describe data assets, ready to be pushed to the
+catalog with the `kcmd` tool.
+
+The agent talks to the catalog **only through `kcmd`** (Metadata as Code) — it
+never calls the Dataplex API directly. It runs the read-only `kcmd init` /
+`kcmd pull` commands itself to scaffold `catalog.yaml` and pull existing entries
+(schema, etc.); you run `kcmd push` to publish.
+
+The agent has three modes:
+
+- **`table`** — pulls a BigQuery dataset's tables (schema) via `kcmd`, routes
+  Google Drive documents to each table by relevance, and writes an enriched
+  overview per table in the `kcmd` `bq-dataset` format. Also emits a `queries`
+  aspect per table that bundles BigQuery `INFORMATION_SCHEMA` query patterns,
+  SQL examples extracted from routed docs, and (optionally) ground-truth SQL
+  from user-feedback proposals. Optionally (`--glossaries`) maps columns to
+  Dataplex glossary terms and injects field-level definition links.
+- **`doc`** — crawls Google Docs (and an optional Drive folder), map-reduce
+  summarizes them, and emits a knowledge-base mdcode snapshot.
+- **`context_overlay`** — pulls 1P BigQuery table entries via `kcmd reference`
+  (read-only) and creates a NEW context-overlay entry per table in an editable
+  entry group. The overlay carries the enriched overview + queries aspect so you
+  can ship richer descriptions without touching the live `@bigquery` entry.
+
+Any of the three modes can optionally ingest **user-feedback proposals** via
+`--feedback_dir` / `--feedback_files`. Feedback is treated as the
+**highest-priority context source** — proposals override conflicting information
+from Drive docs, semantic search, or INFORMATION_SCHEMA-derived patterns.
+
+Any of the three modes can also ingest a **GitHub source-code repository** via
+`--repo` (an extra context source — not a fourth mode). A code-understanding
+agent explores the repo **agentically through the GitHub MCP server** and
+distills it into code *component cards*. In `doc` mode the distinct components
+surface as their own knowledge-base entries; in `table` / `context_overlay` mode
+the cards join the relevance router's candidate pool, so code that reads or
+writes a table (or contains SQL referencing it) grounds that table's overview
+and queries aspect.
+
+After a run, you can iterate on the output with free-text **refinement** —
+either an interactive REPL (`--interactive`) or a single re-invocation
+(`--refine_instruction`). Refinement reuses the already-loaded context and never
+re-reads the source docs or re-pulls the dataset.
+
+## Layout
+
+This repo mirrors the `GoogleCloudPlatform/knowledge-catalog` `agents/` layout:
+
+```
+agents/
+├── mdcode/                      # the kcmd (Metadata as Code) CLI + library
+└── enrichment/
+    ├── src/
+    │   ├── agent_runner.py      # CLI entrypoint: flags + dispatch to a mode
+    │   ├── engine.py            # LLM agents (Vertex Gemini) for all modes
+    │   ├── common.py            # shared helpers (run_text, mdcode parsing, trajectory)
+    │   ├── refine.py            # multi-turn refinement (REPL + persist/re-invoke)
+    │   ├── linking.py           # glossary column→term linking helper (table mode)
+    │   ├── modes/
+    │   │   ├── doc_mode.py             # run(topic, docs, folder, output_dir, model, entry_group, ...)
+    │   │   ├── table_mode.py           # run(dataset, folder, topic, output_dir, model, ...)
+    │   │   └── context_overlay_mode.py # run(dataset, folder, topic, ..., entry_group, ...)
+    │   └── tools/
+    │       ├── kcmd_tools.py     # kcmd init/pull/reference discovery + entry reading
+    │       ├── drive_tools.py    # Google Drive/Docs fetch helpers
+    │       ├── bq_usage_tools.py # INFORMATION_SCHEMA query history + queries-aspect sidecar
+    │       ├── feedback_tools.py # user-feedback proposal loader + per-table router
+    │       └── github_tools.py   # agentic GitHub-repo code source via the GitHub MCP server
+    └── eval/                     # evaluation CLI (dynamic, golden-free)
+        ├── __main__.py          # `python -m eval --output-dir ...`
+        ├── dynamic_eval.py      # golden-free scoring of a single run
+        ├── metrics.py           # metric library (deterministic + LLM-judge)
+        └── loaders.py           # read catalog/ + trajectory.json
+```
+
+## Prerequisites
+
+1. **Build `kcmd`** (the agent shells out to it). From the repo root:
+   ```bash
+   cd agents/mdcode
+   npm install
+   npm run build          # -> agents/mdcode/dist/kcmd
+
+   # Put `kcmd` on your PATH so you can run `kcmd push` from anywhere.
+   # $(pwd) expands to the absolute dist path now (baked into the file), while
+   # \$PATH stays literal so it re-expands on each new shell.
+   echo "export PATH=\"$(pwd)/dist:\$PATH\"" >> ~/.bashrc   # zsh users: ~/.zshrc
+   source ~/.bashrc
+
+   cd ../..
+   ```
+   The agent also finds the binary automatically at `agents/mdcode/dist/kcmd`
+   (override with `$KCMD_BIN`), so adding it to `PATH` is only needed for running
+   `kcmd` yourself (e.g. `kcmd push`). Verify with `which kcmd`.
+
+2. **Python 3.11+** and the agent dependencies (a venv is recommended):
+   ```bash
+   python3 -m venv ~/.venv/kc-enrich
+   source ~/.venv/kc-enrich/bin/activate
+   pip install google-adk google-genai google-api-python-client google-auth \
+               google-cloud-bigquery mcp pypdf pyyaml requests absl-py
+   ```
+   (`google-cloud-bigquery` powers the table-mode usage signal; `mcp` is only
+   needed for the GitHub source over a local stdio server — the default hosted
+   remote server works without it.)
+
+3. **Application Default Credentials** (the agent uses Vertex AI, `kcmd` uses
+   `gcloud` for catalog auth, and Drive access for source docs):
+   ```bash
+   gcloud auth application-default login \
+     --scopes='openid,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive.readonly'
+   ```
+
+The Vertex project/location and the model are supplied per run via flags
+(`--project`, `--location`, `--model`) — nothing is hardcoded.
+
+## Usage
+
+Point `PYTHONPATH` at the package `src`, then run a mode. Supply your own GCP
+project and model.
+
+```bash
+export PYTHONPATH=agents/enrichment/src
+
+# Table mode — enrich a BigQuery dataset's tables, grounded in a Drive folder.
+python3 agents/enrichment/src/agent_runner.py \
+  --mode=table \
+  --dataset=<project>.<dataset> \
+  --folder=<drive_folder_id_or_url> \
+  --topic="<your use case / instruction>" \
+  --project=<your_gcp_project> \
+  --location=<vertex_location> \
+  --model=<vertex_model> \
+  --output_dir=<local_output_dir>
+
+# Doc mode — build a knowledge base from Google Docs (+ optional folder).
+python3 agents/enrichment/src/agent_runner.py \
+  --mode=doc \
+  --docs="https://docs.google.com/document/d/<id>,<id2>" \
+  --folder=<drive_folder_id_or_url> \
+  --topic="<your use case / instruction>" \
+  --entry_group=<project>.<location>.<entryGroupId> \
+  --project=<your_gcp_project> \
+  --location=<vertex_location> \
+  --model=<vertex_model> \
+  --output_dir=<local_output_dir>
+
+# Context-overlay mode — enrich BQ tables into a SEPARATE entry group you own
+# (the live @bigquery entries are read-only, never modified).
+python3 agents/enrichment/src/agent_runner.py \
+  --mode=context_overlay \
+  --dataset=<project>.<dataset> \
+  --entry_group=<project>.<location>.<entryGroupId> \
+  --folder=<drive_folder_id_or_url> \
+  --topic="<your use case / instruction>" \
+  --project=<your_gcp_project> \
+  --model=<vertex_model> \
+  --output_dir=<local_output_dir>
+```
+
+Any mode can additionally pull in a GitHub repository as a code-context source.
+The GitHub MCP server reads a Personal Access Token from its environment:
+
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_...
+python3 agents/enrichment/src/agent_runner.py --mode=doc \
+  --entry_group=<project>.<location>.<entryGroupId> \
+  --topic="Order pipeline" \
+  --repo=my-org/order-service --repo_ref=main \
+  --project=<your_gcp_project> --model=<vertex_model> --output_dir=<local_output_dir>
+```
+
+All values above are yours to choose, e.g. `--topic="Customer 360 data"`,
+`--location=us-central1` (or `global`), `--model=gemini-2.5-pro`,
+`--output_dir=/tmp/enrich_out`.
+
+> **Doc mode — `--entry_group` is required and must already exist.** The target
+> entry group (`project.location.entryGroupId`) must be **created beforehand** in
+> the specified project; the agent does not create it (it runs read-only `kcmd
+> init`/`pull`). Create it first, e.g.:
+> ```bash
+> gcloud dataplex entry-groups create <entryGroupId> \
+>   --project=<project> --location=<location>
+> ```
+> The knowledge-base entries are created with the 1P **generic** entry type, with
+> the enriched content as their `overview` aspect.
+
+### Flags
+
+Every invocation goes through `agent_runner.py` (run it with `--help` for the raw
+list). `--project`, `--model`, and `--output_dir` are required in **every** mode;
+`--dataset` and/or `--entry_group` become required depending on the mode.
+
+**Which flag applies to which mode** — `R` = required, `✓` = optional, `—` = not used:
+
+| Flag | `doc` | `table` | `context_overlay` |
+|------|:-----:|:-------:|:-----------------:|
+| `--project` | R | R | R |
+| `--model` | R | R | R |
+| `--output_dir` | R | R | R |
+| `--location` | ✓ | ✓ | ✓ |
+| `--mode` | ✓ | ✓ | ✓ |
+| `--topic` | ✓ | ✓ | ✓ |
+| `--dataset` | — | R | R |
+| `--entry_group` | R | — | R |
+| `--folder` | ✓ | ✓ | ✓ |
+| `--docs` | ✓ | — | ✓ |
+| `--tables` | — | — | ✓ |
+| `--include_usage` | — | ✓ | ✓ |
+| `--usage_window_days` | — | ✓ | ✓ |
+| `--usage_scope` | — | ✓ | ✓ |
+| `--anonymize_users` | — | ✓ | ✓ |
+| `--glossaries` | — | ✓ | — |
+| `--feedback_dir` | ✓ | ✓ | ✓ |
+| `--feedback_files` | ✓ | ✓ | ✓ |
+| `--repo` | ✓ | ✓ | ✓ |
+| `--repo_ref` | ✓ | ✓ | ✓ |
+| `--repo_subdir` | ✓ | ✓ | ✓ |
+| `--mcp_config` | ✓ | ✓ | ✓ |
+| `--interactive` | ✓ | ✓ | ✓ |
+| `--refine_instruction` | ✓ | ✓ | ✓ |
+
+#### Required in every mode
+
+- **`--project`** — Google Cloud project that hosts the Vertex AI model. Example: `--project=my-gcp-project`.
+- **`--model`** — Vertex AI model id for the reasoning-heavy steps, e.g. `--model=gemini-2.5-pro`. (Small structured steps use a pinned Flash model internally.)
+- **`--output_dir`** — Local directory for the generated mdcode tree, `trajectory.json`, and `refine_session.json`. Example: `--output_dir=/tmp/enrich_out`.
+
+#### Model / location
+
+- **`--location`** — *(optional, default `global`)* Vertex AI location for the model, e.g. `--location=us-central1`.
+
+#### Mode selection & target
+
+- **`--mode`** — *(optional, default inferred)* One of `doc`, `table`, `context_overlay`. If omitted it's inferred: `--dataset` set ⇒ `table`, otherwise `doc`. `context_overlay` is never inferred — pass it explicitly.
+- **`--dataset`** — *(table, context_overlay — required)* BigQuery dataset as `project.dataset`, e.g. `--dataset=my-proj.analytics`. Ignored in doc mode.
+- **`--entry_group`** — *(doc, context_overlay — required)* Entry group `project.location.entryGroupId`. In **doc** mode it **must already exist** (the agent runs read-only `kcmd` and won't create it — see the note above). In **overlay** mode it's where the new overlay entries are created. Ignored in table mode, which writes onto the live `@bigquery` entries.
+
+#### Source context (what the agent reads)
+
+- **`--topic`** — *(optional, default `"Metadata enrichment"`)* Free-text use case/instruction that steers enrichment (and the doc-mode topic reduce). Example: `--topic="Customer 360 data"`.
+- **`--folder`** — *(optional)* Google Drive folder ID or URL to seed source documents from (Docs/Sheets/Slides/PDF). Works in all modes. Example: `--folder=https://drive.google.com/drive/folders/<id>`.
+- **`--docs`** — *(doc, context_overlay)* Comma-separated Google Doc URLs or IDs. In doc mode these are the authoritative depth-0 "spine"; in overlay mode they're routed to tables. **Not used in table mode** — use `--folder` there. Example: `--docs="https://docs.google.com/document/d/<id1>,<id2>"`.
+- **`--tables`** — *(context_overlay only)* Restrict the overlay to specific tables — short names or `proj.ds.table` FQNs, comma-separated. Empty = every table in `--dataset`. Example: `--tables=orders,customers`.
+
+#### BigQuery usage signal — the `queries` aspect *(table, context_overlay)*
+
+- **`--include_usage`** — *(default `true`)* Fetch BigQuery `INFORMATION_SCHEMA` query history per table and emit a `<table>.queries.md` sidecar. `--include_usage=false` skips the BQ scan entirely.
+- **`--usage_window_days`** — *(default `30`)* Days of query history to aggregate. Example: `--usage_window_days=90`.
+- **`--usage_scope`** — *(default `auto`)* `auto` tries `JOBS_BY_PROJECT` then falls back to `JOBS_BY_USER` on a permission error; `project` requires `JOBS_BY_PROJECT`; `user` reads only your own queries (always works, but narrow).
+- **`--anonymize_users`** — *(default `false`)* Replace user emails with stable SHA hashes in the usage signal.
+
+#### Glossary column-linking *(table only)*
+
+- **`--glossaries`** — Comma-separated Dataplex glossaries `project.location.glossaryId`. When set, the agent maps BigQuery columns to glossary terms and injects field-level `links.definition` into each table's entry YAML (published by `kcmd push`). Example: `--glossaries=my-proj.us.business-glossary`.
+
+#### User-feedback proposals *(all modes)*
+
+- **`--feedback_dir`** — Directory of user-feedback files (`.md`/`.json`, pure-JSON `{proposals: [...]}` content), walked recursively. Proposals are the highest-priority context and **override** conflicting info from docs/usage. Routed per-table in table/overlay; applied globally in doc mode.
+- **`--feedback_files`** — Explicit comma-separated feedback file paths; combinable with `--feedback_dir`.
+
+#### GitHub source-code input *(all modes)*
+
+- **`--repo`** — GitHub repo as `owner/name` or a URL, explored agentically via the GitHub MCP server as an extra code-context source. Needs a token in the server's environment (default env var `GITHUB_PERSONAL_ACCESS_TOKEN`). Empty = no code source.
+- **`--repo_ref`** — Branch/tag/SHA to read (default: the repo's default branch). Example: `--repo_ref=main`.
+- **`--repo_subdir`** — Path prefix to scope the exploration, e.g. `--repo_subdir=src/server`.
+- **`--mcp_config`** — Path to an `mcp.json` describing the GitHub MCP server. Falls back to `KC_ENRICH_MCP_CONFIG`, then the hosted remote server (`https://api.githubcopilot.com/mcp/`). Pick a server entry with `KC_ENRICH_GITHUB_MCP_SERVER` (default `github_remote`; use `github` for the local stdio binary).
+
+#### Refinement *(all modes, after a run)*
+
+- **`--interactive`** — *(default `false`)* After the initial run, stay in a `refine>` REPL for free-text changes — rewrite an overview, add/remove/recategorize entries, or ask a question. Reuses loaded context (no doc re-read). No-op on a non-TTY.
+- **`--refine_instruction`** — Apply ONE refinement turn to the saved session in `--output_dir`, then exit (the webapp's persist + re-invoke flow). Requires a prior run's `refine_session.json` in `--output_dir`. Example: `--refine_instruction="make the orders overview more concise"`.
+
+## Output
+
+The agent writes a `kcmd` mdcode tree into `--output_dir`: a `catalog.yaml`
+manifest written by `kcmd init`; the per-entry YAML under `catalog/` (pulled by
+`kcmd pull` in table mode, or generated by the agent in doc mode); and the
+enriched overview sidecar Markdown. It also writes a `trajectory.json` recording
+what the agent read and produced. Inspect it with:
+
+```bash
+find /tmp/enrich_out -type f
+```
+
+## Evaluating the output
+
+Before you publish, you can score an enrichment run with the **dynamic
+(golden-free) evaluator** under `agents/enrichment/eval/`. It needs no
+reference answers — it grounds its checks in the agent's own `trajectory.json`
+(what it actually retrieved), so it works on your own data out of the box.
+
+```bash
+cd agents/enrichment
+pip install -r eval/requirements.txt
+
+# Judge auth — Vertex AI, the same auth the agent uses:
+export GOOGLE_CLOUD_PROJECT=<project>
+gcloud auth application-default login
+
+# Score a run (the same --output_dir you gave the agent):
+python -m eval --output-dir /tmp/enrich_out
+python -m eval --output-dir /tmp/enrich_out --model gemini-2.5-pro
+```
+
+Each run also writes a full **`eval_report.md`** next to `trajectory.json` in the
+output dir — the same metrics with **untruncated** rationales (the terminal
+scorecard abbreviates them to stay readable).
+
+### Flags
+
+Flags (see `python -m eval --help`):
+
+| Flag | Required | Meaning |
+|------|----------|---------|
+| `--output-dir` | yes | The enrichment run's output dir (contains `catalog/` + `trajectory.json`). |
+| `--model` | no | Judge model — any Vertex AI model id you have access to. Defaults to `gemini-2.5-pro`. |
+| `--json` | no | Emit raw JSON instead of the formatted scorecard (for piping/automation). |
+
+It reports the following, each on a 0–1 scale (higher is better):
+
+- **structural_validity** *(deterministic)* — the generated mdcode is well-formed:
+  entry YAML parses, required fields are present, the entry type matches the mode,
+  and overviews are clean Markdown (headers present, no stray YAML frontmatter, no
+  unclosed code fences).
+- **perf** *(report-only)* — token usage and latency for the run, reported for
+  visibility (not gated against a budget; does not affect pass/fail).
+- **hallucination_free** *(judge)* — is every factual claim in the overviews
+  supported by what the agent actually retrieved? The score is the fraction of
+  extracted claims that are grounded; **1.0 = nothing fabricated**. Claims are
+  checked in parallel across chunks of the retrieved source.
+- **redundancy_index** *(judge)* — does the overview add **novel** context beyond
+  echoing column names/schema? **1 = rich synthesis, 0 = tautological restatement.**
+- **disambiguation_efficacy** *(judge)* — is the enrichment enough to tell this
+  entry apart from similar/overlapping ones (its grain and purpose made explicit)?
+  **1 = clearly distinct.**
+- **absence_of_contradictions** *(judge)* — are there contradictions within or
+  across the generated entries (join keys, enums, metric definitions, freshness)?
+  **1 = none, 0 = an explicit conflict.**
+
+### Enabling the judge-based metrics
+
+The **deterministic** metrics (`structural_validity`, `perf`) always run. The
+**judge-based** metrics (`hallucination_free`, `redundancy_index`,
+`disambiguation_efficacy`, `absence_of_contradictions`) run **automatically as
+soon as judge auth is available** — there is no on/off flag. To turn them on, set
+up Vertex AI auth (the same auth the enrichment agent uses):
+
+```bash
+export GOOGLE_CLOUD_PROJECT=<your-project>
+gcloud auth application-default login
+```
+
+Without auth they are simply skipped and shown as `n/a`; the deterministic metrics
+still run. Choose the judge model with `--model` (default `gemini-2.5-pro`).
+
+## Publishing to the catalog
+
+The agent only **generates** mdcode and runs read-only `kcmd` commands. Pushing
+to Dataplex is **your** step, with `kcmd push`:
+
+```bash
+cd /tmp/enrich_out
+CLOUDSDK_CORE_PROJECT=<project> CLOUDSDK_COMPUTE_REGION=<region> \
+  kcmd push     # kcmd from the build step above (on your PATH); otherwise use the full path to agents/mdcode/dist/kcmd
+```
+
+`kcmd` is the Metadata as Code tool from
+[`GoogleCloudPlatform/knowledge-catalog`](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/agents/mdcode),
+vendored here under `agents/mdcode`.

--- a/agents/enrichment/eval/__init__.py
+++ b/agents/enrichment/eval/__init__.py
@@ -1,0 +1,6 @@
+"""Enrichment evaluation toolkit (CLI).
+
+Dynamic (golden-free) evaluation of an enrichment run's output. See README.md.
+"""
+
+from .dynamic_eval import run_dynamic_eval  # noqa: F401

--- a/agents/enrichment/eval/__main__.py
+++ b/agents/enrichment/eval/__main__.py
@@ -1,0 +1,94 @@
+"""CLI for dynamic (golden-free) enrichment evaluation.
+
+Run from `agents/enrichment/`:
+
+    python -m eval --output-dir /path/to/enrichment/output
+    python -m eval --output-dir /path/to/output --model gemini-2.5-pro --json
+
+The output dir is what the enrichment agent wrote (contains `catalog/` and
+`trajectory.json`). Judge auth: Vertex AI — set GOOGLE_CLOUD_PROJECT and
+Application Default Credentials (`gcloud auth application-default login`), the
+same auth the enrichment agent uses. Each run also writes a full `eval_report.md`
+into the output dir with untruncated rationales.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from .dynamic_eval import run_dynamic_eval, fmt_score
+
+
+def _has_judge_auth() -> bool:
+  return bool(os.environ.get("GOOGLE_CLOUD_PROJECT")
+              or os.environ.get("GOOGLE_GENAI_USE_VERTEXAI"))
+
+
+def _fmt(results: dict) -> str:
+  metrics = results.get("metrics", [])
+  # Width the metric column to the longest name (e.g. absence_of_contradictions)
+  # so every score stays aligned.
+  w = max([len(m["name"]) for m in metrics] + [len("metric"), len("AVERAGE")])
+  lines = ["", f"Dynamic eval — {results.get('output_dir')}",
+           f"  mode: {results.get('mode')}  (agent_type={results.get('agent_type')})",
+           "",
+           f"  {'metric':{w}} {'score':>7}   rationale",
+           f"  {'-'*w} {'-'*7}   {'-'*40}"]
+  for m in metrics:
+    sc = m["score"]
+    sc_s = fmt_score(sc)
+    rat = (m.get("rationale") or "").replace("\n", " ")
+    if len(rat) > 90:
+      rat = rat[:90] + "…"
+    lines.append(f"  {m['name']:{w}} {sc_s:>7}   {rat}")
+  avg = results.get("average_score")
+  lines.append(f"  {'-'*w} {'-'*7}")
+  lines.append(f"  {'AVERAGE':{w}} {fmt_score(avg):>7}")
+  t = results.get("telemetry", {})
+  lat = t.get("latency_s")
+  lines.append("")
+  lines.append(f"  tokens: {t.get('tokens_total', 0):,} "
+               f"(in {t.get('tokens_in', 0):,} / out {t.get('tokens_out', 0):,})  ·  "
+               f"tool calls: {t.get('num_tool_calls', 0)}  ·  "
+               f"latency: {('—' if not lat else f'{lat:.1f}s')}")
+  lines.append("")
+  lines.append(f"  full report: {os.path.join(results.get('output_dir', ''), 'eval_report.md')}")
+  lines.append("")
+  return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+  ap = argparse.ArgumentParser(
+      prog="python -m eval",
+      description="Dynamic (golden-free) evaluation of an enrichment run.")
+  ap.add_argument("--output-dir", required=True,
+                  help="Enrichment output dir (contains catalog/ and trajectory.json).")
+  ap.add_argument("--model", default="gemini-2.5-pro",
+                  help="Judge model: any Vertex AI model id you have access to "
+                       "(default: gemini-2.5-pro).")
+  ap.add_argument("--json", action="store_true",
+                  help="Emit raw JSON instead of a formatted scorecard.")
+  args = ap.parse_args(argv)
+
+  if not os.path.isdir(args.output_dir):
+    print(f"error: not a directory: {args.output_dir}", file=sys.stderr)
+    return 2
+  if not _has_judge_auth():
+    print("warning: GOOGLE_CLOUD_PROJECT not set — judge-based metrics "
+          "(hallucination_free, rubric) need Vertex AI auth (set GOOGLE_CLOUD_PROJECT "
+          "+ run `gcloud auth application-default login`). Deterministic metrics still run.",
+          file=sys.stderr)
+
+  results = run_dynamic_eval(args.output_dir, model=args.model)
+  if "error" in results:
+    print(f"error: {results['error']}", file=sys.stderr)
+    return 1
+  print(json.dumps(results, indent=2) if args.json else _fmt(results))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/agents/enrichment/eval/dynamic_eval.py
+++ b/agents/enrichment/eval/dynamic_eval.py
@@ -1,0 +1,223 @@
+"""Dynamic (golden-free) evaluation of a single enrichment run.
+
+Scores the output of one enrichment run with no golden/reference answers needed,
+grounded in the agent's own captured `trajectory.json` (what it actually
+retrieved). Useful for evaluating enrichment on your own data out of the box.
+
+Metrics:
+  - structural_validity : the generated mdcode is well-formed (deterministic)
+  - perf                : token usage + latency against an optional budget
+  - hallucination_free  : every factual claim in the overviews is supported by
+                          what the agent retrieved (chunked, parallel, judge)
+  - rubric dims         : redundancy_index, disambiguation_efficacy,
+                          absence_of_contradictions (judge)
+
+Scores are 0..1 (None = the metric self-skipped, e.g. hallucination with no
+grounding source available). See README.md for usage.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import textwrap
+import time
+
+from . import loaders
+from . import metrics
+
+
+def _log(msg: str) -> None:
+  """Progress line to stderr (keeps stdout/--json clean)."""
+  print(f"[eval] {msg}", file=sys.stderr, flush=True)
+
+
+def _wrap_para(text: str, width: int = 88) -> str:
+  """Wrap a rationale/insight into width-bounded lines so the report stays
+  readable in editors that don't soft-wrap long lines (e.g. nano)."""
+  body = " ".join((text or "").split())
+  return textwrap.fill(body, width=width) if body else "(none)"
+
+
+def fmt_score(score) -> str:
+  """Render a metric score (stored 0..1) on the 0-100 scale shown to users.
+
+  Scores are kept normalized (0..1) internally — thresholds, gating and the JSON
+  output — and only scaled to 0-100 for display in the scorecard, report, and
+  progress logs. None -> "n/a".
+  """
+  return "n/a" if score is None else f"{float(score) * 100:.1f}"
+
+
+def write_report(results: dict, output_dir: str,
+                 filename: str = "eval_report.md") -> str:
+  """Write a full, untruncated eval report (Markdown) next to trajectory.json.
+
+  The terminal scorecard truncates rationales to stay readable; this file keeps
+  the full rationale + insights for every metric. Returns the path written ("" on
+  failure). Reused by both the dynamic and golden evaluators.
+  """
+  t = results.get("telemetry", {})
+  avg = results.get("average_score")
+  lines = ["# Enrichment eval report", ""]
+  lines.append(f"- output: `{results.get('output_dir')}`")
+  if results.get("golden"):
+    lines.append(f"- golden: `{results.get('golden')}`")
+  lines.append(f"- mode: {results.get('mode')} "
+               f"(agent_type={results.get('agent_type')})")
+  lines.append(f"- generated: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+  lines.append(f"- average score: {fmt_score(avg)}/100")
+  lat = t.get("latency_s")
+  lines.append(f"- telemetry: {t.get('tokens_total', 0):,} tokens "
+               f"(in {t.get('tokens_in', 0):,} / out {t.get('tokens_out', 0):,}) · "
+               f"{t.get('num_tool_calls', 0)} tool calls · "
+               f"latency {('n/a' if not lat else f'{lat:.1f}s')}")
+  lines.append("")
+  for m in results.get("metrics", []):
+    sc = m.get("score")
+    lines.append(f"## {m['name']} — {fmt_score(sc)}/100")
+    if m.get("description"):
+      lines.append(f"_{m['description']}_")
+    lines.append("")
+    lines.append("**Rationale:**")
+    lines.append("")
+    lines.append(_wrap_para(m.get("rationale")))
+    if m.get("insights"):
+      lines.append("")
+      lines.append("**Insights:**")
+      lines.append("")
+      lines.append(_wrap_para(m.get("insights")))
+    lines.append("")
+  path = os.path.join(output_dir, filename)
+  try:
+    with open(path, "w", encoding="utf-8") as f:
+      f.write("\n".join(lines) + "\n")
+    _log(f"full report → {path}")
+    return path
+  except OSError as e:
+    _log(f"could not write report: {e}")
+    return ""
+
+
+def run_dynamic_eval(output_dir: str, model: str = "gemini-2.5-pro",
+                     perf_budget: dict | None = None) -> dict:
+  """Evaluate one enrichment run directory. Returns a results dict.
+
+  Args:
+    output_dir: the agent's output dir (contains `catalog/` and `trajectory.json`).
+    model: judge model — any Vertex AI model id you have access to
+      (default gemini-2.5-pro).
+    perf_budget: optional {"max_latency_s":..., "max_total_tokens":...}.
+  """
+  traj = loaders.load_trajectory(output_dir)
+  agent_type = traj.get("agent_type", "doc")
+  mode = "table" if agent_type == "table" else "doc"
+
+  _log(f"scoring {output_dir}  (mode={mode})")
+  arts = loaders.load_mdcode(os.path.join(output_dir, "catalog"))
+  if not arts.get("overview_md") and not arts.get("yaml"):
+    return {"error": f"No generated mdcode found under {output_dir}/catalog."}
+  _log(f"loaded {len(arts.get('overview_md', {}))} overview(s), "
+       f"{len(arts.get('yaml', {}))} entry yaml(s)")
+
+  # Ground hallucination against what the agent actually retrieved at runtime.
+  src_parts = []
+  for t in (traj.get("tool_responses") or []):
+    r = t.get("response") if isinstance(t, dict) else t
+    if isinstance(r, dict):
+      texts = [str(r[k]) for k in ("content", "text", "overview", "description")
+               if r.get(k)]
+      src_parts.extend(texts or [json.dumps(r)[:50000]])
+    elif isinstance(r, str):
+      src_parts.append(r)
+  source_context = "\n\n".join(src_parts)
+
+  tokens = dict(traj.get("token_usage") or {})
+  tokens["total"] = (tokens.get("input", 0) or 0) + (tokens.get("output", 0) or 0)
+  latency = float(traj.get("latency") or 0.0)
+
+  # Only build a real judge when auth is present; otherwise pass a no-op so the
+  # judge-based metrics self-skip (deterministic metrics still run) instead of
+  # hanging on retries / erroring with no credentials.
+  has_auth = bool(os.environ.get("GOOGLE_CLOUD_PROJECT")
+                  or os.environ.get("GOOGLE_GENAI_USE_VERTEXAI"))
+  # Only build a real judge when auth is present; otherwise a no-op so judge-based
+  # metrics self-skip (deterministic metrics still run) instead of hanging/erroring.
+  judge = metrics.default_judge(model) if has_auth else (lambda _p: "")
+  _log(f"judge: {model + ' (on)' if has_auth else 'OFF — no auth, judge metrics will be n/a'}")
+
+  mres = []
+  _log("· structural_validity (deterministic) …")
+  mres.append(metrics.check_structural(arts, mode))
+  _log(f"  = {fmt_score(mres[-1].score)}")
+  _log("· perf (deterministic) …")
+  mres.append(metrics.check_perf(latency, arts, perf_budget or {}, tokens))
+  _log(f"  = {fmt_score(mres[-1].score)}")
+
+  # Table mode: also ground against the pulled 1P schema / reference + produced yaml.
+  extra = ""
+  if mode == "table":
+    refs = loaders.load_references(output_dir)
+    extra = "\n\n".join(
+        list((refs.get("yaml") or {}).values())
+        + list((refs.get("overview_md") or {}).values())
+        + list((arts.get("reference_yaml") or {}).values())
+        + list((arts.get("reference_overview_md") or {}).values())
+        + list((arts.get("yaml") or {}).values()))
+  _log("· hallucination_free (judge: extract claims → verify across chunks) …")
+  _t = time.time()
+  try:
+    mres.append(metrics.check_hallucination(arts, source_context, judge,
+                                            extra_grounding=extra))
+    _log(f"  = {fmt_score(mres[-1].score)}  ({time.time() - _t:.0f}s)")
+  except Exception as e:  # pylint: disable=broad-except
+    # e.g. Vertex auth/ADC missing despite GOOGLE_CLOUD_PROJECT being set. Degrade
+    # to n/a (excluded from the gate) instead of crashing the whole eval.
+    _log(f"  (hallucination skipped: {str(e)[:120]})")
+    mres.append(metrics.MetricResult(
+        "hallucination_free", None, True,
+        "groundedness not scored — judge unavailable (check Vertex AI auth: "
+        "GOOGLE_CLOUD_PROJECT + `gcloud auth application-default login`)"))
+  _log("· rubric: redundancy / disambiguation / contradictions (judge) …")
+  _t = time.time()
+  try:
+    rub = metrics.score_rubric(arts, judge, None)
+    mres.extend(rub)
+    for r in rub:
+      _log(f"    {r.name} = {fmt_score(r.score)}")
+    _log(f"  (rubric done in {time.time() - _t:.0f}s)")
+  except Exception:  # pylint: disable=broad-except
+    _log("  (rubric skipped)")
+  _log("done — scorecard below")
+
+  label = getattr(metrics, "_METRIC_LABEL", {})
+  out_metrics, numeric = [], []
+  for r in mres:
+    sc = None if r.score is None else round(float(r.score), 4)
+    if sc is not None:
+      numeric.append(sc)
+    out_metrics.append({
+        "name": r.name,
+        "score": sc,
+        "description": label.get(r.name, r.name),
+        "rationale": r.detail,
+        "insights": getattr(r, "insights", "") or "",
+    })
+
+  results = {
+      "output_dir": output_dir,
+      "agent_type": agent_type,
+      "mode": mode,
+      "metrics": out_metrics,
+      "average_score": round(sum(numeric) / len(numeric), 4) if numeric else None,
+      "telemetry": {
+          "tokens_in": tokens.get("input", 0),
+          "tokens_out": tokens.get("output", 0),
+          "tokens_total": tokens.get("total", 0),
+          "num_tool_calls": len(traj.get("tool_uses") or []),
+          "latency_s": latency or None,
+      },
+  }
+  write_report(results, output_dir)
+  return results

--- a/agents/enrichment/eval/loaders.py
+++ b/agents/enrichment/eval/loaders.py
@@ -1,0 +1,84 @@
+"""Load the artifacts an enrichment run produced, for evaluation.
+
+Pure file readers — no agent/CLI dependencies. The enrichment agent writes its
+output under `<output_dir>/catalog/` (the generated Metadata-as-Code) and a
+`<output_dir>/trajectory.json` (a record of what it read and produced). In
+BigQuery table mode it also writes pre-enrichment `<table>.ref.{yaml,overview.md}`
+sidecars (the "before" snapshot) inside `catalog/`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+
+
+def load_mdcode(catalog_dir: str) -> dict:
+  """Collect the artifacts under `catalog/`.
+
+  Returns dict of buckets keyed by relative path:
+    - yaml / overview_md / queries_md  : the GENERATED entry files (after)
+    - reference_yaml / reference_overview_md : pre-enrichment 1P `.ref.*` sidecars
+    - manifest : catalog.yaml contents (if present)
+  `.ref.*` files are separated out so they aren't miscounted as generated output.
+  """
+  root = pathlib.Path(catalog_dir)
+  out = {"yaml": {}, "overview_md": {}, "queries_md": {},
+         "reference_yaml": {}, "reference_overview_md": {}, "manifest": None}
+  if not root.is_dir():
+    return out
+  for p in sorted(root.rglob("*")):
+    if p.is_dir():
+      continue
+    rel = str(p.relative_to(root))
+    if p.name == "catalog.yaml":
+      out["manifest"] = p.read_text(encoding="utf-8", errors="replace")
+    elif p.name.endswith(".ref.yaml"):
+      out["reference_yaml"][rel] = p.read_text(encoding="utf-8", errors="replace")
+    elif p.name.endswith(".ref.overview.md"):
+      out["reference_overview_md"][rel] = p.read_text(
+          encoding="utf-8", errors="replace")
+    elif p.name.endswith(".queries.md"):
+      out["queries_md"][rel] = p.read_text(encoding="utf-8", errors="replace")
+    elif p.suffixes[-2:] == [".overview", ".md"] or p.name.endswith(".overview.md"):
+      out["overview_md"][rel] = p.read_text(encoding="utf-8", errors="replace")
+    elif p.suffix == ".yaml":
+      out["yaml"][rel] = p.read_text(encoding="utf-8", errors="replace")
+  return out
+
+
+def load_references(output_dir: str) -> dict:
+  """Collect a `<output_dir>/reference/` dir if present (context-overlay mode).
+
+  Standard table mode writes `.ref.*` inline in `catalog/` (see load_mdcode);
+  this covers the alternate layout where a separate `reference/` dir is pulled.
+  Empty for doc mode.
+  """
+  root = pathlib.Path(output_dir) / "reference"
+  out = {"yaml": {}, "overview_md": {}}
+  if not root.is_dir():
+    return out
+  for p in sorted(root.rglob("*")):
+    if p.is_dir():
+      continue
+    rel = str(p.relative_to(root))
+    if p.name == "catalog.yaml":
+      continue
+    if p.name.endswith(".ref.overview.md") or p.name.endswith(".overview.md"):
+      out["overview_md"][rel] = p.read_text(encoding="utf-8", errors="replace")
+    elif p.suffix == ".yaml":
+      out["yaml"][rel] = p.read_text(encoding="utf-8", errors="replace")
+  return out
+
+
+def load_trajectory(output_dir: str) -> dict:
+  """Read `<output_dir>/trajectory.json` (the agent's run record). {} if absent."""
+  path = os.path.join(output_dir, "trajectory.json")
+  if not os.path.exists(path):
+    return {}
+  try:
+    with open(path, encoding="utf-8") as f:
+      return json.load(f) or {}
+  except (OSError, ValueError):
+    return {}

--- a/agents/enrichment/eval/metrics.py
+++ b/agents/enrichment/eval/metrics.py
@@ -1,0 +1,1064 @@
+"""Metrics for scoring emitted Metadata-as-Code against a case's golden.
+
+Deterministic (no model): structural/contract validity, input-conditioned
+trajectory, perf guardrails, business-term presence.
+LLM-as-judge (pluggable `judge`): topic-flavor matching (concept recall/precision
++ fact coverage with confidence), rubric dimensions, hallucination/groundedness.
+
+`judge` is any Callable[[str], str] returning model text (expected JSON). Tests
+inject a stub so deterministic metrics + wiring run without tokens.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import dataclasses
+import json
+import os
+import re
+from typing import Callable
+
+import yaml
+
+Judge = Callable[[str], str]
+
+
+def _clip(s, n: int) -> str:
+  """Truncate to <= n chars at a WORD boundary (+ ellipsis) so rationales never
+  cut mid-word (e.g. '...replenishment is delay'). Generous default caps."""
+  s = str(s or "").strip()
+  if len(s) <= n:
+    return s
+  cut = s[:n].rsplit(" ", 1)[0].rstrip(" ,;:—-")
+  return (cut or s[:n]) + "…"
+
+
+@dataclasses.dataclass
+class MetricResult:
+  name: str
+  score: float
+  passed: bool
+  detail: str = ""          # rationale: WHY this score
+  insights: str = ""        # actionable: HOW to improve (LLM-judge metrics)
+  extra: dict = dataclasses.field(default_factory=dict)
+
+
+def parse_json(text: str):
+  """Best-effort JSON extraction from an LLM response."""
+  t = (text or "").strip()
+  m = re.search(r"```(?:json)?\s*(.*?)```", t, re.S)
+  if m:
+    t = m.group(1).strip()
+  m = re.search(r"(\{.*\}|\[.*\])", t, re.S)
+  if m:
+    t = m.group(1)
+  try:
+    return json.loads(t)
+  except (ValueError, json.JSONDecodeError):
+    return None
+
+
+def parse_json_obj(text: str) -> dict:
+  """Like parse_json but ALWAYS returns a dict. The judge sometimes emits a JSON
+  array (or non-object); callers that then do `.get(...)` would crash with
+  "'list' object has no attribute 'get'". This guarantees a dict so every
+  object-shaped judge call site is safe."""
+  res = parse_json(text)
+  return res if isinstance(res, dict) else {}
+
+
+# ============================ deterministic ============================
+
+_ENTRY_TYPE = {"doc": "dataplex-types.global.generic",
+               "table": "dataplex-types.global.bigquery-table"}
+
+
+def check_structural(artifacts: dict, mode: str) -> MetricResult:
+  """mdcode contract: entries parse, required fields, correct type, overview present."""
+  yamls = {p: t for p, t in artifacts.get("yaml", {}).items()
+           if not p.endswith("catalog.yaml")}
+  overviews = artifacts.get("overview_md", {})
+  if not yamls:
+    return MetricResult("structural_validity", 0.0, False, "no entry YAML emitted")
+  want_type = _ENTRY_TYPE.get(mode)
+  problems, ok = [], 0
+  for path, text in yamls.items():
+    name = path.rsplit("/", 1)[-1]
+    if len(re.findall(r"^---\s*$", text, re.M)) >= 2:
+      problems.append(f"{name} contains multiple YAML documents (there should be "
+                      "exactly one entry per file)")
+      continue
+    try:
+      doc = yaml.safe_load(text) or {}
+    except yaml.YAMLError as e:
+      first = str(e).strip().splitlines()[0]
+      problems.append(f"{name} isn't valid YAML ({first})")
+      continue
+    if not (doc.get("name") or doc.get("id")):
+      problems.append(f"{name} is missing the required 'name'/'id' field"); continue
+    if not doc.get("type"):
+      problems.append(f"{name} is missing the required 'type' field"); continue
+    if want_type and doc.get("type") != want_type:
+      problems.append(f"{name} has entry type '{doc.get('type')}', but a "
+                      f"{mode}-mode entry must be '{want_type}'"); continue
+    if not isinstance(doc.get("resource"), dict):
+      problems.append(f"{name} has a missing or malformed 'resource' block"); continue
+    ok += 1
+  if not overviews:
+    problems.append("the agent didn't write any overview (.overview.md) files")
+  # Markdown checks (folded in from the former markdown_structure_score). Track the
+  # set of bad overview files so they count against the SCORE, not just pass/fail.
+  bad_ov: set[str] = set()
+  # 1) every overview must have at least one Markdown header.
+  unstructured = [p for p, t in overviews.items()
+                  if not re.search(r"^#{1,6}\s+\S", t or "", re.M)]
+  if unstructured:
+    bad_ov.update(unstructured)
+    problems.append("overview(s) lack Markdown headers/sections: "
+                    + ", ".join(os.path.basename(p) for p in unstructured))
+  # 2) no leading YAML frontmatter -- empty ('--- {} ---') is noise; a populated one
+  #    (e.g. 'title:') isn't part of the `overview` aspect and can break `kcmd push`.
+  bad_fm = []
+  for p, t in overviews.items():
+    fm = re.match(r"\s*---\s*\n(.*?)\n---", t or "", re.S)
+    if fm:
+      body = fm.group(1).strip()
+      kind = "empty '--- {} ---'" if body in ("", "{}", "{ }") else "stray frontmatter (e.g. title:)"
+      bad_ov.add(p)
+      bad_fm.append(f"{os.path.basename(p)} [{kind}]")
+  if bad_fm:
+    problems.append("overview(s) begin with a YAML frontmatter block — overviews "
+                    "should be clean Markdown, not frontmatter: " + ", ".join(bad_fm))
+  # 3) no unclosed code fences.
+  unclosed = [p for p, t in overviews.items() if (t or "").count("```") % 2]
+  if unclosed:
+    bad_ov.update(unclosed)
+    problems.append("overview(s) have an unclosed code fence: "
+                    + ", ".join(os.path.basename(p) for p in unclosed))
+  # Score = fraction of all generated files (entry YAMLs + overview .md) that are
+  # clean. So a markdown problem lowers the score too (no more "score 1.0 but FAIL").
+  total = len(yamls) + len(overviews)
+  clean = ok + (len(overviews) - len(bad_ov))
+  score = (clean / total) if total else 0.0
+  passed = not problems and bool(overviews)
+  detail = ("Some generated files aren't valid Metadata-as-Code: "
+            + "; ".join(problems)) if problems else (
+      f"All {ok} generated " + ("entry is" if ok == 1 else "entries are") +
+      " valid Metadata-as-Code (YAML parses, required fields present, entry type "
+      "matches the mode, an overview was written, and overviews are clean Markdown "
+      "with headers and no stray frontmatter).")
+  return MetricResult("structural_validity", round(score, 3), passed, detail,
+                      extra={"entries_ok": ok, "entries_total": len(yamls),
+                             "overviews_ok": len(overviews) - len(bad_ov),
+                             "overviews_total": len(overviews)})
+
+
+def check_entry_grounding(artifacts: dict) -> MetricResult:
+  """Table-mode precision guard: every generated overview entry must correspond to
+  a REAL pulled dataset table (its entry YAML, which is the source of truth in
+  table mode). Catches invented/spurious entries generated 'on top' of the
+  dataset. Deterministic -- no judge."""
+  norm = lambda p: re.sub(r"[-_]", "", os.path.basename(p)
+                          .replace(".overview.md", "").replace(".yaml", "").lower())
+  refs = {norm(p) for p in artifacts.get("yaml", {}) if not p.endswith("catalog.yaml")}
+  produced = {}
+  for p in artifacts.get("overview_md", {}):
+    produced[norm(p)] = os.path.basename(p).replace(".overview.md", "")
+  if not produced:
+    return MetricResult("entry_grounding", 1.0, True, "No entries produced to check.")
+  if not refs:
+    return MetricResult("entry_grounding", 1.0, True,
+                        "No pulled table references available to check against.")
+  spurious = sorted(orig for n, orig in produced.items() if n not in refs)
+  score = (len(produced) - len(spurious)) / len(produced)
+  ok = not spurious
+  detail = (f"All {len(produced)} generated entries correspond to a real dataset "
+            "table (no invented entries)." if ok else
+            f"{len(spurious)} generated entr{'y' if len(spurious) == 1 else 'ies'} "
+            f"not backed by any dataset table (invented on top): {', '.join(spurious)}.")
+  return MetricResult("entry_grounding", round(score, 3), ok, detail,
+                      extra={"spurious": spurious})
+
+
+def check_expected_headings(artifacts: dict, expected: list[str]) -> MetricResult:
+  """Golden-driven section coverage (replaces the judge 'enrichment_diversity').
+
+  Each golden case can declare the sections it expects the enrichment to contain
+  (e.g. 'Lineage', 'Sample Queries'). Freshness/SLA and Grain are intentionally
+  NOT part of this metric. We check, by case-insensitive heading/text match, how
+  many are present across the overviews. Concrete and deterministic -- no judge,
+  and grounded in what we actually want."""
+  if not expected:
+    return MetricResult("enrichment_diversity", 1.0, True,
+                        "No expected sections declared for this case.")
+  overview_blob = "\n".join(artifacts.get("overview_md", {}).values()).lower()
+  queries_blob = "\n".join(artifacts.get("queries_md", {}).values()).lower()
+  blob = (overview_blob + "\n" + queries_blob).strip()
+  # The agent now emits sample queries in a separate `<table>.queries.md` sidecar
+  # (a YAML `queries:` list) instead of a "## Sample Queries" overview section, so
+  # the literal heading text isn't in either blob -- detect real query content.
+  has_queries = bool(queries_blob.strip()) and (
+      "sql:" in queries_blob or "select " in queries_blob
+      or "queries:" in queries_blob)
+  if not blob:
+    return MetricResult("enrichment_diversity", 0.0, False,
+                        "No overview produced, so none of the expected sections "
+                        f"({', '.join(expected)}) are present.")
+  present, missing = [], []
+  for h in expected:
+    # match any alias separated by '/' or '&' (e.g. "Freshness / SLA")
+    aliases = [a.strip().lower() for a in re.split(r"[/&]", h) if a.strip()]
+    # A "Sample/Common/Example Queries" section is satisfied by a populated
+    # queries.md sidecar even though its YAML body has no heading text.
+    is_query_heading = any("quer" in a for a in aliases)
+    matched = any(a and a in blob for a in aliases) or (
+        is_query_heading and has_queries)
+    (present if matched else missing).append(h)
+  score = len(present) / len(expected)
+  detail = (f"Covers {len(present)} of {len(expected)} expected sections"
+            + (f"; missing: {', '.join(missing)}." if missing else "."))
+  return MetricResult("enrichment_diversity", score, score >= 0.5, detail,
+                      extra={"present": present, "missing": missing})
+
+
+_TRAJECTORY_MARKERS = {
+    "folder_list": [r"Listing Drive folder", r"Found \d+ file"],
+    "drive_fetch": [r"Fetching", r"summariz"],
+    # Table-mode BigQuery dataset discovery ONLY. NOTE: doc mode also runs
+    # `kcmd init --entry-group` + `kcmd pull`, so bare "kcmd"/"pull" must NOT be
+    # markers here or doc mode falsely trips must_not_call:[dataset_pull].
+    "dataset_pull": [r"bigquery-dataset", r"bq-dataset", r"Discovered \d+ table",
+                     r"--dataset\b"],
+    "github_fetch": [r"github"],
+    "sharepoint_fetch": [r"sharepoint"],
+}
+
+
+def fired_tools(stdout: str) -> set[str]:
+  return {tool for tool, pats in _TRAJECTORY_MARKERS.items()
+          if any(re.search(p, stdout or "", re.I) for p in pats)}
+
+
+_TOOL_PHRASE = {
+    "folder_list": "list the Drive folder",
+    "drive_fetch": "fetch the document(s)",
+    "dataset_pull": "pull/discover the BigQuery dataset",
+    "github_fetch": "fetch from GitHub",
+    "sharepoint_fetch": "fetch from SharePoint",
+}
+
+
+def check_trajectory(stdout: str, golden: dict) -> MetricResult:
+  """Input-conditioned tool use: must_call present, must_not_call absent."""
+  fired = fired_tools(stdout)
+  missing = sorted(set(golden.get("must_call", [])) - fired)
+  violated = sorted(set(golden.get("must_not_call", [])) & fired)
+  passed = not missing and not violated
+  phr = lambda ts: ", ".join(_TOOL_PHRASE.get(t, t) for t in ts)
+  if passed:
+    detail = ("The agent used the expected tools for its inputs ("
+              + (phr(sorted(fired)) or "no external sources") +
+              ") and didn't touch any source it wasn't given.")
+  else:
+    parts = []
+    if missing:
+      parts.append("based on its inputs it should have " + phr(missing)
+                   + ", but it didn't")
+    if violated:
+      parts.append("it ran " + phr(violated)
+                   + " even though that input wasn't provided")
+    detail = "The agent's tool use didn't match its inputs: " + "; ".join(parts) + "."
+  return MetricResult("trajectory", 1.0 if passed else 0.0, passed, detail,
+                      extra={"fired": sorted(fired)})
+
+
+def check_perf(latency_s: float, artifacts: dict, budget: dict,
+               tokens: dict | None = None) -> MetricResult:
+  """REPORT-ONLY (does NOT gate). Surfaces latency, token usage, and output size
+  for visibility. No pass/fail threshold is enforced here -- this metric is
+  reported, not gated."""
+  tok = tokens or {}
+  tin, tout = tok.get("input", 0) or 0, tok.get("output", 0) or 0
+  ttot = tok.get("total", (tin + tout))
+  overviews = artifacts.get("overview_md", {})
+  longest = max((len(t) for t in overviews.values()), default=0)
+  tok_txt = (f" Used {ttot:,} tokens ({tin:,} in / {tout:,} out)." if ttot else "")
+  lat_txt = (f"Completed in {latency_s:.0f}s." if latency_s and latency_s > 0
+             else "Latency not recorded (re-run the agent to capture it).")
+  detail = (lat_txt + tok_txt +
+            (f" Longest overview {longest:,} chars." if longest else "") +
+            " (Report-only — not gated.)")
+  # Always passes: report-only so it never fails the case gate.
+  return MetricResult("perf", 1.0, True, detail,
+                      extra={"tokens": {"input": tin, "output": tout, "total": ttot}})
+
+
+def check_business_terms(artifacts: dict, terms: list[str],
+                         judge: Judge | None = None) -> MetricResult:
+  """Are the expected business terms PRESENT? Loose / flavor matching: a term
+  counts if its meaning appears under ANY synonym / paraphrase / abbreviation
+  (a 'flavor' of it) -- exact wording is NOT required. Uses the LLM judge when
+  available; falls back to a case-insensitive substring check otherwise."""
+  if not terms:
+    return MetricResult("business_terms_presence", 1.0, True, "none expected")
+  text = ("\n".join(artifacts.get("overview_md", {}).values()) + "\n" +
+          "\n".join(artifacts.get("yaml", {}).values()))
+  if judge is not None:
+    prompt = ("Which EXPECTED TERMS are present in the documentation? Count a term "
+              "as present if its meaning appears under ANY synonym / paraphrase / "
+              "abbreviation (a 'flavor' of it) -- exact wording is NOT required "
+              "(e.g. 'BOM' counts for 'Bill of Materials').\n"
+              f"EXPECTED TERMS: {terms}\n\nDOCUMENTATION:\n{text[:50000]}\n\n"
+              'Return STRICT JSON: {"present":[<terms from the list present in any flavor>],'
+              '"rationale":"<one sentence>"}')
+    res = parse_json_obj(judge(prompt))
+    present = [t for t in terms if t in (res.get("present") or [])]
+    missing = [t for t in terms if t not in present]
+    base = (res.get("rationale", "").strip()
+            or f"Found {len(present)} of {len(terms)} expected business terms "
+               "(matched by meaning, not exact wording).")
+    return MetricResult(
+        "business_terms_presence", len(present) / len(terms), not missing,
+        base + (f" Missing: {', '.join(missing)}." if missing else ""))
+  low = text.lower()
+  found = [t for t in terms if t.lower() in low]
+  missing = [t for t in terms if t not in found]
+  return MetricResult(
+      "business_terms_presence", len(found) / len(terms), not missing,
+      f"Found {len(found)} of {len(terms)} expected business terms in the output "
+      "(exact-text match — turn on the LLM judge for synonym/flavor matching)."
+      + (f" Not found: {', '.join(missing)}." if missing else ""))
+
+
+def check_context_preservation(artifacts: dict, prebaked_facts: list[str],
+                               judge: Judge | None = None) -> MetricResult:
+  """Merge/update path: when enriching an entry that ALREADY has pre-baked
+  context, that context must be PRESERVED (not clobbered) and then augmented with
+  the new folder facts.
+
+  Each pre-baked fact must still be present (by meaning) in the post-enrichment
+  overview. Loose flavor matching like check_business_terms: LLM judge when
+  available, case-insensitive substring fallback otherwise. Today the agent always
+  scaffolds a CLEAN output dir (doc_mode.py) and regenerates from scratch -- there
+  is no merge-into-existing path -- so this is EXPECTED to fail until that
+  capability lands (a known gap)."""
+  if not prebaked_facts:
+    return MetricResult("context_preservation", 1.0, True,
+                        "No pre-baked context to preserve for this case.")
+  text = "\n".join(artifacts.get("overview_md", {}).values())
+  if not text.strip():
+    return MetricResult(
+        "context_preservation", 0.0, False,
+        "The agent produced no overview, so any pre-existing (pre-baked) context "
+        "on the entry would have been lost rather than preserved.")
+  if judge is not None:
+    prompt = ("An entry had PRE-BAKED CONTEXT before enrichment. Which of these "
+              "pre-baked facts are STILL present (by meaning -- synonym/paraphrase "
+              "is fine) in the post-enrichment documentation? A fact counts as "
+              "preserved only if its substance survived.\n"
+              f"PRE-BAKED FACTS: {prebaked_facts}\n\nPOST-ENRICHMENT DOCUMENTATION:\n"
+              f"{text[:50000]}\n\nReturn STRICT JSON: "
+              '{"preserved":[<facts still present>],"rationale":"<one sentence>"}')
+    res = parse_json_obj(judge(prompt))
+    kept = [f for f in prebaked_facts if f in (res.get("preserved") or [])]
+    lost = [f for f in prebaked_facts if f not in kept]
+    base = (res.get("rationale", "").strip()
+            or f"{len(kept)} of {len(prebaked_facts)} pre-baked facts were "
+               "preserved after enrichment.")
+    return MetricResult(
+        "context_preservation", len(kept) / len(prebaked_facts), not lost,
+        base + (f" Lost: {', '.join(lost)}." if lost else ""))
+  low = text.lower()
+  kept = [f for f in prebaked_facts if f.lower() in low]
+  lost = [f for f in prebaked_facts if f not in kept]
+  return MetricResult(
+      "context_preservation", len(kept) / len(prebaked_facts), not lost,
+      f"{len(kept)} of {len(prebaked_facts)} pre-baked facts survived enrichment "
+      "(exact-text match — turn on the LLM judge for meaning-level matching)."
+      + (f" Lost: {', '.join(lost)}." if lost else ""))
+
+
+# ============================ LLM-as-judge ============================
+
+def _name_tokens(s: str) -> set:
+  """Lowercase alphanumeric tokens of a name/id (kebab/snake/space agnostic)."""
+  return set(re.findall(r"[a-z0-9]+", str(s).lower()))
+
+
+def _deterministic_entry_match(topic: dict, produced_basenames: list[str]) -> str:
+  """Deterministic backstop for concept matching (no LLM).
+
+  Returns the produced entry whose id literally contains ALL tokens of the
+  topic's canonical name (or a declared alias), else "". This rescues the
+  obvious cases the matching judge flakily misses -- e.g. an entry `lead-time`
+  for canonical "Lead Time", or `sku-management` for "SKU".
+
+  Deliberately uses ONLY canonical + explicit `aliases`, NOT the broader
+  `flavor_hints`: hints like "Knowledge Catalog" are generic enough to wrongly
+  swallow unrelated entries (e.g. a `knowledge-catalog-discovery-agent`), so
+  they stay judge-only. A token-SUBSET test (not substring) avoids partial-word
+  false matches.
+  """
+  needle_sets = []
+  for n in [topic.get("canonical", "")] + list(topic.get("aliases") or []):
+    ts = _name_tokens(n)
+    if ts:
+      needle_sets.append(ts)
+  for base in produced_basenames:
+    ent = _name_tokens(re.sub(r"\.(overview\.md|md|yaml)$", "", str(base)))
+    for ns in needle_sets:
+      if ns <= ent:
+        return base
+  return ""
+
+
+def match_topics(artifacts: dict, expected_topics: list[dict], judge: Judge,
+                 confidence_threshold: float = 0.7) -> dict:
+  """Semantic topic-flavor matching (doc mode): recall/precision/fact coverage."""
+  blob = "\n\n".join(f"### {p}\n{t}"
+                     for p, t in artifacts.get("overview_md", {}).items())
+  n_produced = len(artifacts.get("overview_md", {}))
+  if n_produced == 0 or not blob.strip():
+    # No entries produced -> nothing to match; don't waste judge calls.
+    return {"concept_recall": 0.0, "concept_precision": 0.0, "fact_coverage": 0.0,
+            "per_topic": [{"topic": t["canonical"], "confidence": 0.0,
+                           "matched": False, "fact_coverage": 0.0,
+                           "matched_entry_id": "",
+                           "rationale": "no entries produced by the agent"}
+                          for t in expected_topics]}
+  # SINGLE judge call grades ALL expected topics at once (was one call per topic).
+  spec = [{"canonical": t["canonical"],
+           "flavor_hints": t.get("flavor_hints", []),
+           "golden_facts": t.get("golden_facts", [])}
+          for t in expected_topics]
+  prompt = (
+      "Grade a generated knowledge base against EACH expected topic. For every "
+      "topic, find the single best-matching generated entry BY MEANING/CONTENT. "
+      "Match on what the entry is ABOUT -- IGNORE differences in the entry id / "
+      "file name formatting (e.g. 'lead-time' vs 'lead_time' vs 'Lead Time' are the "
+      "same entry). For EACH golden fact, judge SEMANTICALLY whether the entry "
+      "conveys it -- paraphrases and reworded statements fully count; do NOT require "
+      "exact wording -- and give a CONFIDENCE 0..1 that the fact is present. Use "
+      "the FULL range and anchor on these points: 1.0 = fully conveyed (stated "
+      "outright OR clearly paraphrased/inferable) -- a fully-conveyed fact MUST "
+      "score 1.0, do NOT cap it at 0.8; 0.7-0.9 = conveyed but a minor "
+      "qualifier/value is missing; ~0.5 = only partially stated; 0.0 = absent. "
+      "Return one confidence per golden fact, IN THE SAME ORDER as listed.\n\n"
+      "ALSO return a parallel `fact_details` array (same order, one per golden "
+      "fact). For a fact that is fully or near-fully present (confidence >= 0.8) "
+      "use null -- and do NOT lower a fact's confidence merely to justify adding "
+      "a detail. For a fact that is only PARTIALLY present or absent "
+      "(confidence < 0.8), return an object: "
+      '{"covered":"<the part of the fact that IS conveyed, or \\"\\" if none>",'
+      '"quote":"<the exact sentence/phrase from the generated entry that conveys '
+      'the covered part, verbatim, or \\"\\" if none>",'
+      '"missing":"<the specific part of the fact that is NOT conveyed>"}. '
+      "Be concrete: name the sub-claim, value, qualifier, or relationship that is "
+      "missing -- not just 'partially covered'.\n\n"
+      f"EXPECTED TOPICS:\n{json.dumps(spec, indent=2)}\n\n"
+      f"GENERATED ENTRIES:\n{blob[:60000]}\n\n"
+      'Return STRICT JSON: {"topics":[{"canonical":"<topic>","matched_entry_id":'
+      '"<id or empty>","confidence":<0..1>,"fact_confidences":[<one 0..1 per golden '
+      'fact, same order>],"fact_details":[<null or {covered,quote,missing}, same '
+      'order>],"rationale":"<one sentence>"}, ...]} one object per topic.')
+  res = parse_json_obj(judge(prompt))
+  by_canon = {r.get("canonical"): r
+              for r in (res.get("topics") or []) if isinstance(r, dict)}
+  produced_basenames = [os.path.basename(p)
+                        for p in artifacts.get("overview_md", {}).keys()]
+  per_topic, matched_entries, fact_cov = [], set(), []
+  for topic in expected_topics:
+    r = by_canon.get(topic["canonical"]) or {}
+    conf = float(r.get("confidence", 0) or 0)
+    facts = topic.get("golden_facts", []) or []
+    # Per-fact semantic confidence (0..1), averaged -- NOT exact-string matching.
+    fconf = r.get("fact_confidences")
+    if not isinstance(fconf, list):
+      # Back-compat: derive from a covered_facts list if that's what came back.
+      cov_set = r.get("covered_facts", []) or []
+      fconf = [1.0 if f in cov_set else 0.0 for f in facts]
+    confs = []
+    for i, f in enumerate(facts):
+      try:
+        confs.append(max(0.0, min(1.0, float(fconf[i]))))
+      except (IndexError, TypeError, ValueError):
+        confs.append(0.0)
+    cov = (sum(confs) / len(confs)) if confs else 1.0
+    # Per-fact covered/missing breakdown (with a supporting quote) from the judge.
+    fdetails = r.get("fact_details")
+    if not isinstance(fdetails, list):
+      fdetails = []
+    def _detail(i):
+      d = fdetails[i] if i < len(fdetails) and isinstance(fdetails[i], dict) else {}
+      return {"covered": str(d.get("covered", "") or "").strip(),
+              "quote": str(d.get("quote", "") or "").strip(),
+              "missing": str(d.get("missing", "") or "").strip()}
+    # Categorize by semantic-presence confidence: clearly absent vs only partial.
+    # partial_facts carries the breakdown so the report can say which part of the
+    # fact is covered (and by which statement) and which part is not.
+    missing_facts = [f for f, sc in zip(facts, confs) if sc < 0.5]
+    partial_facts = [{"fact": f, **_detail(i)}
+                     for i, (f, sc) in enumerate(zip(facts, confs))
+                     if 0.5 <= sc < 0.8]
+    judge_matched = conf >= confidence_threshold and bool(r.get("matched_entry_id"))
+    # Deterministic backstop: rescue topics the judge flakily marked missing when
+    # a produced entry id literally carries the canonical/alias name. Union with
+    # the judge so recall/precision can only go UP, never down.
+    det_id = "" if judge_matched else _deterministic_entry_match(topic, produced_basenames)
+    matched = judge_matched or bool(det_id)
+    match_id = r.get("matched_entry_id", "") if judge_matched else det_id
+    if matched:
+      matched_entries.add(match_id)
+      # Only trust the judge's per-fact confidences when the JUDGE found the
+      # entry; on a deterministic rescue its fact scores are ~0 (it thought the
+      # topic was absent) and would wrongly tank fact_recall, so skip them.
+      if judge_matched:
+        fact_cov.append(cov)
+    rationale = r.get("rationale", "")
+    if det_id and not judge_matched:
+      rationale = (f"matched deterministically by name to '{det_id}' "
+                   f"(judge missed it). " + (rationale or "")).strip()
+    per_topic.append({"topic": topic["canonical"],
+                      "confidence": 1.0 if det_id and not judge_matched else conf,
+                      "matched": matched, "fact_coverage": cov,
+                      "matched_entry_id": match_id,
+                      "matched_by": ("judge" if judge_matched
+                                     else ("name" if det_id else "")),
+                      "missing_facts": missing_facts,
+                      "partial_facts": partial_facts,
+                      "rationale": rationale})
+  n_topics = len(expected_topics) or 1
+  recall = sum(1 for t in per_topic if t["matched"]) / n_topics
+  precision = (len(matched_entries) / n_produced) if n_produced else 0.0
+  mean_cov = (sum(fact_cov) / len(fact_cov)) if fact_cov else 0.0
+  # Which produced entries are EXTRA (didn't match any expected topic) -- so the
+  # rationale can name e.g. "also produced a 'UPC/GTIN' entry that wasn't expected".
+  _norm = lambda s: os.path.basename(str(s)).replace(".overview.md", "").replace(".md", "").strip().lower()
+  matched_norm = {_norm(x) for x in matched_entries}
+  produced = list(artifacts.get("overview_md", {}).keys())
+  extra = [os.path.basename(p) for p in produced if _norm(p) not in matched_norm]
+  return {"concept_recall": recall, "concept_precision": precision,
+          "fact_coverage": mean_cov, "per_topic": per_topic,
+          "extra_entries": extra,
+          "produced_entries": [os.path.basename(p) for p in produced]}
+
+
+# Rubric dimensions (Jialu's web-app rubric + strategy-doc dims). Each is judged
+# 0..1 against the generated mdcode and (where relevant) the source context.
+# NOTE (per doc comments): markdown_structure_score was folded into the
+# deterministic structural_validity, and enrichment_diversity became the
+# golden-driven check_expected_headings -- so neither is judged here anymore.
+_RUBRIC = {
+    "redundancy_index":
+        "Does the overview add novel semantic context beyond echoing column "
+        "names/schema? 1=rich synthesis, 0=tautological restatement.",
+    "disambiguation_efficacy":
+        "Is the enrichment sufficient to distinguish this entry from "
+        "similar/overlapping ones (grain + purpose explicit)? 1=clearly unique.",
+    "absence_of_contradictions":
+        "Are there contradictions within or across the generated entries "
+        "(join keys, enums, metric defs, freshness)? 1=none, 0=explicit conflict.",
+}
+
+
+# Dedicated business-term Metadata-as-Code files (.md/.yaml per term) are NOT
+# emitted by the agent yet, so check_business_terms_validity is EXPECTED to fail
+# today (terms may still appear inline in the overview -> check_business_terms).
+# Reported but not gated, so it doesn't break a regression suite. When the agent
+# gains per-term file output, it passes with no code change.
+_TERM_FILE_HINTS = ("glossary", "business-term", "business_term", "/terms/", ".term.")
+
+
+def check_business_terms_validity(artifacts: dict, expected_terms: list[str],
+                                  judge: Judge | None = None) -> MetricResult:
+  """Each expected term must have its OWN standalone MaC file AND that file must
+  accurately define the term.
+
+  File *existence* is deterministic; *content* validity is LLM-judged. Today the
+  agent emits no per-term files, so this fails at the existence gate (a known
+  gap). Once per-term files are
+  emitted, the judge validates that every expected term is present and correctly
+  defined.
+  """
+  if not expected_terms:
+    return MetricResult("business_terms_validity", 1.0, True, "no terms expected")
+  yaml_files, md_files = artifacts.get("yaml", {}), artifacts.get("overview_md", {})
+  term_files = {p: (yaml_files.get(p) or md_files.get(p))
+                for p in list(yaml_files) + list(md_files)
+                if any(h in p.lower() for h in _TERM_FILE_HINTS)}
+  if not term_files:
+    return MetricResult(
+        "business_terms_validity", 0.0, False,
+        "The agent didn't write a dedicated file for each business term yet "
+        "(an expected gap for now — the terms may still appear inline in the "
+        "overview, which business_terms_presence checks).")
+  if judge is None:
+    return MetricResult(
+        "business_terms_validity", 1.0, True,
+        f"Found {len(term_files)} dedicated business-term file(s); turn on the "
+        "LLM judge to validate that each one accurately defines its term.")
+  blob = "\n\n".join(f"### {p}\n{c}" for p, c in term_files.items() if c)
+  prompt = ("Validate dedicated business-term files: each EXPECTED TERM must have "
+            "its own standalone file that ACCURATELY defines it.\n"
+            f"EXPECTED TERMS: {expected_terms}\n\nTERM FILES:\n" + blob[:40000] +
+            '\n\nReturn STRICT JSON: {"score":<0..1 fraction present+correctly defined>,'
+            '"missing_or_invalid":[<terms>],"rationale":"<one sentence>"}')
+  res = parse_json_obj(judge(prompt))
+  score = float(res.get("score", 0) or 0)
+  bad = res.get("missing_or_invalid") or []
+  base = (res.get("rationale", "").strip()
+          or f"{len(term_files)} dedicated business-term file(s) were checked.")
+  return MetricResult("business_terms_validity", score, score >= 0.99,
+                      base + (f" Missing or incorrectly defined: {', '.join(bad)}."
+                              if bad else ""))
+
+
+def score_rubric(artifacts: dict, judge: Judge,
+                 expected_terms: list[str] | None = None) -> list[MetricResult]:
+  """Run the LLM-judge rubric over the generated mdcode in a SINGLE judge call.
+
+  All rubric dimensions are scored at once (one prompt -> one JSON object keyed by
+  dimension), instead of one call per dimension. Far fewer round-trips = much
+  faster runs."""
+  content = "\n\n".join(f"### {p}\n{t}"
+                        for p, t in artifacts.get("overview_md", {}).items())
+  if not content.strip():
+    # Agent produced no overview (e.g. failed/quota-starved run). The judge has
+    # nothing to evaluate -- short-circuit with a clear reason instead of a
+    # misleading "no documentation provided", and skip the wasted judge call.
+    return [MetricResult(name, 0.0, False,
+                         "no overview produced by the agent -- nothing to "
+                         "evaluate (see structural_validity / the agent run)")
+            for name in _RUBRIC]
+  criteria = "\n".join(f"- {name}: {desc}" for name, desc in _RUBRIC.items())
+  prompt = (
+      "You are a rigorous but fair Data Governance Auditor. Rate the generated "
+      "data-catalog documentation on EACH criterion below.\n\n"
+      "SCORING DISCIPLINE (rigorous, but don't be perverse):\n"
+      "- Use the FULL 0..1 range and match the score to the actual quality.\n"
+      "- 1.0 = genuinely PERFECT for this criterion, nothing at all to improve "
+      "(should be rare). If you can name any real improvement, score < 1.0.\n"
+      "- 0.9+ is fine for excellent work with almost nothing to improve.\n"
+      "- Don't inflate mediocre or generic output: penalize boilerplate, vague "
+      "claims, and merely restating the schema. But genuinely strong work should "
+      "still earn a high score -- don't lowball good output.\n"
+      "- Judge each criterion independently on its own merits.\n\n"
+      "For every criterion give a score in [0,1], a rationale, and a concrete, "
+      "actionable improvement (1-2 sentences each, as needed).\n"
+      "BE SPECIFIC -- this is the most important part. When you flag a problem, "
+      "NAME it and QUOTE/identify the exact offending content and explain WHY it's "
+      "a problem. E.g. for absence_of_contradictions, state the two conflicting "
+      "statements and why they conflict ('says join key is account_id in the "
+      "overview but customer_id in the example'); for redundancy_index, point to "
+      "the specific lines that just restate the schema. Generic rationales like "
+      "'has some contradictions' are NOT acceptable.\n\n"
+      f"CRITERIA:\n{criteria}\n\nDOCUMENTATION:\n{content[:60000]}\n\n"
+      "Return STRICT JSON mapping EACH criterion name to an object, e.g.: "
+      '{"redundancy_index":{"score":0.7,"rationale":"...","insights":"..."}, ...}')
+  # The judge occasionally returns malformed/incomplete JSON for this batched call;
+  # when that happens every dimension would silently default to score 0 with an
+  # empty rationale (looks like the agent failed, but it's a judge-side flake).
+  # Retry a couple times, and require at least one rubric key to be present.
+  res = {}
+  for _ in range(3):
+    res = parse_json_obj(judge(prompt))
+    if isinstance(res, dict) and any(k in res for k in _RUBRIC):
+      break
+  out = []
+  for name in _RUBRIC:
+    score, rationale, insights = _rubric_dimension(res.get(name))
+    if score is None:
+      # Couldn't get a score for this dimension -- do NOT pretend it's a real 0.
+      # Flag it clearly and exclude it from the gate so a judge flake doesn't
+      # tank the run; score None so it's skipped in aggregation.
+      out.append(MetricResult(
+          name, None, True,
+          "Could not evaluate this run — the rubric judge returned an "
+          "incomplete/unparseable response (a judge-side flake, not an agent "
+          "problem). Re-run to get a score for this dimension.",
+          extra={"judge_error": True}))
+      continue
+    out.append(MetricResult(name, score, score >= 0.7, rationale, insights))
+  return out
+
+
+def _rubric_dimension(v):
+  """Pull (score, rationale, insights) from one rubric dimension's JSON value.
+
+  Normally the judge returns a flat object {"score","rationale","insights"}. It
+  sometimes instead nests one object PER overview file
+  ({"foo.overview.md": {"score": ...}, ...}); in that case average the per-file
+  scores and join their rationales so the dimension still gets a score instead of
+  showing n/a. Returns (None, "", "") when no score can be recovered."""
+  if not isinstance(v, dict):
+    return None, "", ""
+  if "score" in v:
+    return float(v.get("score", 0) or 0), v.get("rationale", ""), v.get("insights", "")
+  subs = [s for s in v.values() if isinstance(s, dict) and "score" in s]
+  if subs:
+    avg = sum(float(s.get("score", 0) or 0) for s in subs) / len(subs)
+    rationale = " ".join(s.get("rationale", "") for s in subs if s.get("rationale"))
+    insights = " ".join(s.get("insights", "") for s in subs if s.get("insights"))
+    return round(avg, 3), rationale, insights
+  return None, "", ""
+
+
+def consistency_judge(run_entries: list[dict], judge: Judge) -> list | None:
+  """SEMANTICALLY align entries across the runs of one agent-case.
+
+  `run_entries` is a list (one per run) of {entry_name: overview_text}. Returns a
+  list of distinct concepts, each with the run numbers it appears in and a
+  content-consistency 0..1 (how consistent its FACTS are across the runs that have
+  it). Used to score concept_consistency + content_consistency cross-run, matching
+  by MEANING (e.g. 'reorder point' == 'replenishment trigger'). None on failure."""
+  payload = [{"run": i + 1,
+              "entries": [{"name": n, "overview": (t or "")[:1200]}
+                          for n, t in re_.items()]}
+             for i, re_ in enumerate(run_entries)]
+  prompt = (
+      "An enrichment agent was run multiple times on the SAME input. Align entries "
+      "ACROSS runs that represent the SAME underlying concept SEMANTICALLY -- match "
+      "by meaning, not by name/formatting (e.g. 'reorder point' and 'replenishment "
+      "trigger', or 'lead-time' and 'lead_time', are the same concept). For each "
+      "DISTINCT concept, report which run numbers contain it and a "
+      "content_consistency 0..1 = how consistent the FACTS stated are across the "
+      "runs that have it (1.0 = same facts, 0.0 = contradictory/divergent).\n\n"
+      f"RUNS:\n{json.dumps(payload, indent=2)[:60000]}\n\n"
+      'Return STRICT JSON: {"concepts":[{"name":"<concept>","runs":[<run numbers>],'
+      '"content_consistency":<0..1>,"note":"<short, what differs if anything>"}]}')
+  res = parse_json_obj(judge(prompt))
+  cs = res.get("concepts")
+  return cs if isinstance(cs, list) else None
+
+
+def _chunk_text(text: str, size: int = 45000, overlap: int = 1500) -> list[str]:
+  """Split a long grounding corpus into overlapping windows so NOTHING is
+  truncated away (the old 50K cap silently dropped real source -> false
+  'fabrication' flags on large corpora). Overlap keeps facts spanning a cut
+  visible to at least one chunk."""
+  text = text or ""
+  if len(text) <= size:
+    return [text] if text.strip() else []
+  out, i = [], 0
+  while i < len(text):
+    out.append(text[i:i + size])
+    i += size - overlap
+  return out
+
+
+def check_hallucination(artifacts: dict, source_context: str, judge: Judge,
+                        extra_grounding: str = "") -> MetricResult:
+  """Groundedness via per-claim, chunked, PARALLEL verification.
+
+  Why this shape: the old single-shot judge capped the
+  source at 50K chars and grounded only against prose. On large corpora that cut
+  dropped real content (codenames flagged as fabricated); in table mode it
+  ignored the schema/dataset facts the overview legitimately states. Now:
+    1. extract atomic claims from the generated overviews (one judge call);
+    2. ground against the FULL corpus (source + table schema/reference),
+       chunked so nothing is truncated;
+    3. fan the chunks out in parallel -- a claim is hallucinated ONLY if NO
+       chunk supports it (supported-by-any = grounded).
+  """
+  # Join the overview BODIES only -- no file-name headers. Prepending
+  # `### lead-time.overview.md` made the extractor invent structural meta-claims
+  # ("the aspectType of lead-time.overview.md is ...generic.overview") that are
+  # obviously absent from prose and tanked the score with noise.
+  content = "\n\n---\n\n".join(t for t in artifacts.get("overview_md", {}).values()
+                               if (t or "").strip())
+  if not content.strip():
+    return MetricResult("hallucination_free", 0.0, False,
+                        "no overview produced by the agent -- nothing to "
+                        "ground-check (see structural_validity)")
+  grounding = (source_context or "")
+  if extra_grounding:
+    grounding += "\n\n=== TABLE SCHEMA / REFERENCE METADATA ===\n" + extra_grounding
+  if not grounding.strip():
+    # No grounding source reachable -> can't judge groundedness. Skip (None) and
+    # exclude from the gate rather than flag every claim as fabricated.
+    return MetricResult("hallucination_free", None, True,
+                        "no grounding source available (Drive unreachable / no "
+                        "source docs) -- groundedness not scored this run")
+
+  # 1. Extract atomic, checkable claims from the generated overviews.
+  cl_prompt = (
+      "Extract the SUBSTANTIVE, checkable DOMAIN claims from the GENERATED "
+      "documentation below — specific facts about the subject matter (systems, "
+      "values, relationships, formulas, paths, behaviors, definitions, "
+      "term-usage rules). One claim per item, self-contained.\n"
+      "EXCLUDE: anything about the document/file itself (file names, aspect "
+      "types, YAML/metadata field values, that a section or heading exists), and "
+      "generic boilerplate ('this table is useful for analysis'). Only claims a "
+      "domain reader would fact-check.\n\n"
+      f"GENERATED:\n{content[:60000]}\n\n"
+      'Return STRICT JSON: {"claims":[<claim strings>]}')
+  # Retry extraction: a single judge hiccup returning {} / no claims would
+  # otherwise score a FALSE perfect 1.0 ("no claims") on a content-rich overview.
+  claims = []
+  for _ in range(3):
+    claims = parse_json_obj(judge(cl_prompt)).get("claims") or []
+    claims = [str(c) for c in claims if str(c).strip()][:80]
+    if claims:
+      break
+  if not claims:
+    # Substantial prose but the extractor kept returning nothing -> almost
+    # certainly a judge failure, not a genuinely claim-free overview. Skip
+    # (None, excluded from the gate) rather than award a misleading 1.0.
+    if len(content.strip()) > 2000:
+      return MetricResult("hallucination_free", None, True,
+                          "claim extraction failed (judge returned no claims for "
+                          "a content-rich overview) -- groundedness not scored")
+    return MetricResult("hallucination_free", 1.0, True,
+                        "no checkable factual claims extracted from the overview")
+
+  # 2/3. Ground each claim against EVERY chunk, in parallel. Supported-by-any wins.
+  chunks = _chunk_text(grounding)
+  numbered = "\n".join(f"{i}. {c}" for i, c in enumerate(claims))
+
+  def _supported_in(chunk: str) -> set:
+    p = ("For each numbered CLAIM, decide if it is SUPPORTED by (stated in, or "
+         "directly inferable from) the SOURCE CHUNK. Schema/column/dataset facts "
+         "count as supported if present in the chunk. Be lenient on paraphrase.\n\n"
+         f"SOURCE CHUNK:\n{chunk[:48000]}\n\nCLAIMS:\n{numbered}\n\n"
+         'Return STRICT JSON: {"supported":[<indices of supported claims>]}')
+    idxs = parse_json_obj(judge(p)).get("supported") or []
+    out = set()
+    for x in idxs:
+      try:
+        out.add(int(x))
+      except (TypeError, ValueError):
+        pass
+    return out
+
+  supported: set = set()
+  if len(chunks) == 1:
+    supported = _supported_in(chunks[0])
+  else:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as ex:
+      for s in ex.map(_supported_in, chunks):
+        supported |= s
+
+  unsupported = [c for i, c in enumerate(claims) if i not in supported]
+  score = round(1.0 - len(unsupported) / len(claims), 3)
+  detail = (f"All {len(claims)} extracted claims are grounded in the source "
+            f"(+schema) across {len(chunks)} chunk(s)."
+            if not unsupported else
+            f"{len(unsupported)} of {len(claims)} claims unsupported by the source "
+            f"(checked across {len(chunks)} chunk(s)) — e.g.: "
+            + "; ".join(_clip(c, 240) for c in unsupported[:3]))
+  return MetricResult("hallucination_free", score,
+                      not unsupported and score >= 0.99, _clip(detail, 1800),
+                      extra={"unsupported_claims": unsupported[:20],
+                             "n_claims": len(claims), "n_chunks": len(chunks)})
+
+
+def check_persona_alignment(artifacts: dict, persona: dict,
+                            judge: Judge) -> MetricResult:
+  """Persona/instruction conditioning: does the output EMPHASIZE this persona's
+  focus areas while still RETAINING the shared high-level concepts?
+
+  This is an emphasis-shift test, not a coverage test: the same source doc is
+  enriched under two different user instructions, and each output should lean into
+  that persona's focus_areas. Crucially, the shared_concepts must still be present
+  (a persona shifts emphasis, it does not delete the rest of the document).
+
+  Score = 0.8 * mean(focus prominence) + 0.2 * mean(shared present). Prominence is
+  0 (absent) / 0.5 (mentioned in passing) / 1 (prominent / detailed); shared is
+  0/1. Rewards emphasis but docks dropped shared concepts.
+  """
+  content = "\n\n---\n\n".join(t for t in artifacts.get("overview_md", {}).values()
+                               if (t or "").strip())
+  if not content.strip():
+    return MetricResult("persona_alignment", 0.0, False,
+                        "no overview produced -- nothing to score")
+  focus = [str(f) for f in (persona.get("focus_areas") or []) if str(f).strip()]
+  shared = [str(s) for s in (persona.get("shared_concepts") or []) if str(s).strip()]
+  instruction = persona.get("instruction", "")
+  prompt = (
+      "A knowledge base was generated from a source document under a specific USER "
+      "INSTRUCTION (persona). Judge how well the output matches that persona.\n\n"
+      f"USER INSTRUCTION:\n{instruction}\n\n"
+      "For each FOCUS AREA (what this persona wants emphasized), rate PROMINENCE: "
+      "0.0 = absent, 0.5 = mentioned only in passing, 1.0 = prominent / covered in "
+      "detail. For each SHARED CONCEPT (high-level context that must NOT be dropped "
+      "even though it's not this persona's focus), rate PRESENT: 1 if present at "
+      "all, else 0.\n\n"
+      f"FOCUS AREAS:\n{json.dumps(focus, indent=2)}\n\n"
+      f"SHARED CONCEPTS:\n{json.dumps(shared, indent=2)}\n\n"
+      f"GENERATED KNOWLEDGE BASE:\n{content[:60000]}\n\n"
+      'Return STRICT JSON: {"focus":[{"area":"<area>","prominence":<0..1>}],'
+      '"shared":[{"concept":"<concept>","present":<0 or 1>}],'
+      '"rationale":"<one sentence naming what was emphasized vs shallow and any '
+      'shared concept dropped>"}')
+  res = parse_json_obj(judge(prompt))
+  fres = {str(x.get("area")): x for x in (res.get("focus") or []) if isinstance(x, dict)}
+  sres = {str(x.get("concept")): x for x in (res.get("shared") or []) if isinstance(x, dict)}
+  def _num(x, default=0.0):
+    try:
+      return max(0.0, min(1.0, float(x)))
+    except (TypeError, ValueError):
+      return default
+  fprom = [_num(fres.get(a, {}).get("prominence")) for a in focus]
+  spres = [_num(sres.get(s, {}).get("present")) for s in shared]
+  # Deterministic backstop (same idea as concept_recall, #42): the judge can
+  # under-rate prominence even when a focus area has its OWN dedicated entry. If a
+  # produced entry name clearly maps to a focus area (>=2 shared significant
+  # tokens), that area IS prominently covered -> floor its prominence at 0.75 so a
+  # lukewarm judge can't sink it. Only raises, never lowers.
+  _noise = {"id", "md", "overview", "the", "a", "an", "of", "and", "or", "to",
+            "plus", "file", "files", "stage"}
+  produced_basenames = [re.sub(r"\.(overview\.md|md|yaml)$", "", os.path.basename(p))
+                        for p in artifacts.get("overview_md", {})]
+  ent_tokens = [(_name_tokens(b) - _noise) for b in produced_basenames]
+  floored = []
+  for i, area in enumerate(focus):
+    if fprom[i] >= 0.75:
+      continue
+    ftoks = _name_tokens(area) - _noise
+    if any(et and len(ftoks & et) >= 2 for et in ent_tokens):
+      fprom[i] = max(fprom[i], 0.75)  # dedicated entry => prominently covered
+      floored.append(area)
+  mean_focus = sum(fprom) / len(fprom) if fprom else 0.0
+  mean_shared = sum(spres) / len(spres) if spres else 1.0
+  score = round(0.8 * mean_focus + 0.2 * mean_shared, 3)
+  emphasized = [a for a, p in zip(focus, fprom) if p >= 0.75]
+  shallow = [a for a, p in zip(focus, fprom) if p < 0.5]
+  dropped = [s for s, p in zip(shared, spres) if p < 0.5]
+  parts = [f"Emphasized {len(emphasized)}/{len(focus)} focus areas"
+           + (f" (well: {', '.join(emphasized[:4])})" if emphasized else "")]
+  if shallow:
+    parts.append("shallow/absent: " + ", ".join(shallow[:4]))
+  parts.append("all shared concepts retained" if not dropped
+               else "DROPPED shared concept(s): " + ", ".join(dropped))
+  if floored:
+    parts.append(f"{len(floored)} area(s) credited via a dedicated entry the judge "
+                 "under-rated")
+  base = (res.get("rationale", "") or "").strip()
+  detail = (". ".join(parts) + ".") + (f" {base}" if base else "")
+  thr = 0.6
+  return MetricResult("persona_alignment", score, score >= thr, _clip(detail, 1800),
+                      extra={"mean_focus": round(mean_focus, 3),
+                             "mean_shared": round(mean_shared, 3),
+                             "shallow": shallow, "dropped_shared": dropped,
+                             "name_floored": floored})
+
+
+# Plain-English labels so the explainer (and any fallback) talks about metrics
+# the way a developer would, not by their internal snake_case name.
+_METRIC_LABEL = {
+    "structural_validity": "structural validity (is the output valid Metadata-as-Code)",
+    "trajectory": "tool trajectory (did the agent use the right sources for its inputs)",
+    "perf": "performance (latency and output size vs budget)",
+    "business_terms_presence": "business-term presence (are expected terms covered)",
+    "business_terms_validity": "business-term validity (dedicated, correctly-defined term files)",
+    "context_preservation": "context preservation (pre-baked entry context survives enrichment)",
+    "concept_recall": "concept recall (did it cover the expected topics)",
+    "concept_precision": "concept precision (are produced entries on-topic)",
+    "fact_recall": "fact recall (did it capture the golden facts)",
+    "redundancy_index": "information density (novel synthesis vs restating the schema)",
+    "enrichment_diversity": "expected sections covered (e.g. Lineage, Sample Queries)",
+    "disambiguation_efficacy": "disambiguation (distinct from similar entries)",
+    "absence_of_contradictions": "absence of contradictions",
+    "hallucination_free": "groundedness (claims supported by the sources)",
+    "persona_alignment": "persona alignment (output emphasizes the user persona's focus, retains shared concepts)",
+}
+
+
+def explain_metrics(metric_list: list[dict], mode: str,
+                    judge: Judge | None,
+                    baselines: dict | None = None) -> dict[str, dict]:
+  """Turn raw metric evidence into human-readable rationale + insights per metric.
+
+  Takes ALL of a single agent-case's metrics at once (name, score, passed, and
+  the metric's own deterministic/judge `detail` as evidence) and asks the LLM to
+  write, for each, a plain-English `rationale` (why it scored that) and a concrete
+  `insights` (how to improve, or "" if passing). This is intentionally
+  non-deterministic — the reasoning comes from the model, grounded in the
+  evidence. Returns {metric_name: {"rationale": str, "insights": str}}; returns
+  {} when no judge is supplied (callers fall back to the deterministic detail).
+  """
+  if judge is None or not metric_list:
+    return {}
+  baselines = baselines or {}
+  payload = [{"metric": m.get("name"),
+              "label": _METRIC_LABEL.get(m.get("name"), m.get("name")),
+              "score": m.get("score"), "passed": m.get("passed"),
+              # Per-run signal so the explainer can detect flakiness/variance.
+              "per_run_scores": m.get("run_scores"),
+              "runs_passed": m.get("runs_passed"),
+              # Optional baseline mean for the same metric (e.g. a prior run).
+              "comparison_baseline_other_version": baselines.get(m.get("name")),
+              "evidence": (m.get("detail") or "").strip()}
+             for m in metric_list]
+  prompt = (
+      "You are explaining knowledge-catalog enrichment-agent eval results to a "
+      f"developer who wants to IMPROVE the agent. The agent was run MULTIPLE times "
+      f"in '{mode}' mode; each metric includes 'score' (mean across runs), "
+      "'per_run_scores' (each run's score, IN RUN ORDER: the first element is Run 1, "
+      "the second is Run 2, etc.), 'runs_passed', 'comparison_baseline_other_version' "
+      "(an optional baseline mean for the same metric, e.g. from a prior run), and 'evidence' (the "
+      "concrete findings). Using ONLY the evidence (do not invent facts), write for "
+      "EVERY metric:\n"
+      "  - rationale (1-3 sentences): WHY it got this score. Be SPECIFIC and "
+      "DETAILED -- the evidence usually names concrete items (the extra/unexpected "
+      "entry, the exact missing facts, the actual contradicting statements, token "
+      "counts, missing sections). PRESERVE those specifics in your rationale: name "
+      "the extra entry, list the missing facts, quote the contradiction. Do NOT "
+      "flatten to a generic high-level summary. SURFACE PER-RUN VARIANCE BY RUN "
+      "NUMBER: when per_run_scores differ, state the scores AND name the specific "
+      "run(s) that were lower so the developer can open them (e.g. 'averaged 0.9 -- "
+      "Run 1 was 1.0 but Run 2 dropped to 0.8'); call it flaky/transient if it "
+      "varies, stable/systematic if consistent. Reference the baseline when it "
+      "differs (e.g. 'vs the baseline 0.875').\n"
+      "  - insights (1-2 sentences, REQUIRED, never empty): the concrete next "
+      "improvement, tied to the specific gap named in the rationale (e.g. 'drop the "
+      "spurious UPC/GTIN entry by tightening the topic filter', or 'add the missing "
+      "ROP formula fact'). When a specific run was lower, tell them to investigate "
+      "that run number (e.g. 'investigate why Run 2 dropped to 0.8'). If genuinely "
+      "perfect and stable, say what would make it even stronger.\n"
+      "Be specific and readable; avoid internal metric jargon.\n\n"
+      f"METRICS:\n{json.dumps(payload, indent=2)}\n\n"
+      'Return STRICT JSON mapping EVERY metric name to an object, e.g.: '
+      '{"trajectory":{"rationale":"...","insights":"..."}, ...}')
+  res = parse_json(judge(prompt))
+  if not isinstance(res, dict):
+    return {}
+  out: dict[str, dict] = {}
+  for name, v in res.items():
+    if isinstance(v, dict):
+      out[name] = {"rationale": str(v.get("rationale", "") or "").strip(),
+                   "insights": str(v.get("insights", "") or "").strip()}
+  return out
+
+
+def default_judge(model: str = "gemini-2.5-pro") -> Judge:
+  """Vertex Gemini judge (ADC project/location from env). Lazy import.
+
+  Bounded + retried: a per-request timeout (no infinite hang) and a few retries
+  on transient errors (timeouts / 429). On exhaustion returns "" so the caller's
+  parse_json_obj yields {} and the metric degrades to None (excluded from the
+  gate) instead of stalling the whole run forever -- a single stuck Vertex call
+  used to hang an entire eval case.
+  """
+  def _judge(prompt: str) -> str:
+    import os
+    import time
+    from google.genai import Client  # pytype: disable=import-error
+    from google.genai.types import HttpOptions  # pytype: disable=import-error
+    from google.auth import default as _adc
+    creds, _ = _adc()
+    client = Client(vertexai=True, credentials=creds,
+                    project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+                    location=os.environ.get("GOOGLE_CLOUD_LOCATION", "global"),
+                    http_options=HttpOptions(timeout=180_000))  # ms
+    last = ""
+    for attempt in range(3):
+      try:
+        resp = client.models.generate_content(model=model, contents=prompt)
+        return resp.text or ""
+      except Exception as e:  # pylint: disable=broad-except
+        last = str(e)
+        time.sleep(8 * (attempt + 1))
+    print(f"[judge] giving up after retries: {last[:200]}", flush=True)
+    return ""
+  return _judge

--- a/agents/enrichment/eval/requirements.txt
+++ b/agents/enrichment/eval/requirements.txt
@@ -1,0 +1,4 @@
+# Enrichment eval (dynamic, golden-free) — judge + parsing deps.
+google-genai>=1.0.0
+google-auth>=2.0.0
+pyyaml>=6.0

--- a/agents/enrichment/src/agent_runner.py
+++ b/agents/enrichment/src/agent_runner.py
@@ -1,0 +1,306 @@
+"""Unified enrichment agent entrypoint.
+
+Dispatches to one of three flows based on `--mode`:
+  * doc    — recursive Google-Docs crawl -> map-reduce summarize -> LLM-emitted
+             knowledge-base mdcode entries (manifest scaffolded by
+             `kcmd init --entry-group`; a normal entry group, STANDARD layout).
+  * table  — kcmd-pulled BigQuery dataset discovery -> relevance-routed,
+             folder-grounded table overviews (kcmd bq-dataset format).
+  * context_overlay — like table, but the 1P table entries are pulled READ-ONLY
+             via `kcmd reference`; one NEW context-overlay entry is created per
+             table in the editable `--entry-group` (overlay output format).
+
+When `--mode` is empty it is inferred: a `--dataset` implies table, else doc.
+(context_overlay is never inferred — pass `--mode=context_overlay` explicitly.)
+
+The agent runs the READ-ONLY kcmd commands itself (`init`, `pull`); generating
+`catalog.yaml` + the local entries. The customer runs `kcmd push` to publish.
+
+Nothing is project-specific: pass your own `--project`, `--location`, and
+`--model`; for doc mode also pass `--entry-group`.
+"""
+
+import asyncio
+import os
+
+from absl import app
+from absl import flags
+from modes import context_overlay_mode, doc_mode, table_mode
+import refine
+
+_MODE = flags.DEFINE_enum(
+    "mode",
+    "",
+    ["", "doc", "table", "context_overlay"],
+    "Which enrichment flow to run. Empty = infer from flags.",
+)
+_TOPIC = flags.DEFINE_string(
+    "topic",
+    "Metadata enrichment",
+    "Free-text use case / instruction guiding enrichment (anything).",
+)
+_DOCS = flags.DEFINE_list(
+    "docs", [], "Comma-separated list of Google Doc URLs or IDs (doc mode)."
+)
+_FOLDER = flags.DEFINE_string(
+    "folder", None, "Optional Google Drive folder ID/URL to seed from."
+)
+
+# --- Source code input (all modes): agentic GitHub repo understanding -------
+# When --repo is set, a code-understanding agent explores the repository via the
+# GitHub MCP server and contributes code component cards as an additional
+# context source. In doc mode the components can surface as their own KB
+# entries; in table/context_overlay mode they join the relevance-router's
+# candidate pool so code that touches a table grounds that table's overview.
+# See tools/github_tools.py. The MCP server is configured via --mcp_config (or
+# KC_ENRICH_MCP_CONFIG); a GitHub PAT is supplied to the server via its env
+# (default env var GITHUB_PERSONAL_ACCESS_TOKEN).
+_REPO = flags.DEFINE_string(
+    "repo",
+    "",
+    "Optional GitHub repo as `owner/name` or a github URL — an extra code"
+    " context source for ANY mode (explored agentically via the GitHub MCP"
+    " server).",
+)
+_REPO_REF = flags.DEFINE_string(
+    "repo_ref",
+    "",
+    "Optional branch/tag/SHA for --repo (empty = the repo's default branch).",
+)
+_REPO_SUBDIR = flags.DEFINE_string(
+    "repo_subdir",
+    "",
+    "Optional path prefix to scope the --repo exploration (e.g. `src/server`).",
+)
+_MCP_CONFIG = flags.DEFINE_string(
+    "mcp_config",
+    "",
+    "Path to an mcp.json describing the GitHub MCP server (falls back to"
+    " KC_ENRICH_MCP_CONFIG, then a built-in `github-mcp-server stdio`"
+    " default).",
+)
+_DATASET = flags.DEFINE_string(
+    "dataset",
+    "",
+    "BigQuery dataset as `project.dataset` (table/context_overlay mode).",
+)
+_TABLES = flags.DEFINE_list(
+    "tables",
+    [],
+    "Optional table filter for context_overlay mode (short names or"
+    " `proj.ds.table` FQNs). Empty = enrich every table in --dataset.",
+)
+_OUTPUT_DIR = flags.DEFINE_string(
+    "output_dir", None, "Local directory path for the generated mdcode."
+)
+
+# Customer-supplied GCP + model configuration (nothing is hardcoded).
+_PROJECT = flags.DEFINE_string(
+    "project", None, "Google Cloud project for the Vertex AI model (required)."
+)
+_LOCATION = flags.DEFINE_string(
+    "location", "global", "Vertex AI location for the model."
+)
+_MODEL = flags.DEFINE_string(
+    "model", None, "Model for the agent, e.g. `gemini-2.5-pro` (required)."
+)
+_ENTRY_GROUP = flags.DEFINE_string(
+    "entry_group",
+    None,
+    "Knowledge Base entry group `project.location.entryGroupId` (doc mode).",
+)
+_GLOSSARIES = flags.DEFINE_list(
+    "glossaries",
+    [],
+    "Optional. Comma-separated list of existing Dataplex Glossaries "
+    "`project.location.glossaryId`. When supplied in table mode, the agent "
+    "additionally maps BQ columns to glossary terms and injects field-level "
+    "`links.definition`.",
+)
+_INTERACTIVE = flags.DEFINE_bool(
+    "interactive",
+    False,
+    "After the initial enrichment, stay in an interactive REPL to accept"
+    " free-text refinement requests (reuses loaded context — no doc re-read).",
+)
+_REFINE_INSTRUCTION = flags.DEFINE_string(
+    "refine_instruction",
+    "",
+    "Apply ONE refinement turn to the saved session in --output_dir, then exit"
+    " (no pipeline re-run). Used by the webapp's persist+re-invoke refine flow;"
+    " requires --output_dir, --project, --model.",
+)
+
+# --- table mode: BQ query-history usage signals ---------------------------
+# Pull from `region-<R>.INFORMATION_SCHEMA.JOBS_BY_PROJECT` (with
+# JOBS_BY_USER fallback) and emit a `<table>.queries.md` aspect sidecar
+# alongside `<table>.overview.md`. The queries sidecar conforms to the
+# Dataplex `queries` aspect type (`dataplex-types.global.queries`) and is
+# pushed via `kcmd push` because `dataplex-types.global.queries` is now in
+# `publishing.aspects` of `_BQ_MANIFEST` in kcmd_tools.py.
+_INCLUDE_USAGE = flags.DEFINE_bool(
+    "include_usage",
+    True,
+    "Table mode: fetch BQ query-history usage signal per table from"
+    " INFORMATION_SCHEMA.JOBS_BY_*. Off skips the BQ step entirely.",
+)
+_USAGE_WINDOW_DAYS = flags.DEFINE_integer(
+    "usage_window_days",
+    30,
+    "Days of query history to aggregate (default 30).",
+)
+_ANONYMIZE_USERS = flags.DEFINE_bool(
+    "anonymize_users",
+    False,
+    "Replace user emails with stable SHA hashes in the usage signal.",
+)
+_USAGE_SCOPE = flags.DEFINE_enum(
+    "usage_scope",
+    "auto",
+    ["auto", "project", "user"],
+    "auto = try JOBS_BY_PROJECT then fall back to JOBS_BY_USER on permission"
+    " failure; project = require JOBS_BY_PROJECT; user = only the caller's"
+    " own queries (always works but narrow).",
+)
+
+# --- User-feedback proposals (applies to all 3 modes) -------------------
+# Feedback files are pure JSON (typically with `.md` extension by upstream
+# convention) shaped `{"proposals": [...]}`. Each proposal targets a
+# table/column FQN and carries a `proposed_enrichment` action + an optional
+# `eval_candidate.golden_sql`. The agent treats these as HIGHEST priority —
+# they OVERRIDE conflicting context from Drive docs, search hits, and
+# INFORMATION_SCHEMA-derived patterns. See tools/feedback_tools.py for
+# the full schema + routing semantics.
+_FEEDBACK_DIR = flags.DEFINE_string(
+    "feedback_dir",
+    None,
+    "Optional directory containing user-feedback `.md`/`.json` files."
+    " Walked recursively; each file holds a `{proposals: [...]}` JSON"
+    " payload from the upstream feedback collector.",
+)
+_FEEDBACK_FILES = flags.DEFINE_list(
+    "feedback_files",
+    [],
+    "Optional explicit list of user-feedback file paths (alternative to /"
+    " in addition to --feedback_dir).",
+)
+
+
+def main(argv):
+  if len(argv) > 1:
+    raise app.UsageError("Too many command-line arguments.")
+  if not _PROJECT.value:
+    raise app.UsageError("--project is required (your Google Cloud project).")
+  if not _MODEL.value:
+    raise app.UsageError("--model is required (e.g. --model=gemini-2.5-pro).")
+
+  # Configure Vertex AI for the agent's model from the customer's flags.
+  os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+  os.environ["GOOGLE_CLOUD_PROJECT"] = _PROJECT.value
+  os.environ["GOOGLE_CLOUD_LOCATION"] = _LOCATION.value
+
+  # Refinement re-invocation: rehydrate the saved session and apply one turn,
+  # skipping the enrichment pipeline entirely (no doc re-read / dataset re-pull).
+  if _REFINE_INSTRUCTION.value:
+    if not _OUTPUT_DIR.value:
+      raise app.UsageError("--output_dir is required with --refine_instruction.")
+    asyncio.run(
+        refine.run_one_refinement(
+            _OUTPUT_DIR.value, _REFINE_INSTRUCTION.value, _MODEL.value
+        )
+    )
+    return
+
+  mode = _MODE.value or ("table" if _DATASET.value else "doc")
+
+  if mode == "context_overlay":
+    if not _DATASET.value:
+      raise app.UsageError(
+          "--dataset is required for context_overlay mode (`project.dataset`)."
+      )
+    if not _ENTRY_GROUP.value:
+      raise app.UsageError(
+          "--entry_group is required for context_overlay mode "
+          "(`project.location.entryGroupId` where overlays are created)."
+      )
+    session = asyncio.run(
+        context_overlay_mode.run(
+            _DATASET.value,
+            _FOLDER.value,
+            _TOPIC.value,
+            _OUTPUT_DIR.value,
+            _MODEL.value,
+            _ENTRY_GROUP.value,
+            docs=_DOCS.value,
+            tables_filter=_TABLES.value,
+            include_usage=_INCLUDE_USAGE.value,
+            usage_window_days=_USAGE_WINDOW_DAYS.value,
+            anonymize_users=_ANONYMIZE_USERS.value,
+            usage_scope=_USAGE_SCOPE.value,
+            feedback_dir=_FEEDBACK_DIR.value,
+            feedback_files=_FEEDBACK_FILES.value,
+            repo=_REPO.value,
+            repo_ref=_REPO_REF.value,
+            repo_subdir=_REPO_SUBDIR.value,
+            mcp_config=_MCP_CONFIG.value,
+        )
+    )
+  elif mode == "table":
+    session = asyncio.run(
+        table_mode.run(
+            _DATASET.value,
+            _FOLDER.value,
+            _TOPIC.value,
+            _OUTPUT_DIR.value,
+            _MODEL.value,
+            include_usage=_INCLUDE_USAGE.value,
+            usage_window_days=_USAGE_WINDOW_DAYS.value,
+            anonymize_users=_ANONYMIZE_USERS.value,
+            usage_scope=_USAGE_SCOPE.value,
+            feedback_dir=_FEEDBACK_DIR.value,
+            feedback_files=_FEEDBACK_FILES.value,
+            glossaries=_GLOSSARIES.value or None,
+            repo=_REPO.value,
+            repo_ref=_REPO_REF.value,
+            repo_subdir=_REPO_SUBDIR.value,
+            mcp_config=_MCP_CONFIG.value,
+        )
+    )
+  else:
+    if not _ENTRY_GROUP.value:
+      raise app.UsageError(
+          "--entry_group is required for doc mode "
+          "(`project.location.entryGroupId`)."
+      )
+    session = asyncio.run(
+        doc_mode.run(
+            _TOPIC.value,
+            _DOCS.value,
+            _FOLDER.value,
+            _OUTPUT_DIR.value,
+            _MODEL.value,
+            _ENTRY_GROUP.value,
+            feedback_dir=_FEEDBACK_DIR.value,
+            feedback_files=_FEEDBACK_FILES.value,
+            repo=_REPO.value,
+            repo_ref=_REPO_REF.value,
+            repo_subdir=_REPO_SUBDIR.value,
+            mcp_config=_MCP_CONFIG.value,
+        )
+    )
+
+  # Persist the session so a later `--refine_instruction` re-invocation (the
+  # webapp refine flow) can rehydrate it without re-running the pipeline. Cheap
+  # and harmless for one-shot/CLI runs.
+  if session:
+    refine.save_session(session)
+
+  # Multi-turn refinement: stay in a REPL reusing the loaded context. Opt-in via
+  # --interactive so the default one-shot behavior (and the webapp subprocess
+  # path) is unchanged. run_repl is a no-op on a non-tty or empty session.
+  if _INTERACTIVE.value and session:
+    asyncio.run(refine.run_repl(session, _MODEL.value))
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/agents/enrichment/src/common.py
+++ b/agents/enrichment/src/common.py
@@ -1,0 +1,332 @@
+"""Helpers shared by the doc and table enrichment modes."""
+
+import asyncio
+import json
+import os
+import re
+import threading
+import uuid
+
+from engine import EnumerationResult, create_enumeration_runner
+from google.genai import Client, types
+
+# v2.5 #4 + v2.6 #5: bypass ADK's LlmAgent/InMemoryRunner.
+# Per-thread client cache — the genai SDK's pyOpenSSL transport mutates an SSL
+# context per request, which is not thread-safe; sharing one client across many
+# `asyncio.to_thread` workers fails with "Context has already been used to
+# create a Connection, it cannot be mutated again". Thread-local clients (same
+# pattern as drive_tools.get_service) avoid the race.
+_DIRECT_CLIENT_TL = threading.local()
+
+
+def _direct_genai_client() -> Client:
+  """Per-thread Vertex genai client for direct-API generation calls."""
+  client = getattr(_DIRECT_CLIENT_TL, "client", None)
+  if client is None:
+    from google.auth import default
+
+    creds, _ = default()
+    client = Client(
+        vertexai=True,
+        credentials=creds,
+        project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+        location=os.environ.get("GOOGLE_CLOUD_LOCATION", "global"),
+    )
+    _DIRECT_CLIENT_TL.client = client
+  return client
+
+
+async def generate_text_direct(
+    system_instruction: str, user_prompt: str, model: str, usage_acc: dict
+) -> str:
+  """Direct generate_content call bypassing ADK.
+
+  Used wherever we want Flash long-context (or just want to skip LlmAgent
+  overhead) — the writer (v2.5) and the summarizer (v2.6) both call this.
+
+  Builds a fresh client per call. The genai SDK's pyOpenSSL transport mutates
+  an SSL context per request, and any shared client (even thread-local) trips
+  `Context has already been used to create a Connection, it cannot be mutated
+  again` once a worker thread is reused for a second call. Per-call clients
+  are cheap relative to the LLM call latency itself.
+  """
+
+  def _call():
+    from google.auth import default
+
+    creds, _ = default()
+    client = Client(
+        vertexai=True,
+        credentials=creds,
+        project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+        location=os.environ.get("GOOGLE_CLOUD_LOCATION", "global"),
+    )
+    config = types.GenerateContentConfig(system_instruction=system_instruction)
+    return client.models.generate_content(
+        model=model, contents=user_prompt, config=config
+    )
+
+  response = await asyncio.to_thread(_call)
+  usage = getattr(response, "usage_metadata", None)
+  if usage is not None and usage_acc is not None:
+    usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+    usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+  return response.text or ""
+
+
+# Back-compat alias for the v2.5 writer callers (semantically the same function).
+write_entry_direct = generate_text_direct
+
+
+async def run_enumeration(
+    topic: str,
+    compiled_context: str,
+    seed_entries: list[dict] | None,
+    model: str,
+    usage_acc: dict,
+    extra_guidance: str = "",
+    drop_ids: set[str] | None = None,
+) -> EnumerationResult:
+  """Shared EnumerationAgent invocation.
+
+  Returns the structured EnumerationResult.
+
+  seed_entries (table mode): list of {id, display_name, kind} dicts. Each must
+    appear in the output with the exact id. Pass None for doc mode (the agent
+    enumerates entries freely from the context).
+  compiled_context: free-form text (doc mode: compiled batch summaries;
+    table mode: per-table routing descriptors).
+  extra_guidance: optional free-text steer for a re-enumeration refinement turn
+    (e.g. "add a topic about X", "split Y into A and B"). Empty for the initial
+    run, so the default behavior is unchanged.
+  drop_ids: optional ids the user removed; rendered as an explicit "do NOT
+    include these" directive so a re-enumeration honors removals even though the
+    source context still mentions them.
+  """
+  runner = create_enumeration_runner(model)
+  user_id = str(uuid.uuid4())
+  session = await runner.session_service.create_session(
+      app_name=runner.app_name, user_id=user_id
+  )
+
+  seed_block = ""
+  if seed_entries:
+    seed_block = (
+        "PRE-EXISTING SEED ENTRIES (these MUST appear in your output with the"
+        " EXACT id given, and with `kind` set to the value shown):\n"
+        + "\n".join(
+            f"- id: {e['id']}, display_name: {e.get('display_name', e['id'])}, "
+            f"kind: {e.get('kind', 'kb')}"
+            for e in seed_entries
+        )
+        + "\n\n"
+    )
+  guidance_block = ""
+  if extra_guidance:
+    guidance_block += (
+        "USER REFINEMENT GUIDANCE (apply this to the entry set — it OVERRIDES"
+        " the default enumeration; keep all OTHER existing entries and their"
+        " categories stable unless this guidance requires"
+        f" otherwise):\n{extra_guidance}\n\n"
+    )
+  if drop_ids:
+    guidance_block += (
+        "DO NOT include these entry ids — the user explicitly removed"
+        f" them: {', '.join(sorted(drop_ids))}\n\n"
+    )
+  prompt = (
+      f"TOPIC: {topic}\n\n{seed_block}{guidance_block}"
+      f"COMPILED CONTEXT:\n{compiled_context}\n\n"
+      "Produce the canonical categorized entry list per the schema."
+  )
+  raw_text = ""
+  async for event in runner.run_async(
+      user_id=user_id,
+      session_id=session.id,
+      new_message=types.Content(
+          role="user", parts=[types.Part.from_text(text=prompt)]
+      ),
+  ):
+    usage = getattr(event, "usage_metadata", None)
+    if usage:
+      usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+      usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+    if event.content and event.content.parts:
+      for part in event.content.parts:
+        if part.text:
+          raw_text += part.text
+  cleaned = raw_text.strip()
+  if cleaned.startswith("```"):
+    m = re.match(r"^```(?:json)?\s*\n(.*)\n```$", cleaned, re.S)
+    if m:
+      cleaned = m.group(1).strip()
+  return EnumerationResult.model_validate_json(cleaned)
+
+
+async def run_schema_agent(runner, prompt: str, model_cls, usage_acc: dict):
+  """Run a schema-constrained ADK runner once and parse its JSON output.
+
+  Generalizes the run_async + ```-fence-strip + model_validate_json dance used
+  by run_enumeration, for any LlmAgent created with an `output_schema`. Returns
+  an instance of `model_cls` (a pydantic BaseModel subclass).
+  """
+  user_id = str(uuid.uuid4())
+  session = await runner.session_service.create_session(
+      app_name=runner.app_name, user_id=user_id
+  )
+  raw_text = ""
+  async for event in runner.run_async(
+      user_id=user_id,
+      session_id=session.id,
+      new_message=types.Content(
+          role="user", parts=[types.Part.from_text(text=prompt)]
+      ),
+  ):
+    usage = getattr(event, "usage_metadata", None)
+    if usage and usage_acc is not None:
+      usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+      usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+    if event.content and event.content.parts:
+      for part in event.content.parts:
+        if part.text:
+          raw_text += part.text
+  cleaned = raw_text.strip()
+  if cleaned.startswith("```"):
+    m = re.match(r"^```(?:json)?\s*\n(.*)\n```$", cleaned, re.S)
+    if m:
+      cleaned = m.group(1).strip()
+  return model_cls.model_validate_json(cleaned)
+
+
+async def run_text(runner, prompt: str, usage_acc: dict | None = None) -> str:
+  """Runs an InMemoryRunner once and returns the concatenated text output.
+
+  Accumulates token usage into usage_acc when provided.
+  """
+  user_id = str(uuid.uuid4())
+  session = await runner.session_service.create_session(
+      app_name=runner.app_name, user_id=user_id
+  )
+  out = ""
+  async for event in runner.run_async(
+      user_id=user_id,
+      session_id=session.id,
+      new_message=types.Content(
+          role="user", parts=[types.Part.from_text(text=prompt)]
+      ),
+  ):
+    usage = getattr(event, "usage_metadata", None)
+    if usage and usage_acc is not None:
+      usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+      usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+    if event.content and event.content.parts:
+      for part in event.content.parts:
+        if part.text:
+          out += part.text
+  return out
+
+
+async def run_structured(
+    runner, prompt: str, schema_class, usage_acc: dict | None = None
+):
+  """Runs an InMemoryRunner once and returns a validated structured result."""
+  raw_text = await run_text(runner, prompt, usage_acc)
+  cleaned = raw_text.strip()
+  if cleaned.startswith("```"):
+    m = re.match(r"^```(?:json)?\s*\n(.*)\n```$", cleaned, re.S)
+    if m:
+      cleaned = m.group(1).strip()
+  try:
+    return schema_class.model_validate_json(cleaned)
+  except Exception as e:
+    print(f"[!] Error parsing structured output: {e}\nRaw output: {raw_text}")
+    return None
+
+
+def clean_overview_body(text: str) -> str:
+  """Strip stray code fences / YAML frontmatter the model may have added, so the
+
+  sidecar body is pure Markdown (table mode).
+  """
+  t = (text or "").strip()
+  # Strip an outer ```...``` fence ONLY if the model wrongly wrapped the whole
+  # body in one. Greedy so inner ```sql blocks (Sample SQL) are preserved.
+  if t.startswith("```"):
+    m = re.match(r"^```[a-zA-Z]*\s*\n(.*)\n```$", t, re.S)
+    if m:
+      t = m.group(1).strip()
+  # Strip a leading YAML frontmatter block if present (we add our own). The
+  # middle is optional so an EMPTY block (`---\n---`) is stripped too.
+  if t.startswith("---"):
+    m = re.match(r"^---\s*\n(?:.*?\n)?---\s*\n(.*)$", t, re.S)
+    if m:
+      t = m.group(1).strip()
+  return t
+
+
+def parse_mdcode_blocks(text: str, output_dir: str) -> list[str]:
+  """Parse fenced code blocks preceded by a backticked relative path and write
+
+  them under output_dir. Used by doc mode where the LLM emits the mdcode files.
+  """
+  written = []
+  if not output_dir:
+    return written
+  blocks = re.split(r"```(yaml|markdown|json|md)", text)
+  for i in range(1, len(blocks), 2):
+    block_content = blocks[i + 1].split("```")[0].strip()
+    preceding_text = blocks[i - 1].strip().split("\n")[-1].strip()
+    filename = None
+    if preceding_text.startswith("`") and preceding_text.endswith("`"):
+      filename = (
+          preceding_text.replace("`", "")
+          .replace("'", "")
+          .replace('"', "")
+          .strip()
+      )
+    if not filename:
+      continue
+    full_path = os.path.join(output_dir, filename)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, "w") as f:
+      f.write(block_content + "\n")
+    written.append(filename)
+    print(f"[+] Saved {filename} to {full_path}")
+  return written
+
+
+def write_trajectory(
+    output_dir: str,
+    agent_type: str,
+    user_input: str,
+    tool_uses: list,
+    tool_responses: list,
+    final_text: str,
+    usage_acc: dict,
+    latency: float = 0.0,
+) -> None:
+  """Persist trajectory.json capturing the agent's run (same shape for both modes).
+
+  Written next to the generated mdcode as a record of what the agent read and
+  produced; consumed by external evaluation/tooling that reads it by path.
+  `latency` is the wall-clock seconds the run took (0 if not measured).
+  """
+  if not output_dir:
+    return
+  os.makedirs(output_dir, exist_ok=True)
+  trajectory = {
+      "agent_type": agent_type,
+      "user_input": user_input,
+      "tool_uses": tool_uses,
+      "tool_responses": tool_responses,
+      "final_text": final_text,
+      "token_usage": {
+          "input": usage_acc["input"],
+          "output": usage_acc["output"],
+      },
+      "latency": round(latency, 2),
+  }
+  traj_path = os.path.join(output_dir, "trajectory.json")
+  with open(traj_path, "w") as f:
+    json.dump(trajectory, f, indent=2, default=str)
+  print(f"\n[+] Saved trajectory to {traj_path}")

--- a/agents/enrichment/src/engine.py
+++ b/agents/enrichment/src/engine.py
@@ -1,0 +1,774 @@
+"""LLM agents for the unified enrichment agent (doc + table modes).
+
+Shared (used by both modes):
+  * EnumerationAgent     — produces a canonical categorized entry list from
+                           context. Output is a strict Pydantic-schema JSON
+                           ({categories: [{id, title, entries: [...]}]}) so the
+                           entry ids and dedup decisions are stable across runs.
+                           Used in doc mode to derive entries from a compiled
+                           summary, and in table mode to categorize the entries
+                           kcmd already pulled.
+  * EntryWriterAgent     — writes ONE entry's overview body. Fanned out per
+                           entry by both modes; small inputs keep us on Flash.
+
+Doc mode (legacy MdcodeAgent retained for backward compat / fallback):
+  * SummarizerAgent      — map-reduce summarizer over crawled Google Docs.
+  * MdcodeAgent          — emits the knowledge-base mdcode from the compiled
+                           summary (legacy; superseded by EnumerationAgent +
+                           per-entry EntryWriterAgent fan-out).
+
+Table mode:
+  * DocSummarizerAgent   — distills ONE Drive doc into a compact router
+  descriptor.
+  * RelevanceRouterAgent — picks which docs are relevant to a given table.
+  * TableOverviewAgent   — (legacy) writes one table's enriched overview from
+                           its relevant docs. Superseded by EntryWriterAgent.
+
+Nothing here is project-specific: the model is supplied by the caller (the
+`--model` CLI flag) and the Vertex project/location come from the environment
+(`GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION`, set by the CLI from
+`--project` / `--location`).
+"""
+
+import os
+import typing as t
+
+from google.adk.agents import llm_agent
+from google.adk.models import Gemini
+from google.adk.runners import InMemoryRunner
+from google.genai import Client
+from pydantic import BaseModel, Field
+
+
+class VertexGemini(Gemini):
+  """Gemini on Vertex AI via Application Default Credentials.
+
+  Project/location are read from the environment so the tool works in any
+  customer project.
+  """
+
+  _cached_client = None
+
+  @property
+  def api_client(self) -> Client:
+    if self._cached_client is None:
+      from google.auth import default
+
+      creds, _ = default()
+      self._cached_client = Client(
+          vertexai=True,
+          credentials=creds,
+          project=os.environ.get("GOOGLE_CLOUD_PROJECT"),
+          location=os.environ.get("GOOGLE_CLOUD_LOCATION", "global"),
+      )
+    return self._cached_client
+
+
+# Pinned for structured-extraction steps with SMALL inputs (per-doc descriptors,
+# JSON routing). Flash is ~3-4x faster. The caller's --model is used for: (a)
+# the heavy write steps where quality matters, and (b) the doc-mode batch
+# summarizer — see comment on create_summarizer_runner below.
+_LIGHT_MODEL = "gemini-3.5-flash"
+
+# Per-doc summarizer model. Each call is ONE doc in (≤60K chars), one neutral
+# card out (~2K chars) — small enough to stay well under Flash's per-call
+# context limits regardless of routing, and lighter on latency / cost than
+# Pro. Result is cached at ~/.kc_enrich_cache/summaries/ keyed on
+# (doc_id, modifiedTime), so any drift introduced by using a smaller model
+# only shows up on the FIRST run against a doc.
+PER_DOC_SUMMARIZER_MODEL = _LIGHT_MODEL
+
+
+# ============================ Doc mode ============================
+
+# Public so callers can pass it to common.generate_text_direct (v2.6 #5: direct
+# API for the summarizer to use Flash long-context without ADK's 32K routing trap).
+SUMMARIZER_INSTRUCTION = """You are an expert technical summarizer for a Metadata as Code generation pipeline.
+Given a topic, a MASTER SCOPE document, and a batch of raw Google Documents:
+1. Understand the overarching projects and goals from the MASTER SCOPE.
+2. For each document in the batch, extract all relevant architectural requirements, proposals, and details.
+3. STRUCTURED EXTRACTION: You MUST map every finding to one of the overarching projects defined in the MASTER SCOPE. Do not create orphaned topics.
+4. SOURCE TRACKING: You MUST append an explicit "Source References" section to every single finding or sub-topic you extract. Instead of using raw URLs, you MUST format the sources as Markdown links using the Document's Title (inferred from the document content) as the link text (e.g., `[Document Title](URL)`). Do not drop URLs.
+5. Do not output final mdcode formats; output a structured, dense markdown summary grouping findings by the Master Scope projects."""
+
+
+def create_summarizer_runner(model: str) -> InMemoryRunner:
+  """Legacy ADK-runner factory for SummarizerAgent. Kept for back-compat.
+
+  The current doc-mode pipeline calls common.generate_text_direct directly
+  with SUMMARIZER_INSTRUCTION (v2.6 #5) — bypassing ADK lets us use Flash on
+  big-input batches without hitting the 32K ADK Flash routing cap.
+  """
+  agent = llm_agent.LlmAgent(
+      name="SummarizerAgent",
+      description="Summarizes Google Drive documents.",
+      model=VertexGemini(model=model),
+      instruction=SUMMARIZER_INSTRUCTION,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+# Topic-agnostic per-doc summarizer. The output is CACHED at
+# ~/.kc_enrich_cache/summaries/<doc_id>.summary and reused across runs
+# regardless of what `topic` the run is enriching for, so the prompt MUST
+# NOT bake any topic-specific framing into the output. Downstream the
+# topic-shaped reduction step (see doc_mode._reduce_summaries_with_topic)
+# is responsible for filtering / re-grouping these neutral cards through
+# the topic lens.
+PER_DOC_SUMMARIZER_INSTRUCTION = """You are summarizing ONE Google Drive document into a reusable, topic-NEUTRAL "doc card" that will be cached and reused for many different downstream analyses with different focus topics.
+
+NEUTRAL means: do not filter by any topic, do not editorialize, do not collapse multiple claims into a generic overview. Capture enough that any analyst could understand what the document is about, what it discusses, and what claims it makes, without re-reading it.
+
+Output EXACTLY this Markdown shape and nothing else:
+
+# {document title — as it appears in the doc, or a 6-word descriptor if untitled}
+
+**Source:** [{document title}]({source url})
+
+## Identity
+- **Type:** {design doc / runbook / README / launch plan / chat log / wiki page / etc.}
+- **Purpose (1 sentence):** {what the document is for, neutrally stated}
+- **Status (if stated):** {draft / proposal / approved / archived — only if the doc says so explicitly}
+
+## Topics and Entities
+Comma-separated list of EVERY distinct named project, system, agent, framework, product, service, team, repository, dataset, table, column, metric, business concept, or person that the document explicitly names. Be exhaustive. Preserve the exact spellings the document uses. Do not invent or paraphrase entity names.
+
+## Key Claims and Facts
+Bullet list of every substantive claim, decision, requirement, design choice, fact, metric value, data point, schedule, or constraint asserted in the document. One claim per bullet. Include numbers / specifics / pre-decided tradeoffs verbatim where possible. Do not editorialize.
+
+## References Cited
+Bullet list of every external link, document reference, code path (e.g. `src/path/to/file.py`), table FQN, or system URL the document points to. One per bullet. If the document cites no external references, write "(none)".
+
+## Open Questions / TODOs (if any)
+Bullet list of questions or TODOs the document leaves unresolved. Skip this section if the document raises none.
+
+Rules:
+- Be faithful. Quote specifics rather than paraphrasing when in doubt.
+- Be neutral. Do NOT decide what's important or relevant — the downstream stage does that with the topic.
+- Do not output a closing summary, conclusion, or recommendation."""
+
+
+def create_per_doc_summarizer_runner(model: str) -> InMemoryRunner:
+  """Topic-agnostic per-doc summarizer factory.
+
+  Used by the cached per-doc Map stage in doc_mode.
+  """
+  agent = llm_agent.LlmAgent(
+      name="PerDocSummarizerAgent",
+      description=(
+          "Summarizes a single document into a reusable, topic-neutral doc"
+          " card. Output is cached across runs."
+      ),
+      model=VertexGemini(model=model),
+      instruction=PER_DOC_SUMMARIZER_INSTRUCTION,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+DOC_QUERY_EXTRACTOR_INSTRUCTION = """You extract SQL queries from documentation that reference a specific BigQuery table.
+
+You will receive:
+- TABLE: a fully-qualified `project.dataset.table` name.
+- DOC SNIPPETS: one or more documentation excerpts that may or may not contain SQL queries referencing the table.
+
+Find every distinct, runnable SQL query that:
+- Explicitly references the target TABLE by name (e.g. backticked `project.dataset.table` or unqualified `table` when the surrounding context makes the dataset unambiguous), AND
+- Is presented as an EXAMPLE the reader is meant to run/adapt (typically inside a ```sql code block or a fenced code block, occasionally inline if the doc is short and informal).
+
+For EACH extracted query, output ONE line of compact JSON (no trailing commas, no surrounding array brackets, no commentary):
+
+{"description": "<1-sentence summary of what the query does, in plain English>", "sql": "<the FULL SQL with newlines escaped as \\n>"}
+
+Rules:
+- Output ONLY JSON Lines (JSONL). No prose, no markdown fences, no headers.
+- If you find zero queries, output nothing (an empty response).
+- Preserve the query exactly as written — do NOT normalize literals, do NOT reformat whitespace beyond escaping newlines, do NOT strip comments.
+- Skip queries that reference other tables but not the target TABLE.
+- Skip SELECT * sanity checks and other trivial 1-liners unless they're the only example present.
+"""
+
+
+def create_doc_query_extractor_runner(model: str) -> InMemoryRunner:
+  """Extractor agent for SQL examples found in routed documentation.
+
+  Per-table call: given the docs that the router selected for ONE table,
+  pull out any SQL queries that reference that table. Output is JSON
+  Lines for trivial parsing. Used by table_mode.py to merge doc-derived
+  queries into the per-table `queries` aspect alongside the
+  INFORMATION_SCHEMA-derived ones.
+
+  Args:
+    model: Model name.
+
+  Returns:
+    An InMemoryRunner for the extractor agent.
+  """
+  del model  # unused
+  agent = llm_agent.LlmAgent(
+      name="DocQueryExtractorAgent",
+      description=(
+          "Extracts SQL examples for ONE table from its routed documentation."
+      ),
+      model=VertexGemini(model=_LIGHT_MODEL),
+      instruction=DOC_QUERY_EXTRACTOR_INSTRUCTION,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+# Topic-shaped reducer. Consumes a batch of neutral per-doc cards (from
+# the cached Map stage) and produces a topic-relevant grouped summary
+# the enumerator can act on. The output of this stage is NOT cached —
+# it depends on the user's topic, which is allowed to change run-to-run.
+TOPIC_REDUCER_INSTRUCTION = """You are reducing a batch of neutral per-document summary cards through a TOPIC LENS for a Metadata as Code generation pipeline.
+
+You will receive:
+- TOPIC: the focus topic the user is enriching the knowledge base for
+- MASTER SCOPE: an overarching scope document grouping the corpus into named projects (may be empty)
+- BATCH CARDS: K neutral per-doc cards, each with Identity / Topics and Entities / Key Claims and Facts / References Cited sections
+
+Your job:
+1. Identify which Topics/Entities/Claims across the batch are relevant to the TOPIC and MASTER SCOPE.
+2. STRUCTURED EXTRACTION: map every relevant finding to one of the overarching projects defined in the MASTER SCOPE. Do not create orphaned topics.
+3. SOURCE TRACKING: every finding MUST carry the source link from the doc card it came from, formatted as a Markdown link using the Document Title (e.g., `[Document Title](URL)`). Do not drop URLs.
+4. Skip cards that are not relevant to the TOPIC — do not pad the output with filler.
+5. Output a structured, dense Markdown summary grouping findings by MASTER SCOPE project. Do NOT output final mdcode."""
+
+
+def create_topic_reducer_runner(model: str) -> InMemoryRunner:
+  """Topic-shaped reducer factory.
+
+  Operates on per-doc summaries (not raw docs), so its input is much smaller
+  than the legacy batch summarizer.
+  """
+  agent = llm_agent.LlmAgent(
+      name="TopicReducerAgent",
+      description=(
+          "Reduces a batch of neutral per-doc summaries through a topic"
+          " lens, producing a structured grouped summary."
+      ),
+      model=VertexGemini(model=model),
+      instruction=TOPIC_REDUCER_INSTRUCTION,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+_MDCODE_INSTRUCTION = """You are an expert Document Knowledge Base Enrichment Agent for Google Cloud Dataplex.
+
+Your workflow:
+1. You will receive a compiled summary of multiple Google Docs regarding a specific topic.
+
+2. ENUMERATE NAMED PROJECTS FIRST. Before drafting any entries, scan the compiled summary and produce a numbered list of every distinct named project, agent, system, framework, product, service, or work area that:
+   (a) appears as its own heading or sub-heading in the compiled summary, OR
+   (b) is referenced by a specific name in two or more of the batch summaries.
+   Do NOT merge similar-sounding items at this step — list them separately and let later deduplication handle true synonyms. Output this list inline as the first thing in your response, wrapped in <enumeration>...</enumeration> tags so a downstream parser can audit it.
+
+3. ONE-TO-ONE MAPPING. The entries you output MUST map 1:1 to the enumeration in step 2 — same count, same identities. If the enumeration has K items, you MUST output K entries. Do NOT fold a smaller/lesser-documented project into a larger one "because it's related" — generate its entry with whatever evidence the summary provides, even if the resulting overview is short. The only allowed deviation is collapsing TRUE SYNONYMS (e.g. "KC Discovery" and "knowledge-catalog-discovery-agent" referring to the same system); in that case, note the merge in a brief comment line above the affected entry's code block.
+
+4. Map to Entries: Map each enumerated item to an individual Dataplex entry of type `__ENTRY_TYPE__`.
+
+5. Create Aspects: For each entry, synthesize all relevant information and format it as Markdown sidecar files (Aspects) attached to the entry.
+
+6. Output mdcode: Your final output must strictly follow the Metadata-as-Code (mdcode) YAML standard.
+   - Do NOT output a `catalog.yaml` manifest — it is generated separately by the CLI. Output ONLY the entry files and their markdown sidecars.
+   - The entry count from step 2's enumeration is binding. Dropping or merging entries beyond true synonyms is a failure. Ensure all collected source URLs are populated in the Overview sidecar under a 'Source References' section, strictly formatted as Markdown links using the Document Title (e.g., `* [Document Title](URL)`).
+   - You MUST output all individual entry YAML files and markdown sidecar files within a `catalog/` directory to adhere to the Metadata-as-Code directory hierarchy (e.g., `` `catalog/[entry_id].yaml` ``). Do not wrap filenames in single quotes (`'`). The entry file MUST include `id`, `type` (`__ENTRY_TYPE__`), `resource` (as an object with `name`, `displayName`, and `description` to populate the UI properly). **CRITICAL: You MUST wrap all text values for `description` and `displayName` inside double quotes (`""`) to prevent YAML parser syntax errors caused by colons or special characters.**
+   - Unstructured text content in aspects (like overviews containing your extracted requirements/links) MUST be represented as sidecar markdown files in the catalog directory (e.g., `` `catalog/[entry_id].overview.md` ``). The markdown file MUST have YAML frontmatter (between `---` lines) and the unstructured text below it.
+   - Precede every code block with a backtick-wrapped relative filepath (e.g. `catalog/[entry_id].yaml`).
+
+For example, an entry YAML should look like:
+```yaml
+id: my-project
+type: __ENTRY_TYPE__
+resource:
+  name: __RESOURCE_NAME_PREFIX__/my-project
+  displayName: "My Project Name"
+  description: "A short 1-sentence summary of the project."
+```"""
+
+
+def create_mdcode_runner(
+    model: str, entry_type: str, resource_name_prefix: str
+) -> InMemoryRunner:
+  instruction = _MDCODE_INSTRUCTION.replace(
+      "__ENTRY_TYPE__", entry_type
+  ).replace("__RESOURCE_NAME_PREFIX__", resource_name_prefix)
+  agent = llm_agent.LlmAgent(
+      name="MdcodeAgent",
+      description="Generates Dataplex mdcode entries from summaries.",
+      model=VertexGemini(model=model),
+      instruction=instruction,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+# =========================== Table mode ===========================
+
+
+def create_doc_summarizer_runner(model: str) -> InMemoryRunner:
+  """Distills ONE folder document into a compact, router-friendly descriptor."""
+  agent = llm_agent.LlmAgent(
+      name="DocSummarizerAgent",
+      description=(
+          "Summarizes a single Drive document into a compact descriptor."
+      ),
+      model=VertexGemini(model=_LIGHT_MODEL),
+      instruction="""You are summarizing ONE document so a router can decide which BigQuery tables it is relevant to.
+
+Output EXACTLY this Markdown shape and nothing else:
+
+Title: <the document's inferred title>
+Summary: <2-4 sentences on what data/system/domain this document describes>
+Key entities: <comma-separated tables, datasets, columns, metrics, systems, or business terms this document actually discusses>
+
+Be concrete and faithful — list the specific entities/columns/metrics named in the document. Do not invent. Do not add any other sections.""",
+  )
+  return InMemoryRunner(agent=agent)
+
+
+def create_router_runner(model: str) -> InMemoryRunner:
+  """Decides which folder docs are relevant to a single table."""
+  agent = llm_agent.LlmAgent(
+      name="RelevanceRouterAgent",
+      description="Scores folder-document relevance to one BigQuery table.",
+      model=VertexGemini(model=_LIGHT_MODEL),
+      instruction="""You are a precise relevance router. You are given ONE BigQuery table (its name and columns) and a numbered list of candidate documents (each with a title, summary, and key entities).
+
+Decide which documents genuinely provide domain knowledge that would help DOCUMENT THIS SPECIFIC TABLE — e.g. they define this table, its columns/metrics, its source system, or the business process it records. A document that merely shares a broad theme but does not concern this table's data is NOT relevant.
+
+Output ONLY a JSON array (no prose, no code fences). Each element: {"doc": <number>, "score": <0.0-1.0>, "reason": "<short reason>"}. Include an element ONLY for documents with score >= 0.3; if none qualify, output []. Be conservative — prefer precision over recall.""",
+  )
+  return InMemoryRunner(agent=agent)
+
+
+def create_table_overview_runner(model: str) -> InMemoryRunner:
+  """Writes the enriched OVERVIEW prose for one table (the caller assembles the
+
+  mdcode files deterministically).
+  """
+  agent = llm_agent.LlmAgent(
+      name="TableOverviewAgent",
+      description=(
+          "Writes the enriched overview for one BigQuery table from its"
+          " relevant docs."
+      ),
+      model=VertexGemini(model=model),
+      instruction="""You are a Knowledge Catalog Enrichment Agent for Google Cloud Dataplex.
+
+You will receive:
+  - RELEVANT CONTEXT DOCUMENTS (zero or more) that a router has already determined pertain to THIS table, each with its title and source URL, and
+  - the metadata for ONE BigQuery table (its name and schema columns).
+
+Your job: write a rich, accurate OVERVIEW for THIS table, grounded STRICTLY in the provided context documents, the schema, and the existing metadata.
+
+GROUNDING RULES — do not make anything up:
+   - Every statement must be supported by the provided context documents, the schema columns, or the existing metadata. Do NOT invent facts, owners, SLAs, pipelines, semantics, or values that are not present in the input.
+   - If something is not covered by the inputs, leave it out — never guess or fill gaps with plausible-sounding content.
+
+ALWAYS emphasize these two sections when the inputs support them (this is the default focus):
+   1. `## Lineage` — describe upstream sources, the producing pipeline/job, transformations, and downstream consumers, but ONLY as documented in the provided context documents. Cite the source for each lineage claim. If the documents do not describe lineage, write a brief note that lineage is not documented in the provided sources (do not fabricate it).
+   2. `## Sample SQL` — provide one or more example queries in fenced ```sql blocks. SQL MUST reference ONLY columns that exist in the provided schema, and the fully-qualified table name `project.dataset.table` derived from the table metadata. Any joins, filters, or derivations may ONLY reflect logic explicitly described in the provided documents; if no such logic is documented, keep the examples to simple, schema-grounded queries (e.g. column selection, basic aggregation over real columns) and do not invent business rules. If the schema is unavailable, omit this section.
+
+Also cover, where the inputs support them: what the table contains, what it is used for, the meaning of key columns, and derivations/metrics. Additional relevant topics from the user's instruction may be included as further sections. End with a `## Source References` section listing the `[Title](URL)` links of the provided context documents that actually informed the overview.
+
+If NO context documents are provided, write the overview from the table's schema and existing metadata ONLY (you may still include schema-grounded `## Sample SQL` and a "lineage not documented" note), and OMIT the `## Source References` section entirely (do not fabricate sources).
+
+OUTPUT RULES (important):
+   - Output ONLY the overview as Markdown body text. Start with a single top-level heading line (e.g. `# <Table> Overview`).
+   - Do NOT output YAML, do NOT output frontmatter (no `---` lines), and do NOT print any file paths. (Fenced ```sql code blocks inside the body ARE allowed for the Sample SQL section.) Just the Markdown overview itself.""",
+  )
+  return InMemoryRunner(agent=agent)
+
+
+# ============================ Shared: enumeration + writer ============================
+
+# Pydantic models used as the EnumerationAgent's `output_schema`. Strict JSON
+# output kills the surface-form drift we saw in the v3 prompt-only attempt
+# (`brewmax` + `brewmax-framework` getting emitted as two entries, etc.) — the
+# model has to pick ONE canonical id and list other forms as aliases.
+
+
+class EnumeratedEntry(BaseModel):
+  id: str = Field(
+      description=(
+          "kebab-case canonical identifier used as the filename stem. Stable"
+          " across runs — pick the most fully-spelled form of the project's"
+          " name."
+      )
+  )
+  display_name: str = Field(description="Human-readable name (Title Case).")
+  aliases: list[str] = Field(
+      default_factory=list,
+      description=(
+          "All other surface forms (acronyms, alternate spellings, "
+          "framework/agent suffix variants) for this same project that "
+          "appeared in the input. The model MUST list them here rather "
+          "than as separate entries."
+      ),
+  )
+  description: str = Field(
+      description="Single sentence summary of what this entry is."
+  )
+  primary_source_urls: list[str] = Field(
+      default_factory=list,
+      description=(
+          "1-5 Google Doc URLs from the input that most directly describe this"
+          " entry. Used by the downstream writer to scope its grounding."
+      ),
+  )
+  kind: t.Literal["kb", "table"] = Field(
+      description=(
+          "'table' if this entry was a seeded BigQuery table (table mode); "
+          "'kb' if the entry was discovered from documents (doc mode)."
+      )
+  )
+
+
+class Category(BaseModel):
+  id: str = Field(
+      description="kebab-case category identifier used as a subdirectory name."
+  )
+  title: str = Field(description="Human-readable category title.")
+  description: str = Field(
+      description="Single sentence describing the theme of this category."
+  )
+  entries: list[EnumeratedEntry] = Field(
+      description="Entries that belong to this category."
+  )
+
+
+class EnumerationResult(BaseModel):
+  categories: list[Category] = Field(
+      description=(
+          "3-8 categories grouping all entries. Use a 'miscellaneous' "
+          "category as a sink for entries that don't fit a multi-entry group, "
+          "rather than fragmenting into many 1-entry categories."
+      )
+  )
+
+
+_ENUMERATION_INSTRUCTION = """You are a knowledge-graph editor. Your job is to take a body of context (a compiled summary of multiple sources, optionally with a list of pre-existing entries that MUST appear in the output) and produce a CANONICAL, DEDUPLICATED, CATEGORIZED entry list.
+
+CRITICAL RULES:
+
+1. CANONICALIZATION. Two surface forms refer to the SAME entry if any of these apply:
+   - They share most of their substantive words (e.g. "brewmax" and "brewmax-framework" -> same; "data-engineering-agent" and "data-engineering-agents" -> same).
+   - One is an acronym of the other (e.g. "dea" and "data-engineering-agent" -> same; "ucp" and "universal-context-platform" -> same).
+   - One is a sub-feature explicitly belonging to the other (e.g. "hatteras-online-prompt-evaluation" -> alias of "hatteras", not its own entry).
+   When merging, pick the MOST FULLY SPELLED canonical form for `id` and `display_name`, and list every other form in `aliases`. Do NOT emit separate entries for the same underlying project.
+
+2. CATEGORIZATION. Group entries into 3-8 categories by theme. Each category MUST contain 2+ entries — if an entry doesn't fit a multi-entry category, put it in a category called `miscellaneous` rather than creating a 1-entry category. Categories must be themed (e.g. "data-curation", "agent-orchestration", "evaluation"), not generic ("group-1", "other").
+
+3. SEED ENTRIES (when provided). If the input lists pre-existing entries (table mode supplies tables this way), each one MUST appear in the output with the EXACT id given. You may add other entries discovered in the context, but seeded ones cannot be dropped or renamed.
+
+4. SOURCE LINKING. For each entry, populate `primary_source_urls` with 1-5 of the most directly relevant source URLs from the context. These are used to scope the downstream writer's grounding — be specific, not exhaustive.
+
+5. OUTPUT. Strict JSON conforming to the provided schema. No prose, no Markdown, no fenced blocks."""
+
+
+def create_enumeration_runner(model: str) -> InMemoryRunner:
+  """Canonicalizes + categorizes entries from context.
+
+  Output is schema-validated JSON.
+  """
+  agent = llm_agent.LlmAgent(
+      name="EnumerationAgent",
+      description="Produces a canonical, deduplicated, categorized entry list.",
+      model=VertexGemini(model=model),
+      instruction=_ENUMERATION_INSTRUCTION,
+      output_schema=EnumerationResult,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+def create_entry_writer_runner(model: str) -> InMemoryRunner:
+  """Writes ONE entry's overview body. Fanned out per entry by both modes.
+
+  Small per-call input (one entry's slice of context, typically <20K tokens)
+  keeps us safely under the ADK 32K Flash routing cap, so Flash is the
+  intended model here.
+  """
+  agent = llm_agent.LlmAgent(
+      name="EntryWriterAgent",
+      description=(
+          "Writes one entry's overview Markdown body from grounded context."
+      ),
+      model=VertexGemini(model=model),
+      instruction=ENTRY_WRITER_INSTRUCTION,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+ENTRY_WRITER_INSTRUCTION = """You are writing the overview prose for ONE knowledge catalog entry. You are given:
+  - The entry's canonical name, description, and category.
+  - The aliases that other sources use for the same entry.
+  - The relevant context (excerpts of the source documents that mention this entry).
+
+Write a rich, accurate Markdown OVERVIEW for this entry, grounded STRICTLY in the provided context.
+
+GROUNDING RULES — do not make anything up:
+  - Every statement must be supported by the provided context.
+  - If the context is thin, the overview can be short — DO NOT pad with plausible-sounding generalities.
+  - Keep all source-document links verbatim.
+
+STRUCTURE:
+  - Start with a single H1 like `# {Display Name} Overview`.
+  - Brief intro paragraph (1-3 sentences) on what this entry is.
+  - Use H2 sections (`## Lineage`, `## Key Features`, `## Sample Usage`, `## Architecture`, etc.) as the context supports — DO NOT include sections you can't ground.
+  - End with `## Source References` listing the context documents as `* [Title](URL)` markdown links.
+
+OUTPUT RULES:
+  - Output ONLY the Markdown body. Do NOT output YAML, do NOT output frontmatter, do NOT print file paths.
+  - Fenced ```sql or ```python code blocks inside the body are allowed where the context supports them."""
+
+
+# Context-overlay writer. Used by context_overlay_mode via
+# common.generate_text_direct. Fuses the table's AUTHORITATIVE BASE ENTRY (the
+# read-only 1P catalog entry pulled by `kcmd reference`) with routed document
+# context into a NEW overlay entry's overview — preserve-and-augment, cite sources.
+OVERLAY_WRITER_INSTRUCTION = """You are writing the enriched OVERVIEW prose for a context-overlay knowledge catalog entry that augments ONE BigQuery table.
+
+You are given:
+  - The AUTHORITATIVE BASE ENTRY: the real first-party (1P) catalog entry for this table — its full schema (every column + dataType + description) and its existing description/overview. This is the source of truth.
+  - RELEVANT CONTEXT DOCUMENTS (zero or more) that a router determined pertain to this table, each with its title and source URL.
+
+Write a rich, accurate Markdown OVERVIEW that FUSES the base entry with the document context.
+
+PRESERVE-AND-AUGMENT (critical):
+  - The overlay must be a SUPERSET of the base entry. Retain ALL of its information — never drop, rename, or shorten any column, dataType, or fact.
+  - AUGMENT it with business/domain context from the documents: what the data represents, how it maps to the documented domain concepts, analytical use cases, lineage, and governance/usage notes.
+
+GROUNDING RULES — do not make anything up:
+  - Every statement must be supported by the base entry, the schema, or the provided context documents. Do NOT invent owners, SLAs, pipelines, or semantics.
+  - Every claim drawn from a document MUST cite its source as an inline Markdown link.
+  - If the documents are thin, the overview can be short — DO NOT pad with plausible-sounding generalities.
+
+STRUCTURE:
+  - Start with a single H1 like `# {Display Name} Overview`.
+  - Use H2 sections (`## Schema`, `## Lineage`, `## Sample SQL`, `## Usage`, etc.) as the inputs support — omit any section you cannot ground.
+  - Prefer a `## Sample SQL` section with fenced ```sql blocks that reference ONLY real columns and the fully-qualified `project.dataset.table` name when the inputs support it.
+  - End with `## Source References` listing the context documents as `* [Title](URL)` markdown links. OMIT this section entirely if no documents informed the overview.
+
+OUTPUT RULES:
+  - Output ONLY the Markdown body. Do NOT output YAML, do NOT output frontmatter, do NOT print file paths.
+  - Fenced ```sql or ```python code blocks inside the body are allowed where the context supports them."""
+
+
+class GlossaryTerm(BaseModel):
+  id: str = Field(description="kebab-case identifier for the glossary term.")
+  display_name: str = Field(description="Human-readable name for the term.")
+  description: str = Field(
+      description="Clear, business-oriented definition of the term."
+  )
+
+
+class GlossaryResult(BaseModel):
+  terms: list[GlossaryTerm] = Field(
+      description="List of extracted business terms."
+  )
+
+
+_GLOSSARY_INSTRUCTION = """You are a business domain expert. Your job is to extract a canonical set of Business Glossary Terms from the provided context (database schemas, technical documentation, etc.).
+
+RULES:
+1. IDENTIFY BUSINESS CONCEPTS: Look for recurring entities, metrics, or domain-specific jargon that require a standard definition.
+2. DEDUPLICATE: Merge similar concepts into a single canonical term.
+3. BUSINESS-ORIENTED: Definitions should be clear to a non-technical business user.
+4. NAMING: Use kebab-case for `id`, and Title Case for `display_name`.
+5. OUTPUT: Strict JSON conforming to the provided schema."""
+
+
+def create_glossary_runner(model: str) -> InMemoryRunner:
+  """Extracts business terms from context."""
+  agent = llm_agent.LlmAgent(
+      name="GlossaryAgent",
+      description="Extracts business glossary terms from context.",
+      model=VertexGemini(model=model),
+      instruction=_GLOSSARY_INSTRUCTION,
+      output_schema=GlossaryResult,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+# ===================== Multi-turn refinement =====================
+#
+# After the initial enrichment, the agent can stay in an interactive REPL
+# (agent_runner --interactive) and accept free-text refinement requests. Two
+# pieces live here:
+#   * REFINEMENT_WRITER_INSTRUCTION — re-writes ONE entry's overview, applying
+#     the user's change while preserving still-valid content. Used via
+#     common.generate_text_direct, reusing the SAME grounding context that
+#     produced the original overview (so docs are never re-read).
+#   * RefinementPlan + the dispatch runner — one schema-validated call that maps
+#     a free-text request to a structured plan (which entries, what change, or a
+#     direct answer to a question).
+# See refine.py for the session model + REPL that drive these.
+
+REFINEMENT_WRITER_INSTRUCTION = """You are REVISING an existing knowledge catalog entry's overview based on a user's refinement request.
+
+You are given:
+  - The ORIGINAL GROUNDING CONTEXT that was used to write the overview (topic, the entry's metadata/schema, and the relevant source documents). This is the same source of truth as before.
+  - The CURRENT OVERVIEW (the Markdown body produced so far).
+  - The REFINEMENT HISTORY: earlier changes already applied across previous turns (honor them — do not undo them).
+  - The USER REFINEMENT REQUEST for this turn.
+
+Your job: produce a REVISED overview that applies the user's request.
+
+RULES:
+  - Apply the requested change faithfully. If it asks to add/expand a section, add it; to shorten/remove, do so; to fix a fact, correct it.
+  - PRESERVE everything in the current overview that is still valid and not contradicted by the request — do not drop content or regress earlier refinements.
+  - Stay GROUNDED in the original grounding context. Do NOT invent facts, owners, SLAs, pipelines, or semantics that are not supported by the context or the user's explicit instruction.
+  - If the request asks for something the context cannot support, apply what you can and keep the rest unchanged rather than fabricating.
+  - Keep all source-document links that remain relevant.
+
+OUTPUT RULES (identical to the original writer):
+  - Output ONLY the revised Markdown body. Do NOT output YAML, do NOT output frontmatter, do NOT print file paths.
+  - Fenced ```sql or ```python code blocks inside the body are allowed where the context supports them."""
+
+
+class RefinementPlan(BaseModel):
+  """Structured dispatch decision for one free-text refinement request."""
+
+  operation: t.Literal["rewrite", "answer", "noop", "reenumerate"] = Field(
+      description=(
+          "'rewrite' to re-generate one or more entries' overviews with a"
+          " change; 'reenumerate' to change WHICH entries exist (add a missing"
+          " topic, remove a wrong one, split/merge, or re-categorize) by"
+          " re-running enumeration over the already-loaded context; 'answer' to"
+          " respond to a question about the output without changing any files;"
+          " 'noop' when the request is unclear and needs clarification."
+      )
+  )
+  target_entry_ids: list[str] = Field(
+      default_factory=list,
+      description=(
+          "For 'rewrite': the entry ids to revise, chosen from the provided"
+          " entry list. Use an EMPTY list to mean ALL entries (e.g. 'add a"
+          " section to every table'). Ignored for 'answer'/'noop'/"
+          "'reenumerate'."
+      ),
+  )
+  instruction: str = Field(
+      default="",
+      description=(
+          "For 'rewrite': a clear, self-contained restatement of the change to"
+          " apply to each targeted entry (the per-entry writer sees only this"
+          " plus the entry's own context). Empty for 'answer'/'noop'/"
+          "'reenumerate'."
+      ),
+  )
+  remove_entry_ids: list[str] = Field(
+      default_factory=list,
+      description=(
+          "For 'reenumerate': entry ids the user wants DROPPED from the entry"
+          " set (resolve names from the provided entry list to their ids)."
+          " Empty for other operations."
+      ),
+  )
+  enumeration_guidance: str = Field(
+      default="",
+      description=(
+          "For 'reenumerate': a clear, self-contained instruction steering the"
+          " re-enumeration — e.g. 'add a topic about X covering ...', 'split Y"
+          " into A and B', 'these topics are too coarse, group them by Z'."
+          " Empty for other operations."
+      ),
+  )
+  answer: str = Field(
+      default="",
+      description=(
+          "For 'answer': the response to show the user. For 'noop': a short"
+          " clarifying question. Empty for 'rewrite'/'reenumerate'."
+      ),
+  )
+
+
+_REFINEMENT_DISPATCH_INSTRUCTION = """You are the dispatcher for an interactive knowledge-catalog enrichment agent. The initial enrichment has finished and produced a set of entries, each with an overview. The user now types a free-text message; you decide what to do.
+
+You will receive:
+  - The user's message.
+  - The list of current entries: each with its id, display name, category, and a short snippet of its current overview.
+
+Choose ONE operation:
+  - 'rewrite' — the user wants to change the CONTENT of one or more EXISTING overviews (make concise, add/remove a section, fix a fact, change tone, etc.). The set of entries stays the same. Resolve which entries they mean from their wording and the entry list:
+      * a specific entry ("the orders table", a name) -> that entry's id in target_entry_ids.
+      * all/every/each entry, or a global change -> EMPTY target_entry_ids (means ALL).
+      * several named entries -> list each id.
+    Put a clear, self-contained restatement of the requested change in `instruction` (the per-entry writer sees only `instruction` plus that entry's own grounding context, so do not rely on conversation history).
+  - 'reenumerate' — the user thinks the ENTRY SET itself is wrong: a topic/entry is MISSING and should be added, an entry is incorrect/spurious and should be REMOVED, two entries should be split or merged, or the CATEGORIZATION is off. This re-runs enumeration over the already-loaded source context (it can surface a missing topic only if the original sources mention it). Fill:
+      * `remove_entry_ids` — ids of entries the user wants dropped (resolve names from the entry list). Empty if none.
+      * `enumeration_guidance` — a clear, self-contained instruction describing the desired change to the entry set (e.g. "add a topic about X covering ...", "split Y into A and B", "merge P and Q", "regroup the entries by lifecycle stage"). Leave `target_entry_ids`/`instruction` empty.
+    Prefer 'reenumerate' over 'rewrite' whenever the request is about WHICH entries exist or how they are grouped, not the prose of a single existing overview.
+  - 'answer' — the user is asking a QUESTION about the output (e.g. "why is X in that category?", "what did you cover for Y?"). Answer it directly in `answer` using the entry list/snippets. Change nothing.
+  - 'noop' — the request is too vague to act on. Put a short clarifying question in `answer`.
+
+Output strict JSON conforming to the schema. No prose, no Markdown, no fenced blocks."""
+
+
+def create_refinement_dispatch_runner(model: str) -> InMemoryRunner:
+  """Maps a free-text refinement request to a structured RefinementPlan.
+
+  Schema-validated JSON output (same pattern as create_enumeration_runner).
+  """
+  agent = llm_agent.LlmAgent(
+      name="RefinementDispatchAgent",
+      description=(
+          "Classifies a free-text refinement request into a structured plan."
+      ),
+      model=VertexGemini(model=model),
+      instruction=_REFINEMENT_DISPATCH_INSTRUCTION,
+      output_schema=RefinementPlan,
+  )
+  return InMemoryRunner(agent=agent)
+
+
+# ============================ Linking Agent ============================
+
+
+class ColumnLink(BaseModel):
+  column_name: str = Field(description="Name of the BigQuery column.")
+  term_fqn: str = Field(
+      description=(
+          "Full Resource Name (FQN) of the matched Glossary Term"
+          " (projects/*/locations/*/glossaries/*/terms/*)."
+      )
+  )
+  reason: str = Field(description="Brief technical rationale for the mapping.")
+
+
+class TableLinkingResult(BaseModel):
+  links: list[ColumnLink] = Field(
+      description="List of discovered column-to-term links."
+  )
+
+
+_LINKING_INSTRUCTION = """You are a Metadata Governance Expert. Your mission is to map technical BigQuery columns to a canonical set of Business Glossary Terms.
+
+CONTEXT PROVIDED:
+1. ALLOWED GLOSSARY TERMS: A list of established terms with their IDs, Names, and Definitions.
+2. EXISTING GOVERNANCE: A list of current mappings (Column -> Term) to help you understand established patterns.
+3. TARGET TABLE SCHEMA: The schema of the table you are currently enriching.
+
+GOAL:
+For each column in the TARGET TABLE, determine if it matches the business definition of one (and only one) ALLOWED GLOSSARY TERM.
+
+RULES:
+- You MUST only use IDs from the ALLOWED GLOSSARY TERMS list.
+- Do NOT create new terms.
+- Only create a link if you are highly confident in the semantic match.
+- If a column does not match any existing term, skip it.
+- Focus on the 'definition' link type.
+
+OUTPUT:
+Strict JSON conforming to the TableLinkingResult schema."""
+
+
+def create_linking_runner(model: str) -> InMemoryRunner:
+  """Maps technical columns to glossary terms."""
+  agent = llm_agent.LlmAgent(
+      name="LinkingAgent",
+      description="Maps table columns to glossary terms.",
+      model=VertexGemini(model=model),
+      instruction=_LINKING_INSTRUCTION,
+      output_schema=TableLinkingResult,
+  )
+  return InMemoryRunner(agent=agent)

--- a/agents/enrichment/src/linking.py
+++ b/agents/enrichment/src/linking.py
@@ -1,0 +1,193 @@
+"""Shared LinkingAgent helper.
+
+Maps BigQuery columns to existing glossary terms and injects column-level
+`links.definition` into each `<table>.yaml`. Designed to be called from any
+mode (currently glossary_mode and table_mode) after the workspace has been
+set up via `kcmd_tools.init_pull_dataset(with_glossary_links=True)` plus a
+`kcmd_tools.pull_glossary_as_reference(...)` so that:
+
+  * Glossary terms have been pulled into `catalog/glossaries/.../*.ref.yaml`
+    (so `kcmd_tools.list_glossaries(output_dir)` returns the allowed terms).
+  * The catalog manifest declares `snapshot.entryLinks: [definition, ...]`
+    so existing remote links are present in `<table>.yaml`'s field-level
+    `links` (which we use as few-shot governance context).
+
+The function mutates `<table>.yaml` files in place — `kcmd push` afterwards
+publishes the new links to Dataplex.
+"""
+
+import os
+from typing import Optional
+
+import common
+import engine
+from tools import kcmd_tools
+import yaml
+
+
+def _safe_load_yaml(path: str) -> dict:
+  with open(path) as f:
+    return yaml.safe_load(f) or {}
+
+
+def _safe_dump_yaml(data: dict, path: str):
+  with open(path, "w") as f:
+    yaml.safe_dump(data, f, sort_keys=False)
+
+
+async def apply_column_linking(
+    output_dir: str,
+    bq_project: str,
+    bq_dataset: str,
+    model: str,
+    usage_acc: Optional[dict] = None,
+) -> int:
+  """Runs the LinkingAgent over every table in the dataset and injects the
+
+  discovered column→term mappings into each `<table>.yaml`.
+
+  Returns the total number of new links injected. `usage_acc` (a dict with
+  `input`/`output` keys) is mutated to track token usage when provided.
+  """
+  if usage_acc is None:
+    usage_acc = {"input": 0, "output": 0}
+
+  # A. Allowed terms (must be present in workspace, pulled via glossary
+  # reference). If empty, linking is impossible — bail loudly.
+  existing_entries = kcmd_tools.list_glossaries(output_dir)
+  if not existing_entries:
+    print(
+        "[Linking] ⚠️  No glossary entries found in workspace — skipping."
+        " (Did you pull glossary terms before calling apply_column_linking?)"
+    )
+    return 0
+
+  terms_context = "ALLOWED GLOSSARY TERMS:\n"
+  found_terms = False
+  for t in existing_entries:
+    if t["type"] == "glossaryTerm":
+      found_terms = True
+      ident = t["fqn"] or t["id"]
+      terms_context += (
+          f"- FQN: {ident}\n  Name: {t['display_name']}\n  Description:"
+          f" {t['description']}\n"
+      )
+  if not found_terms:
+    print("[Linking] ⚠️  No glossary terms found — skipping.")
+    return 0
+
+  # B. Existing governance (few-shot) + target tables.
+  table_names = kcmd_tools.list_tables(output_dir, bq_project, bq_dataset)
+  governance_context = "EXISTING GOVERNANCE (Few-shot samples):\n"
+  tables_to_map = []
+
+  for tname in table_names:
+    meta = kcmd_tools.read_table_meta(output_dir, bq_project, bq_dataset, tname)
+    tables_to_map.append(meta)
+
+    path = os.path.join(
+        kcmd_tools._dataset_dir(output_dir, bq_project, bq_dataset),  # pylint: disable=protected-access
+        f"{tname}.yaml",
+    )
+    if not os.path.exists(path):
+      continue
+    entry_data = _safe_load_yaml(path)
+
+    if "links" in entry_data and "definition" in entry_data["links"]:
+      for link in entry_data["links"]["definition"]:
+        governance_context += f"- Table: {tname} -> {link['target']}\n"
+
+    schema = entry_data.get("aspects", {}).get(
+        "dataplex-types.global.schema", {}
+    )
+    if not schema:
+      schema = entry_data.get("aspects", {}).get("schema", {})
+
+    for field in schema.get("fields", []):
+      if "links" in field and "definition" in field["links"]:
+        for link in field["links"]["definition"]:
+          governance_context += (
+              f"- Table: {tname}, Column: {field['name']} -> {link['target']}\n"
+          )
+
+  # C. Run LinkingAgent per table and inject results.
+  runner = engine.create_linking_runner(model)
+  total_injected = 0
+
+  for meta in tables_to_map:
+    print(f"[Linking] Mapping columns for table: {meta['table']}...")
+    target_schema = kcmd_tools.flatten_table_for_prompt(meta)
+    prompt = (
+        f"{terms_context}\n\n"
+        f"{governance_context}\n\n"
+        f"TARGET TABLE SCHEMA:\n{target_schema}\n\n"
+        "Analyze the schema and map columns to terms."
+    )
+    result = await common.run_structured(
+        runner, prompt, engine.TableLinkingResult, usage_acc
+    )
+    if not result or not result.links:
+      print(f"[Linking] No new links discovered for {meta['table']}.")
+      continue
+
+    print(
+        f"[Linking] Discovered {len(result.links)} link(s) for {meta['table']}."
+    )
+
+    path = os.path.join(
+        kcmd_tools._dataset_dir(output_dir, bq_project, bq_dataset),  # pylint: disable=protected-access
+        f"{meta['table']}.yaml",
+    )
+    entry_data = _safe_load_yaml(path)
+
+    schema_key = "dataplex-types.global.schema"
+    if schema_key not in entry_data.get("aspects", {}):
+      if "schema" in entry_data.get("aspects", {}):
+        schema_key = "schema"
+      else:
+        print(
+            f"[Linking] ⚠️  Schema aspect not found for {meta['table']} —"
+            " skipping injection."
+        )
+        continue
+
+    fields = entry_data["aspects"][schema_key].get("fields", [])
+    injected_this_table = 0
+
+    for link in result.links:
+      for field in fields:
+        if field["name"] != link.column_name:
+          continue
+        if "links" not in field:
+          field["links"] = {}
+        if "definition" not in field["links"]:
+          field["links"]["definition"] = []
+        if any(
+            l.get("id") == link.term_fqn or l.get("target") == link.term_fqn
+            for l in field["links"]["definition"]
+        ):
+          break  # already linked
+
+        # Human-readable target: project.location.glossary.term (UID-based;
+        # kcmd pull will normalize to display-name form on next pull).
+        target = link.term_fqn
+        if "/glossaries/" in link.term_fqn:
+          parts = link.term_fqn.split("/")
+          if len(parts) >= 8 and parts[len(parts) - 2] == "terms":
+            target = f"{parts[1]}.{parts[3]}.{parts[5]}.{parts[7]}"
+          elif len(parts) >= 6 and parts[len(parts) - 2] == "glossaries":
+            target = f"{parts[1]}.{parts[3]}.{parts[5]}"
+
+        field["links"]["definition"].append({
+            "target": target,
+            "id": link.term_fqn,
+        })
+        print(f"  [+] Linked {link.column_name} -> {target} ({link.reason})")
+        injected_this_table += 1
+        break
+
+    if injected_this_table:
+      _safe_dump_yaml(entry_data, path)
+      total_injected += injected_this_table
+
+  return total_injected

--- a/agents/enrichment/src/modes/context_overlay_mode.py
+++ b/agents/enrichment/src/modes/context_overlay_mode.py
@@ -1,0 +1,723 @@
+"""Context-overlay mode: table mode + `kcmd reference`, distinct output.
+
+Mostly identical to table_mode — discover the dataset's tables, fetch + route
+the
+Drive-folder docs per table, and write a doc-grounded overview per table. Two
+deltas only:
+
+  1. Sourcing. The 1P BigQuery table entries are pulled READ-ONLY via
+     `kcmd reference` instead of `kcmd init --bigquery-dataset` + `pull`. `kcmd
+     reference` writes them straight into the catalog tree as
+     `catalog/bigquery/<project>/<dataset>/<table>.ref.yaml` (+ a
+     `<table>.ref.overview.md` sidecar when the table has an overview). For each
+     table a NEW "context overlay" entry is created in the editable
+     `--entry-group` (1 overlay : 1 table); the 1P entry is never touched.
+
+  2. Output format, per table, under `catalog/bigquery/<project>/<dataset>/`:
+       <table>.yaml             -- overlay entry (pushable; overlay_id == table)
+       <table>.overview.md      -- enriched, doc-grounded overview
+       <table>.ref.yaml         -- read-only copy of the 1P table  (by kcmd)
+       <table>.ref.overview.md  -- the table's overview, if any     (by kcmd)
+
+This mode writes ONLY the overlay pair; the `.ref.*` mirror is produced by `kcmd
+reference`. Only the overlay entry + its overview are pushed (the `.ref.*` are
+read-only bigquery-table entries, filtered out of publishing; the webapp also
+stages only the selected overlay files).
+"""
+
+import asyncio
+import os
+import time
+
+import common
+from engine import (
+    OVERLAY_WRITER_INSTRUCTION,
+    create_doc_summarizer_runner,
+)
+from modes import table_mode
+import refine
+from tools import bq_usage_tools
+from tools import feedback_tools
+from tools import github_tools
+from tools import kcmd_tools
+from tools.drive_tools import extract_folder_id, extract_gdoc_id, fetch_doc_text
+from tools.drive_tools import get_cache_stats
+import yaml
+
+# Overlay entries are generic-typed in the editable entry group; the enriched
+# content lands in the `overview` aspect (same convention as doc mode).
+_OVERLAY_ENTRY_TYPE = "dataplex-types.global.generic"
+# Flash for the per-table writers (small inputs) — matches table mode.
+_WRITER_MODEL = "gemini-3.5-flash"
+CONCURRENCY_LIMIT = 12
+MAX_DOC_CHARS = 30000
+
+
+def _parse_eg(entry_group: str) -> tuple[str, str, str]:
+  parts = (entry_group or "").split(".")
+  if len(parts) != 3 or not all(parts):
+    raise ValueError(
+        "--entry_group must be `project.location.entryGroupId` (got"
+        f" '{entry_group}')."
+    )
+  return parts[0], parts[1], parts[2]
+
+
+async def _prepare_explicit_docs(
+    doc_urls: list[str], usage_acc: dict, model: str
+) -> list[dict]:
+  """Fetch + summarize individual Google Doc URLs into router descriptors.
+
+  Companion to `table_mode._prepare_docs` (which handles a Drive folder); used
+  so the context-overlay UI's combined "doc URLs OR folder URLs" field works
+  either way. Returns {id, name, url, content, descriptor} dicts (ids reassigned
+  by caller).
+  """
+  if not doc_urls:
+    return []
+  sem = asyncio.Semaphore(CONCURRENCY_LIMIT)
+
+  async def _prep(idx, url):
+    content = await asyncio.to_thread(
+        fetch_doc_text, extract_gdoc_id(url) or url, ""
+    )
+    async with sem:
+      prompt = (
+          f"DOCUMENT TITLE: {url}\nSOURCE URL: {url}\n\nDOCUMENT"
+          f" CONTENT:\n{content[:50000]}"
+      )
+      descriptor = await common.run_text(
+          create_doc_summarizer_runner(model), prompt, usage_acc
+      )
+    return {
+        "id": idx,
+        "name": url,
+        "url": url,
+        "content": content,
+        "descriptor": descriptor.strip(),
+    }
+
+  return list(
+      await asyncio.gather(*[_prep(i, u) for i, u in enumerate(doc_urls)])
+  )
+
+
+async def _prepare_all_docs(
+    topic: str,
+    folder: str | None,
+    doc_urls: list[str] | None,
+    usage_acc: dict,
+    model: str,
+    repo: str = "",
+    repo_ref: str = "",
+    repo_subdir: str = "",
+    mcp_config: str = "",
+) -> list[dict]:
+  """Build the router-descriptor doc list from a folder, explicit URLs, and/or a
+
+  GitHub repo.
+
+  The router indexes docs by their `id` == list position, so ids are reassigned
+  sequentially after merging the sources. Code component cards (when --repo is
+  set) join the pool in the same shape and are routed to tables like any other
+  candidate document.
+  """
+  docs = []
+  if folder:
+    docs.extend(await table_mode._prepare_docs(topic, folder, usage_acc, model))
+  if doc_urls:
+    docs.extend(await _prepare_explicit_docs(doc_urls, usage_acc, model))
+  if repo:
+    docs.extend(
+        await github_tools.gather_repo_context(
+            repo,
+            repo_ref,
+            repo_subdir,
+            topic,
+            model,
+            usage_acc,
+            mcp_config_path=mcp_config or None,
+        )
+    )
+  for i, d in enumerate(docs):
+    d["id"] = i
+  return docs
+
+
+def _write_overlay_files(
+    output_dir: str,
+    eg_project: str,
+    eg_location: str,
+    eg_id: str,
+    ref_project: str,
+    ref_dataset: str,
+    overlay_id: str,
+    table: str,
+    meta: dict,
+    category_id: str,
+    overlay_overview: str,
+) -> list[str]:
+  """Write the overlay entry alongside its `kcmd reference` source table.
+
+  Returns rel paths. Writes ONLY the pushable overlay pair, into the same source
+  subfolder `kcmd reference` already populated with the read-only 1P mirror:
+    <table>.yaml         -- overlay entry (pushable)
+    <table>.overview.md  -- enriched, doc-grounded overview
+
+  The read-only `<table>.ref.yaml` / `<table>.ref.overview.md` mirror is
+  produced
+  by `kcmd reference` itself (no longer written here).
+  """
+  rel_dir = os.path.join("catalog", "bigquery", ref_project, ref_dataset)
+  catalog_dir = os.path.join(output_dir, rel_dir)
+  os.makedirs(catalog_dir, exist_ok=True)
+  written = []
+
+  # --- Overlay entry (pushable) ---
+  # kcmd's EntryGroupSource keys the local entry name as
+  # `<eg_id>/<eg_project>/<eg_location>/<entryId>` and derives the pushed entry id
+  # from `name.split('/').slice(3)` (entrygroup.ts serviceName). The `name:` must
+  # use that nested form or the created entry id comes out empty (`.../entries/`).
+  local_name = f"{eg_id}/{eg_project}/{eg_location}/{overlay_id}"
+  overlay_entry = {
+      "name": local_name,
+      "id": overlay_id,
+      "type": _OVERLAY_ENTRY_TYPE,
+      "category": category_id,
+      "resource": {
+          "displayName": meta.get("display_name") or table,
+          "description": (
+              meta.get("description") or f"Context overlay for {table}."
+          ),
+      },
+      "aspects": {
+          "dataplex-types.global.generic": {
+              "type": "context-overlay",
+              "system": "enrichment-agent",
+          },
+      },
+  }
+
+  overlay_yaml = os.path.join(catalog_dir, f"{overlay_id}.yaml")
+  with open(overlay_yaml, "w") as f:
+    yaml.safe_dump(overlay_entry, f, sort_keys=False, allow_unicode=True)
+  written.append(os.path.join(rel_dir, f"{overlay_id}.yaml"))
+
+  overlay_md = os.path.join(catalog_dir, f"{overlay_id}.overview.md")
+  with open(overlay_md, "w") as f:
+    f.write(common.clean_overview_body(overlay_overview) + "\n")
+  written.append(os.path.join(rel_dir, f"{overlay_id}.overview.md"))
+
+  return written
+
+
+async def run(
+    dataset: str,
+    folder: str | None,
+    topic: str,
+    output_dir: str | None,
+    model: str,
+    entry_group: str,
+    docs: list[str] | None = None,
+    tables_filter: list[str] | None = None,
+    include_usage: bool = True,
+    usage_window_days: int = 30,
+    anonymize_users: bool = False,
+    usage_scope: str = "auto",
+    feedback_dir: str | None = None,
+    feedback_files: list[str] | None = None,
+    repo: str = "",
+    repo_ref: str = "",
+    repo_subdir: str = "",
+    mcp_config: str = "",
+):
+  _t0 = time.monotonic()
+  project, dataset_id = table_mode._parse_dataset(dataset)
+  eg_project, eg_location, eg_id = _parse_eg(entry_group)
+  folder = extract_folder_id(folder) if folder else folder
+  # Same up-front feedback load as table_mode — proposals route per-table
+  # to the overlay's own _write_one below.
+  all_feedback = feedback_tools.load_feedback(feedback_dir, feedback_files)
+
+  print("=" * 60)
+  print("=== CONTEXT-OVERLAY AGENT: tables + documents ===")
+  print(f"Topic: {topic}")
+  print(
+      f"Dataset: {project}.{dataset_id}  |  Folder: {folder or '(none)'}  | "
+      f" Entry group: {entry_group}"
+  )
+  if all_feedback:
+    print(
+        f"[Feedback] 📝 Loaded {len(all_feedback)} user-feedback"
+        " proposal(s) — these will OVERRIDE conflicting context per overlay.",
+        flush=True,
+    )
+  print("=" * 60)
+
+  if not output_dir:
+    print(
+        "[kcmd] ❌ output_dir is required (kcmd writes the snapshot there).",
+        flush=True,
+    )
+    return
+  usage_acc = {"input": 0, "output": 0}
+
+  # 1. Pull the read-only 1P table entries via `kcmd reference`
+  #    (-> catalog/bigquery/<proj>/<dataset>/<table>.ref.yaml).
+  print(
+      f"[kcmd] 🔎 Referencing {project}.{dataset_id} via kcmd reference ...",
+      flush=True,
+  )
+  ok, msg = await asyncio.to_thread(
+      kcmd_tools.init_reference,
+      output_dir,
+      entry_group,
+      project,
+      dataset_id,
+      _OVERLAY_ENTRY_TYPE,
+  )
+  print(f"[kcmd] {'OK' if ok else '⚠️  FAILED'}: {msg}", flush=True)
+
+  table_names = kcmd_tools.list_reference_tables(
+      output_dir, project, dataset_id
+  )
+  # Optional filter: enrich only the requested tables (accepts short names or
+  # full `project.dataset.table` FQNs). Empty/None = all tables in the dataset.
+  if tables_filter:
+    wanted = {t.strip().split(".")[-1] for t in tables_filter if t.strip()}
+    filtered = [t for t in table_names if t in wanted]
+    if filtered:
+      table_names = filtered
+    else:
+      print(
+          f"[kcmd] ⚠️  None of --tables {sorted(wanted)} matched pulled tables"
+          f" {table_names}; enriching all.",
+          flush=True,
+      )
+  tables = [
+      kcmd_tools.read_reference_table_meta(output_dir, project, dataset_id, t)
+      for t in table_names
+  ]
+  for meta in tables:
+    print(
+        f"[kcmd] 📑 {meta['table']} ({len(meta['schema_fields'])} cols)",
+        flush=True,
+    )
+  if not tables:
+    print(
+        "[kcmd] ❌ No reference table entries pulled — nothing to enrich. "
+        "Check the dataset id and that you can read its @bigquery entries.",
+        flush=True,
+    )
+    return
+
+  # 2. In parallel: fetch + summarize the context docs AND pull BQ
+  #    query-history usage signals from INFORMATION_SCHEMA per table. Usage
+  #    feeds the overlay's `queries` aspect (Option B: the queries aspect
+  #    lands on the overlay entry, not on the live 1P table) — see
+  #    _OVERLAY_MANIFEST in kcmd_tools.py which now declares
+  #    dataplex-types.global.queries in publishing.aspects so the push picks
+  #    up the <overlay_id>.queries.md sidecar.
+  async def _fetch_usage_or_empty():
+    if not include_usage:
+      print("[BQ Usage] ⏭️  Skipped (--include_usage=false).", flush=True)
+      return {}
+    table_ids = [m["table"] for m in tables]
+    print(
+        f"[BQ Usage] 📊 Fetching query history (window={usage_window_days}d,"
+        f" scope={usage_scope}) for {len(table_ids)} table(s)...",
+        flush=True,
+    )
+    by_table = await asyncio.to_thread(
+        bq_usage_tools.fetch_dataset_usage,
+        project,
+        dataset_id,
+        table_ids,
+        window_days=usage_window_days,
+        anonymize_users=anonymize_users,
+        scope=usage_scope,
+    )
+    hits = sum(1 for u in by_table.values() if u.total_queries > 0)
+    print(
+        f"[BQ Usage] ✅ {hits}/{len(table_ids)} table(s) have usage signal"
+        " in the window.",
+        flush=True,
+    )
+    return by_table
+
+  doc_descriptors, usage_by_table = await asyncio.gather(
+      _prepare_all_docs(
+          topic,
+          folder,
+          docs,
+          usage_acc,
+          model,
+          repo=repo,
+          repo_ref=repo_ref,
+          repo_subdir=repo_subdir,
+          mcp_config=mcp_config,
+      ),
+      _fetch_usage_or_empty(),
+  )
+  if not doc_descriptors:
+    print(
+        "[Folder] ⚠️  No document context — overlays will be documented from"
+        " the base entry / schema only.",
+        flush=True,
+    )
+
+  # 3. Per-table routing — pick relevant folder docs for each table.
+  print(
+      f"\n[Agent] 🧮 Routing folder docs to {len(tables)} table(s)...",
+      flush=True,
+  )
+  sem = asyncio.Semaphore(CONCURRENCY_LIMIT)
+
+  async def _route_one(meta):
+    async with sem:
+      selected = await table_mode._route_docs_for_table(
+          meta, doc_descriptors, usage_acc, model
+      )
+      label = (
+          ", ".join(
+              f"{doc_descriptors[i]['name']} ({s:.2f})" for (i, s) in selected
+          )
+          or "(none — schema-only)"
+      )
+      print(f"[Router] {meta['table']} ← {label}", flush=True)
+      return meta["table"], selected
+
+  routing = dict(await asyncio.gather(*[_route_one(m) for m in tables]))
+
+  # 4. ENUMERATE — shared EnumerationAgent derives each overlay's canonical id +
+  # category (tables seeded 1:1 so every table yields exactly one overlay).
+  print(
+      f"[Agent] 🧭 Categorizing {len(tables)} table(s) into overlays...",
+      flush=True,
+  )
+  enum_context_lines = [f"DATASET: {project}.{dataset_id}", ""]
+  for meta in tables:
+    sel = routing.get(meta["table"], [])
+    sel_descs = [doc_descriptors[i]["descriptor"][:400] for (i, _s) in sel[:5]]
+    enum_context_lines.append(
+        f"- {meta['table']}: {meta.get('description', '')[:200]}"
+    )
+    enum_context_lines.append(
+        f"  schema_fields ({len(meta['schema_fields'])}): "
+        f"{', '.join(f['name'] for f in meta['schema_fields'][:10])}"
+    )
+    if sel_descs:
+      enum_context_lines.append(
+          "  routed_docs:"
+          f" {' | '.join(s.splitlines()[0][:120] for s in sel_descs)}"
+      )
+  enum_context = "\n".join(enum_context_lines)
+  seed_entries = [
+      {
+          "id": m["table"],
+          "display_name": m.get("display_name") or m["table"],
+          "kind": "table",
+      }
+      for m in tables
+  ]
+  enumeration = await common.run_enumeration(
+      topic,
+      enum_context,
+      seed_entries=seed_entries,
+      model=model,
+      usage_acc=usage_acc,
+  )
+  cat_by_entry_id = {e.id: c for c in enumeration.categories for e in c.entries}
+  print(
+      f"[Agent] ✅ {len(enumeration.categories)} categories: "
+      f"{[(c.id, len(c.entries)) for c in enumeration.categories]}",
+      flush=True,
+  )
+
+  # 5. WRITE — overlay overview (fused) + read-only reference copy, per table.
+  print(
+      "[Agent] 🏗️  Writing overlays via direct Flash (concurrency"
+      f" {CONCURRENCY_LIMIT})...",
+      flush=True,
+  )
+  sem2 = asyncio.Semaphore(CONCURRENCY_LIMIT)
+
+  async def _write_one(meta):
+    async with sem2:
+      table = meta["table"]
+      sel = routing.get(table, [])
+      sel_docs = [doc_descriptors[i] for (i, _s) in sel]
+      cat = cat_by_entry_id.get(table)
+      cat_id = cat.id if cat else "uncategorized"
+      # overlay id == enumerated entry id (table seeded 1:1).
+      overlay_id = table
+      table_block = kcmd_tools.flatten_table_for_prompt(meta)
+
+      if sel_docs:
+        context = "\n\n".join(
+            f"--- DOCUMENT: {d['name']} ({d['url']})"
+            f" ---\n{d['content'][:MAX_DOC_CHARS]}"
+            for d in sel_docs
+        )
+      else:
+        context = (
+            "(none — document this table from its base entry / schema only)"
+        )
+
+      # Same SQL-suppression directive as table_mode: SQL examples belong in
+      # the queries aspect (written separately by the queries sidecar below),
+      # NOT inlined in the overlay overview body.
+      overlay_directive = (
+          "\n\nIMPORTANT — CONTEXT-OVERLAY MODE: Do NOT include any SQL"
+          " query examples in the overview body (no ```sql blocks, no inline"
+          " queries). SQL examples are captured separately in this overlay"
+          " entry's `queries` aspect by another pipeline step. The overview"
+          " should describe WHAT the table is and HOW it's used in narrative"
+          " prose, while leaving the runnable SQL to the queries aspect."
+      )
+      # Per-overlay feedback routing. Overlay entries are 1:1 with their
+      # source BQ table, so the routing key is the underlying table's FQN
+      # (not the overlay entry id which lives in a different EG).
+      table_fqn = f"{project}.{dataset_id}.{table}"
+      table_feedback = feedback_tools.route_proposals_to_table(
+          all_feedback, table_fqn
+      )
+      if table_feedback:
+        print(
+            f"[Feedback] 📝 {table_fqn}: {len(table_feedback)} proposal(s)"
+            " applied to overlay — OVERRIDE conflicting context.",
+            flush=True,
+        )
+      feedback_block = feedback_tools.proposals_to_prompt_block(table_feedback)
+      overlay_prompt = (
+          f"TOPIC: {topic}\n\nOVERLAY ID: {overlay_id}\n\n"
+          "=== AUTHORITATIVE BASE ENTRY (1P, read-only) ===\n"
+          f"{table_block}\n\n"
+          "=== RELEVANT CONTEXT DOCUMENTS (routed for this table only) ===\n"
+          f"{context}\n\n"
+          "Write the fused context-overlay overview Markdown body now."
+          + overlay_directive
+          + feedback_block
+      )
+      overlay_overview = await common.generate_text_direct(
+          OVERLAY_WRITER_INSTRUCTION, overlay_prompt, _WRITER_MODEL, usage_acc
+      )
+
+      # The read-only `<table>.ref.*` mirror is written by `kcmd reference`
+      # itself (into the same source subfolder); we only add the overlay pair.
+      written = _write_overlay_files(
+          output_dir,
+          eg_project,
+          eg_location,
+          eg_id,
+          project,
+          dataset_id,
+          overlay_id,
+          table,
+          meta,
+          cat_id,
+          overlay_overview,
+      )
+
+      # Merge INFORMATION_SCHEMA-derived patterns with SQL examples extracted
+      # from routed docs into a `<overlay_id>.queries.md` sidecar that lands
+      # next to the overlay yaml. Reuses table_mode's extract + writer helpers
+      # because the overlay sidecar path == bq dataset_dir (overlay_id == table
+      # name; standard.ts matches the `.queries` suffix back to the
+      # `dataplex-types.global.queries` key declared in _OVERLAY_MANIFEST).
+      # Option B routing: the queries aspect attaches to the OVERLAY entry in
+      # the editable EG, not to the 1P @bigquery entry — pushing this CL's
+      # output never modifies the live table.
+      usage = usage_by_table.get(table) if usage_by_table else None
+      feedback_queries = feedback_tools.proposals_to_queries(table_feedback)
+      # Same gate as table_mode: run the extractor whenever ANY signal is
+      # available — a non-None TableUsage (even with 0 patterns from a 403
+      # fallback to JOBS_BY_USER) or feedback. Gating on
+      # `usage.total_queries > 0` would silently drop doc-extracted SQL on
+      # tables in projects where the caller lacks `bigquery.jobs.listAll`,
+      # which was the bug that motivated the table_mode fix.
+      if (usage or feedback_queries) and output_dir:
+        # Floor usage so the writer doesn't crash when only feedback or
+        # only docs supplied SQL (INFORMATION_SCHEMA returned nothing).
+        if usage is None:
+          usage = bq_usage_tools.TableUsage(window_days=usage_window_days)
+        doc_queries = await table_mode.extract_doc_queries(
+            meta, sel_docs, project, dataset_id, model, usage_acc
+        )
+        queries_path = table_mode.write_queries_sidecar(
+            output_dir,
+            project,
+            dataset_id,
+            meta,
+            usage,
+            doc_queries,
+            feedback_queries=feedback_queries,
+        )
+        if queries_path:
+          written.append(queries_path)
+        if doc_queries or feedback_queries:
+          print(
+              f"[DocQueries] {table}: {len(doc_queries)} doc-extracted"
+              f" + {len(feedback_queries)} user-feedback SQL example(s)",
+              flush=True,
+          )
+      print(
+          f"[Agent] ✅ {cat_id}/{overlay_id}: wrote {', '.join(written)}",
+          flush=True,
+      )
+      # Per-entry state for multi-turn refinement. A refinement overwrites only
+      # the overlay overview sidecar (the overlay YAML is unchanged); docs aren't
+      # re-read.
+      entry_state = refine.EntryState(
+          entry_id=overlay_id,
+          display_name=meta.get("display_name") or table,
+          description=meta.get("description", "") or "",
+          category_id=cat_id,
+          grounding_prompt=overlay_prompt,
+          writer_model=_WRITER_MODEL,
+          overview_body=overlay_overview,
+          overview_path=os.path.join(
+              output_dir,
+              "catalog",
+              "bigquery",
+              project,
+              dataset_id,
+              f"{overlay_id}.overview.md",
+          ),
+          kind="table",
+      )
+      return meta, sel_docs, overlay_overview, entry_state
+
+  results = await asyncio.gather(*[_write_one(m) for m in tables])
+
+  # 6. Persist trajectory (mirrors table mode): tables, routed docs, enumeration.
+  tool_uses = [
+      {"name": "reference_table", "args": {"table": m["table"]}} for m in tables
+  ]
+  tool_responses = [
+      {
+          "name": "reference_table",
+          "response": {
+              "table": m["table"],
+              "schema_fields": m["schema_fields"],
+          },
+      }
+      for m in tables
+  ]
+  for meta, sel_docs, _text, _es in results:
+    tool_uses.append({"name": "route_docs", "args": {"table": meta["table"]}})
+    tool_responses.append({
+        "name": "route_docs",
+        "response": {
+            "table": meta["table"],
+            "relevant_docs": [
+                {
+                    "name": d["name"],
+                    "url": d["url"],
+                    "content": d["content"][:50000],
+                }
+                for d in sel_docs
+            ],
+        },
+    })
+  tool_uses.append({"name": "enumerate", "args": {"topic": topic}})
+  tool_responses.append(
+      {"name": "enumerate", "response": enumeration.model_dump()}
+  )
+  final_text = "\n\n".join(t for (_m, _d, t, _es) in results)
+  traj_user_input = (
+      f"TOPIC: {topic} | DATASET: {project}.{dataset_id} | EG: {entry_group}"
+  )
+  common.write_trajectory(
+      output_dir,
+      "context_overlay",
+      traj_user_input,
+      tool_uses,
+      tool_responses,
+      final_text,
+      usage_acc,
+      latency=time.monotonic() - _t0,
+  )
+  print(f"[Cache] doc-fetch stats: {get_cache_stats()}", flush=True)
+
+  # Build the refinement session (consumed by agent_runner --interactive).
+  return refine.EnrichmentSession(
+      mode="context_overlay",
+      topic=topic,
+      model=model,
+      output_dir=output_dir,
+      entries={es.entry_id: es for (_m, _d, _t, es) in results},
+      usage_acc=usage_acc,
+      # Phase-2 state for a `reenumerate` refinement. Overlay entries are pinned
+      # 1:1 to the dataset's tables, so re-enumeration only re-categorizes — see
+      # apply_reenumeration below.
+      enum_context=enum_context,
+      writer_params={
+          "project": project,
+          "dataset_id": dataset_id,
+          "eg_project": eg_project,
+          "eg_location": eg_location,
+          "eg_id": eg_id,
+      },
+      traj_meta={
+          "agent_type": "context_overlay",
+          "user_input": traj_user_input,
+          "tool_uses": tool_uses,
+          "tool_responses": tool_responses,
+      },
+  )
+
+
+def _set_overlay_category(
+    output_dir: str, project: str, dataset_id: str, overlay_id: str, cat_id: str
+) -> None:
+  """Rewrite the `category:` field on an overlay entry YAML (best-effort)."""
+  path = os.path.join(
+      output_dir,
+      "catalog",
+      "bigquery",
+      project,
+      dataset_id,
+      f"{overlay_id}.yaml",
+  )
+  if not os.path.exists(path):
+    return
+  try:
+    with open(path) as f:
+      data = yaml.safe_load(f) or {}
+    data["category"] = cat_id
+    with open(path, "w") as f:
+      yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
+  except (OSError, yaml.YAMLError):
+    pass
+
+
+async def apply_reenumeration(session, new_enum, removed_ids) -> None:
+  """Materialize a context-overlay re-enumeration delta — re-categorization ONLY.
+
+  Like table mode, overlay entries are pinned 1:1 to the dataset's tables, so a
+  re-enumeration can neither add nor remove an overlay. We apply only category
+  changes by rewriting the `category:` field on the overlay entry YAML (files
+  stay under `catalog/bigquery/{proj}/{dataset}/`). Mutates session.entries.
+  """
+  wp = session.writer_params or {}
+  project = wp.get("project", "")
+  dataset_id = wp.get("dataset_id", "")
+  output_dir = session.output_dir
+  new_cat_by_id = {
+      e.id: cat for cat in new_enum.categories for e in cat.entries
+  }
+  if removed_ids:
+    print(
+        "[refine] ℹ️  context_overlay mode: overlays are pinned to the dataset"
+        f" — cannot remove {sorted(set(removed_ids))}; applying category"
+        " changes only.",
+        flush=True,
+    )
+  for eid, es in session.entries.items():
+    cat = new_cat_by_id.get(eid)
+    if cat is None or cat.id == es.category_id:
+      continue
+    _set_overlay_category(output_dir, project, dataset_id, eid, cat.id)
+    es.category_id = cat.id
+    print(f"[refine] 🔀 recategorized {eid} -> {cat.id}", flush=True)

--- a/agents/enrichment/src/modes/doc_mode.py
+++ b/agents/enrichment/src/modes/doc_mode.py
@@ -1,0 +1,1005 @@
+"""Doc mode: recursive depth-crawl of Google Docs → map-reduce summarize →
+
+LLM-emitted knowledge-base mdcode. Ported from the former doc_agent_runner.
+"""
+
+import asyncio
+import glob
+import os
+import re
+import time
+import uuid
+
+import common
+from engine import (
+    ENTRY_WRITER_INSTRUCTION,  # legacy ADK path, kept for compat
+    EnumerationResult,
+    PER_DOC_SUMMARIZER_INSTRUCTION,
+    PER_DOC_SUMMARIZER_MODEL,
+    TOPIC_REDUCER_INSTRUCTION,
+    create_entry_writer_runner,  # legacy fallback, no longer wired in
+    create_enumeration_runner,
+    create_mdcode_runner,
+    create_summarizer_runner,  # v2.5 #4: passed to common.generate_text_direct
+)
+from google.genai import types
+import refine
+from tools import feedback_tools
+from tools import github_tools
+from tools import kcmd_tools
+from tools.drive_tools import (
+    extract_folder_id,
+    extract_gdoc_id,
+    fetch_doc_text,
+    get_cache_mode,
+    list_folder_files,
+    read_summary_cache,
+    write_summary_cache,
+)
+import yaml
+
+MAX_BATCH_SIZE = 10  # Reverted from v2.6's 3 (back to v2.5). v2.6 tried Flash via direct API to allow bigger throughput but Vertex routes Flash to a 32K-capped backend variant regardless of API path for this project, forcing batch=3, which then over-saturated Flash quota on back-to-back runs and bloated the EnumerationAgent's input.
+MAX_DEPTH = 2  # Was 3 — depth-3 mostly surfaced tangential links; dropping it cuts crawl + summarize ~30% (v2.5 optimization #1).
+CONCURRENCY_LIMIT = 6  # Reverted from v2.6's 12 (back to v2.5). Summarizer is on Pro again; 12 trips Vertex 429s on big-input Pro calls.
+# Stage 1 (per-doc summary) runs on PER_DOC_SUMMARIZER_MODEL (Flash) — small
+# per-call payloads, well within Flash routing limits, tolerates 20-way
+# concurrency without 429s. Stage 1 is the cold-run hot path; cache hits
+# bypass it entirely so warm-cache runs ignore this limit.
+PER_DOC_CONCURRENCY = 20
+
+# The 1P "generic" entry type that all knowledge-base entries are created as
+# (cloud/dataplex/catalog/types/entry-types/generic.textproto -> the global
+# Dataplex type). The enriched content lands as the `overview` aspect on these
+# entries. This is fixed -- there is no per-run entry-type choice.
+_GENERIC_ENTRY_TYPE = "dataplex-types.global.generic"
+
+
+def _slugify(name: str) -> str:
+  """kebab-case id from a component name (e.g.
+
+  'Metadata as Code CLI (kcmd)' -> 'metadata-as-code-cli-kcmd'). Used to give
+  code components stable seed ids.
+  """
+  slug = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+  return slug or "code-component"
+
+
+async def _fetch_url(
+    url: str, depth: int, mime_type: str = "", modified_time: str | None = None
+):
+  print(f"[Crawler] 📥 Fetching (Depth {depth}): {url}", flush=True)
+  content = await asyncio.to_thread(
+      fetch_doc_text, url, mime_type, modified_time=modified_time
+  )
+  return url, depth, content
+
+
+async def _summarize_one_doc(
+    url: str,
+    raw_content: str,
+    modified_time: str | None,
+    sem: asyncio.Semaphore,
+    model: str,
+    usage_acc: dict | None,
+) -> str:
+  """Stage-1 Map (cache-aware): produce a topic-NEUTRAL per-doc summary card.
+
+  On summary-cache HIT (key = `(doc_id, modified_time)`), skip the LLM call
+  entirely and return the cached card. On MISS, summarize the raw text via
+  the direct-API path (faster than ADK runner) and persist the card.
+
+  The cache layer (drive_tools.read_summary_cache / write_summary_cache) is
+  a no-op unless `KC_ENRICH_CACHE_MODE=summary` — in `raw` or `off` mode
+  every call falls through to the LLM.
+  """
+  doc_id = extract_gdoc_id(url)
+  cached = read_summary_cache(doc_id, modified_time)
+  if cached is not None:
+    return cached
+  prompt = f"DOCUMENT URL: {url}\n\nDOCUMENT CONTENT:\n{raw_content[:60000]}"
+  async with sem:
+    summary = await common.generate_text_direct(
+        PER_DOC_SUMMARIZER_INSTRUCTION,
+        prompt,
+        model=model,
+        usage_acc=usage_acc,
+    )
+  write_summary_cache(doc_id, summary, modified_time)
+  return summary
+
+
+async def _reduce_summaries_with_topic(
+    topic: str,
+    master_scope_text: str,
+    batch_summaries: list[tuple[str, int, str]],
+    sem: asyncio.Semaphore,
+    model: str,
+    usage_acc: dict | None,
+) -> str:
+  """Stage-2 Reduce (uncached): collapse a batch of neutral per-doc cards
+
+  through the user's TOPIC lens.
+
+  Input is much smaller than the legacy batch summarizer (cards are ~5×
+  smaller than raw doc text), so each batch call is fast and cheap.
+  Output is concatenated by the caller into `compiled_summary` and fed to
+  the enumerator — identical wire shape to the legacy pipeline.
+  """
+  cards_text = "\n\n".join(
+      f"--- DOC CARD (Depth {depth}): {url} ---\n{card}"
+      for (url, depth, card) in batch_summaries
+  )
+  prompt = (
+      f"TOPIC: {topic}\n\nMASTER SCOPE:\n{master_scope_text}\n\nBATCH"
+      f" CARDS:\n{cards_text}"
+  )
+  async with sem:
+    return await common.generate_text_direct(
+        TOPIC_REDUCER_INSTRUCTION,
+        prompt,
+        model=model,
+        usage_acc=usage_acc,
+    )
+
+
+async def _summarize_batch(
+    topic: str,
+    master_scope_text: str,
+    batch_docs: list,
+    sem: asyncio.Semaphore,
+    model: str,
+    usage_acc: dict | None = None,
+) -> str:
+  """Batch summarizer (Pro via ADK runner — v2.5 state, after v2.6 was reverted).
+
+  History (for future readers): v2.6 attempted to swap this to Flash via
+  common.generate_text_direct to bypass the LlmAgent path's 32K Flash routing
+  cap. That cap held even for direct generate_content calls when the request
+  shape included SUMMARIZER_INSTRUCTION as system_instruction (Vertex
+  routed Flash to a 32K-capped backend variant regardless of API). The
+  workaround (MAX_BATCH_SIZE=3) tripled batch count, bloated the
+  EnumerationAgent's input ~3×, and saturated Flash quota on back-to-back
+  runs. Net: 12% latency win vs much worse reliability. Reverted.
+  """
+  async with sem:
+    runner = create_summarizer_runner(model)
+    user_id = str(uuid.uuid4())
+    session = await runner.session_service.create_session(
+        app_name=runner.app_name, user_id=user_id
+    )
+
+    docs_text = ""
+    for url, depth, content in batch_docs:
+      docs_text += (
+          f"\n\n--- DOCUMENT (Depth {depth}): {url} ---\n{content[:50000]}\n"
+      )
+
+    prompt = (
+        f"TOPIC: {topic}\n\nMASTER SCOPE:\n{master_scope_text}\n\nRAW BATCH"
+        f" DOCUMENTS:\n{docs_text}"
+    )
+
+    new_summary = ""
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=types.Content(
+            role="user", parts=[types.Part.from_text(text=prompt)]
+        ),
+    ):
+      usage = getattr(event, "usage_metadata", None)
+      if usage and usage_acc is not None:
+        usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+        usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+      if event.content and event.content.parts:
+        for part in event.content.parts:
+          if part.text:
+            new_summary += part.text
+    print(f"[Agent] ✅ Batch of {len(batch_docs)} documents summarized.")
+    return new_summary
+
+
+def _build_synthetic_scope(topic: str, folder_files: list[dict]) -> str:
+  """Synthesize a Master Scope when seeding purely from a Drive folder.
+
+  A folder has no single authoritative document, so flattening every file into
+  depth 0 leaves the summarizer without a coherent scope to map findings onto.
+  Instead we fabricate a scope doc that names the topic as the overarching
+  project and enumerates the folder's files as its constituent sources.
+  """
+  lines = [
+      f"# Master Scope (synthetic): {topic}",
+      "",
+      (
+          f'Treat "{topic}" as the single overarching project for this'
+          " knowledge base. The following source documents were collected from"
+          " a Google Drive folder. Group all extracted findings into coherent"
+          " sub-topics under this project; do not treat each source file as"
+          " its own top-level project."
+      ),
+      "",
+      "## Source documents",
+  ]
+  for f in folder_files:
+    lines.append(f"- {f.get('name', 'Untitled')} ({f.get('mimeType', '')})")
+  return "\n".join(lines)
+
+
+def _normalize_entries(output_dir: str) -> list[str]:
+  """Normalize every generated KB entry YAML so `kcmd push` accepts it:
+
+  * Ensure a top-level `name:` — the entry-group STANDARD layout indexes
+    entries by `name` (standard.ts), but the LLM emits `id:`; without a
+    `name` the layout indexes zero entries and `kcmd push` silently no-ops.
+  * Ensure the required `generic` aspect — the generic entry type declares
+    `required_aspects { aspectTypes/generic }`, so an entry missing it is
+    rejected on push. We add `dataplex-types.global.generic` with the
+    template's freeform `type`/`system` fields. The enriched prose stays in
+    the separate `overview` aspect (the `<id>.overview.md` sidecar).
+  """
+  catalog_dir = os.path.join(output_dir, "catalog")
+  if not os.path.isdir(catalog_dir):
+    return []
+  fixed = []
+  for yaml_path in sorted(glob.glob(os.path.join(catalog_dir, "*.yaml"))):
+    if os.path.basename(yaml_path) == "catalog.yaml":
+      continue
+    try:
+      with open(yaml_path) as f:
+        entry = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+      continue
+    changed = False
+    if not entry.get("name"):
+      name = entry.get("id") or os.path.basename(yaml_path)[: -len(".yaml")]
+      entry = {"name": name, **entry}  # name first; keep other fields
+      changed = True
+    aspects = entry.get("aspects") or {}
+    if not any(
+        isinstance(k, str) and k.split(".")[-1] == "generic" for k in aspects
+    ):
+      aspects["dataplex-types.global.generic"] = {
+          "type": "knowledge-base",
+          "system": "enrichment-agent",
+      }
+      entry["aspects"] = aspects
+      changed = True
+    if changed:
+      with open(yaml_path, "w") as f:
+        yaml.safe_dump(entry, f, sort_keys=False, allow_unicode=True)
+      fixed.append(os.path.join("catalog", os.path.basename(yaml_path)))
+  return fixed
+
+
+async def run(
+    topic: str,
+    docs: list[str],
+    folder: str | None,
+    output_dir: str | None,
+    model: str,
+    entry_group: str,
+    feedback_dir: str | None = None,
+    feedback_files: list[str] | None = None,
+    repo: str = "",
+    repo_ref: str = "",
+    repo_subdir: str = "",
+    mcp_config: str = "",
+):
+  _t0 = time.monotonic()
+  # Doc mode generates per-KB-entry overviews. Feedback proposals target
+  # tables/columns rather than KB entries, so there's no clean per-entry
+  # routing — instead the loaded proposals are prepended globally to
+  # every entry's writer prompt with the OVERRIDE directive. The writer
+  # incorporates whichever proposals are relevant to the current entry
+  # (typically by entry id / display name overlap with target_asset.name).
+  all_feedback = feedback_tools.load_feedback(feedback_dir, feedback_files)
+  feedback_block_global = (
+      feedback_tools.proposals_to_prompt_block(all_feedback)
+      if all_feedback
+      else ""
+  )
+  if all_feedback:
+    print(
+        f"[Feedback] 📝 Loaded {len(all_feedback)} user-feedback"
+        " proposal(s) — prepended to every entry writer prompt with"
+        " OVERRIDE directive.",
+        flush=True,
+    )
+  # entry_group is `project.location.entryGroupId`; derive the resource-name
+  # prefix for the generated KB entries. All entries use the 1P generic entry
+  # type (no per-run choice); the enriched content is their `overview` aspect.
+  eg_parts = entry_group.split(".")
+  if len(eg_parts) != 3:
+    raise ValueError(
+        "--entry-group must be `project.location.entryGroupId` (got"
+        f" '{entry_group}')."
+    )
+  eg_project, eg_location, _eg_id = eg_parts
+  entry_type = _GENERIC_ENTRY_TYPE
+  resource_name_prefix = (
+      f"projects/{eg_project}/locations/{eg_location}/catalog"
+  )
+
+  # Scaffold the manifest up front with `kcmd init --entry-group` AND pull any
+  # pre-existing entries from KC. The pulled entries become seed inputs to
+  # the EnumerationAgent (so they MUST appear in the output even if there's
+  # little new content to enrich them), and their existing overview is fed
+  # to the per-entry writer as additional grounding context — see
+  # _write_one_kb_entry.
+  existing_kb_entries = []
+  if output_dir:
+    ok, msg = kcmd_tools.init_pull_entry_group(
+        output_dir, entry_group, entry_type
+    )
+    print(
+        f"[kcmd] init+pull --entry-group {entry_group}:"
+        f" {'OK' if ok else 'FAILED'} {msg}",
+        flush=True,
+    )
+    existing_kb_entries = kcmd_tools.list_kb_entries(output_dir)
+    if existing_kb_entries:
+      print(
+          f"[kcmd] pulled {len(existing_kb_entries)} pre-existing KB entries —"
+          " they will be preserved as seed entries.",
+          flush=True,
+      )
+    else:
+      print(
+          f"[kcmd] entry group is empty — no seed entries to preserve.",
+          flush=True,
+      )
+    # The pulled entries were read into memory above (with their existing
+    # overview); their on-disk files live at the EG-nested catalog path. Every
+    # entry is re-emitted into a category subdir below, so remove the pulled
+    # originals now to keep a single source of truth (avoids duplicate entries
+    # on push).
+    for _e in existing_kb_entries:
+      _yp = _e.get("yaml_path")
+      if not _yp:
+        continue
+      for _p in (_yp, _yp[: -len(".yaml")] + ".overview.md"):
+        try:
+          if os.path.exists(_p):
+            os.remove(_p)
+        except OSError:
+          pass
+
+  # Maps a file id/url to its known Drive mimeType (empty = treat as a Google
+  # Doc and let fetch_doc_text dispatch). Crawled gdoc links default to "".
+  mime_by_id = {}
+  # v5 #2: also remember the modifiedTime for cache validation on folder seeds.
+  mtime_by_id = {}
+  start_docs = list(docs or [])  # explicit --docs: authoritative depth-0 spine
+  folder_seed_urls = []  # folder files: injected as depth-1 children
+  folder_files = []
+
+  folder = extract_folder_id(folder) if folder else folder
+
+  # Seed additional inputs by listing a Drive folder (Docs, Sheets, Slides, PDFs).
+  if folder:
+    print(f"[Crawler] 📁 Listing Drive folder: {folder}", flush=True)
+    folder_files = list_folder_files(folder)
+    print(
+        f"[Crawler] 📁 Found {len(folder_files)} file(s) in folder.", flush=True
+    )
+    for f in folder_files:
+      fid = f.get("id")
+      if not fid:
+        continue
+      mime_by_id[fid] = f.get("mimeType", "")
+      if f.get("modifiedTime"):
+        mtime_by_id[fid] = f.get("modifiedTime")
+      folder_seed_urls.append(fid)
+
+  # When seeding purely from a folder there is no authoritative document to be
+  # the Master Scope, so synthesize one and treat the folder files as its
+  # depth-1 children. If explicit --docs were given, those remain the spine.
+  synthetic_scope_text = ""
+  if folder_seed_urls and not start_docs:
+    synthetic_scope_text = _build_synthetic_scope(topic, folder_files)
+
+  print("=" * 60)
+  print(
+      f"=== ADK DOC AGENT: Parallel Depth-Weighted Knowledge Base"
+      f" Enrichment ==="
+  )
+  print(f"Topic: {topic}")
+  print(
+      f"Start Docs: {len(start_docs)} | Folder files (depth 1):"
+      f" {len(folder_seed_urls)}"
+  )
+  print("=" * 60)
+
+  # 1. Parallel Crawl
+  # Seeds are injected at specific depths: explicit --docs at depth 0 (the
+  # authoritative spine), folder files at depth 1 (children of the synthetic
+  # Master Scope). This keeps a folder's heterogeneous files from flattening
+  # into depth 0 and drowning the scope.
+  seeds_by_depth = {0: list(start_docs)}
+  if folder_seed_urls:
+    seeds_by_depth.setdefault(1, []).extend(folder_seed_urls)
+
+  visited_ids = set()
+  carried_urls = []  # links discovered while crawling the previous depth
+  all_fetched_docs = []  # list of (url, depth, content)
+
+  for depth in range(MAX_DEPTH + 1):
+    # Merge carried-over crawl links with any seeds registered for this depth.
+    current_level_urls = carried_urls + seeds_by_depth.get(depth, [])
+    if not current_level_urls:
+      carried_urls = []
+      continue  # deeper seeds (e.g. folder files at depth 1) may still arrive
+
+    fetch_tasks = []
+    for url in current_level_urls:
+      doc_id = extract_gdoc_id(url)
+      if doc_id not in visited_ids:
+        visited_ids.add(doc_id)
+        fetch_tasks.append(
+            _fetch_url(
+                url,
+                depth,
+                mime_by_id.get(doc_id, mime_by_id.get(url, "")),
+                modified_time=mtime_by_id.get(doc_id, mtime_by_id.get(url)),
+            )
+        )
+
+    results = await asyncio.gather(*fetch_tasks) if fetch_tasks else []
+    all_fetched_docs.extend(results)
+
+    next_level_urls = set()
+    if depth < MAX_DEPTH:
+      for url, d, content in results:
+        links = set(
+            re.findall(
+                r"https://docs\.google\.com/document/d/[a-zA-Z0-9-_]+", content
+            )
+        )
+        for link in links:
+          if extract_gdoc_id(link) not in visited_ids:
+            next_level_urls.add(link)
+    carried_urls = list(next_level_urls)
+
+  print(
+      f"\n[Crawler] 🏁 Finished fetching {len(all_fetched_docs)} documents"
+      " total.\n"
+  )
+
+  # Extract Depth 0 documents as Master Scope. When seeding from a folder
+  # there are no depth-0 docs, so the synthetic scope stands in as the spine.
+  master_scope_docs = [doc for doc in all_fetched_docs if doc[1] == 0]
+  master_scope_text = synthetic_scope_text
+  if master_scope_text:
+    master_scope_text += "\n\n"
+  for url, depth, content in master_scope_docs:
+    master_scope_text += (
+        f"--- MASTER SCOPE DOC: {url} ---\n{content[:50000]}\n\n"
+    )
+
+  # 2a. Stage-1 Map (cache-aware): topic-NEUTRAL per-doc summary card.
+  # Runs on PER_DOC_SUMMARIZER_MODEL (Flash) at higher concurrency since each
+  # call is one small doc in / one short card out — no batch context, well
+  # under Flash routing limits. Cache key = (doc_id, modified_time) under
+  # ~/.kc_enrich_cache/summaries/ when KC_ENRICH_CACHE_MODE=summary (default);
+  # HIT skips the LLM call entirely, so warm re-runs only pay for Stage-2.
+  cache_mode = get_cache_mode()
+  print(
+      "[Agent] 🧠 Stage 1: per-doc summary (cache mode:"
+      f" {cache_mode}, model: {PER_DOC_SUMMARIZER_MODEL}, concurrency:"
+      f" {PER_DOC_CONCURRENCY})...",
+      flush=True,
+  )
+  # Stage-1 gets its own semaphore so Flash throughput isn't gated by
+  # CONCURRENCY_LIMIT (which is sized for Pro batch summarizer / writer fan-out).
+  per_doc_sem = asyncio.Semaphore(PER_DOC_CONCURRENCY)
+  # Stage 2+ continues to use the Pro-sized semaphore.
+  sem = asyncio.Semaphore(CONCURRENCY_LIMIT)
+  # Accumulate enrichment-agent token usage across Stage 1 + Stage 2 phases.
+  usage_acc = {"input": 0, "output": 0}
+
+  per_doc_tasks = []
+  for url, depth, content in all_fetched_docs:
+    doc_id = extract_gdoc_id(url)
+    per_doc_tasks.append(
+        _summarize_one_doc(
+            url,
+            content,
+            mtime_by_id.get(doc_id, mtime_by_id.get(url)),
+            per_doc_sem,
+            PER_DOC_SUMMARIZER_MODEL,
+            usage_acc,
+        )
+    )
+  per_doc_summaries_text = await asyncio.gather(*per_doc_tasks)
+  per_doc_cards = [
+      (url, depth, summary)
+      for (url, depth, _content), summary in zip(
+          all_fetched_docs, per_doc_summaries_text
+      )
+  ]
+  print(
+      f"\n[Agent] ✅ Stage 1 done: {len(per_doc_cards)} doc card(s).",
+      flush=True,
+  )
+
+  # 2a-bis. Source-code source (optional): explore a GitHub repo agentically.
+  # NOTE: code component cards are deliberately NOT fed through Stage-2 (the
+  # topic-shaped reduce), because that step drops anything off-topic — which
+  # silently discarded code components whenever the run's --topic was framed
+  # around the docs. Instead we (a) append the code cards verbatim to the
+  # compiled summary AFTER the reduce, so the enumerator + per-entry writer see
+  # the real code context, and (b) add each component as a seed entry below so
+  # it is GUARANTEED to become its own KB entry regardless of topic phrasing.
+  code_cards = []
+  if repo:
+    code_cards = await github_tools.gather_repo_context(
+        repo,
+        repo_ref,
+        repo_subdir,
+        topic,
+        model,
+        usage_acc,
+        mcp_config_path=mcp_config or None,
+    )
+
+  # 2b. Stage-2 Reduce (uncached): topic-shaped batch reduction over the
+  # neutral per-doc cards. Cards are ~5× smaller than raw doc text, so each
+  # batch call is cheap relative to the legacy raw-text summarizer.
+  print(
+      "[Agent] 🎯 Stage 2: topic-shaped reduce (batches of"
+      f" {MAX_BATCH_SIZE})...",
+      flush=True,
+  )
+  reduce_tasks = []
+  for i in range(0, len(per_doc_cards), MAX_BATCH_SIZE):
+    batch = per_doc_cards[i : i + MAX_BATCH_SIZE]
+    reduce_tasks.append(
+        _reduce_summaries_with_topic(
+            topic, master_scope_text, batch, sem, model, usage_acc
+        )
+    )
+  all_summaries = await asyncio.gather(*reduce_tasks)
+  print(f"\n[Agent] ✅ Stage 2 done: {len(all_summaries)} reduced batch(es).\n")
+
+  compiled_summary = "\n\n".join(
+      [f"--- BATCH SUMMARY {i+1} ---\n{s}" for i, s in enumerate(all_summaries)]
+  )
+
+  # Append code component cards verbatim (post-reduce, so they're not filtered
+  # by the topic lens). The per-entry writer's _slice_summary_for_entry will
+  # match these by display_name when grounding each code entry.
+  code_seed_entries = []
+  if code_cards:
+    code_block = "\n\n".join(
+        f"--- CODE COMPONENT: {c['name']} ({c['url']}) ---\n{c['content']}"
+        for c in code_cards
+    )
+    compiled_summary += (
+        "\n\n--- SOURCE CODE COMPONENTS (from "
+        f"{repo}{' /' + repo_subdir if repo_subdir else ''}) ---\n\n"
+        + code_block
+    )
+    code_seed_entries = [
+        {
+            "id": _slugify(c["name"]),
+            "display_name": c["name"],
+            "kind": "kb",
+        }
+        for c in code_cards
+    ]
+
+  # 3. ENUMERATE — one schema-validated call producing the canonical entry list.
+  # Pre-existing KB entries (from kcmd pull) are passed as seed_entries so
+  # they MUST appear in the output even if the new docs add little. The
+  # enumerator may add other entries it discovers in the new context. Code
+  # components are seeded too, so they always become their own entries.
+  seed_entries = [
+      {
+          "id": e["id"],
+          "display_name": e["display_name"] or e["id"],
+          "kind": "kb",
+      }
+      for e in existing_kb_entries
+  ] + code_seed_entries
+  if seed_entries:
+    print(
+        f"[Agent] 🧭 Enumerating with {len(seed_entries)} seed entries from"
+        " KC...",
+        flush=True,
+    )
+  else:
+    print(
+        "[Agent] 🧭 Enumerating canonical entries from compiled summary...",
+        flush=True,
+    )
+  enumeration = await common.run_enumeration(
+      topic,
+      compiled_summary,
+      seed_entries=seed_entries or None,
+      model=model,
+      usage_acc=usage_acc,
+  )
+  n_entries = sum(len(c.entries) for c in enumeration.categories)
+  print(
+      f"[Agent] ✅ Enumerated {n_entries} entries across"
+      f" {len(enumeration.categories)} categories:"
+      f" {[c.id for c in enumeration.categories]}",
+      flush=True,
+  )
+
+  # Build a lookup from canonical entry id → existing overview content, so
+  # the per-entry writer can use it as additional grounding (and so we don't
+  # regress KC content when there's little new material for an entry).
+  existing_overview_by_id = {
+      e["id"]: e["existing_overview"]
+      for e in existing_kb_entries
+      if e.get("existing_overview")
+  }
+
+  # 4. FAN OUT — write each entry independently with its own writer call.
+  # Per-entry inputs are small (one entry's slice of context) and the writer
+  # uses Flash. v2.5 optimization #3: 12 → 24 (Flash quota and the smaller per-
+  # call payload allow it).
+  write_concurrency = max(CONCURRENCY_LIMIT, 24)
+  print(
+      f"[Agent] 🏗️  Writing {n_entries} entries in parallel (concurrency"
+      f" {write_concurrency})...",
+      flush=True,
+  )
+  sem = asyncio.Semaphore(write_concurrency)
+  write_tasks = []
+  for cat in enumeration.categories:
+    for entry in cat.entries:
+      write_tasks.append(
+          _write_one_kb_entry(
+              entry,
+              cat,
+              topic,
+              compiled_summary,
+              output_dir,
+              entry_type,
+              resource_name_prefix,
+              sem,
+              model,
+              usage_acc,
+              existing_overview=existing_overview_by_id.get(entry.id, ""),
+              feedback_block=feedback_block_global,
+          )
+      )
+  write_results = await asyncio.gather(*write_tasks)
+  all_overviews = [body for (body, _es) in write_results]
+  entry_states = [es for (_body, es) in write_results if es is not None]
+
+  # Trajectory persists: per-doc fetches (the "tools" of doc mode) plus the
+  # enumerated entry list so eval can ground scoring in BOTH what was read and
+  # what was emitted.
+  tool_uses = [
+      {"name": "fetch_gdoc", "args": {"url": url, "depth": depth}}
+      for (url, depth, _content) in all_fetched_docs
+  ]
+  tool_responses = [
+      {
+          "name": "fetch_gdoc",
+          "response": {"url": url, "depth": depth, "content": content[:50000]},
+      }
+      for (url, depth, content) in all_fetched_docs
+  ]
+  for c in code_cards:
+    tool_uses.append({"name": "explore_repo", "args": {"component": c["name"]}})
+    tool_responses.append({
+        "name": "explore_repo",
+        "response": {"url": c["url"], "content": c["content"]},
+    })
+  tool_uses.append({"name": "enumerate", "args": {"topic": topic}})
+  tool_responses.append(
+      {"name": "enumerate", "response": enumeration.model_dump()}
+  )
+  final_text = "\n\n".join(t for t in all_overviews if t)
+  common.write_trajectory(
+      output_dir,
+      "doc",
+      f"TOPIC: {topic}",
+      tool_uses,
+      tool_responses,
+      final_text,
+      usage_acc,
+      latency=time.monotonic() - _t0,
+  )
+  from tools.drive_tools import get_cache_stats
+
+  print(f"[Cache] doc-fetch stats: {get_cache_stats()}", flush=True)
+
+  # Build the refinement session (consumed by agent_runner --interactive).
+  return refine.EnrichmentSession(
+      mode="doc",
+      topic=topic,
+      model=model,
+      output_dir=output_dir or "",
+      entries={es.entry_id: es for es in entry_states},
+      usage_acc=usage_acc,
+      # Phase-2 state so a `reenumerate` refinement can re-run enumeration over
+      # the same compiled context and write/move/delete entries without
+      # re-reading any source docs (see refine._reenumerate -> apply_reenumeration).
+      enum_context=compiled_summary,
+      writer_params={
+          "entry_type": entry_type,
+          "resource_name_prefix": resource_name_prefix,
+          "feedback_block_global": feedback_block_global,
+      },
+      traj_meta={
+          "agent_type": "doc",
+          "user_input": f"TOPIC: {topic}",
+          "tool_uses": tool_uses,
+          "tool_responses": tool_responses,
+      },
+  )
+
+
+def _slice_summary_for_entry(entry, compiled_summary: str) -> str:
+  """Return a focused slice of the compiled summary for one entry.
+
+  We try to extract just the paragraphs that mention the entry's display_name
+  or any alias. If nothing matches (the summary might use the canonical id),
+  fall back to the entire compiled summary capped at 60K chars (still well
+  under the EntryWriterAgent's Flash limit per single-entry call).
+  """
+  needles = [entry.display_name] + list(entry.aliases) + [entry.id]
+  needles_lower = [n.lower() for n in needles if n]
+  paragraphs = [
+      p
+      for p in compiled_summary.split("\n\n")
+      if any(n in p.lower() for n in needles_lower)
+  ]
+  if paragraphs:
+    joined = "\n\n".join(paragraphs)
+    return joined[:60000] if len(joined) > 60000 else joined
+  return compiled_summary[:60000]
+
+
+async def _write_one_kb_entry(
+    entry,
+    category,
+    topic: str,
+    compiled_summary: str,
+    output_dir: str | None,
+    entry_type: str,
+    resource_name_prefix: str,
+    sem: asyncio.Semaphore,
+    model: str,
+    usage_acc: dict,
+    existing_overview: str = "",
+    feedback_block: str = "",
+) -> str:
+  """Generate one entry's YAML + overview.md and write to disk.
+
+  Layout: catalog/{category.id}/{entry.id}.yaml +
+  catalog/{category.id}/{entry.id}.overview.md
+  The YAML is composed deterministically here (no LLM); the overview body
+  comes from a direct Flash call (v2.5 #4: bypassing ADK runner overhead).
+
+  If `existing_overview` is non-empty (this entry already exists in KC, pulled
+  via `kcmd init+pull`), the writer is told to update/extend it rather than
+  write from scratch — and is forbidden from dropping any factual content
+  from the existing overview unless directly contradicted by new context.
+  """
+  async with sem:
+    context_slice = _slice_summary_for_entry(entry, compiled_summary)
+    sources_block = (
+        "\n".join(f"  - {u}" for u in entry.primary_source_urls)
+        or "  (none listed)"
+    )
+    existing_block = ""
+    if existing_overview:
+      existing_block = (
+          "\nEXISTING OVERVIEW (already published in Knowledge Catalog for"
+          f" this entry):\n```markdown\n{existing_overview[:30000]}\n```\nUse"
+          " the existing overview as the foundation. Update or extend it with"
+          " the new context above. Do NOT drop any factual content from the"
+          " existing overview unless it is directly contradicted by new"
+          " context — preservation matters even if there's little new material"
+          " to add for this entry.\n"
+      )
+    user_prompt = (
+        f"TOPIC: {topic}\n\nENTRY CANONICAL NAME: {entry.display_name}\nENTRY"
+        f" ID: {entry.id}\nCATEGORY: {category.title} ({category.id})\nALIASES:"
+        f" {', '.join(entry.aliases) if entry.aliases else '(none)'}\nDESCRIPTION:"
+        f" {entry.description}\nPRIMARY SOURCE"
+        f" URLS:\n{sources_block}\n\nRELEVANT CONTEXT (excerpts of source"
+        " summaries that mention this"
+        f" entry):\n{context_slice}\n{existing_block}\nWrite the overview"
+        " Markdown body for this entry now."
+        + feedback_block
+    )
+    body = await common.generate_text_direct(
+        ENTRY_WRITER_INSTRUCTION,
+        user_prompt,
+        _LIGHT_MODEL_FOR_WRITER,
+        usage_acc,
+    )
+
+  if not output_dir:
+    return body, None
+  cat_dir = os.path.join(output_dir, "catalog", category.id)
+  os.makedirs(cat_dir, exist_ok=True)
+  # YAML: deterministic, no LLM. Includes the required `generic` aspect and a
+  # `category:` field so downstream consumers can group by it.
+  # `name:` is the LOCAL name (just the entry id). kcmd's entrygroup source
+  # source.serviceName() prepends `<eg-path>/entries/` to produce the full
+  # Dataplex resource path at push time — see agents/mdcode/src/libts/
+  # sources/entrygroup.ts line 48-50. Setting `name:` to the full path here
+  # causes a double-prefix at push.
+  entry_yaml = {
+      "name": entry.id,
+      "id": entry.id,
+      "type": entry_type,
+      "category": category.id,
+      "resource": {
+          "name": f"{resource_name_prefix}/{entry.id}",
+          "displayName": entry.display_name,
+          "description": entry.description,
+      },
+      "aspects": {
+          "dataplex-types.global.generic": {
+              "type": "knowledge-base",
+              "system": "enrichment-agent",
+          },
+      },
+  }
+  yaml_path = os.path.join(cat_dir, f"{entry.id}.yaml")
+  with open(yaml_path, "w") as f:
+    yaml.safe_dump(entry_yaml, f, sort_keys=False, allow_unicode=True)
+  overview_path = os.path.join(cat_dir, f"{entry.id}.overview.md")
+  with open(overview_path, "w") as f:
+    f.write(common.clean_overview_body(body) + "\n")
+  print(f"[Agent] ✅ {category.id}/{entry.id}", flush=True)
+
+  # Per-entry state for multi-turn refinement. A refinement overwrites only the
+  # overview sidecar (the entry YAML is unchanged by a content refinement).
+  entry_state = refine.EntryState(
+      entry_id=entry.id,
+      display_name=entry.display_name,
+      description=entry.description,
+      category_id=category.id,
+      grounding_prompt=user_prompt,
+      writer_model=_LIGHT_MODEL_FOR_WRITER,
+      overview_body=body,
+      overview_path=overview_path,
+      kind="kb",
+  )
+  return body, entry_state
+
+
+def _delete_doc_entry_files(es) -> None:
+  """Delete a doc entry's `.yaml` + `.overview.md` from disk (best-effort).
+
+  Only touches local mdcode under output_dir — never live Dataplex content.
+  """
+  overview_path = es.overview_path
+  if not overview_path:
+    return
+  cat_dir = os.path.dirname(overview_path)
+  yaml_path = os.path.join(cat_dir, f"{es.entry_id}.yaml")
+  for p in (overview_path, yaml_path):
+    try:
+      if os.path.exists(p):
+        os.remove(p)
+    except OSError:
+      pass
+
+
+def _recategorize_doc_entry(es, new_cat, output_dir: str) -> None:
+  """Move a kept doc entry's files into the new category dir; update YAML + state.
+
+  Doc-mode layout is `catalog/{category}/{entry}.{yaml,overview.md}`, so a
+  category change is a file move. The overview body (and any prior refinement
+  edits) is preserved — only its location and the YAML `category:` field change.
+  """
+  old_overview = es.overview_path
+  old_dir = os.path.dirname(old_overview) if old_overview else None
+  new_dir = os.path.join(output_dir, "catalog", new_cat.id)
+  os.makedirs(new_dir, exist_ok=True)
+  new_overview = os.path.join(new_dir, f"{es.entry_id}.overview.md")
+  # Move the overview sidecar.
+  try:
+    if (
+        old_overview
+        and os.path.exists(old_overview)
+        and old_overview != new_overview
+    ):
+      os.replace(old_overview, new_overview)
+  except OSError:
+    pass
+  # Move the entry YAML and update its `category:` field.
+  old_yaml = os.path.join(old_dir, f"{es.entry_id}.yaml") if old_dir else None
+  new_yaml = os.path.join(new_dir, f"{es.entry_id}.yaml")
+  data = {}
+  if old_yaml and os.path.exists(old_yaml):
+    try:
+      with open(old_yaml) as f:
+        data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+      data = {}
+  data["category"] = new_cat.id
+  try:
+    with open(new_yaml, "w") as f:
+      yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
+    if old_yaml and os.path.exists(old_yaml) and old_yaml != new_yaml:
+      os.remove(old_yaml)
+  except OSError:
+    pass
+  es.category_id = new_cat.id
+  es.overview_path = new_overview
+
+
+async def apply_reenumeration(session, new_enum, removed_ids) -> None:
+  """Materialize a doc-mode re-enumeration delta (add / remove / recategorize).
+
+  Called by refine._reenumerate after the EnumerationAgent produced a new
+  categorized entry list from session.enum_context (the original compiled
+  summary — so nothing is re-read). New entries are written via
+  _write_one_kb_entry, re-categorized entries are moved, and removed entries'
+  local files are deleted. Kept entries' overviews + refinement history are
+  preserved untouched. Mutates `session.entries` in place.
+  """
+  output_dir = session.output_dir
+  wp = session.writer_params or {}
+  entry_type = wp.get("entry_type", _GENERIC_ENTRY_TYPE)
+  resource_name_prefix = wp.get("resource_name_prefix", "")
+  feedback_block = wp.get("feedback_block_global", "")
+  removed_ids = set(removed_ids or [])
+
+  new_by_id = {
+      e.id: (e, cat) for cat in new_enum.categories for e in cat.entries
+  }
+  old_ids = set(session.entries)
+  # Drop anything no longer enumerated, plus anything the user explicitly asked
+  # to remove (so a re-add by the enumerator from the same context is ignored).
+  to_remove = (old_ids - set(new_by_id)) | removed_ids
+  for eid in sorted(to_remove):
+    es = session.entries.get(eid)
+    if es is None:
+      continue
+    _delete_doc_entry_files(es)
+    session.entries.pop(eid, None)
+    print(f"[refine] 🗑️  removed entry: {eid}", flush=True)
+
+  # Additions + recategorizations.
+  sem = asyncio.Semaphore(max(CONCURRENCY_LIMIT, 24))
+  add_tasks = []
+  for eid, (entry, cat) in new_by_id.items():
+    if eid in removed_ids:
+      continue
+    if eid not in session.entries:
+      add_tasks.append(
+          _write_one_kb_entry(
+              entry,
+              cat,
+              session.topic,
+              session.enum_context,
+              output_dir,
+              entry_type,
+              resource_name_prefix,
+              sem,
+              session.model,
+              session.usage_acc,
+              existing_overview="",
+              feedback_block=feedback_block,
+          )
+      )
+    elif session.entries[eid].category_id != cat.id:
+      _recategorize_doc_entry(session.entries[eid], cat, output_dir)
+      print(f"[refine] 🔀 recategorized {eid} -> {cat.id}", flush=True)
+
+  if add_tasks:
+    for _body, es in await asyncio.gather(*add_tasks):
+      if es is not None:
+        session.entries[es.entry_id] = es
+        print(
+            f"[refine] ➕ added entry: {es.category_id}/{es.entry_id}",
+            flush=True,
+        )
+
+
+# Flash for the writer step: per-entry inputs are small (one entry's slice of
+# context, typically <20K tokens) so the ADK 32K Flash routing trap doesn't bite.
+_LIGHT_MODEL_FOR_WRITER = "gemini-3.5-flash"

--- a/agents/enrichment/src/modes/table_mode.py
+++ b/agents/enrichment/src/modes/table_mode.py
@@ -1,0 +1,900 @@
+"""Table mode: Dataplex-sourced, folder-grounded BigQuery table enrichment.
+
+Discovers a BigQuery dataset's tables via the Dataplex Catalog, then for EACH
+table
+routes only the relevant Drive-folder documents to it (via an LLM relevance
+router)
+and enriches it with Metadata-as-Code (an entry YAML + an overview sidecar)
+grounded
+in those documents. Tables with no relevant docs get a schema-only overview.
+Output
+is scoped to the dataset's real `@bigquery` entry group so the overview can land
+on
+the live Dataplex entries. Ported from the former table_agent_runner.
+"""
+
+import asyncio
+import json
+import os
+import re
+import time
+import typing as t
+import common
+from engine import (
+    create_doc_query_extractor_runner,
+    create_doc_summarizer_runner,
+    create_router_runner,
+    create_table_overview_runner,
+)
+import refine
+from tools import bq_usage_tools
+from tools import feedback_tools
+from tools import github_tools
+from tools import kcmd_tools
+from tools.drive_tools import extract_folder_id, fetch_doc_text, list_folder_files
+import yaml
+
+# kcmd's canonical entry type for BigQuery tables under a bq-dataset scope.
+_BQ_TABLE_TYPE = "dataplex-types.global.bigquery-table"
+
+CONCURRENCY_LIMIT = (
+    12  # parallel LLM calls (doc summaries, routing, per-table gen)
+)
+RELEVANCE_THRESHOLD = 0.5  # min router score for a doc to feed a table
+MAX_DOC_CHARS = (
+    30000  # per-doc content budget when building a table's focused context
+)
+
+
+def _parse_dataset(dataset: str) -> tuple[str, str]:
+  """`project.dataset` -> (project, dataset). The project must be explicit."""
+  dataset = (dataset or "").strip()
+  if "." not in dataset:
+    raise ValueError(
+        "--dataset must be fully qualified as `project.dataset` (got"
+        f" '{dataset}')."
+    )
+  project, ds = dataset.split(".", 1)
+  return project, ds
+
+
+def _write_table_files(
+    output_dir: str,
+    project: str,
+    dataset_id: str,
+    meta: t.Dict[str, t.Any],
+    overview_body: str,
+) -> list[str]:
+  """Add the enriched overview sidecar next to the table entry that
+
+  `kcmd init --pull` already wrote. We do NOT rewrite the entry YAML — the
+  pulled entry (with its 1P schema/storage aspects) is the source of truth; we
+  only contribute the `overview` aspect via a `<table>.overview.md` sidecar
+  (md-sidecar support), and publish only that aspect.
+  """
+  if not output_dir:
+    return []
+  table = meta["table"]
+  abs_dir = kcmd_tools._dataset_dir(  # pylint: disable=protected-access
+      output_dir, project, dataset_id
+  )
+  rel_dir = os.path.relpath(abs_dir, output_dir)
+  os.makedirs(abs_dir, exist_ok=True)
+
+  # If the pull somehow didn't produce the entry, write a minimal one so push
+  # still has a target.
+  entry_path = os.path.join(abs_dir, f"{table}.yaml")
+  if not os.path.exists(entry_path):
+    resource = {
+        "name": f"projects/{project}/datasets/{dataset_id}/tables/{table}",
+        "displayName": table,
+    }
+    if meta.get("description"):
+      resource["description"] = meta["description"]
+    with open(entry_path, "w") as f:
+      yaml.safe_dump(
+          {
+              "name": f"bigquery/{project}/{dataset_id}/{table}",
+              "type": _BQ_TABLE_TYPE,
+              "resource": resource,
+              "aspects": {},
+          },
+          f,
+          sort_keys=False,
+          allow_unicode=True,
+      )
+
+  # Overview sidecar — pure Markdown body, NO frontmatter. kcmd merges any
+  # sidecar frontmatter straight into the aspect payload (standard layout), and
+  # the live `dataplex-types.global.overview` aspectType only accepts
+  # content/contentType — emitting e.g. `userManaged` makes `kcmd push` fail
+  # with "Unknown property". contentType=MARKDOWN is inferred from the
+  # `.overview` suffix on load, so no frontmatter is needed.
+  overview_path = os.path.join(abs_dir, f"{table}.overview.md")
+  with open(overview_path, "w") as f:
+    f.write(common.clean_overview_body(overview_body) + "\n")
+
+  # kcmd's standard layout (see agents/mdcode/src/libts/layouts/standard.ts)
+  # routes BOTH `<table>.overview.md` AND
+  # `<table>.dataplex-types.global.overview.md`
+  # to the same aspect key — files are processed in readdir order and the
+  # last one wins via `Object.assign + content`. `kcmd pull` produces the
+  # fully-qualified-suffix file as a side effect, and on most filesystems
+  # it sorts AFTER our short-suffix file, so without this deletion the
+  # pulled (existing live) content silently overwrites the agent's new
+  # overview on push — kcmd reports success but Dataplex never changes.
+  # We delete the pulled sidecar after writing our own so there's exactly
+  # one source of truth for the overview aspect.
+  pulled = os.path.join(abs_dir, f"{table}.dataplex-types.global.overview.md")
+  if os.path.exists(pulled):
+    try:
+      os.remove(pulled)
+    except OSError:
+      pass
+
+  return [os.path.join(rel_dir, f"{table}.overview.md")]
+
+
+async def _prepare_docs(
+    topic: str, folder_id: str | None, usage_acc: t.Dict[str, int], model: str
+) -> t.List[t.Dict[str, t.Any]]:
+  """Fetch folder docs and summarize each into a compact router descriptor.
+
+  Args:
+    topic: Focus topic.
+    folder_id: Folder ID.
+    usage_acc: Usage accumulator.
+    model: Model name.
+
+  Returns:
+    A list of {id, name, url, content, descriptor}.
+  """
+  del topic  # unused
+  if not folder_id:
+    return []
+
+  print(f"[Folder] 📁 Listing Drive folder: {folder_id}", flush=True)
+  files = list_folder_files(folder_id)
+  print(
+      f"[Folder] 📁 Found {len(files)} file(s). Fetching + summarizing...",
+      flush=True,
+  )
+
+  sem = asyncio.Semaphore(CONCURRENCY_LIMIT)
+
+  async def _prep(idx, f):
+    fid = f.get("id")
+    url = f.get("webViewLink") or fid
+    name = f.get("name", "")
+    # v5 #2: pass modifiedTime so the per-doc cache invalidates when Drive
+    # reports the file changed since the last run.
+    content = await asyncio.to_thread(
+        fetch_doc_text,
+        fid,
+        f.get("mimeType", ""),
+        modified_time=f.get("modifiedTime"),
+    )
+    async with sem:
+      prompt = (
+          f"DOCUMENT TITLE: {name}\nSOURCE URL: {url}\n\nDOCUMENT"
+          f" CONTENT:\n{content[:50000]}"
+      )
+      descriptor = await common.run_text(
+          create_doc_summarizer_runner(model), prompt, usage_acc
+      )
+    return {
+        "id": idx,
+        "name": name,
+        "url": url,
+        "content": content,
+        "descriptor": descriptor.strip(),
+    }
+
+  docs = await asyncio.gather(
+      *[_prep(i, f) for i, f in enumerate(f for f in files if f.get("id"))]
+  )
+  return list(docs)
+
+
+def _parse_router(text: str, n_docs: int) -> list[tuple[int, float]]:
+  """Parse the router's JSON array into [(doc_index, score)] above threshold."""
+  txt = (text or "").strip()
+  m = re.search(r"```(?:json)?\s*(.*?)```", txt, re.S)
+  if m:
+    txt = m.group(1).strip()
+  if not txt.startswith("["):
+    m = re.search(r"\[.*\]", txt, re.S)
+    txt = m.group(0) if m else "[]"
+  try:
+    arr = json.loads(txt)
+  except (ValueError, json.JSONDecodeError):
+    return []
+  out = []
+  for o in arr if isinstance(arr, list) else []:
+    try:
+      idx = int(o["doc"])
+      score = float(o.get("score", 0))
+    except (KeyError, ValueError, TypeError):
+      continue
+    if 0 <= idx < n_docs and score >= RELEVANCE_THRESHOLD:
+      out.append((idx, score))
+  return sorted(out, key=lambda x: -x[1])
+
+
+async def extract_doc_queries(
+    table_meta: t.Dict[str, t.Any],
+    sel_docs: t.List[t.Dict[str, t.Any]],
+    project: str,
+    dataset_id: str,
+    model: str,
+    usage_acc: t.Dict[str, int],
+) -> t.List[t.Dict[str, t.Any]]:
+  """Pull SQL examples that reference this table out of its routed docs.
+
+  Returns a list of `{description, sql}` dicts (one per query found),
+  ready to merge into the `queries` aspect alongside the
+  INFORMATION_SCHEMA-derived patterns. Empty list when no docs are
+  routed to this table OR when none of them contain a SQL example
+  referencing it.
+
+  The extractor (engine.create_doc_query_extractor_runner) returns
+  JSONL — one JSON object per line. We parse line-by-line and silently
+  drop unparseable lines so a partial response still yields whatever
+  the LLM produced cleanly.
+
+  Args:
+    table_meta: Table metadata.
+    sel_docs: Selected docs.
+    project: Project ID.
+    dataset_id: Dataset ID.
+    model: Model name.
+    usage_acc: Usage accumulator.
+
+  Returns:
+    List of query dictionaries.
+  """
+  if not sel_docs:
+    return []
+  table_fqn = f"{project}.{dataset_id}.{table_meta['table']}"
+  doc_blob = "\n\n".join(
+      f"--- DOCUMENT: {d['name']} ({d['url']})"
+      f" ---\n{d['content'][:MAX_DOC_CHARS]}"
+      for d in sel_docs
+  )
+  prompt = f"TABLE: {table_fqn}\n\nDOC SNIPPETS:\n{doc_blob}"
+  text = await common.run_text(
+      create_doc_query_extractor_runner(model), prompt, usage_acc
+  )
+  out: t.List[t.Dict[str, t.Any]] = []
+  for line in (text or "").splitlines():
+    line = line.strip()
+    if not line or line.startswith("```"):
+      continue
+    try:
+      obj = json.loads(line)
+    except json.JSONDecodeError:
+      continue
+    if not isinstance(obj, dict):
+      continue
+    desc = (obj.get("description") or "").strip()
+    sql = (obj.get("sql") or "").strip()
+    if not sql:
+      continue
+    out.append({"description": desc, "sql": sql})
+  return out
+
+
+def write_queries_sidecar(
+    output_dir: str,
+    project: str,
+    dataset_id: str,
+    meta: t.Dict[str, t.Any],
+    usage: "bq_usage_tools.TableUsage",
+    doc_queries: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
+    feedback_queries: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
+) -> str:
+  """Write the per-table `queries` aspect sidecar as `<table>.queries.md`.
+
+  YAML frontmatter ONLY (no body), conforming to the Dataplex `queries`
+  aspect type (`dataplex-types.global.queries`). kcmd
+  push uploads this as the `queries` aspect because it's declared in
+  publishing.aspects in kcmd_tools._BQ_MANIFEST.
+
+  Three query sources merge into the one aspect:
+    1. INFORMATION_SCHEMA observed patterns from `usage`.
+    2. SQL examples extracted from the routed documentation
+       (`doc_queries`, from `extract_doc_queries`).
+    3. User-feedback golden_sql payloads (`feedback_queries`, from
+       feedback_tools.proposals_to_queries) — these are ground-truth
+       SQL from direct user feedback proposals and emit FIRST in the
+       aspect (most prominent) with `source: USER`.
+
+  Each is attributed in the description prefix (`[Source:
+  INFORMATION_SCHEMA]` / `[Source: Documentation]` / `[Source: User
+  Feedback]`); the aspect's `source` enum is closed (AGENT | USER) per
+  the proto schema — AGENT for the first two sources, USER for the
+  feedback-derived entries.
+
+  The queries aspect requires the `dataplex.entryGroups.useQueriesAspect`
+  permission per the aspect's `authorization.alternate_use_permission`
+  declaration; if the caller lacks the perm, kcmd push will fail with 403
+  on the queries aspect specifically. The overview aspect still goes through.
+
+  Args:
+    output_dir: Output directory.
+    project: Project ID.
+    dataset_id: Dataset ID.
+    meta: Table metadata.
+    usage: Table usage data.
+    doc_queries: SQL extracted from routed documentation (AGENT source).
+    feedback_queries: SQL from direct user-feedback proposals (USER source).
+      Highest priority — emitted first in the sidecar.
+
+  Returns:
+    Path to the written sidecar.
+  """
+  table = meta["table"]
+  abs_dir = kcmd_tools._dataset_dir(  # pylint: disable=protected-access
+      output_dir, project, dataset_id
+  )
+  rel_dir = os.path.relpath(abs_dir, output_dir)
+  os.makedirs(abs_dir, exist_ok=True)
+  table_fqn = f"{project}.{dataset_id}.{table}"
+  path = os.path.join(abs_dir, f"{table}.queries.md")
+  with open(path, "w") as f:
+    f.write(
+        bq_usage_tools.format_queries_sidecar(
+            usage,
+            table_fqn,
+            doc_queries=doc_queries,
+            feedback_queries=feedback_queries,
+        )
+    )
+  return os.path.join(rel_dir, f"{table}.queries.md")
+
+
+async def _route_docs_for_table(
+    table_meta: t.Dict[str, t.Any],
+    docs: t.List[t.Dict[str, t.Any]],
+    usage_acc: t.Dict[str, int],
+    model: str,
+) -> list[tuple[int, float]]:
+  """Ask the router which docs are relevant to this table; return [(idx, score)]."""
+  if not docs:
+    return []
+  table_block = kcmd_tools.flatten_table_for_prompt(table_meta, max_fields=80)
+  catalog = "\n\n".join(f"[{d['id']}] {d['descriptor']}" for d in docs)
+  prompt = (
+      f"TARGET TABLE:\n{table_block}\n\n"
+      f"CANDIDATE DOCUMENTS (numbered):\n{catalog}\n\n"
+      "Return the JSON array of relevant documents for THIS table."
+  )
+  text = await common.run_text(create_router_runner(model), prompt, usage_acc)
+  return _parse_router(text, len(docs))
+
+
+async def run(
+    dataset: str,
+    folder: str | None,
+    topic: str,
+    output_dir: str | None,
+    model: str,
+    *,
+    include_usage: bool = True,
+    usage_window_days: int = 30,
+    anonymize_users: bool = False,
+    usage_scope: str = "auto",
+    feedback_dir: str | None = None,
+    feedback_files: list[str] | None = None,
+    glossaries: list[str] | None = None,
+    repo: str = "",
+    repo_ref: str = "",
+    repo_subdir: str = "",
+    mcp_config: str = "",
+):
+  _t0 = time.monotonic()
+  project, dataset_id = _parse_dataset(dataset)
+  # Accept either a bare folder id or a full Drive folder URL.
+  folder = extract_folder_id(folder) if folder else folder
+  # Load user-feedback proposals up front so per-table routing is cheap.
+  # Empty list = no feedback path provided (or no proposals found); the
+  # rest of the pipeline degrades to "no feedback" semantics naturally.
+  all_feedback = feedback_tools.load_feedback(feedback_dir, feedback_files)
+
+  print("=" * 60)
+  print("=== ADK TABLE AGENT: Dataplex-Sourced, Folder-Grounded Enrichment ===")
+  print(f"Topic: {topic}")
+  print(f"Dataset: {project}.{dataset_id}  |  Folder: {folder or '(none)'}")
+  if all_feedback:
+    print(
+        f"[Feedback] 📝 Loaded {len(all_feedback)} user-feedback"
+        " proposal(s) — these will OVERRIDE conflicting context per table.",
+        flush=True,
+    )
+  print(f"Glossaries: {glossaries or '(none — column linking disabled)'}")
+  print("=" * 60)
+
+  usage_acc = {"input": 0, "output": 0}
+  if not output_dir:
+    print(
+        "[kcmd] ❌ output_dir is required (kcmd writes the snapshot there).",
+        flush=True,
+    )
+    return
+
+  # 1. Discover tables via kcmd — NO direct Dataplex API. Runs `kcmd init
+  #    --bigquery-dataset <proj>.<dataset>`, writes a schema-declaring manifest,
+  #    then `kcmd pull` -> catalog/<proj>.<dataset>/<table>.yaml with schema.
+  #    (kcmd_tools echoes each real command it runs.)
+  #
+  # When `glossaries` is provided, the manifest also wires snapshot+publishing+
+  # reference entryLinks so `kcmd pull` brings down existing column-level links
+  # (used as few-shot governance context for the LinkingAgent below) and
+  # `kcmd push` reconciles agent-added links to Dataplex.
+  glossary_scope = None
+  if glossaries:
+    glossary_scope, warning = kcmd_tools.build_glossary_scope(glossaries)
+    if glossary_scope is None:
+      print(
+          f"[Linking] ⚠️  {warning} — disabling glossary linking.", flush=True
+      )
+      glossaries = None
+    elif warning:
+      print(f"[Linking] ⚠️  {warning}", flush=True)
+
+  print(
+      f"[kcmd] 🔎 Discovering {project}.{dataset_id} via kcmd init + pull"
+      f"{' (with glossary links)' if glossary_scope else ''} ...",
+      flush=True,
+  )
+  ok, msg = await asyncio.to_thread(
+      kcmd_tools.init_pull_dataset,
+      output_dir,
+      project,
+      dataset_id,
+      bool(glossary_scope),
+  )
+  print(f"[kcmd] {'OK' if ok else '⚠️  FAILED'}: {msg}", flush=True)
+
+  # Side-channel pull of glossary terms so the LinkingAgent's terms_context
+  # is populated. This swaps catalog.yaml temporarily (kcmd_tools restores it).
+  if glossary_scope:
+    print(
+        f"[kcmd] 🔎 Pulling glossary terms ({glossary_scope}) as reference ...",
+        flush=True,
+    )
+    ok_g, msg_g = await asyncio.to_thread(
+        kcmd_tools.pull_glossary_as_reference,
+        output_dir,
+        project,
+        dataset_id,
+        glossary_scope,
+    )
+    print(
+        f"[kcmd] {'OK' if ok_g else '⚠️  FAILED'} (glossary reference):"
+        f" {msg_g}",
+        flush=True,
+    )
+
+  table_names = kcmd_tools.list_tables(output_dir, project, dataset_id)
+  tables = [
+      kcmd_tools.read_table_meta(output_dir, project, dataset_id, t)
+      for t in table_names
+  ]
+  for meta in tables:
+    print(
+        f"[kcmd] 📑 {meta['table']} ({len(meta['schema_fields'])} cols)",
+        flush=True,
+    )
+
+  if not tables:
+    print(
+        "[kcmd] ❌ No table entries pulled — nothing to enrich. "
+        "Check the dataset id and that you can read its @bigquery entries.",
+        flush=True,
+    )
+    return
+
+  # 2a. Fetch + summarize the Drive folder + (in parallel) fetch BQ
+  # query-history usage signals via INFORMATION_SCHEMA. The two are
+  # independent (Drive API vs BigQuery API) so we overlap them to keep the
+  # critical-path wall-clock identical to docs-only.
+  if include_usage:
+    print(
+        f"[BQ Usage] 📊 Fetching query history (window={usage_window_days}d,"
+        f" scope={usage_scope}) for {len(tables)} table(s)...",
+        flush=True,
+    )
+    docs, usage_by_table = await asyncio.gather(
+        _prepare_docs(topic, folder, usage_acc, model),
+        asyncio.to_thread(
+            bq_usage_tools.fetch_dataset_usage,
+            project,
+            dataset_id,
+            [m["table"] for m in tables],
+            window_days=usage_window_days,
+            anonymize_users=anonymize_users,
+            scope=usage_scope,
+        ),
+    )
+    n_with_signal = sum(
+        1 for u in usage_by_table.values() if u.total_queries > 0
+    )
+    print(
+        f"[BQ Usage] ✅ {n_with_signal}/{len(tables)} table(s) have usage"
+        " signal in the window.",
+        flush=True,
+    )
+  else:
+    docs = await _prepare_docs(topic, folder, usage_acc, model)
+    usage_by_table = {}
+  # Source-code source (optional): explore a GitHub repo agentically and add its
+  # component cards to the candidate-document pool. They are scored by the same
+  # relevance router as Drive docs, so a code component that reads/writes a table
+  # (or contains SQL referencing it) gets routed to that table and grounds its
+  # overview + queries aspect. ids are reassigned to keep id == list position
+  # (the router/writer index `docs` positionally).
+  if repo:
+    code_docs = await github_tools.gather_repo_context(
+        repo,
+        repo_ref,
+        repo_subdir,
+        topic,
+        model,
+        usage_acc,
+        mcp_config_path=mcp_config or None,
+    )
+    docs.extend(code_docs)
+    for i, d in enumerate(docs):
+      d["id"] = i
+
+  if not docs:
+    print(
+        "[Folder] ⚠️  No folder/code content — tables will be documented from"
+        " schema only.",
+        flush=True,
+    )
+
+  # 3. Per-table routing — pick relevant folder docs for each table (existing).
+  print(
+      f"\n[Agent] 🧮 Routing folder docs to {len(tables)} table(s)...",
+      flush=True,
+  )
+  sem = asyncio.Semaphore(CONCURRENCY_LIMIT)
+
+  async def _route_one(meta):
+    async with sem:
+      selected = await _route_docs_for_table(meta, docs, usage_acc, model)
+      label = (
+          ", ".join(f"{docs[i]['name']} ({s:.2f})" for (i, s) in selected)
+          or "(none — schema-only)"
+      )
+      print(f"[Router] {meta['table']} ← {label}", flush=True)
+      return meta["table"], selected
+
+  routing = dict(await asyncio.gather(*[_route_one(m) for m in tables]))
+
+  # 4. ENUMERATE — shared EnumerationAgent groups tables into categories.
+  # Seed entries are the tables themselves; the agent only assigns categories.
+  print(
+      f"[Agent] 🧭 Categorizing {len(tables)} table(s) into themes...",
+      flush=True,
+  )
+  enum_context_lines = [f"DATASET: {project}.{dataset_id}", ""]
+  for meta in tables:
+    sel = routing.get(meta["table"], [])
+    sel_descs = [docs[i]["descriptor"][:400] for (i, _s) in sel[:5]]
+    enum_context_lines.append(
+        f"- {meta['table']}: {meta.get('description', '')[:200]}"
+    )
+    enum_context_lines.append(
+        f"  schema_fields ({len(meta['schema_fields'])}): "
+        f"{', '.join(f['name'] for f in meta['schema_fields'][:10])}"
+    )
+    if sel_descs:
+      enum_context_lines.append(
+          "  routed_docs:"
+          f" {' | '.join(s.splitlines()[0][:120] for s in sel_descs)}"
+      )
+  enum_context = "\n".join(enum_context_lines)
+  seed_entries = [
+      {"id": m["table"], "display_name": m["table"], "kind": "table"}
+      for m in tables
+  ]
+  enumeration = await common.run_enumeration(
+      topic,
+      enum_context,
+      seed_entries=seed_entries,
+      model=model,
+      usage_acc=usage_acc,
+  )
+  print(
+      f"[Agent] ✅ {len(enumeration.categories)} categories: "
+      f"{[(c.id, len(c.entries)) for c in enumeration.categories]}",
+      flush=True,
+  )
+  cat_by_entry_id = {e.id: c for c in enumeration.categories for e in c.entries}
+
+  # 5. WRITE — shared per-entry write fan-out (direct generate_content, v5 #4).
+  from engine import ENTRY_WRITER_INSTRUCTION
+
+  print(
+      "[Agent] 🏗️  Writing per-table overviews via direct Flash (concurrency"
+      f" {CONCURRENCY_LIMIT})...",
+      flush=True,
+  )
+  sem2 = asyncio.Semaphore(CONCURRENCY_LIMIT)
+
+  async def _write_one(meta):
+    async with sem2:
+      sel = routing.get(meta["table"], [])
+      sel_docs = [docs[i] for (i, _s) in sel]
+      cat = cat_by_entry_id.get(meta["table"])
+      cat_id = cat.id if cat else "uncategorized"
+      cat_title = cat.title if cat else "Uncategorized"
+      # Per-table feedback routing. Proposals whose target_asset.name's
+      # table-prefix matches this table apply here (TABLE targets match
+      # directly; COLUMN targets strip the trailing column segment).
+      table_fqn = f"{project}.{dataset_id}.{meta['table']}"
+      table_feedback = feedback_tools.route_proposals_to_table(
+          all_feedback, table_fqn
+      )
+      if table_feedback:
+        print(
+            f"[Feedback] 📝 {table_fqn}: {len(table_feedback)} proposal(s)"
+            " applied — these OVERRIDE conflicting context.",
+            flush=True,
+        )
+      if sel_docs:
+        context = "\n\n".join(
+            f"--- DOCUMENT: {d['name']} ({d['url']})"
+            f" ---\n{d['content'][:MAX_DOC_CHARS]}"
+            for d in sel_docs
+        )
+      else:
+        context = "(none — document this table from its schema/metadata only)"
+      table_block = kcmd_tools.flatten_table_for_prompt(meta)
+      # Table-mode-specific directive on top of the shared writer
+      # instruction: any SQL example we find in the docs belongs in the
+      # `queries` aspect (handled separately by extract_doc_queries +
+      # the queries sidecar), NOT inlined in the overview body. Without
+      # this, the writer routinely embeds ```sql blocks in the overview
+      # which then get pushed as part of the overview aspect content and
+      # duplicate what's in the queries aspect.
+      table_mode_directive = (
+          "\n\nIMPORTANT — TABLE MODE: Do NOT include any SQL query"
+          " examples in the overview body (no ```sql blocks, no inline"
+          " queries). SQL examples are captured separately in this entry's"
+          " `queries` aspect by another pipeline step. The overview should"
+          " describe WHAT the table is and HOW it's used in narrative"
+          " prose, while leaving the runnable SQL to the queries aspect."
+      )
+      # Feedback block carries the OVERRIDE directive + instructs the
+      # writer to surface a "## User Corrections" section near the top
+      # of the overview. Empty string when no feedback applies to this
+      # table, so the concatenation is a no-op then.
+      feedback_block = feedback_tools.proposals_to_prompt_block(table_feedback)
+      prompt = (
+          f"TOPIC: {topic}\n\nENTRY CANONICAL NAME: {meta['table']}\nENTRY ID:"
+          f" {meta['table']}\nCATEGORY: {cat_title} ({cat_id})\nALIASES:"
+          " (none)\nDESCRIPTION: BigQuery table"
+          f" {project}.{dataset_id}.{meta['table']}\nPRIMARY SOURCE URLS:\n"
+          + ("\n".join(f"  - {d['url']}" for d in sel_docs) or "  (none)")
+          + "\n\nTARGET TABLE METADATA (from kcmd"
+          f" snapshot):\n{table_block}\n\nRELEVANT CONTEXT DOCUMENTS (routed"
+          f" for this table only):\n{context}\n\nWrite the overview Markdown"
+          " body for this table now."
+          + table_mode_directive
+          + feedback_block
+      )
+      body = await common.generate_text_direct(
+          ENTRY_WRITER_INSTRUCTION, prompt, _WRITER_MODEL, usage_acc
+      )
+      written = _write_table_files(output_dir, project, dataset_id, meta, body)
+      # Merge INFORMATION_SCHEMA-derived patterns + SQL examples extracted
+      # from the routed docs + user-feedback golden_sql payloads into a
+      # single `<table>.queries.md` aspect sidecar. Each is attributed in
+      # the description prefix (`[Source: INFORMATION_SCHEMA]`,
+      # `[Source: Documentation]`, or `[Source: User Feedback]`); the
+      # aspect's `source` enum is AGENT for the first two and USER for
+      # the feedback-derived entries (proto schema is closed enum).
+      usage = usage_by_table.get(meta["table"]) if usage_by_table else None
+      feedback_queries = feedback_tools.proposals_to_queries(table_feedback)
+      if (usage or feedback_queries) and output_dir:
+        # Use an empty TableUsage as the floor so the sidecar writer
+        # doesn't crash when INFORMATION_SCHEMA wasn't reachable but
+        # feedback supplied SQL.
+        if usage is None:
+          usage = bq_usage_tools.TableUsage(window_days=usage_window_days)
+        doc_queries = await extract_doc_queries(
+            meta, sel_docs, project, dataset_id, model, usage_acc
+        )
+        queries_path = write_queries_sidecar(
+            output_dir,
+            project,
+            dataset_id,
+            meta,
+            usage,
+            doc_queries,
+            feedback_queries=feedback_queries,
+        )
+        if queries_path:
+          written.append(queries_path)
+        if doc_queries or feedback_queries:
+          print(
+              f"[DocQueries] {meta['table']}: {len(doc_queries)} doc-extracted"
+              f" + {len(feedback_queries)} user-feedback SQL example(s)",
+              flush=True,
+          )
+      # Inject category into the kcmd-pulled entry YAML (top-level field;
+      # kcmd ignores unknown fields, downstream consumers can group by it).
+      if cat and output_dir:
+        _inject_category(output_dir, project, dataset_id, meta["table"], cat.id)
+      print(
+          f"[Agent] ✅ {cat_id}/{meta['table']}: wrote {', '.join(written)}",
+          flush=True,
+      )
+      # Capture per-entry state for multi-turn refinement (reuses `prompt`, so
+      # docs are never re-read). overview_path is the sidecar a refinement
+      # overwrites — the same file _write_table_files just wrote.
+      entry_state = refine.EntryState(
+          entry_id=meta["table"],
+          display_name=meta["table"],
+          description=meta.get("description", "") or "",
+          category_id=cat_id,
+          grounding_prompt=prompt,
+          writer_model=_WRITER_MODEL,
+          overview_body=body,
+          overview_path=os.path.join(
+              kcmd_tools._dataset_dir(output_dir, project, dataset_id),
+              f"{meta['table']}.overview.md",
+          ),
+          kind="table",
+      )
+      return meta, sel_docs, body, entry_state
+
+  results = await asyncio.gather(*[_write_one(m) for m in tables])
+
+  # 5b. Optional glossary column-linking: when --glossaries was provided,
+  # run the LinkingAgent over each table and inject column->term mappings
+  # into the same <table>.yaml that overview generation just enriched. Kept
+  # AFTER overview gen so token usage and trajectory both reflect the full
+  # enrichment pass.
+  if glossary_scope:
+    import linking  # local import to avoid cycle at module load
+
+    print("[Linking] 🔗 Mapping columns to glossary terms ...", flush=True)
+    n_links = await linking.apply_column_linking(
+        output_dir, project, dataset_id, model, usage_acc
+    )
+    print(f"[Linking] ✅ Injected {n_links} column link(s) total.", flush=True)
+
+  # 6. Persist trajectory for dynamic eval (mirrors doc mode). Records the
+  # tables, their routed docs, AND the enumeration so eval can ground scoring.
+  if output_dir:
+    tool_uses = [
+        {"name": "get_table_entry", "args": {"table": m["table"]}}
+        for m in tables
+    ]
+    tool_responses = [
+        {
+            "name": "get_table_entry",
+            "response": {
+                "table": m["table"],
+                "schema_fields": m["schema_fields"],
+            },
+        }
+        for m in tables
+    ]
+    for meta, sel_docs, _text, _es in results:
+      tool_uses.append({"name": "route_docs", "args": {"table": meta["table"]}})
+      tool_responses.append({
+          "name": "route_docs",
+          "response": {
+              "table": meta["table"],
+              "relevant_docs": [
+                  {
+                      "name": d["name"],
+                      "url": d["url"],
+                      "content": d["content"][:50000],
+                  }
+                  for d in sel_docs
+              ],
+          },
+      })
+    tool_uses.append({"name": "enumerate", "args": {"topic": topic}})
+    tool_responses.append(
+        {"name": "enumerate", "response": enumeration.model_dump()}
+    )
+    final_text = "\n\n".join(t for (_m, _d, t, _es) in results)
+    common.write_trajectory(
+        output_dir,
+        "table",
+        f"TOPIC: {topic} | DATASET: {project}.{dataset_id}",
+        tool_uses,
+        tool_responses,
+        final_text,
+        usage_acc,
+        latency=time.monotonic() - _t0,
+    )
+  from tools.drive_tools import get_cache_stats
+
+  print(f"[Cache] doc-fetch stats: {get_cache_stats()}", flush=True)
+
+  # Build the refinement session (consumed by agent_runner --interactive).
+  return refine.EnrichmentSession(
+      mode="table",
+      topic=topic,
+      model=model,
+      output_dir=output_dir,
+      entries={es.entry_id: es for (_m, _d, _t, es) in results},
+      usage_acc=usage_acc,
+      # Phase-2 state for a `reenumerate` refinement. Table entries are pinned
+      # 1:1 to the dataset's tables, so re-enumeration here only re-categorizes
+      # (it cannot add/remove entries) — see apply_reenumeration below.
+      enum_context=enum_context,
+      writer_params={"project": project, "dataset_id": dataset_id},
+      traj_meta={
+          "agent_type": "table",
+          "user_input": f"TOPIC: {topic} | DATASET: {project}.{dataset_id}",
+          "tool_uses": tool_uses if output_dir else [],
+          "tool_responses": tool_responses if output_dir else [],
+      },
+  )
+
+
+async def apply_reenumeration(session, new_enum, removed_ids) -> None:
+  """Materialize a table-mode re-enumeration delta — re-categorization ONLY.
+
+  Table entries are pinned 1:1 to the dataset's tables, so a re-enumeration
+  can neither add a topic (no underlying table) nor remove one (the table still
+  exists). We therefore ignore additions/removals and apply only category
+  changes: rewrite the `category:` field on the kcmd-pulled entry YAML (files
+  stay under `catalog/{proj}.{dataset}/`, so no move). Mutates session.entries.
+  """
+  wp = session.writer_params or {}
+  project = wp.get("project", "")
+  dataset_id = wp.get("dataset_id", "")
+  output_dir = session.output_dir
+  new_cat_by_id = {
+      e.id: cat for cat in new_enum.categories for e in cat.entries
+  }
+  if removed_ids:
+    print(
+        "[refine] ℹ️  table mode: entries are pinned to the dataset — cannot"
+        f" remove {sorted(set(removed_ids))}; applying category changes only.",
+        flush=True,
+    )
+  for eid, es in session.entries.items():
+    cat = new_cat_by_id.get(eid)
+    if cat is None or cat.id == es.category_id:
+      continue
+    _inject_category(output_dir, project, dataset_id, eid, cat.id)
+    es.category_id = cat.id
+    print(f"[refine] 🔀 recategorized {eid} -> {cat.id}", flush=True)
+
+
+def _inject_category(
+    output_dir: str, project: str, dataset_id: str, table: str, category_id: str
+):
+  """Add `category: <id>` to the top of the kcmd-pulled entry YAML."""
+  path = os.path.join(
+      kcmd_tools._dataset_dir(output_dir, project, dataset_id),  # pylint: disable=protected-access
+      f"{table}.yaml",
+  )
+  if not os.path.exists(path):
+    return
+  try:
+    with open(path) as f:
+      data = yaml.safe_load(f) or {}
+    data["category"] = category_id
+    with open(path, "w") as f:
+      yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
+  except (OSError, yaml.YAMLError):
+    pass
+
+
+# Flash for the per-table writer: small inputs (one table + a few docs) stay
+# well under the ADK 32K Flash routing cap. Pro is still the user-supplied
+# --model and is used by the enumerator (which needs reasoning across all tables).
+_WRITER_MODEL = "gemini-3.5-flash"

--- a/agents/enrichment/src/refine.py
+++ b/agents/enrichment/src/refine.py
@@ -1,0 +1,468 @@
+"""Multi-turn refinement for the enrichment agent.
+
+After the initial enrichment finishes, the customer can refine the output with
+free-text feedback. An LLM dispatcher (engine.create_refinement_dispatch_runner)
+maps each request to a structured plan, and we re-run ONLY the affected work —
+reusing the context that was already loaded during the initial run. Crucially,
+refinement NEVER re-reads the source docs or re-pulls the dataset: each entry
+carries the exact grounding prompt that produced its overview, so a rewrite is
+just one more writer call.
+
+Two surfaces consume this module:
+  * CLI: `agent_runner --interactive` keeps the process alive at a `refine>`
+    REPL (run_repl), holding the EnrichmentSession in memory.
+  * Webapp: stdin can't be wired into the streamed subprocess, so refinement
+    uses PERSIST + RE-INVOKE. The initial run saves the session to
+    `<output_dir>/refine_session.json` (save_session); each "Refine" click
+    spawns `agent_runner --refine_instruction=...`, which rehydrates the session
+    (load_session), applies ONE turn (run_one_refinement), and exits.
+
+The session model is mode-agnostic: every mode (table / context_overlay / doc)
+populates an EnrichmentSession of plain-data EntryState objects at the end of its
+run(). Each EntryState records the absolute path of its overview sidecar
+(`overview_path`), so refine.py rewrites it directly without per-mode knowledge —
+and the whole session serializes to JSON (no closures).
+
+First version supports two operations (see engine.RefinementPlan):
+  * rewrite — re-generate selected (or all) entries' overviews with a change.
+  * answer  — respond to a question about the output; no files change.
+"""
+
+import asyncio
+import dataclasses
+from dataclasses import dataclass, field
+import json
+import os
+import sys
+
+import common
+from engine import (
+    REFINEMENT_WRITER_INSTRUCTION,
+    RefinementPlan,
+    create_refinement_dispatch_runner,
+)
+
+# Saved next to the generated mdcode so a later `--refine_instruction` invocation
+# (webapp) can rehydrate the session without re-running the pipeline.
+SESSION_FILE = "refine_session.json"
+
+
+@dataclass
+class EntryState:
+  """Everything needed to refine ONE entry without re-ingesting anything.
+
+  Pure data (no closures) so the whole session serializes to JSON.
+  """
+
+  entry_id: str
+  display_name: str
+  description: str
+  category_id: str
+  # The exact writer user-prompt built during the initial run. Already contains
+  # the topic, the entry's metadata/schema, and the routed source-doc content —
+  # so refinement reuses it verbatim and never re-reads docs.
+  grounding_prompt: str
+  writer_model: str
+  # Current overview body (mutated each refine turn).
+  overview_body: str
+  # Absolute path of the `.overview.md` sidecar this entry owns; a refinement
+  # overwrites exactly this file (the entry YAML is unchanged by content edits).
+  overview_path: str
+  # Distilled instructions applied so far (oldest first).
+  refinement_history: list[str] = field(default_factory=list)
+  # 'kb' (doc mode, discovered) or 'table' (table/overlay, seeded from the
+  # dataset). Used to re-seed enumeration on a `reenumerate` refinement turn.
+  kind: str = "kb"
+
+  def write(self, body: str) -> list[str]:
+    """Overwrite the overview sidecar with `body`; returns the path written."""
+    if not self.overview_path:
+      return []
+    os.makedirs(os.path.dirname(self.overview_path), exist_ok=True)
+    with open(self.overview_path, "w") as f:
+      f.write(common.clean_overview_body(body) + "\n")
+    return [self.overview_path]
+
+
+@dataclass
+class EnrichmentSession:
+  """State carried from the initial run into refinement (in-memory or on disk)."""
+
+  mode: str
+  topic: str
+  model: str
+  output_dir: str
+  entries: dict[str, EntryState]
+  usage_acc: dict
+  # Args to re-persist trajectory.json after a refine turn (see _persist).
+  traj_meta: dict = field(default_factory=dict)
+  # Refinement turns recorded for trajectory.json.
+  refinements: list[dict] = field(default_factory=list)
+  # Phase-2 (enumeration) state, so a `reenumerate` refinement can re-run
+  # enumeration over the SAME context and add/remove/recategorize entries
+  # without re-reading any source. enum_context is the exact compiled context
+  # the initial run fed to common.run_enumeration; writer_params holds the
+  # mode-specific bits needed to materialize new/moved entries (see each mode's
+  # apply_reenumeration). Empty on sessions saved before this feature.
+  enum_context: str = ""
+  writer_params: dict = field(default_factory=dict)
+
+
+def session_path(output_dir: str) -> str:
+  return os.path.join(output_dir, SESSION_FILE)
+
+
+def save_session(session: EnrichmentSession) -> None:
+  """Persist the session to `<output_dir>/refine_session.json` (webapp re-invoke).
+
+  Safe no-op without an output_dir. usage_acc is intentionally not persisted
+  (per-process token accounting starts fresh on a re-invocation).
+  """
+  if not session.output_dir:
+    return
+  data = {
+      "mode": session.mode,
+      "topic": session.topic,
+      "model": session.model,
+      "output_dir": session.output_dir,
+      "traj_meta": session.traj_meta,
+      "refinements": session.refinements,
+      "enum_context": session.enum_context,
+      "writer_params": session.writer_params,
+      "entries": [dataclasses.asdict(e) for e in session.entries.values()],
+  }
+  os.makedirs(session.output_dir, exist_ok=True)
+  with open(session_path(session.output_dir), "w") as f:
+    json.dump(data, f, indent=2, default=str)
+
+
+def load_session(
+    output_dir: str, model_override: str | None = None
+) -> EnrichmentSession | None:
+  """Rehydrate a saved session, or None if there isn't one."""
+  path = session_path(output_dir)
+  if not os.path.exists(path):
+    return None
+  with open(path) as f:
+    data = json.load(f)
+  entries = {}
+  for ed in data.get("entries", []):
+    es = EntryState(**ed)
+    entries[es.entry_id] = es
+  return EnrichmentSession(
+      mode=data.get("mode", ""),
+      topic=data.get("topic", ""),
+      model=model_override or data.get("model", ""),
+      output_dir=data.get("output_dir", output_dir),
+      entries=entries,
+      usage_acc={"input": 0, "output": 0},
+      traj_meta=data.get("traj_meta", {}),
+      refinements=data.get("refinements", []),
+      enum_context=data.get("enum_context", ""),
+      writer_params=data.get("writer_params", {}),
+  )
+
+
+def _entry_snippet(body: str, limit: int = 500) -> str:
+  body = (body or "").strip()
+  return body[:limit] + ("…" if len(body) > limit else "")
+
+
+def _dispatch_context(session: EnrichmentSession) -> str:
+  """Render the entry list + overview snippets for the dispatcher."""
+  lines = []
+  for e in session.entries.values():
+    lines.append(
+        f"- id: {e.entry_id} | display_name: {e.display_name} | category:"
+        f" {e.category_id}"
+    )
+    lines.append(f"  overview_snippet: {_entry_snippet(e.overview_body, 400)}")
+  return "\n".join(lines)
+
+
+async def plan_refinement(
+    user_text: str, session: EnrichmentSession, model: str
+) -> RefinementPlan:
+  """One schema-validated dispatcher call → a RefinementPlan."""
+  prompt = (
+      f"USER MESSAGE:\n{user_text}\n\n"
+      f"CURRENT ENTRIES ({len(session.entries)}):\n"
+      f"{_dispatch_context(session)}\n\n"
+      "Decide the operation and produce the plan per the schema."
+  )
+  runner = create_refinement_dispatch_runner(model)
+  return await common.run_schema_agent(
+      runner, prompt, RefinementPlan, session.usage_acc
+  )
+
+
+async def _rewrite_entry(entry: EntryState, instruction: str, usage_acc: dict):
+  """Re-generate one entry's overview applying `instruction`, reusing context."""
+  history_block = ""
+  if entry.refinement_history:
+    history_block = (
+        "\nREFINEMENT HISTORY (earlier changes already applied — honor"
+        " them):\n"
+        + "\n".join(f"  - {h}" for h in entry.refinement_history)
+        + "\n"
+    )
+  refine_prompt = (
+      "=== ORIGINAL GROUNDING CONTEXT (same sources as the first draft) ==="
+      f"\n{entry.grounding_prompt}\n\n"
+      "=== CURRENT OVERVIEW ===\n"
+      f"```markdown\n{entry.overview_body}\n```\n"
+      f"{history_block}\n"
+      f"=== USER REFINEMENT REQUEST (this turn) ===\n{instruction}\n\n"
+      "Produce the revised overview Markdown body now."
+  )
+  new_body = await common.generate_text_direct(
+      REFINEMENT_WRITER_INSTRUCTION,
+      refine_prompt,
+      entry.writer_model,
+      usage_acc,
+  )
+  new_body = common.clean_overview_body(new_body)
+  written = entry.write(new_body)
+  entry.overview_body = new_body
+  entry.refinement_history.append(instruction)
+  return written
+
+
+async def apply_refinement(plan: RefinementPlan, session: EnrichmentSession):
+  """Execute a RefinementPlan against the session."""
+  if plan.operation == "answer":
+    print(f"\n{plan.answer}\n", flush=True)
+    return
+  if plan.operation == "noop":
+    msg = plan.answer or (
+        "Could not interpret that — please rephrase, e.g. 'make the X"
+        " overview more concise'."
+    )
+    print(f"\n[refine] {msg}\n", flush=True)
+    return
+
+  if plan.operation == "reenumerate":
+    await _reenumerate(plan, session)
+    return
+
+  # rewrite
+  if plan.target_entry_ids:
+    targets = [
+        session.entries[i] for i in plan.target_entry_ids if i in session.entries
+    ]
+    unknown = [i for i in plan.target_entry_ids if i not in session.entries]
+    if unknown:
+      print(f"[refine] ⚠️  Unknown entry id(s) ignored: {unknown}", flush=True)
+  else:
+    targets = list(session.entries.values())  # empty list = ALL entries
+
+  if not targets:
+    print("[refine] No matching entries to rewrite.", flush=True)
+    return
+
+  print(
+      f"[refine] ✍️  Rewriting {len(targets)} entr"
+      f"{'y' if len(targets) == 1 else 'ies'}: {plan.instruction}",
+      flush=True,
+  )
+  results = await asyncio.gather(
+      *[_rewrite_entry(e, plan.instruction, session.usage_acc) for e in targets]
+  )
+  for entry, written in zip(targets, results):
+    print(f"[refine] ✅ {entry.entry_id}: {', '.join(written)}", flush=True)
+
+  session.refinements.append({
+      "operation": "rewrite",
+      "instruction": plan.instruction,
+      "entries": [e.entry_id for e in targets],
+  })
+  _persist(session)
+  # Persist the updated session so the next refine turn (esp. a fresh webapp
+  # re-invocation) sees the compounded bodies + history.
+  save_session(session)
+
+
+async def _reenumerate(plan: RefinementPlan, session: EnrichmentSession):
+  """Re-run enumeration over the loaded context and materialize the delta.
+
+  Re-enters the pipeline at Phase 2 (enumeration): re-seeds with the current
+  entries (minus any the user removed), steers the EnumerationAgent with the
+  user's guidance, then hands the new entry list to the mode-specific
+  apply_reenumeration to add/remove/recategorize files on disk. No source doc is
+  re-read — enumeration runs against session.enum_context (the original compiled
+  context captured at the end of the initial run).
+  """
+  if not session.enum_context:
+    print(
+        "[refine] ⚠️  This session predates entry-set refinement (no saved"
+        " enumeration context) — re-run the enrichment to enable add/remove/"
+        "recategorize.",
+        flush=True,
+    )
+    return
+
+  remove = set(plan.remove_entry_ids or [])
+  seeds = [
+      {"id": e.entry_id, "display_name": e.display_name, "kind": e.kind}
+      for e in session.entries.values()
+      if e.entry_id not in remove
+  ]
+  print(
+      f"[refine] 🧭 Re-enumerating ({len(seeds)} kept seed(s)"
+      f"{', removing ' + ', '.join(sorted(remove)) if remove else ''})"
+      f"{': ' + plan.enumeration_guidance if plan.enumeration_guidance else ''}",
+      flush=True,
+  )
+  new_enum = await common.run_enumeration(
+      session.topic,
+      session.enum_context,
+      seed_entries=seeds or None,
+      model=session.model,
+      usage_acc=session.usage_acc,
+      extra_guidance=plan.enumeration_guidance,
+      drop_ids=remove,
+  )
+
+  # Delegate file-level materialization to the mode (it owns the on-disk layout).
+  from modes import context_overlay_mode, doc_mode, table_mode
+
+  handler = {
+      "doc": doc_mode,
+      "table": table_mode,
+      "context_overlay": context_overlay_mode,
+  }.get(session.mode)
+  if handler is None:
+    print(f"[refine] ⚠️  Unknown mode '{session.mode}' — cannot re-enumerate.")
+    return
+  await handler.apply_reenumeration(session, new_enum, remove)
+
+  session.refinements.append({
+      "operation": "reenumerate",
+      "instruction": plan.enumeration_guidance,
+      "removed": sorted(remove),
+      "entries": sorted(session.entries),
+  })
+  _persist(session)
+  save_session(session)
+  print(
+      f"[refine] ✅ Re-enumeration complete — {len(session.entries)} entr"
+      f"{'y' if len(session.entries) == 1 else 'ies'} now.",
+      flush=True,
+  )
+
+
+def _persist(session: EnrichmentSession):
+  """Re-write trajectory.json with the latest overviews + refinement log."""
+  if not session.output_dir or not session.traj_meta:
+    return
+  m = session.traj_meta
+  final_text = "\n\n".join(
+      e.overview_body for e in session.entries.values() if e.overview_body
+  )
+  tool_uses = list(m.get("tool_uses", []))
+  tool_responses = list(m.get("tool_responses", []))
+  for r in session.refinements:
+    tool_uses.append({"name": "refine", "args": {"instruction": r["instruction"]}})
+    tool_responses.append({"name": "refine", "response": r})
+  common.write_trajectory(
+      session.output_dir,
+      m.get("agent_type", session.mode),
+      m.get("user_input", f"TOPIC: {session.topic}"),
+      tool_uses,
+      tool_responses,
+      final_text,
+      session.usage_acc,
+  )
+
+
+_BANNER = """
+============================================================
+Refinement mode — the docs and context are still loaded.
+Type how you'd like to refine the output, e.g.
+  · make the <name> overview more concise
+  · add a "Data freshness" section to every entry
+  · add a topic about <X> / remove the <name> entry  (re-enumerate)
+  · regroup the entries by <theme>                    (re-categorize)
+  · why is <name> in that category?
+Commands: :entries (list)  :show <id> (print overview)  :quit
+============================================================"""
+
+
+def _print_summary(session: EnrichmentSession):
+  print(_BANNER, flush=True)
+  print(f"Mode: {session.mode}  |  Output: {session.output_dir}", flush=True)
+  print(f"{len(session.entries)} entr"
+        f"{'y' if len(session.entries) == 1 else 'ies'}:", flush=True)
+  for e in session.entries.values():
+    print(f"  · {e.entry_id}  ({e.category_id})", flush=True)
+
+
+async def run_repl(session: EnrichmentSession, model: str):
+  """Interactive refinement loop. No-op on a non-tty or empty session."""
+  if not session or not session.entries:
+    return
+  if not sys.stdin.isatty():
+    print(
+        "[refine] stdin is not a TTY — skipping interactive refinement.",
+        flush=True,
+    )
+    return
+
+  _print_summary(session)
+  while True:
+    try:
+      text = input("\nrefine> ").strip()
+    except (EOFError, KeyboardInterrupt):
+      print("\n[refine] Exiting.", flush=True)
+      return
+    if not text:
+      continue
+    low = text.lower()
+    if low in (":quit", ":q", ":exit", "quit", "exit"):
+      print("[refine] Exiting.", flush=True)
+      return
+    if low == ":entries":
+      for e in session.entries.values():
+        print(f"  · {e.entry_id}  ({e.category_id})  — {e.display_name}")
+      continue
+    if low.startswith(":show"):
+      parts = text.split(maxsplit=1)
+      if len(parts) == 2 and parts[1] in session.entries:
+        print(f"\n{session.entries[parts[1]].overview_body}\n")
+      else:
+        print("[refine] usage: :show <entry_id>")
+      continue
+    try:
+      plan = await plan_refinement(text, session, model)
+      await apply_refinement(plan, session)
+    except Exception as ex:  # pylint: disable=broad-except
+      print(f"[refine] ⚠️  Refinement failed: {ex}", flush=True)
+
+
+async def run_one_refinement(output_dir: str, instruction: str, model: str):
+  """Apply a SINGLE refinement turn against a saved session, then exit.
+
+  This is the webapp's non-interactive entrypoint (agent_runner
+  --refine_instruction): rehydrate the session persisted by the initial run,
+  dispatch + apply the one instruction, and persist the result. Streams the same
+  `[refine] …` progress lines the REPL prints, which the webapp tails.
+  """
+  session = load_session(output_dir, model_override=model)
+  if session is None:
+    print(
+        f"[refine] ❌ No saved session at {session_path(output_dir)} — run an"
+        " enrichment first.",
+        flush=True,
+    )
+    return
+  if not session.entries:
+    print("[refine] ❌ Saved session has no entries to refine.", flush=True)
+    return
+  print(
+      f"[refine] 🔁 Refining {len(session.entries)} entr"
+      f"{'y' if len(session.entries) == 1 else 'ies'} in {output_dir}",
+      flush=True,
+  )
+  plan = await plan_refinement(instruction, session, model)
+  await apply_refinement(plan, session)
+  print("[refine] ✅ Done.", flush=True)

--- a/agents/enrichment/src/tools/bq_usage_tools.py
+++ b/agents/enrichment/src/tools/bq_usage_tools.py
@@ -1,0 +1,880 @@
+"""BigQuery query-history "usage signals" for kc_v2 table-mode enrichment.
+
+For each table in a dataset, pull recent queries from
+`region-<R>.INFORMATION_SCHEMA.JOBS_BY_PROJECT` (with `JOBS_BY_USER` fallback
+when the caller lacks `bigquery.jobs.listAll`) and aggregate them into a
+compact, prompt-ready "TableUsage" — top users, top normalized query patterns,
+frequent join partners, most-referenced columns.
+
+The design decisions baked in here:
+
+1. **One batched query per dataset, not per table.** The job-history views
+   scan by partition (`creation_time`) regardless of how many tables we
+   filter to; firing 14 separate queries for a 14-table dataset costs ~14×
+   the BQ scan for the same data. We fetch once, group by client-side.
+2. **Cache the whole dataset's usage** at
+   `~/.kc_enrich_cache/usage/<project>.<dataset>.json` keyed on
+   (`project.dataset`, `YYYY-MM-DD`). Same-day re-runs are free.
+3. **Strip literals** from query text before caching or surfacing to the
+   LLM — defense-in-depth against PII / business-logic leakage.
+4. **Snapshot-table fast path is deliberately NOT implemented in v1**
+   per user direction; the env var name is reserved for the v2 follow-up.
+"""
+
+import dataclasses
+import datetime as _dt
+import hashlib
+import json
+import os
+import re
+import typing as t
+
+# --- Config / env --------------------------------------------------------
+
+# Reuse the same cache root + mode flag as drive_tools / engine summaries so
+# users have a single knob (`KC_ENRICH_CACHE_MODE`) and a single dir
+# (`~/.kc_enrich_cache/`, chmod 700) to reason about.
+_CACHE_DIR = os.path.join(os.environ.get("HOME", "/tmp"), ".kc_enrich_cache")
+_USAGE_CACHE_DIR = os.path.join(_CACHE_DIR, "usage")
+
+# Reserved for the v2 snapshot-table fast path. Reading it now (even though
+# unused) keeps the env-var name stable across versions.
+_SNAPSHOT_TABLE_ENV = "KC_ENRICH_USAGE_SNAPSHOT_TABLE"
+
+_DEFAULT_WINDOW_DAYS = 30
+# Per-table aggregate caps — keep the surfaced signal compact enough to fit
+# in the writer prompt alongside schema + Drive context without blowing the
+# Pro context budget.
+_MAX_TOP_USERS = 5
+_MAX_TOP_PATTERNS = 3
+_MAX_TOP_JOIN_PARTNERS = 5
+_MAX_TOP_COLUMNS = 10
+
+
+def _resolve_cache_mode() -> str:
+  """Mirror drive_tools._resolve_cache_mode so usage cache obeys the same flag.
+
+  Importing from drive_tools would create a cycle in some embedding contexts;
+  we duplicate the (tiny) resolver to stay decoupled.
+
+  Returns:
+    Cache mode string.
+  """
+  legacy = os.environ.get("KC_ENRICH_CACHE", "").lower()
+  if legacy in ("off", "0", "false", "no"):
+    return "off"
+  mode = os.environ.get("KC_ENRICH_CACHE_MODE", "").lower().strip()
+  if mode in ("off", "raw", "summary"):
+    return mode
+  return "summary"
+
+
+# --- Data shape ----------------------------------------------------------
+
+
+@dataclasses.dataclass
+class TableUsage:
+  """Aggregated query-history signal for ONE table over a fixed window.
+
+  Empty `total_queries` + scope='unavailable' means we tried and got
+  nothing usable (no perm, no jobs, or the table isn't referenced in the
+  window) — callers SHOULD render "(no usage observed)" rather than
+  fabricating a paragraph.
+  """
+
+  total_queries: int = 0
+  total_bytes_processed: int = 0
+  top_users: t.List[t.Any] = dataclasses.field(default_factory=list)
+  top_query_patterns: t.List[t.Any] = dataclasses.field(default_factory=list)
+  top_join_partners: t.List[t.Any] = dataclasses.field(default_factory=list)
+  top_referenced_columns: t.List[t.Any] = dataclasses.field(
+      default_factory=list
+  )
+  # 'snapshot' | 'project' | 'user' | 'unavailable'
+  scope: str = "unavailable"
+  window_days: int = _DEFAULT_WINDOW_DAYS
+  fetched_at: str = ""
+
+
+def _empty(window_days: int) -> TableUsage:
+  """Returns an empty TableUsage.
+
+  Args:
+    window_days: Window days.
+
+  Returns:
+    Empty TableUsage.
+  """
+  return TableUsage(window_days=window_days, fetched_at=_now_iso())
+
+
+def _now_iso() -> str:
+  """Returns current time in ISO format.
+
+  Returns:
+    ISO time string.
+  """
+  return _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+
+
+# --- Literal stripper ----------------------------------------------------
+
+# Normalize query text so different queries with the same shape collapse to
+# the same pattern. Regex-based; covers strings, numerics, IN-lists, and
+# common date literals — the 80% case. For SQL with unusual literal shapes
+# the pattern just collapses less aggressively, which only weakens
+# aggregation (not correctness).
+_LITERAL_PATTERNS = [
+    (re.compile(r"'(?:[^']|'')*'"), "{STR}"),
+    (re.compile(r'"(?:[^"]|"")*"'), "{STR}"),
+    (re.compile(r"\bDATE\s*'[^']*'", re.IGNORECASE), "{DATE}"),
+    (re.compile(r"\bTIMESTAMP\s*'[^']*'", re.IGNORECASE), "{TS}"),
+    (
+        re.compile(r"\bIN\s*\(\s*(?:[^()]|\([^()]*\))*\)", re.IGNORECASE),
+        "IN ({LIT_LIST})",
+    ),
+    (re.compile(r"\b\d+\.\d+\b"), "{NUM}"),
+    (re.compile(r"\b\d+\b"), "{NUM}"),
+]
+
+# Collapse whitespace AFTER literal stripping so patterns dedupe cleanly.
+_WS_RE = re.compile(r"\s+")
+
+
+def normalize_query(sql: str) -> str:
+  """Strip literals + collapse whitespace.
+
+  Used for pattern grouping AND for the prompt-surfaced sample, so the LLM never
+  sees raw user data.
+
+  Args:
+    sql: Raw SQL query.
+
+  Returns:
+    Normalized SQL query.
+  """
+  if not sql:
+    return ""
+  out = sql.strip()
+  for pat, replacement in _LITERAL_PATTERNS:
+    out = pat.sub(replacement, out)
+  return _WS_RE.sub(" ", out).strip()
+
+
+def _hash_user(email: str) -> str:
+  """One-way hash for --anonymize-users mode.
+
+  Stable across days so the same user shows the same hash in different runs
+  (helps the LLM recognize recurring callers without revealing emails).
+
+  Args:
+    email: User email.
+
+  Returns:
+    Hashed user string.
+  """
+  return "user_" + hashlib.sha256(email.encode("utf-8")).hexdigest()[:10]
+
+
+# --- Cache ---------------------------------------------------------------
+
+
+def _cache_path(project: str, dataset: str) -> str:
+  """Returns the cache path.
+
+  Args:
+    project: Project ID.
+    dataset: Dataset ID.
+
+  Returns:
+    Cache path string.
+  """
+  safe = re.sub(r"[^A-Za-z0-9_.-]", "_", f"{project}.{dataset}")[:200]
+  return os.path.join(_USAGE_CACHE_DIR, f"{safe}.json")
+
+
+def _today() -> str:
+  """Returns today's date in ISO format.
+
+  Returns:
+    Today's date string.
+  """
+  return _dt.date.today().isoformat()
+
+
+def _read_usage_cache(
+    project: str, dataset: str, window_days: int
+) -> t.Optional[t.Dict[str, t.Any]]:
+  """Return cached `{table_id: TableUsage-as-dict}` if fresh, else None.
+
+  Stale = different day OR different window_days. Treating window as part
+  of the key prevents a 7-day cached fetch from serving a 30-day request.
+
+  Args:
+    project: Project ID.
+    dataset: Dataset ID.
+    window_days: Window days.
+
+  Returns:
+    Cached usage dict or None.
+  """
+  if _resolve_cache_mode() == "off":
+    return None
+  path = _cache_path(project, dataset)
+  if not os.path.exists(path):
+    return None
+  try:
+    with open(path) as f:
+      blob = json.load(f)
+  except (OSError, json.JSONDecodeError):
+    return None
+  if blob.get("day") != _today() or blob.get("window_days") != window_days:
+    return None
+  return blob.get("tables") or {}
+
+
+def _write_usage_cache(
+    project: str,
+    dataset: str,
+    window_days: int,
+    tables: t.Dict[str, TableUsage],
+):
+  """Writes usage cache.
+
+  Args:
+    project: Project ID.
+    dataset: Dataset ID.
+    window_days: Window days.
+    tables: Dict of TableUsage.
+  """
+  if _resolve_cache_mode() == "off":
+    return
+  try:
+    os.makedirs(_USAGE_CACHE_DIR, exist_ok=True)
+    # Tighten the cache root once on every write — same hardening as
+    # drive_tools, in case the dir was created by some other path.
+    os.chmod(_CACHE_DIR, 0o700)
+  except OSError:
+    pass
+  blob = {
+      "day": _today(),
+      "window_days": window_days,
+      "tables": {tid: dataclasses.asdict(u) for tid, u in tables.items()},
+  }
+  tmp = _cache_path(project, dataset) + ".tmp"
+  try:
+    with open(tmp, "w") as f:
+      json.dump(blob, f)
+    os.replace(tmp, _cache_path(project, dataset))
+  except OSError:
+    try:
+      os.remove(tmp)
+    except OSError:
+      pass
+
+
+# --- Dataset region lookup -----------------------------------------------
+
+
+def get_dataset_region(project: str, dataset: str) -> str | None:
+  """Return the lowercased region of a dataset (e.g. 'us', 'us-central1').
+
+  Needed because `JOBS_BY_*` is regional — querying the wrong region
+  returns zero rows silently. Returns None on permission/lookup failure,
+  in which case the caller should fall back to the default region 'us'
+  (the most common location for our test corpora).
+
+  Args:
+    project: Project ID.
+    dataset: Dataset ID.
+
+  Returns:
+    Region string or None.
+  """
+  try:
+    from google.cloud import bigquery  # pylint: disable=g-import-not-at-top
+  except ImportError:
+    return None
+  try:
+    client = bigquery.Client(project=project)
+    ds = client.get_dataset(f"{project}.{dataset}")
+    loc = (ds.location or "").lower()
+    return loc or None
+  except Exception:  # pylint: disable=broad-except
+    return None
+
+
+# --- Batched fetch -------------------------------------------------------
+
+# One INFO_SCHEMA query per dataset: the EXISTS clause limits returned rows
+# to jobs that touched any table in the dataset. Python aggregates per
+# `referenced_tables.table_id` from the result. `creation_time` is the
+# partition key on these views; the date filter prunes scan to the window.
+_JOBS_SQL_TEMPLATE = """
+SELECT
+  job_id,
+  user_email,
+  query,
+  total_bytes_processed,
+  creation_time,
+  referenced_tables
+FROM `region-{region}`.INFORMATION_SCHEMA.{jobs_view}
+WHERE creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @window_days DAY)
+  AND job_type = 'QUERY'
+  AND state = 'DONE'
+  AND EXISTS (
+    SELECT 1 FROM UNNEST(referenced_tables) rt
+    WHERE rt.project_id = @project AND rt.dataset_id = @dataset
+  )
+"""
+
+
+def _run_jobs_query(
+    project: str,
+    dataset: str,
+    region: str,
+    window_days: int,
+    use_user_scope: bool,
+):
+  """Yield (job_id, user_email, query, total_bytes, creation_time, referenced_tables).
+
+  tuples. Raises on permission / SQL errors; caller decides whether to fall
+  back.
+
+  Args:
+    project: Project ID.
+    dataset: Dataset ID.
+    region: Region.
+    window_days: Window days.
+    use_user_scope: Whether to use JOBS_BY_USER.
+
+  Yields:
+    Row data.
+  """
+  from google.cloud import bigquery  # pylint: disable=g-import-not-at-top
+
+  view = "JOBS_BY_USER" if use_user_scope else "JOBS_BY_PROJECT"
+  sql = _JOBS_SQL_TEMPLATE.format(region=region, jobs_view=view)
+  client = bigquery.Client(project=project)
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter("window_days", "INT64", window_days),
+          bigquery.ScalarQueryParameter("project", "STRING", project),
+          bigquery.ScalarQueryParameter("dataset", "STRING", dataset),
+      ]
+  )
+  for row in client.query(sql, job_config=job_config).result():
+    yield row
+
+
+def _aggregate(
+    rows,
+    table_ids: t.List[str],
+    project: str,
+    dataset: str,
+    anonymize_users: bool,
+    window_days: int,
+) -> t.Dict[str, TableUsage]:
+  """Group raw rows by (referenced_tables.table_id) → TableUsage.
+
+  Each row may contribute to multiple tables (a join over two of our tables
+  shows up in both buckets) — that's the intended semantics.
+
+  Args:
+    rows: Rows to aggregate.
+    table_ids: Table IDs.
+    project: Project ID.
+    dataset: Dataset ID.
+    anonymize_users: Whether to anonymize users.
+    window_days: Window days.
+
+  Returns:
+    Dict of TableUsage.
+  """
+  table_set = set(table_ids)
+  # Per-table accumulators
+  buckets: t.Dict[str, t.Dict[str, t.Any]] = {
+      tid: {
+          "queries": 0,
+          "bytes": 0,
+          "users": {},
+          "patterns": {},
+          "join_partners": {},
+          "columns": {},
+      }
+      for tid in table_ids
+  }
+  for row in rows:
+    refs = (
+        row.get("referenced_tables")
+        if isinstance(row, dict)
+        else (row.referenced_tables or [])
+    )
+    # Convert BQ Row objects to plain dicts for uniform access.
+    ref_list = []
+    for r in refs:
+      r_dict = dict(r) if hasattr(r, "items") else r
+      ref_list.append(r_dict)
+    # Identify which of OUR tables this job touched.
+    touched_here = [
+        r["table_id"]
+        for r in ref_list
+        if r.get("project_id") == project
+        and r.get("dataset_id") == dataset
+        and r.get("table_id") in table_set
+    ]
+    if not touched_here:
+      continue
+    user = row.user_email or ""
+    user_key = _hash_user(user) if anonymize_users and user else user
+    norm = normalize_query(row.query or "")
+    bytes_ = int(row.total_bytes_processed or 0)
+    # Other (non-bucket) tables this job touched → join partners
+    other_partners = [
+        f"{r['project_id']}.{r['dataset_id']}.{r['table_id']}"
+        for r in ref_list
+        if r.get("table_id") not in touched_here
+        or r.get("dataset_id") != dataset
+        or r.get("project_id") != project
+    ]
+    for tid in touched_here:
+      b = buckets[tid]
+      b["queries"] += 1
+      b["bytes"] += bytes_
+      if user_key:
+        b["users"][user_key] = b["users"].get(user_key, 0) + 1
+      if norm:
+        b["patterns"][norm] = b["patterns"].get(norm, 0) + 1
+      for partner in other_partners:
+        b["join_partners"][partner] = b["join_partners"].get(partner, 0) + 1
+      # Column-level signal — only available in `referenced_tables.columns`
+      # for jobs where the query was column-pruned; fall back to nothing.
+      for r in ref_list:
+        if (
+            r.get("project_id") == project
+            and r.get("dataset_id") == dataset
+            and r.get("table_id") == tid
+        ):
+          for col in r.get("columns", []) or []:
+            cname = col if isinstance(col, str) else col.get("name", "")
+            if cname:
+              b["columns"][cname] = b["columns"].get(cname, 0) + 1
+
+  scope = "project"  # set by caller
+  fetched = _now_iso()
+  out: t.Dict[str, TableUsage] = {}
+  for tid, b in buckets.items():
+    out[tid] = TableUsage(
+        total_queries=b["queries"],
+        total_bytes_processed=b["bytes"],
+        top_users=_topn(b["users"], _MAX_TOP_USERS),
+        top_query_patterns=_topn(b["patterns"], _MAX_TOP_PATTERNS),
+        top_join_partners=_topn(b["join_partners"], _MAX_TOP_JOIN_PARTNERS),
+        top_referenced_columns=_topn(b["columns"], _MAX_TOP_COLUMNS),
+        scope=scope,
+        window_days=window_days,
+        fetched_at=fetched,
+    )
+  return out
+
+
+def _topn(counter: t.Dict[str, int], n: int) -> t.List[t.Any]:
+  """Return [(key, count)] sorted by count desc, truncated to n.
+
+  Stable on ties.
+
+  Args:
+    counter: Counter dict.
+    n: Top N.
+
+  Returns:
+    List of top N items.
+  """
+  return sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))[:n]
+
+
+# --- Public entrypoint ---------------------------------------------------
+
+
+def fetch_dataset_usage(
+    project: str,
+    dataset: str,
+    table_ids: t.List[str],
+    *,
+    window_days: int = _DEFAULT_WINDOW_DAYS,
+    anonymize_users: bool = False,
+    region: str | None = None,
+    scope: str = "auto",
+) -> t.Dict[str, TableUsage]:
+  """Pull aggregated query-history usage for a dataset's tables.
+
+  Strategy:
+    1. Honor the daily cache at ~/.kc_enrich_cache/usage/.
+    2. (Reserved) Snapshot-table fast path — currently a no-op; the
+       KC_ENRICH_USAGE_SNAPSHOT_TABLE env var is read but the path is
+       deliberately not yet implemented (v2 step function per design doc).
+    3. JOBS_BY_PROJECT (rich) — try first when scope=='auto' or 'project'.
+    4. JOBS_BY_USER (narrow) — fall back to on Forbidden / NotFound, or
+       use directly when scope=='user'.
+
+  Returns `{table_id: TableUsage}`. Tables with no observed queries get
+  an empty `TableUsage(scope='unavailable')` — callers should render a
+  graceful "no usage observed" rather than fabricating signal.
+
+  Failure modes (network down, bq client missing, region lookup fails)
+  all return empty results rather than raising — the writer prompt then
+  just omits the usage section.
+
+  Args:
+    project: Project ID.
+    dataset: Dataset ID.
+    table_ids: Table IDs.
+    window_days: Window days.
+    anonymize_users: Whether to anonymize users.
+    region: Region.
+    scope: Scope string.
+
+  Returns:
+    Dict of TableUsage.
+  """
+  cached = _read_usage_cache(project, dataset, window_days)
+  if cached is not None:
+    return _hydrate_cached(cached, table_ids, window_days)
+
+  # Snapshot-table path reserved for v2 step function — for now we only
+  # log when the env var is set so users know we saw it.
+  snapshot_table = os.environ.get(_SNAPSHOT_TABLE_ENV, "").strip()
+  if snapshot_table:
+    print(
+        f"[bq_usage] note: {_SNAPSHOT_TABLE_ENV} is set ({snapshot_table})"
+        " but the snapshot fast path isn't implemented yet — falling"
+        " through to INFORMATION_SCHEMA. Tracked as v2 step function.",
+        flush=True,
+    )
+
+  region = (region or get_dataset_region(project, dataset) or "us").lower()
+  results = {tid: _empty(window_days) for tid in table_ids}
+  try_user_scope = scope == "user"
+
+  if scope in ("auto", "project") and not try_user_scope:
+    try:
+      rows = list(
+          _run_jobs_query(
+              project, dataset, region, window_days, use_user_scope=False
+          )
+      )
+      results = _aggregate(
+          rows, table_ids, project, dataset, anonymize_users, window_days
+      )
+      for tid in results:
+        if results[tid].total_queries > 0 or scope == "project":
+          results[tid].scope = "project"
+      _write_usage_cache(project, dataset, window_days, results)
+      return results
+    except Exception as e:  # pylint: disable=broad-except
+      # Permission-denied on bigquery.jobs.listAll is the most common case;
+      # fall back to user scope. Other failures (region typo, billing
+      # disabled) also fall through, but those won't be helped by the
+      # fallback either — they just return empty.
+      print(
+          f"[bq_usage] JOBS_BY_PROJECT failed ({type(e).__name__}: {e!s:.180});"
+          " falling back to JOBS_BY_USER",
+          flush=True,
+      )
+      try_user_scope = True
+
+  if try_user_scope or scope == "user":
+    try:
+      rows = list(
+          _run_jobs_query(
+              project, dataset, region, window_days, use_user_scope=True
+          )
+      )
+      results = _aggregate(
+          rows, table_ids, project, dataset, anonymize_users, window_days
+      )
+      for tid in results:
+        results[tid].scope = "user"
+      _write_usage_cache(project, dataset, window_days, results)
+      return results
+    except Exception as e:  # pylint: disable=broad-except
+      print(
+          f"[bq_usage] JOBS_BY_USER also failed ({type(e).__name__}: "
+          f"{e!s:.180}); returning empty usage",
+          flush=True,
+      )
+
+  return results
+
+
+def _hydrate_cached(
+    cached: t.Dict[str, t.Any], table_ids: t.List[str], window_days: int
+) -> t.Dict[str, TableUsage]:
+  """Build a {table_id: TableUsage} dict from cached JSON, defaulting any.
+
+  table not in the cache to an empty TableUsage. Lets us add a new table
+  to a dataset mid-day without busting the entire cache.
+
+  Args:
+    cached: Cached dict.
+    table_ids: Table IDs.
+    window_days: Window days.
+
+  Returns:
+    Dict of TableUsage.
+  """
+  out: t.Dict[str, TableUsage] = {}
+  for tid in table_ids:
+    raw = cached.get(tid)
+    if raw:
+      out[tid] = TableUsage(**raw)
+    else:
+      out[tid] = _empty(window_days)
+  return out
+
+
+# --- Prompt-surface formatter --------------------------------------------
+
+
+def format_usage_section(usage: TableUsage, table_fqn: str) -> str:
+  """Render TableUsage as a Markdown section the writer prompt can ingest.
+
+  Kept for callers that want a flat narrative — the table_mode sidecar
+  writer now uses `format_queries_sidecar` instead, which produces a
+  kcmd-style sidecar conforming to the `queries` aspect type
+  (cloud/dataplex/catalog/types/aspect-types/queries.textproto).
+
+  Args:
+    usage: TableUsage.
+    table_fqn: Table FQN.
+
+  Returns:
+    Formatted Markdown string.
+  """
+  if usage.total_queries == 0:
+    return (
+        "## Observed Usage\n\n"
+        f"_(No usage observed for `{table_fqn}` in the last"
+        f" {usage.window_days} days, or query-history access is"
+        " unavailable.)_\n"
+    )
+  lines = [
+      "## Observed Usage",
+      "",
+      (
+          f"_Last {usage.window_days} days · scope: {usage.scope} · "
+          f"fetched {usage.fetched_at}_"
+      ),
+      "",
+      (
+          f"- **{usage.total_queries} queries** ·"
+          f" **{_human_bytes(usage.total_bytes_processed)} processed**"
+      ),
+  ]
+  if usage.top_users:
+    rendered = ", ".join(f"{u} ({n})" for u, n in usage.top_users)
+    lines.append(f"- **Top users:** {rendered}")
+  if usage.top_query_patterns:
+    lines.append("- **Top query patterns:**")
+    for pat, n in usage.top_query_patterns:
+      lines.append(f"    - ({n}×) `{_truncate(pat, 240)}`")
+  if usage.top_join_partners:
+    rendered = ", ".join(f"{p} ({n})" for p, n in usage.top_join_partners)
+    lines.append(f"- **Frequently joined with:** {rendered}")
+  if usage.top_referenced_columns:
+    rendered = ", ".join(
+        f"`{c}` ({n})" for c, n in usage.top_referenced_columns
+    )
+    lines.append(f"- **Most-referenced columns:** {rendered}")
+  return "\n".join(lines) + "\n"
+
+
+# YAML serializer note: we hand-emit a small, well-controlled subset rather
+# than pull in PyYAML's full dumper, so the frontmatter looks identical
+# across Python versions and we can use block-scalars (`|`) for SQL bodies
+# without depending on PyYAML's default_flow_style heuristics. The shape
+# matches the Dataplex `queries` aspect type (`dataplex-types.global.queries`).
+
+_JOB_NAME = "kc_v2_table_mode_enrichment"
+
+
+def _yaml_escape_scalar(s: str) -> str:
+  r"""Minimal escaping for a single-line YAML string value.
+
+  Wraps in double quotes and backslash-escapes embedded `"` and `\\`.
+
+  Args:
+    s: Input string.
+
+  Returns:
+    Escaped string.
+  """
+  s = s.replace("\\", "\\\\").replace('"', '\\"')
+  return f'"{s}"'
+
+
+def _yaml_block_sql(sql: str, indent: int) -> str:
+  """Emit `sql` as a YAML block scalar (`|`) so newlines + special chars.
+
+  in the query body don't need quoting.
+
+  Args:
+    sql: SQL string.
+    indent: Indent level.
+
+  Returns:
+    YAML block string.
+  """
+  pad = " " * indent
+  lines = [f"{pad}{line}" if line else pad.rstrip() for line in sql.split("\n")]
+  return "|\n" + "\n".join(lines)
+
+
+def format_queries_sidecar(
+    usage: TableUsage,
+    table_fqn: str,
+    *,
+    doc_queries: t.Optional[t.List[t.Dict[str, t.Any]]] | None = None,
+    feedback_queries: t.Optional[t.List[t.Dict[str, t.Any]]] | None = None,
+) -> str:
+  """Render the `queries` aspect sidecar for a single table.
+
+  Three sources merge into one sidecar:
+    1. `usage.top_query_patterns` — normalized patterns observed in
+       INFORMATION_SCHEMA.JOBS_BY_PROJECT. Each gets a description
+       prefix `[Source: INFORMATION_SCHEMA]`.
+    2. `doc_queries` (optional) — `{description, sql}` dicts extracted
+       from routed documentation by `_extract_doc_queries`. Each gets a
+       description prefix `[Source: Documentation]`.
+    3. `feedback_queries` (optional) — `{description, sql}` dicts
+       sourced from direct user feedback (eval_candidate.golden_sql
+       payloads via feedback_tools.proposals_to_queries). Each gets a
+       description prefix `[Source: User Feedback]` AND the aspect's
+       `source` enum is set to USER (not AGENT) — these queries are
+       ground-truth user input, not LLM inference.
+
+  The aspect type's `source` enum is closed (AGENT | USER) per the Dataplex
+  `queries` aspect type schema (`dataplex-types.global.queries`);
+  the prefix in the description disambiguates the AGENT-sourced entries
+  further (INFORMATION_SCHEMA vs Documentation).
+
+  YAML frontmatter ONLY (no body): kcmd's patched standard layout
+  (agents/mdcode/src/libts/layouts/standard.ts) skips `content`
+  injection when the body is empty, which keeps Dataplex push happy
+  (the queries aspect has no `content` field).
+
+  Args:
+    usage: TableUsage.
+    table_fqn: Table FQN.
+    doc_queries: SQL extracted from routed documentation (AGENT source).
+    feedback_queries: SQL from user-feedback proposals (USER source).
+
+  Returns:
+    Formatted YAML string.
+  """
+  # job.runTime: when THIS agent run wrote the aspect, NOT when the
+  # underlying BQ sample was taken. The daily usage cache means
+  # `usage.fetched_at` can be hours stale by the time we write the aspect,
+  # which made re-pushes within the same day look like no-ops at the
+  # aspect-data level (even though Dataplex's server-side aspect.updateTime
+  # did advance). Using _now_iso() keeps job.runTime semantically aligned
+  # with `aspect.updateTime` — a stale BQ sample is a separate concern
+  # already encoded by the per-query description (`Observed N× in last
+  # window_days days`).
+  run_time = _now_iso()
+  doc_queries = doc_queries or []
+  feedback_queries = feedback_queries or []
+
+  # Build the frontmatter as a deterministic YAML string.
+  fm_lines = ["---", "queries:"]
+
+  # User-feedback entries emit FIRST so they're the most prominent in the
+  # rendered aspect — these are ground truth from real user interactions
+  # and outrank everything else when readers scan the queries.
+  for q in feedback_queries:
+    raw_desc = (q.get("description") or "").strip()
+    if not raw_desc:
+      raw_desc = "User-feedback query example."
+    desc = f"[Source: User Feedback] {raw_desc}"
+    sql = (q.get("sql") or "").strip()
+    if not sql:
+      continue
+    fm_lines.append(f"  - description: {_yaml_escape_scalar(desc)}")
+    fm_lines.append(f"    sql: {_yaml_block_sql(sql, indent=6)}")
+    fm_lines.append("    source: USER")
+    fm_lines.append("    sqlDialect: GOOGLE_SQL")
+
+  for pat, n in usage.top_query_patterns:
+    desc = (
+        f"[Source: INFORMATION_SCHEMA] Observed {n}× in last"
+        f" {usage.window_days} days. Normalized from query history —"
+        " substitute literal values before running."
+    )
+    fm_lines.append(f"  - description: {_yaml_escape_scalar(desc)}")
+    fm_lines.append(f"    sql: {_yaml_block_sql(pat, indent=6)}")
+    fm_lines.append("    source: AGENT")
+    fm_lines.append("    sqlDialect: GOOGLE_SQL")
+
+  for q in doc_queries:
+    raw_desc = (q.get("description") or "").strip()
+    if not raw_desc:
+      raw_desc = "Example query extracted from documentation."
+    desc = f"[Source: Documentation] {raw_desc}"
+    sql = (q.get("sql") or "").strip()
+    if not sql:
+      continue
+    fm_lines.append(f"  - description: {_yaml_escape_scalar(desc)}")
+    fm_lines.append(f"    sql: {_yaml_block_sql(sql, indent=6)}")
+    fm_lines.append("    source: AGENT")
+    fm_lines.append("    sqlDialect: GOOGLE_SQL")
+
+  if len(fm_lines) == 2:
+    # All three sources produced nothing. The aspect requires the
+    # `queries` array to be present + non-empty, so emit one placeholder
+    # so the file stays well-formed for push.
+    fm_lines.append(
+        '  - description: "[Source: INFORMATION_SCHEMA] (no queries'
+        ' observed in window; placeholder for future enrichment)"'
+    )
+    fm_lines.append(
+        f'    sql: "-- No queries observed for {table_fqn} in last'
+        f' {usage.window_days} days."'
+    )
+    fm_lines.append("    source: AGENT")
+    fm_lines.append("    sqlDialect: GOOGLE_SQL")
+
+  fm_lines.append("userManaged: false")
+  fm_lines.append("job:")
+  fm_lines.append(f"  name: {_yaml_escape_scalar(_JOB_NAME)}")
+  fm_lines.append(f"  runTime: {_yaml_escape_scalar(run_time)}")
+  fm_lines.append("---")
+  return "\n".join(fm_lines) + "\n"
+
+
+def _truncate(s: str, n: int) -> str:
+  """Truncates a string.
+
+  Args:
+    s: Input string.
+    n: Max length.
+
+  Returns:
+    Truncated string.
+  """
+  return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _human_bytes(b: int) -> str:
+  """Formats bytes.
+
+  Args:
+    b: Bytes.
+
+  Returns:
+    Human readable string.
+  """
+  for unit in ("B", "KB", "MB", "GB", "TB", "PB"):
+    if b < 1024 or unit == "PB":
+      return f"{b:.1f} {unit}" if unit != "B" else f"{b} B"
+    b /= 1024
+  return f"{b:.1f} PB"

--- a/agents/enrichment/src/tools/drive_tools.py
+++ b/agents/enrichment/src/tools/drive_tools.py
@@ -1,0 +1,488 @@
+"""Google Drive input helpers: folder discovery + multi-format content reads.
+
+Folder listing and all content reads (Google Docs, Sheets, Slides, PDF) go
+through the public Drive v3 API, which requires an ADC token with the
+drive.readonly scope. If you see 403 insufficientPermissions on content reads,
+re-run:
+
+    gcloud auth application-default login --scopes='openid,\\
+    https://www.googleapis.com/auth/userinfo.email,\\
+    https://www.googleapis.com/auth/cloud-platform,\\
+    https://www.googleapis.com/auth/drive.readonly'
+"""
+
+import io
+import os
+import re
+import threading
+
+_DOC_MIME = "application/vnd.google-apps.document"
+_SHEET_MIME = "application/vnd.google-apps.spreadsheet"
+_SLIDES_MIME = "application/vnd.google-apps.presentation"
+_PDF_MIME = "application/pdf"
+
+_DEFAULT_MAX_CHARS = 60000
+
+_DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
+
+# Per-thread Drive service cache. googleapiclient is built on httplib2, whose
+# Http/connection objects are NOT thread-safe: sharing one service across the
+# crawler's worker threads leads to concurrent SSL socket use and heap
+# corruption (double free -> SIGABRT). Each thread therefore gets its own
+# service (and its own httplib2.Http) via thread-local storage.
+_thread_local = threading.local()
+
+
+def get_service():
+  """Returns a thread-local, authenticated Drive v3 service via ADC.
+
+  The underlying ADC token must include the drive.readonly scope (see module
+  docstring). The googleapiclient import is local so importing this module is
+  cheap for callers that never read Drive content.
+
+  A fresh service is built per thread because the underlying httplib2 transport
+  is not thread-safe; reusing one across threads corrupts the SSL connection.
+  """
+  service = getattr(_thread_local, "service", None)
+  if service is None:
+    from google.auth import default
+    from googleapiclient.discovery import build
+
+    creds, _ = default(scopes=[_DRIVE_SCOPE])
+    service = build("drive", "v3", credentials=creds, cache_discovery=False)
+    _thread_local.service = service
+  return service
+
+
+def extract_gdoc_id(url_or_id: str) -> str:
+  """Extracts the Doc ID from a Google Doc URL or returns the ID if already clean."""
+  match = re.search(
+      r"https://docs\.google\.com/document/d/([a-zA-Z0-9-_]+)", url_or_id or ""
+  )
+  return match.group(1) if match else (url_or_id or "")
+
+
+def extract_folder_id(url_or_id: str) -> str:
+  """Extracts the folder ID from a Drive folder URL or returns the ID as-is.
+
+  Accepts any of: a bare folder id, or a full URL such as
+  https://drive.google.com/corp/drive/folders/<id>,
+  https://drive.google.com/drive/folders/<id>, or
+  https://drive.google.com/drive/u/0/folders/<id> (with optional query/anchor).
+  """
+  s = (url_or_id or "").strip()
+  match = re.search(r"/folders/([a-zA-Z0-9_-]+)", s)
+  if match:
+    return match.group(1)
+  # Bare id (possibly with stray query params/trailing slash) — keep the id token.
+  return s.split("?", 1)[0].rstrip("/")
+
+
+def list_folder_files(folder_id: str, page_size: int = 100) -> list[dict]:
+  """List supported files in a Drive folder as structured dicts.
+
+  Returns a list of {id, name, mimeType, webViewLink} for Docs, Sheets,
+  Slides, and PDFs. Returns [] on error (caller decides how to surface it).
+  """
+  from googleapiclient.errors import HttpError
+
+  folder_id = extract_folder_id(folder_id)
+  service = get_service()
+  drive_q = (
+      f"'{folder_id}' in parents and trashed = false and "
+      f"(mimeType='{_DOC_MIME}' or mimeType='{_SHEET_MIME}' or "
+      f"mimeType='{_SLIDES_MIME}' or mimeType='{_PDF_MIME}')"
+  )
+  out = []
+  page_token = None
+  try:
+    while True:
+      resp = (
+          service.files()
+          .list(
+              q=drive_q,
+              fields=(
+                  "nextPageToken, files(id, name, mimeType, webViewLink,"
+                  " modifiedTime)"
+              ),
+              pageSize=page_size,
+              pageToken=page_token,
+              supportsAllDrives=True,
+              includeItemsFromAllDrives=True,
+          )
+          .execute()
+      )
+      out.extend(resp.get("files", []))
+      page_token = resp.get("nextPageToken")
+      if not page_token:
+        break
+  except HttpError:
+    return out
+  return out
+
+
+# Cache config — three modes, gated by KC_ENRICH_CACHE_MODE.
+#
+#   off     — no caching at all. Every run re-fetches from Drive and
+#             re-summarizes from scratch.
+#   raw     — legacy behavior: cache the raw doc text on disk. Fast re-runs
+#             but raw text can contain sensitive content.
+#   summary — DEFAULT. Cache topic-agnostic per-doc summaries (see
+#             modes/doc_mode.py + engine.summarize_single_doc). Re-runs of
+#             the SAME corpus skip both the Drive fetch AND the per-doc
+#             summarizer LLM call. Raw text is NEVER persisted to disk.
+#
+# Compat: KC_ENRICH_CACHE=off (legacy flag) still forces mode=off.
+#
+# Cache dir lives under $HOME (not /tmp) and is chmod 700 so other users on
+# the machine can't read it. This addresses the "raw doc text leaking via
+# /tmp" concern that motivated the summary-cache redesign.
+
+_CACHE_DIR = os.path.join(os.environ.get("HOME", "/tmp"), ".kc_enrich_cache")
+_DOC_CACHE_DIR = os.path.join(_CACHE_DIR, "docs")  # raw text (mode=raw only)
+_SUMMARY_CACHE_DIR = os.path.join(
+    _CACHE_DIR, "summaries"
+)  # per-doc summaries (mode=summary)
+
+
+def _resolve_cache_mode() -> str:
+  """Resolve cache mode from env.
+
+  Priority: KC_ENRICH_CACHE=off compat alias beats everything; otherwise
+  KC_ENRICH_CACHE_MODE wins; otherwise default.
+  """
+  legacy = os.environ.get("KC_ENRICH_CACHE", "").lower()
+  if legacy in ("off", "0", "false", "no"):
+    return "off"
+  mode = os.environ.get("KC_ENRICH_CACHE_MODE", "").lower().strip()
+  if mode in ("off", "raw", "summary"):
+    return mode
+  return "summary"
+
+
+_CACHE_MODE = _resolve_cache_mode()
+# Back-compat alias used by older call sites still in this file.
+_CACHE_DISABLED = _CACHE_MODE == "off"
+
+# Per-cache stats. `docs.*` covers raw-text cache (mode=raw); `summary.*`
+# covers per-doc summary cache (mode=summary). Both are populated by
+# `get_cache_stats()` and printed at the end of a doc-mode run.
+_CACHE_STATS = {
+    "hit": 0,
+    "miss": 0,
+    "stale": 0,  # raw-text cache
+    "summary_hit": 0,
+    "summary_miss": 0,
+    "summary_stale": 0,  # summary cache
+}
+
+
+def _ensure_private_dir(path: str):
+  """Create dir (if missing) and force chmod 700 on the cache root.
+
+  Idempotent. The chmod runs every call so manual perm changes get fixed up
+  next run. Errors are swallowed — caching is best-effort.
+  """
+  try:
+    os.makedirs(path, exist_ok=True)
+    # Tighten perms on the root only; subdirs inherit umask but the root
+    # being 700 prevents traversal regardless of subdir mode.
+    os.chmod(_CACHE_DIR, 0o700)
+  except OSError:
+    pass
+
+
+def _safe_filename(doc_id: str) -> str:
+  return re.sub(r"[^A-Za-z0-9_.-]", "_", doc_id)[:200]
+
+
+def _cache_paths(file_id: str) -> tuple[str, str]:
+  """Returns (content_path, meta_path) for a doc's RAW-text cache entries."""
+  safe = _safe_filename(extract_gdoc_id(file_id))
+  return (
+      os.path.join(_DOC_CACHE_DIR, f"{safe}.txt"),
+      os.path.join(_DOC_CACHE_DIR, f"{safe}.meta"),
+  )
+
+
+def _summary_paths(file_id: str) -> tuple[str, str]:
+  """Returns (summary_path, meta_path) for a doc's SUMMARY cache entries."""
+  safe = _safe_filename(extract_gdoc_id(file_id))
+  return (
+      os.path.join(_SUMMARY_CACHE_DIR, f"{safe}.summary"),
+      os.path.join(_SUMMARY_CACHE_DIR, f"{safe}.meta"),
+  )
+
+
+def _read_cache(file_id: str, modified_time: str | None) -> str | None:
+  """Raw-text cache read. Only active when KC_ENRICH_CACHE_MODE=raw."""
+  if _CACHE_MODE != "raw":
+    return None
+  content_p, meta_p = _cache_paths(file_id)
+  if not os.path.exists(content_p):
+    _CACHE_STATS["miss"] += 1
+    return None
+  if modified_time and os.path.exists(meta_p):
+    try:
+      with open(meta_p) as f:
+        cached_mtime = f.read().strip()
+      if cached_mtime != modified_time:
+        _CACHE_STATS["stale"] += 1
+        return None
+    except OSError:
+      pass
+  _CACHE_STATS["hit"] += 1
+  try:
+    with open(content_p, encoding="utf-8") as f:
+      return f.read()
+  except OSError:
+    return None
+
+
+def _write_cache(file_id: str, content: str, modified_time: str | None):
+  """Raw-text cache write. Only active when KC_ENRICH_CACHE_MODE=raw."""
+  if _CACHE_MODE != "raw" or not content:
+    return
+  if content.startswith(("Error:", "Failed to export")):
+    return  # never cache failures
+  try:
+    _ensure_private_dir(_DOC_CACHE_DIR)
+    content_p, meta_p = _cache_paths(file_id)
+    with open(content_p, "w", encoding="utf-8") as f:
+      f.write(content)
+    if modified_time:
+      with open(meta_p, "w") as f:
+        f.write(modified_time)
+  except OSError:
+    pass
+
+
+def read_summary_cache(file_id: str, modified_time: str | None) -> str | None:
+  """Per-doc summary cache read. Active when KC_ENRICH_CACHE_MODE=summary.
+
+  Returns the cached summary text, or None on miss / stale / mode-disabled.
+  Stale check: when modified_time is provided and the cached mtime doesn't
+  match, the entry is treated as miss and `summary_stale` is incremented.
+  """
+  if _CACHE_MODE != "summary":
+    return None
+  summary_p, meta_p = _summary_paths(file_id)
+  if not os.path.exists(summary_p):
+    _CACHE_STATS["summary_miss"] += 1
+    return None
+  if modified_time and os.path.exists(meta_p):
+    try:
+      with open(meta_p) as f:
+        cached_mtime = f.read().strip()
+      if cached_mtime != modified_time:
+        _CACHE_STATS["summary_stale"] += 1
+        return None
+    except OSError:
+      pass
+  _CACHE_STATS["summary_hit"] += 1
+  try:
+    with open(summary_p, encoding="utf-8") as f:
+      return f.read()
+  except OSError:
+    return None
+
+
+def write_summary_cache(file_id: str, summary: str, modified_time: str | None):
+  """Per-doc summary cache write. Active when KC_ENRICH_CACHE_MODE=summary.
+
+  Skipped for empty summaries and for placeholder error strings — we never
+  want to poison the cache with a failure that gets reused forever.
+  """
+  if _CACHE_MODE != "summary" or not summary:
+    return
+  if summary.startswith(("Error:", "Failed to")):
+    return
+  try:
+    _ensure_private_dir(_SUMMARY_CACHE_DIR)
+    summary_p, meta_p = _summary_paths(file_id)
+    with open(summary_p, "w", encoding="utf-8") as f:
+      f.write(summary)
+    if modified_time:
+      with open(meta_p, "w") as f:
+        f.write(modified_time)
+  except OSError:
+    pass
+
+
+def get_cache_mode() -> str:
+  """Public accessor — used by doc_mode logs + tests."""
+  return _CACHE_MODE
+
+
+def fetch_doc_text(
+    file_id: str,
+    mime_type: str = "",
+    max_chars: int = _DEFAULT_MAX_CHARS,
+    modified_time: str | None = None,
+) -> str:
+  """Unified fetch via the Drive API, dispatched by mimeType in get_doc_content.
+
+  `mime_type` is accepted for caller convenience but the authoritative mimeType
+  is re-read from Drive metadata inside get_doc_content.
+
+  Caching behavior depends on KC_ENRICH_CACHE_MODE:
+    * `summary` (default) — raw text is NEVER persisted to disk; the doc-mode
+      pipeline caches the per-doc summary at a higher level instead. This
+      call still happens (we need the raw text in memory to summarize), but
+      nothing about it lands on the filesystem.
+    * `raw` — legacy behavior. Cache raw text under ~/.kc_enrich_cache/docs/
+      keyed on (doc_id, modified_time).
+    * `off` — no caching of any kind.
+
+  Returns text, truncated at max_chars.
+  """
+  del mime_type  # mimeType is resolved from Drive metadata in get_doc_content.
+  cached = _read_cache(file_id, modified_time)
+  if cached is not None:
+    if len(cached) > max_chars:
+      return (
+          cached[:max_chars] + f"\n\n[truncated, original {len(cached)} chars]"
+      )
+    return cached
+
+  text = get_doc_content(file_id, max_chars=max_chars)
+  _write_cache(file_id, text, modified_time)
+  return text
+
+
+def get_cache_stats() -> dict:
+  """Returns hit/miss/stale counts for the current process."""
+  return dict(_CACHE_STATS)
+
+
+def reset_cache_stats():
+  for k in list(_CACHE_STATS.keys()):
+    _CACHE_STATS[k] = 0
+
+
+def get_doc_content(file_id: str, max_chars: int = _DEFAULT_MAX_CHARS) -> str:
+  """Fetch a Drive file's text content, dispatched by mimeType.
+
+  Google Docs → Markdown; Sheets → CSV; Slides → plain text;
+  PDFs → bytes downloaded and text-extracted via pypdf.
+  Output is truncated at max_chars with an indication of the original length.
+  """
+  from googleapiclient.errors import HttpError
+
+  service = get_service()
+  try:
+    meta = (
+        service.files()
+        .get(
+            fileId=extract_gdoc_id(file_id),
+            fields="id, name, mimeType, size",
+            supportsAllDrives=True,
+        )
+        .execute()
+    )
+  except HttpError as e:
+    return _format_drive_error("Get doc failed (metadata fetch)", e)
+
+  mt = meta.get("mimeType", "")
+  name = meta.get("name", "")
+  fid = meta.get("id", extract_gdoc_id(file_id))
+
+  try:
+    if mt == _DOC_MIME:
+      data = (
+          service.files()
+          .export_media(fileId=fid, mimeType="text/markdown")
+          .execute()
+      )
+      text = data.decode("utf-8") if isinstance(data, bytes) else str(data)
+    elif mt == _SHEET_MIME:
+      data = (
+          service.files()
+          .export_media(fileId=fid, mimeType="text/csv")
+          .execute()
+      )
+      text = data.decode("utf-8") if isinstance(data, bytes) else str(data)
+    elif mt == _SLIDES_MIME:
+      data = (
+          service.files()
+          .export_media(fileId=fid, mimeType="text/plain")
+          .execute()
+      )
+      text = data.decode("utf-8") if isinstance(data, bytes) else str(data)
+    elif mt == _PDF_MIME:
+      text = _extract_pdf_text(service, fid)
+    else:
+      return f"Unsupported mimeType: {mt}"
+  except HttpError as e:
+    return _format_drive_error("Get doc failed (content fetch)", e)
+
+  header = f"# {name} ({mt})\n\n"
+  if len(text) > max_chars:
+    return (
+        header
+        + text[:max_chars]
+        + f"\n\n[truncated, original {len(text)} chars]"
+    )
+  return header + text
+
+
+def _format_drive_error(prefix: str, err) -> str:
+  """Turn raw HttpError into an actionable message.
+
+  Most common failure here is OAuth-scope insufficiency: the user
+  authenticated with `drive.metadata.readonly` (lists files but cannot
+  read content) instead of `drive.readonly`. That returns 403 with reason
+  `insufficientPermissions`. Detecting and explaining it inline saves a
+  round-trip to logs.
+  """
+  status = getattr(err.resp, "status", None) if hasattr(err, "resp") else None
+  reason = ""
+  try:
+    import json as _json
+
+    if getattr(err, "content", None):
+      body = _json.loads(err.content.decode("utf-8"))
+      errs = body.get("error", {}).get("errors", [])
+      if errs:
+        reason = errs[0].get("reason", "")
+  except Exception:
+    pass
+
+  if status == 403 and reason == "insufficientPermissions":
+    return (
+        f"{prefix}: 403 insufficientPermissions. Your ADC token cannot"
+        " read Drive file content. Most likely you authenticated with"
+        " drive.metadata.readonly (lists only). Re-run:\n"
+        "  gcloud auth application-default login --scopes='openid,"
+        "https://www.googleapis.com/auth/userinfo.email,"
+        "https://www.googleapis.com/auth/cloud-platform,"
+        "https://www.googleapis.com/auth/drive.readonly'"
+    )
+  if status == 403:
+    return (
+        f"{prefix}: 403 {reason or 'forbidden'}. The authenticated"
+        " account may not have permission to open this specific file."
+        f" Raw: {err}"
+    )
+  if status == 404:
+    return f"{prefix}: 404 not found. Double-check the file_id. Raw: {err}"
+  return f"{prefix}: {err}"
+
+
+def _extract_pdf_text(service, file_id: str) -> str:
+  """Download a PDF from Drive and extract its text via pypdf."""
+  from googleapiclient.http import MediaIoBaseDownload
+
+  request = service.files().get_media(fileId=file_id, supportsAllDrives=True)
+  buf = io.BytesIO()
+  downloader = MediaIoBaseDownload(buf, request)
+  done = False
+  while not done:
+    _, done = downloader.next_chunk()
+  buf.seek(0)
+
+  from pypdf import PdfReader  # local import to defer the dep until needed
+
+  reader = PdfReader(buf)
+  pages = [p.extract_text() or "" for p in reader.pages]
+  return "\n\n".join(pages)

--- a/agents/enrichment/src/tools/feedback_tools.py
+++ b/agents/enrichment/src/tools/feedback_tools.py
@@ -1,0 +1,261 @@
+"""User-feedback file loader + per-table router for the enrichment agent.
+
+Feedback files are pure JSON (typically with a `.md` extension, by upstream
+convention) shaped like:
+
+    {
+      "proposals": [
+        {
+          "classification": {"detection_signal": "...", "gap_type": "..."},
+          "target_asset": {"type": "COLUMN|TABLE|...", "name": "<FQN>"},
+          "current_context_flaw": "<what was wrong>",
+          "proposed_enrichment": {"action": "ADD_SYNONYM|...", "value": "..."},
+          "evidence": {"reasoning": "...", "trajectory_quote": "..."},
+          "confidence_grade": 0.0-1.0,
+          "eval_candidate": {
+            "is_valid_candidate": true,
+            "user_query_intent": "<NL question>",
+            "golden_sql": "SELECT ... FROM `<table>` ..."
+          }
+        }
+      ]
+    }
+
+The agent treats these as **direct user corrections** — semantically higher-
+priority than any other context source (Drive docs, Dataplex semantic search,
+codesearch, even INFORMATION_SCHEMA query history). When this module's prompt
+block lands in the writer prompt, it carries an explicit "OVERRIDE conflicting
+info" directive. The eval_candidate's golden_sql becomes a `[Source: User
+Feedback]` entry in the queries aspect — that SQL is by definition correct.
+
+Routing: `target_asset.name` is FQN-shaped, with depth depending on `type`:
+  - TABLE   → `project.dataset.table`        (3 segments)
+  - COLUMN  → `project.dataset.table.column` (4 segments — strip last)
+  - DATASET → `project.dataset`              (2 segments — table FQN starts with
+  this)
+A feedback proposal applies to a given table FQN if its target's table-level
+prefix matches.
+"""
+
+import glob
+import json
+import os
+from typing import Any
+
+
+def _files_from_input(
+    feedback_dir: str | None,
+    feedback_files: list[str] | None,
+) -> list[str]:
+  """Expand a dir + explicit files list into a flat de-duped path list.
+
+  `feedback_dir`: walked recursively for `.md` and `.json` files.
+  `feedback_files`: paths added verbatim (after existence check).
+  Files appearing in both inputs are de-duplicated. Order is dir-then-files,
+  sorted within each group for determinism.
+  """
+  out: list[str] = []
+  seen: set[str] = set()
+  if feedback_dir and os.path.isdir(feedback_dir):
+    matches = sorted(
+        glob.glob(os.path.join(feedback_dir, "**", "*.md"), recursive=True)
+        + glob.glob(os.path.join(feedback_dir, "**", "*.json"), recursive=True)
+    )
+    for p in matches:
+      if p not in seen:
+        seen.add(p)
+        out.append(p)
+  for p in feedback_files or []:
+    p = (p or "").strip()
+    if p and os.path.isfile(p) and p not in seen:
+      seen.add(p)
+      out.append(p)
+  return out
+
+
+def _parse_one(path: str) -> list[dict[str, Any]]:
+  """Parse one feedback file → list of proposals (empty on any error)."""
+  try:
+    with open(path, "r", encoding="utf-8") as f:
+      raw = f.read()
+  except OSError:
+    return []
+  try:
+    obj = json.loads(raw)
+  except json.JSONDecodeError:
+    # File may be markdown with embedded ```json blocks; fall back to
+    # extracting the first fenced JSON block. This is a courtesy — the
+    # documented format is pure JSON.
+    fenced = _extract_fenced_json(raw)
+    if fenced is None:
+      return []
+    obj = fenced
+  proposals = obj.get("proposals") if isinstance(obj, dict) else None
+  if not isinstance(proposals, list):
+    return []
+  # Tag each proposal with its source-file path so downstream rendering
+  # can cite it (useful in trajectory + audit).
+  out = []
+  for p in proposals:
+    if not isinstance(p, dict):
+      continue
+    p["_source_file"] = path
+    out.append(p)
+  return out
+
+
+def _extract_fenced_json(text: str) -> Any | None:
+  """Pull the first ```json ... ``` block out of `text` and parse it."""
+  marker = "```json"
+  i = text.find(marker)
+  if i < 0:
+    return None
+  j = text.find("```", i + len(marker))
+  if j < 0:
+    return None
+  blob = text[i + len(marker) : j].strip()
+  try:
+    return json.loads(blob)
+  except json.JSONDecodeError:
+    return None
+
+
+def load_feedback(
+    feedback_dir: str | None = None,
+    feedback_files: list[str] | None = None,
+) -> list[dict[str, Any]]:
+  """Load + parse all feedback files; return a flat list of proposals.
+
+  Each returned proposal is the raw dict from the file, augmented with
+  `_source_file` (absolute path of origin). Caller deals with routing.
+  """
+  proposals: list[dict[str, Any]] = []
+  for path in _files_from_input(feedback_dir, feedback_files):
+    proposals.extend(_parse_one(path))
+  return proposals
+
+
+def _table_fqn_from_target(target: dict[str, Any]) -> str | None:
+  """Extract the `project.dataset.table` prefix from a target_asset dict.
+
+  Handles type=TABLE (3 segments → use as-is) and type=COLUMN (4 segments
+  → drop the column). For type=DATASET or anything shallower, returns
+  None (proposal applies to multiple tables; not routed here).
+  """
+  name = (target or {}).get("name") or ""
+  parts = name.split(".")
+  ttype = (target.get("type") or "").upper() if target else ""
+  if ttype == "TABLE" and len(parts) == 3:
+    return name
+  if ttype == "COLUMN" and len(parts) == 4:
+    return ".".join(parts[:3])
+  # Permissive fallback: anything with ≥3 dotted segments → assume first
+  # three are project.dataset.table. Handles missing/wrong `type`.
+  if len(parts) >= 3:
+    return ".".join(parts[:3])
+  return None
+
+
+def route_proposals_to_table(
+    proposals: list[dict[str, Any]],
+    table_fqn: str,
+) -> list[dict[str, Any]]:
+  """Return proposals whose target_asset's table prefix matches `table_fqn`."""
+  out: list[dict[str, Any]] = []
+  for p in proposals:
+    routed = _table_fqn_from_target(p.get("target_asset") or {})
+    if routed == table_fqn:
+      out.append(p)
+  return out
+
+
+def proposals_to_queries(
+    proposals: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+  """Pluck eval_candidate.golden_sql out of proposals into queries-aspect dicts.
+
+  Output shape matches what `bq_usage_tools.format_queries_sidecar` accepts
+  via its `feedback_queries` kwarg: `[{"description": "...", "sql": "..."},
+  ...]`.
+  Only proposals where `eval_candidate.is_valid_candidate == True` AND
+  `golden_sql` is non-empty contribute an entry. Each entry's description
+  starts from `user_query_intent` (the original NL question), giving the
+  queries aspect a human-readable hook back to the user's intent.
+  """
+  out: list[dict[str, str]] = []
+  for p in proposals:
+    ec = p.get("eval_candidate") or {}
+    if not ec.get("is_valid_candidate"):
+      continue
+    sql = (ec.get("golden_sql") or "").strip()
+    if not sql:
+      continue
+    intent = (ec.get("user_query_intent") or "").strip()
+    out.append({
+        "description": intent or "User-feedback golden SQL example.",
+        "sql": sql,
+    })
+  return out
+
+
+def proposals_to_prompt_block(
+    proposals: list[dict[str, Any]],
+    section_heading: str = "USER FEEDBACK PROPOSALS (HIGHEST PRIORITY)",
+) -> str:
+  """Render proposals as a prompt-ready block.
+
+  The block carries an explicit OVERRIDE directive so the writer LLM treats
+  these proposals as ground truth when they conflict with other inputs
+  (Drive docs, search hits, INFORMATION_SCHEMA-derived patterns, etc.).
+  Returns empty string when there are no proposals so the caller can
+  unconditionally concatenate.
+  """
+  if not proposals:
+    return ""
+  lines = [
+      "",
+      f"=== {section_heading} ===",
+      "These are direct user corrections collected from real user",
+      "interactions with prior versions of this knowledge catalog entry.",
+      "They OVERRIDE any conflicting information from other sources",
+      "(Drive docs, semantic search hits, codesearch results, etc.).",
+      "Each proposal MUST be reflected in the final overview body —",
+      "preferably in a clearly-marked `## User Corrections` section near",
+      "the TOP of the overview, with one bullet per proposal.",
+      "",
+  ]
+  for i, p in enumerate(proposals, start=1):
+    cls = p.get("classification") or {}
+    tgt = p.get("target_asset") or {}
+    pen = p.get("proposed_enrichment") or {}
+    ev = p.get("evidence") or {}
+    ec = p.get("eval_candidate") or {}
+    src = p.get("_source_file") or "(unknown source)"
+    lines.append(f"--- Proposal #{i} (from {os.path.basename(src)}) ---")
+    lines.append(f"Target: {tgt.get('type', '?')} {tgt.get('name', '?')}")
+    lines.append(
+        "Detection signal:"
+        f" {cls.get('detection_signal', '?')}"
+        f" | Gap type: {cls.get('gap_type', '?')}"
+        f" | Confidence: {p.get('confidence_grade', '?')}"
+    )
+    flaw = (p.get("current_context_flaw") or "").strip()
+    if flaw:
+      lines.append(f"Current context flaw: {flaw}")
+    action = pen.get("action") or ""
+    value = pen.get("value") or ""
+    if action or value:
+      lines.append(f"Proposed enrichment: {action} → {value!r}")
+    reasoning = (ev.get("reasoning") or "").strip()
+    if reasoning:
+      lines.append(f"Evidence (reasoning): {reasoning}")
+    quote = (ev.get("trajectory_quote") or "").strip()
+    if quote:
+      lines.append(f"Evidence (user quote): {quote!r}")
+    if ec.get("is_valid_candidate") and ec.get("golden_sql"):
+      intent = (ec.get("user_query_intent") or "").strip()
+      if intent:
+        lines.append(f"Validated user intent (NL): {intent}")
+      lines.append("Golden SQL (will be added to queries aspect): present")
+    lines.append("")
+  return "\n".join(lines)

--- a/agents/enrichment/src/tools/github_tools.py
+++ b/agents/enrichment/src/tools/github_tools.py
@@ -1,0 +1,622 @@
+"""Source code input: agentic repo understanding via the GitHub MCP server.
+
+This is the *fourth* input source for the enrichment agent (alongside Google
+Docs, a Drive folder, and BigQuery `INFORMATION_SCHEMA` usage). Unlike the
+others it is **agentic**: an ADK `LlmAgent` is given the GitHub MCP server's
+tools (read repo tree, read file contents, search code, …) and asked to explore
+a repository on its own, then distill it into a set of *code component cards*.
+
+Each card is emitted in the SAME router-descriptor doc shape every mode already
+consumes — `{id, name, url, content, descriptor}` — so the existing pipelines
+fold code context in with zero per-mode plumbing:
+
+  * doc mode             — cards are appended as neutral per-doc cards and flow
+                           into the topic reduce → enumerate → write pipeline,
+                           so distinct components surface as their own KB
+                           entries.
+  * table / overlay mode — cards join the candidate-document pool the relevance
+                           router scores per table, so e.g. an ETL module that
+                           populates a table grounds that table's overview (and
+                           any SQL it contains feeds the queries aspect).
+
+MCP server wiring is fully config-driven (no hardcoded server) so it works for
+github.com or a GitHub Enterprise server, run locally over stdio or reached as a
+remote HTTP endpoint. See `load_mcp_server_config` for the precedence rules and
+`samples/enrichment/sample/config/github_mcp.json` for the shape.
+
+Authentication: the GitHub MCP server reads a Personal Access Token from its own
+environment (the official server uses `GITHUB_PERSONAL_ACCESS_TOKEN`). We pass
+the current process environment through to the spawned server and let the config
+declare which env var carries the token, so no secret is ever written to disk by
+this tool.
+
+Failure is non-fatal: if the repo can't be reached, the server can't be
+launched, or the model returns nothing parseable, we log a warning and return an
+empty list. A run with `--repo` set therefore degrades to "no code context"
+rather than crashing the whole enrichment.
+"""
+
+import json
+import os
+import re
+import typing as t
+import uuid
+
+from engine import VertexGemini
+from google.adk.agents import llm_agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+# GitHub's hosted (remote) MCP server. This is the DEFAULT transport: it needs
+# no local binary, just network egress + a token. Override to local stdio by
+# selecting a stdio server entry (e.g. KC_ENRICH_GITHUB_MCP_SERVER=github).
+_DEFAULT_REMOTE_URL = "https://api.githubcopilot.com/mcp/"
+# Stdio launch for the official `github-mcp-server` binary (local fallback).
+# `stdio` is the binary's subcommand for MCP-over-stdio.
+_DEFAULT_COMMAND = "github-mcp-server"
+_DEFAULT_ARGS = ["stdio"]
+# The official server's token env var. The config may point at a different one
+# (e.g. for a GHE wrapper) via the server entry's `env` block.
+_DEFAULT_TOKEN_ENV = "GITHUB_PERSONAL_ACCESS_TOKEN"
+
+# Which server entry to use from a multi-server mcp.json. Defaults to the remote
+# entry so no local server is needed; override with KC_ENRICH_GITHUB_MCP_SERVER
+# (e.g. =github for the local stdio binary). If the named key is absent but the
+# config has exactly one server, that one is used (see load_mcp_server_config).
+_SERVER_KEY = os.environ.get("KC_ENRICH_GITHUB_MCP_SERVER", "github_remote")
+
+# Cap the agent's exploration so a huge monorepo can't run away. The agent is
+# told to budget its reads; this is the hard ceiling on tool-driving turns.
+_MAX_EXPLORE_TURNS = 40
+
+
+def _short_args(args: dict) -> str:
+  """Compact one-line rendering of tool-call args for logging."""
+  parts = []
+  for k, v in (args or {}).items():
+    s = str(v)
+    if len(s) > 60:
+      s = s[:57] + "..."
+    parts.append(f"{k}={s}")
+  return ", ".join(parts)
+
+
+def _response_text(response: t.Any) -> str:
+  """Best-effort extraction of textual content from an MCP tool response.
+
+  MCP/ADK wrap tool results in varied shapes (a dict with 'result'/'content',
+  a list of content blocks with 'text', or a bare string). We only need the
+  length/text to gauge whether real content came back, so we stringify
+  defensively.
+  """
+  if response is None:
+    return ""
+  if isinstance(response, str):
+    return response
+  if isinstance(response, dict):
+    for key in ("text", "content", "result", "output"):
+      if key in response:
+        return _response_text(response[key])
+    return str(response)
+  if isinstance(response, (list, tuple)):
+    return "".join(_response_text(x) for x in response)
+  # genai/MCP content blocks often expose `.text`.
+  text_attr = getattr(response, "text", None)
+  if isinstance(text_attr, str):
+    return text_attr
+  return str(response)
+
+
+def parse_repo(repo: str) -> tuple[str, str]:
+  """`owner/name` or a github URL -> (owner, name). Raises on un-parseable."""
+  s = (repo or "").strip()
+  if not s:
+    raise ValueError("empty repo")
+  # SSH scp-like form: git@github.com:owner/name(.git) -> normalize the ':'.
+  m = re.match(r"^[^@/]+@[^:/]+:(.+)$", s)
+  if m:
+    s = m.group(1)
+  # Full URL form: https://github.com/owner/name(.git)(/...)
+  m = re.search(r"github\.[^/]+/([^/]+)/([^/#?]+)", s)
+  if m:
+    owner, name = m.group(1), m.group(2)
+  else:
+    parts = [p for p in s.split("/") if p]
+    if len(parts) < 2:
+      raise ValueError(
+          f"--repo must be `owner/name` or a github URL (got '{repo}')."
+      )
+    owner, name = parts[-2], parts[-1]
+  return owner, name.removesuffix(".git")
+
+
+def _expand_env(value: t.Any) -> t.Any:
+  """Recursively expand ${VAR} / $VAR in strings within a JSON-loaded value."""
+  if isinstance(value, str):
+    return os.path.expandvars(value)
+  if isinstance(value, list):
+    return [_expand_env(v) for v in value]
+  if isinstance(value, dict):
+    return {k: _expand_env(v) for k, v in value.items()}
+  return value
+
+
+def load_mcp_server_config(config_path: str | None) -> dict:
+  """Resolve the GitHub MCP server launch spec.
+
+  Precedence:
+    1. `config_path` flag, else `KC_ENRICH_MCP_CONFIG` env — a JSON file shaped
+       like the sample (`{"mcpServers": {"<key>": {...}}}`). `${VAR}` tokens are
+       expanded from the environment. The `_SERVER_KEY` entry is selected; if
+       that key is absent but the config defines exactly one server, that one is
+       used (so a single-server mcp.json under any key still works).
+    2. Built-in default (no config file): GitHub's hosted REMOTE server over
+       HTTP, authenticated with `GITHUB_PERSONAL_ACCESS_TOKEN` from the
+       environment — no local binary required.
+
+  Returns a normalized dict, one of:
+    * stdio:  {"transport": "stdio", "command", "args", "env"}
+    * http:   {"transport": "http",  "url", "headers"}
+  """
+  path = config_path or os.environ.get("KC_ENRICH_MCP_CONFIG", "")
+  if path:
+    with open(os.path.expanduser(path)) as f:
+      raw = _expand_env(json.load(f))
+    servers = raw.get("mcpServers", raw)
+    if _SERVER_KEY in servers:
+      spec = servers[_SERVER_KEY]
+    elif len(servers) == 1:
+      # Single-server config: use it regardless of its key name.
+      only_key = next(iter(servers))
+      print(
+          f"[Code] ℹ️  MCP config has no '{_SERVER_KEY}'; using its only"
+          f" server '{only_key}'.",
+          flush=True,
+      )
+      spec = servers[only_key]
+    else:
+      raise ValueError(
+          f"MCP config '{path}' has no '{_SERVER_KEY}' server (found:"
+          f" {sorted(servers)}). Set KC_ENRICH_GITHUB_MCP_SERVER to the right"
+          " key."
+      )
+    if spec.get("url"):
+      return {
+          "transport": "http",
+          "url": spec["url"],
+          "headers": spec.get("headers", {}),
+      }
+    return {
+        "transport": "stdio",
+        "command": spec.get("command", _DEFAULT_COMMAND),
+        "args": spec.get("args", list(_DEFAULT_ARGS)),
+        "env": spec.get("env", {}),
+    }
+  # Built-in default (no config file): remote HTTP server, no local binary.
+  token = os.environ.get(_DEFAULT_TOKEN_ENV, "")
+  return {
+      "transport": "http",
+      "url": os.environ.get("KC_ENRICH_GITHUB_MCP_URL", _DEFAULT_REMOTE_URL),
+      "headers": {"Authorization": f"Bearer {token}"},
+  }
+
+
+def _resolve_command(command: str) -> str:
+  """Resolve a bare server command to an absolute path.
+
+  `go install` drops the binary in $GOBIN (or $GOPATH/bin, default ~/go/bin),
+  which is frequently NOT on PATH in the shell that launches the agent/webapp.
+  Rather than force the user to edit PATH, we fall back to those well-known Go
+  bin dirs when a bare command isn't found on PATH. Commands given as an
+  explicit path (containing a separator) are returned untouched.
+  """
+  import shutil
+
+  if not command or os.sep in command:
+    return command
+  found = shutil.which(command)
+  if found:
+    return found
+  candidates = []
+  gobin = os.environ.get("GOBIN")
+  if gobin:
+    candidates.append(os.path.join(gobin, command))
+  gopath = os.environ.get("GOPATH") or os.path.expanduser("~/go")
+  candidates.append(os.path.join(gopath, "bin", command))
+  candidates.append(os.path.expanduser(f"~/go/bin/{command}"))
+  for cand in candidates:
+    if os.path.isfile(cand) and os.access(cand, os.X_OK):
+      print(f"[Code] ℹ️  Resolved MCP server '{command}' -> {cand}", flush=True)
+      return cand
+  return command  # leave as-is; the launch error will be clear
+
+
+def _build_toolset(cfg: dict):
+  """Build an ADK McpToolset from a normalized config dict."""
+  from google.adk.tools.mcp_tool.mcp_session_manager import (
+      StdioConnectionParams,
+  )
+  from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+  if cfg["transport"] == "http":
+    from google.adk.tools.mcp_tool.mcp_session_manager import (
+        StreamableHTTPConnectionParams,
+    )
+
+    return McpToolset(
+        connection_params=StreamableHTTPConnectionParams(
+            url=cfg["url"], headers=cfg.get("headers", {})
+        )
+    )
+
+  from mcp import StdioServerParameters
+
+  # The spawned server inherits our environment (so ADC, PATH, etc. survive),
+  # overlaid with the config's `env` block — which is where the PAT lives.
+  child_env = {**os.environ, **(cfg.get("env") or {})}
+  return McpToolset(
+      connection_params=StdioConnectionParams(
+          server_params=StdioServerParameters(
+              command=_resolve_command(cfg["command"]),
+              args=cfg.get("args", []),
+              env=child_env,
+          ),
+          timeout=120.0,
+      )
+  )
+
+
+_EXPLORER_INSTRUCTION = """You are a senior software architect creating a structured map of a GitHub repository for a metadata-enrichment pipeline. You have tools to browse the repository (list the file tree, read file contents, search code). Use them to UNDERSTAND the codebase, then describe it.
+
+REPOSITORY: {owner}/{repo}
+DEFAULT OWNER/REPO for every tool call: owner=`{owner}`, repo=`{repo}`.
+{ref_directive}{scope_directive}
+EXPLORATION STRATEGY (be efficient — you have a limited tool budget):
+1. FIRST call the tree/list tool on the SCOPE ROOT path above (not on file paths) to see what is actually there. Every file path you read MUST start with the scope root.
+2. Read the README and any docs WITHIN the scope root first to learn its purpose.
+3. Read build/manifest/config files within the scope root (e.g. package.json, pyproject.toml, go.mod, BUILD, Dockerfile, requirements.txt) to learn the tech stack, entry points, and dependencies.
+4. Read the MOST IMPORTANT source files for each major component under the scope root — entry points, core modules, public interfaces, data models, schema/migration files. Do NOT read every file; sample enough to understand each component faithfully.
+
+THEN identify the distinct LOGICAL COMPONENTS found UNDER THE SCOPE ROOT — a component is a coherent module, package, service, library, CLI, or subsystem a reader would want documented as its own unit. Aim for the natural granularity of the project (typically 3-15 components); do not over-split tightly-coupled files or lump unrelated subsystems together.
+
+For EACH component, derive:
+  - name: a clear human-readable name (Title Case).
+  - path: the primary directory or file path, as a FULL repo-relative path including the scope-root prefix (e.g. `agents/enrichment/src`, not just `src`).
+  - purpose: ONE sentence on what it does.
+  - key_entities: the concrete named things it defines or references that a catalog should know — exported classes/functions, public APIs/endpoints, CLI commands, config keys, env vars, data models, and especially any DATA ASSETS the code reads or writes (BigQuery tables/columns, dataset names, topics, file paths). Be specific and use the exact spellings from the code.
+  - details: a dense Markdown description (a few paragraphs or bullets) covering responsibilities, architecture, key interfaces, important data flows, dependencies, and any SQL queries or table references found in the code (quote them).
+  - languages: the main languages used.
+  - evidence_paths: the list of ACTUAL repo file paths (full repo-relative) you OPENED and read to derive this component. Every component MUST cite at least one file you actually read.
+
+GROUNDING (CRITICAL — do not hallucinate):
+- A component may ONLY be reported if you actually READ one or more real files belonging to it with the tools. List those files in evidence_paths.
+- NEVER infer or invent components from the repository name, the topic, common project conventions, or your prior knowledge. If the tool results don't show it, it does not exist.
+- If your tool calls returned errors or no content, do NOT guess — output an empty array [].
+- Describe only what the files you read actually contain. Quote real identifiers, paths, and SQL verbatim.
+
+OUTPUT: when done exploring, output ONLY a single JSON array of component objects (no prose before or after, no markdown fence). Each object has exactly the keys: name, path, purpose, key_entities (array of strings), details (string), languages (array of strings), evidence_paths (array of strings). If the repository is empty, unreadable, or your tools returned no content, output [].
+"""
+
+
+def _component_card(owner: str, repo: str, ref: str, comp: dict) -> dict:
+  """Render one parsed component into the shared router-descriptor doc shape."""
+  name = (comp.get("name") or "Unnamed component").strip()
+  path = (comp.get("path") or "").strip().lstrip("/")
+  purpose = (comp.get("purpose") or "").strip()
+  entities = comp.get("key_entities") or []
+  if isinstance(entities, str):
+    entities = [entities]
+  entities = [str(e).strip() for e in entities if str(e).strip()]
+  details = (comp.get("details") or "").strip()
+  languages = comp.get("languages") or []
+  if isinstance(languages, str):
+    languages = [languages]
+  languages = [str(l).strip() for l in languages if str(l).strip()]
+  evidence = comp.get("evidence_paths") or []
+  if isinstance(evidence, str):
+    evidence = [evidence]
+  evidence = [str(e).strip().lstrip("/") for e in evidence if str(e).strip()]
+
+  ref_seg = ref or "HEAD"
+  if path:
+    url = f"https://github.com/{owner}/{repo}/tree/{ref_seg}/{path}"
+  else:
+    url = f"https://github.com/{owner}/{repo}"
+
+  entities_str = ", ".join(entities) if entities else "(none listed)"
+  lang_str = ", ".join(languages) if languages else "n/a"
+
+  # Full card — used as the routed-document content (table/overlay) and as a
+  # neutral per-doc card (doc mode). Mirrors the per-doc summarizer card shape.
+  content = (
+      f"# {name}\n\n"
+      f"**Source:** [{owner}/{repo}: {path or name}]({url})\n\n"
+      "## Identity\n"
+      f"- **Type:** source-code component ({owner}/{repo})\n"
+      f"- **Path:** `{path or '(repo root)'}`\n"
+      f"- **Languages:** {lang_str}\n"
+      f"- **Purpose:** {purpose or '(not stated)'}\n\n"
+      "## Key Entities\n"
+      f"{entities_str}\n\n"
+      "## Details\n"
+      f"{details or '(no further detail extracted)'}\n"
+      + (
+          "\n## Source Files Read\n"
+          + "\n".join(f"- `{e}`" for e in evidence)
+          + "\n"
+          if evidence
+          else ""
+      )
+  )
+
+  # Compact descriptor — what the relevance router scores. Matches the shape
+  # emitted by engine.create_doc_summarizer_runner (Title/Summary/Key entities).
+  descriptor = (
+      f"Title: {name}\nSummary:"
+      f" {purpose or 'Source-code component of ' + owner + '/' + repo}\nKey"
+      f" entities: {entities_str}"
+  )
+
+  return {
+      "name": name,
+      "url": url,
+      "content": content,
+      "descriptor": descriptor,
+  }
+
+
+def _parse_components(raw_text: str) -> list[dict]:
+  """Leniently parse the explorer agent's JSON array of components."""
+  text = (raw_text or "").strip()
+  if not text:
+    return []
+  # Strip a ```json / ``` fence if the model wrapped its output.
+  fence = re.match(r"^```(?:json)?\s*\n(.*)\n```$", text, re.S)
+  if fence:
+    text = fence.group(1).strip()
+  # Fall back to the outermost [...] span if there's stray prose around it.
+  if not text.startswith("["):
+    m = re.search(r"\[.*\]", text, re.S)
+    if m:
+      text = m.group(0)
+  try:
+    data = json.loads(text)
+  except (ValueError, json.JSONDecodeError):
+    return []
+  if not isinstance(data, list):
+    return []
+  return [c for c in data if isinstance(c, dict)]
+
+
+async def gather_repo_context(
+    repo: str,
+    ref: str,
+    subdir: str,
+    topic: str,
+    model: str,
+    usage_acc: dict,
+    mcp_config_path: str | None = None,
+) -> list[dict]:
+  """Agentically explore a GitHub repo and return code component cards.
+
+  Returns a list of router-descriptor dicts `{name, url, content, descriptor}`
+  (the caller assigns `id`). Always returns a list — on any failure it logs a
+  warning and returns `[]` so the enrichment run continues without code context.
+
+  Args:
+    repo: `owner/name` or a github URL.
+    ref: optional branch/tag/sha (empty = the repo's default branch).
+    subdir: optional path prefix to scope the exploration.
+    topic: the run's focus topic (passed to the agent for relevance).
+    model: the model name for the exploration agent (the user's --model).
+    usage_acc: token-usage accumulator (mutated in place).
+    mcp_config_path: optional path to an mcp.json describing the server.
+  """
+  try:
+    owner, name = parse_repo(repo)
+  except ValueError as e:
+    print(f"[Code] ⚠️  Skipping repo source: {e}", flush=True)
+    return []
+
+  try:
+    cfg = load_mcp_server_config(mcp_config_path)
+  except (OSError, ValueError, json.JSONDecodeError) as e:
+    print(f"[Code] ⚠️  MCP config error, skipping repo source: {e}", flush=True)
+    return []
+
+  ref = (ref or "").strip()
+  subdir = (subdir or "").strip().strip("/")
+  ref_note = f" (ref: {ref})" if ref else ""
+  # Hard directives baked into the instruction. The subdir scope is the key
+  # lever: without an explicit "treat this as the root, never read outside it"
+  # constraint the model tends to explore the repo root and ignore the subdir.
+  if ref:
+    ref_directive = (
+        f"REF: pass `{ref}` as the branch/ref/sha argument to EVERY tool call"
+        " (do not read the default branch).\n"
+    )
+  else:
+    ref_directive = ""
+  if subdir:
+    scope_directive = (
+        f"SCOPE ROOT (MANDATORY): `{subdir}`. Treat `{subdir}` as the root of"
+        " your exploration. ONLY list, read, and describe paths that start with"
+        f" `{subdir}/` (or `{subdir}` itself). Do NOT read files outside it"
+        " (e.g. the repo root README, top-level configs) — they are out of"
+        " scope. If a tool returns the repo root, immediately re-call it with"
+        f" the path `{subdir}`.\n"
+    )
+  else:
+    scope_directive = (
+        "SCOPE ROOT: the entire repository (no subdirectory filter).\n"
+    )
+  instruction = _EXPLORER_INSTRUCTION.format(
+      owner=owner,
+      repo=name,
+      ref_directive=ref_directive,
+      scope_directive=scope_directive,
+  )
+
+  print(
+      f"[Code] 🐙 Exploring {owner}/{name}{ref_note}"
+      f"{(' subdir=' + subdir) if subdir else ''} via GitHub MCP"
+      f" ({cfg['transport']})...",
+      flush=True,
+  )
+
+  toolset = None
+  try:
+    toolset = _build_toolset(cfg)
+    agent = llm_agent.LlmAgent(
+        name="CodeUnderstandingAgent",
+        description=(
+            "Explores a GitHub repository via MCP tools and emits structured"
+            " code component cards."
+        ),
+        model=VertexGemini(model=model),
+        instruction=instruction,
+        tools=[toolset],
+    )
+    runner = InMemoryRunner(agent=agent)
+    user_id = str(uuid.uuid4())
+    session = await runner.session_service.create_session(
+        app_name=runner.app_name, user_id=user_id
+    )
+    scope_reminder = (
+        f" START by listing the tree at path `{subdir}` and confine ALL reads"
+        f" to paths under `{subdir}`."
+        if subdir
+        else ""
+    )
+    kickoff = (
+        f"Explore the repository {owner}/{name} and produce the JSON array of"
+        " code component cards. Focus topic for relevance:"
+        f" {topic}.{scope_reminder}"
+    )
+    raw_text = ""
+    turns = 0
+    n_tool_calls = 0
+    read_paths = set()  # paths the agent actually fetched content for
+    total_read_chars = 0  # total chars of real file content the tools returned
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=types.Content(
+            role="user", parts=[types.Part.from_text(text=kickoff)]
+        ),
+    ):
+      turns += 1
+      usage = getattr(event, "usage_metadata", None)
+      if usage and usage_acc is not None:
+        usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+        usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+      # Visibility into what the agent actually did with the MCP tools. Without
+      # this, a silently-failing server looks identical to a real exploration —
+      # the model just hallucinates components from the repo name. We log each
+      # call and tally how much real content came back.
+      for fc in event.get_function_calls() or []:
+        n_tool_calls += 1
+        args = fc.args or {}
+        path_arg = (
+            args.get("path")
+            or args.get("file_path")
+            or args.get("filepath")
+            or args.get("tree_sha")
+            or ""
+        )
+        print(
+            f"[Code]    → tool {fc.name}({_short_args(args)})",
+            flush=True,
+        )
+        if path_arg:
+          read_paths.add(str(path_arg))
+      for fr in event.get_function_responses() or []:
+        resp_len = len(_response_text(fr.response))
+        total_read_chars += resp_len
+        print(f"[Code]    ← {fr.name}: {resp_len} chars", flush=True)
+      if event.content and event.content.parts:
+        for part in event.content.parts:
+          if part.text:
+            raw_text += part.text
+      if turns > _MAX_EXPLORE_TURNS * 4:  # events ≈ several per turn
+        print(
+            "[Code] ⚠️  Exploration exceeded turn budget; using output so far.",
+            flush=True,
+        )
+        break
+    print(
+        f"[Code] 🔧 MCP usage: {n_tool_calls} tool call(s),"
+        f" {total_read_chars} chars of content read.",
+        flush=True,
+    )
+  except Exception as e:  # pylint: disable=broad-except
+    # MCP launch / auth / network failures all land here. Non-fatal by design.
+    print(
+        f"[Code] ⚠️  GitHub MCP exploration failed ({type(e).__name__}: {e}) —"
+        " continuing without code context.",
+        flush=True,
+    )
+    return []
+  finally:
+    if toolset is not None:
+      try:
+        await toolset.close()
+      except Exception:  # pylint: disable=broad-except
+        pass
+
+  # Hallucination guard: if the tools never returned real file content, any
+  # "components" the model emitted are invented from its priors (this is what
+  # produced the bogus 'Image Generation Utility' / 'Slack Notification
+  # Utility'). Refuse them rather than poison the enrichment.
+  if total_read_chars == 0:
+    print(
+        "[Code] ⛔ The GitHub MCP server returned NO file content"
+        f" ({n_tool_calls} tool call(s)). Not emitting any components (would be"
+        " hallucinated). Check: the server is reachable, the token has read"
+        " access to this repo, and the repo/ref/subdir exist.",
+        flush=True,
+    )
+    return []
+
+  components = _parse_components(raw_text)
+  if not components:
+    print(
+        "[Code] ⚠️  No parseable components returned from repo exploration.",
+        flush=True,
+    )
+    return []
+
+  # Drop components not backed by a file the agent actually read. A component is
+  # kept only if one of its evidence_paths matches a fetched path (substring
+  # either way, to tolerate trailing-file vs directory granularity). If the
+  # model omitted evidence_paths entirely we keep the component but flag it.
+  kept, dropped = [], []
+  for c in components:
+    ev = c.get("evidence_paths") or []
+    if isinstance(ev, str):
+      ev = [ev]
+    ev = [str(p).strip().lstrip("/") for p in ev if str(p).strip()]
+    if not ev:
+      kept.append(c)  # no claim to verify; keep but it won't show evidence
+      continue
+    grounded = any(any(e in rp or rp in e for rp in read_paths) for e in ev)
+    (kept if grounded else dropped).append(c)
+  if dropped:
+    print(
+        f"[Code] 🗑️  Dropped {len(dropped)} ungrounded component(s) (no read"
+        f" file matched their evidence): {[d.get('name') for d in dropped]}",
+        flush=True,
+    )
+  if not kept:
+    print(
+        "[Code] ⚠️  All components were ungrounded — emitting none.", flush=True
+    )
+    return []
+
+  cards = [_component_card(owner, name, ref, c) for c in kept]
+  print(
+      f"[Code] ✅ Derived {len(cards)} code component(s) from {owner}/{name}:"
+      f" {[c['name'] for c in cards]}",
+      flush=True,
+  )
+  return cards

--- a/agents/enrichment/src/tools/kcmd_tools.py
+++ b/agents/enrichment/src/tools/kcmd_tools.py
@@ -1,0 +1,736 @@
+"""kcmd-based catalog access for the unified agents.
+
+The enrichment agents talk to the Knowledge Catalog ONLY through the vendored
+`kcmd` CLI (Metadata-as-Code), never the Dataplex API directly:
+
+  * table_mode -> `kcmd init --bigquery-dataset <proj>.<dataset>` + a manifest
+    declaring the schema aspect + `kcmd pull`, then reads schema from the pulled
+    `catalog/` entries.
+  * doc_mode   -> `kcmd init --entry-group <proj>.<loc>.<eg>` to scaffold the
+    entry-group manifest (scope + snapshot + publishing); the agent then
+    generates
+    the entries. We use a normal entry group (STANDARD layout: `<id>.yaml` +
+    `<id>.overview.md`) rather than `--kb` (DOCUMENTS layout) so the agent's
+    generated entry files are consumed directly without reformatting.
+
+`kcmd push` is intentionally NOT run here — publishing is the user's action.
+"""
+
+import glob
+import os
+import shutil
+import subprocess
+
+import yaml
+
+
+def _resolve_kcmd() -> str:
+  """Locate the kcmd binary: $KCMD_BIN, then the vendored
+
+  agents/mdcode/dist/kcmd (built via `cd agents/mdcode && npm install &&
+  npm run build`), then `kcmd` on PATH (e.g. an `npm install -g`ed kcmd).
+  """
+  env_bin = os.environ.get("KCMD_BIN")
+  if env_bin and os.path.exists(env_bin):
+    return env_bin
+  # tools/ -> src -> enrichment_agent -> <repo root>
+  vendored = os.path.abspath(
+      os.path.join(os.path.dirname(__file__), "../../../mdcode/dist/kcmd")
+  )
+  if os.path.exists(vendored):
+    return vendored
+  return shutil.which("kcmd") or vendored
+
+
+KCMD_BIN = _resolve_kcmd()
+
+# Manifest for a bq-dataset scope. The snapshot declares ALL of the entry's
+# aspects so `kcmd pull` fetches everything about each table (schema columns,
+# table properties, storage, and any existing overview + queries) — init's
+# default snapshot does NOT include these. We publish the `overview` and
+# `queries` aspects back to the dataset's live @bigquery entries. No `reference:` section: table mode pulls
+# its entries directly and never reads `.ref.*` mirrors (that flow belongs to
+# context_overlay mode via _OVERLAY_MANIFEST + init_reference).
+#
+# The `queries` aspect requires the `dataplex.entryGroups.useQueriesAspect`
+# permission per the Dataplex `queries` aspect type's authorization
+# declaration. If the
+# caller lacks this perm, kcmd push will fail with a 403 on the queries
+# aspect specifically — overview will still go through. The per-table
+# `<table>.queries.md` sidecars produced by bq_usage_tools are kcmd-standard
+# layout aspect sidecars (YAML frontmatter merged into the aspect payload),
+# so no further wiring is needed beyond this manifest change.
+_BQ_MANIFEST = (
+    "scope: bq-dataset.{project}.{dataset}\n"
+    "snapshot:\n"
+    "  entries:\n"
+    "    - dataplex-types.global.bigquery-table\n"
+    "  aspects:\n"
+    "    - dataplex-types.global.schema\n"
+    "    - dataplex-types.global.bigquery-table\n"
+    "    - dataplex-types.global.storage\n"
+    "    - dataplex-types.global.overview\n"
+    "    - dataplex-types.global.queries\n"
+    "publishing:\n"
+    "  aspects:\n"
+    "    - dataplex-types.global.overview\n"
+    "    - dataplex-types.global.queries\n"
+)
+
+
+def _build_bq_manifest(
+    project: str, dataset: str, with_glossary_links: bool = False
+) -> str:
+  """Build the BigQuery-dataset manifest, optionally wiring glossary-linking
+
+  config into snapshot/publishing/reference. When `with_glossary_links` is
+  True, snapshot+reference declare `entryLinks: [definition, synonym]` (so
+  `kcmd pull`/`reference` fetch existing column links) and publishing
+  declares `entryLinks: [definition]` (so `kcmd push` reconciles agent-added
+  links to Dataplex).
+  """
+  if not with_glossary_links:
+    return _BQ_MANIFEST.format(project=project, dataset=dataset)
+  return (
+      f"scope: bq-dataset.{project}.{dataset}\n"
+      "snapshot:\n"
+      "  entries:\n"
+      "    - dataplex-types.global.bigquery-table\n"
+      "  aspects:\n"
+      "    - dataplex-types.global.schema\n"
+      "    - dataplex-types.global.bigquery-table\n"
+      "    - dataplex-types.global.storage\n"
+      "    - dataplex-types.global.overview\n"
+      "    - dataplex-types.global.queries\n"
+      "  entryLinks:\n"
+      "    - definition\n"
+      "    - synonym\n"
+      "publishing:\n"
+      "  aspects:\n"
+      "    - dataplex-types.global.overview\n"
+      "    - dataplex-types.global.queries\n"
+      "  entryLinks:\n"
+      "    - definition\n"
+      "reference:\n"
+      f"  scope: bq-dataset.{project}.{dataset}\n"
+      "  snapshot:\n"
+      "    entries:\n"
+      "      - dataplex-types.global.bigquery-table\n"
+      "    aspects:\n"
+      "      - dataplex-types.global.schema\n"
+      "      - dataplex-types.global.overview\n"
+      "    entryLinks:\n"
+      "      - definition\n"
+      "      - synonym\n"
+  )
+
+
+# Manifest for the doc-mode entry group. `kcmd init --entry-group` writes only a
+# bare `scope:` line (no snapshot/publishing), which makes `kcmd push` load no
+# entry types and silently no-op; so — mirroring init_pull_dataset for bq-dataset
+# — we always write this complete manifest after init. The entry-group source
+# token is `entryGroup` (source.ts) and uses the STANDARD layout. `entry_type` is
+# the full `project.location.entryTypeId` (the 1P `dataplex-types.global.generic`
+# type for doc-mode KB entries); kcmd requires entry types to be 3-part, and
+# publishing entries must be a subset of snapshot entries.
+_EG_MANIFEST = (
+    "scope: entryGroup.{project}.{location}.{eg}\n"
+    "snapshot:\n"
+    "  entries:\n"
+    "    - {entry_type}\n"
+    "  aspects:\n"
+    "    - dataplex-types.global.generic\n"
+    "    - dataplex-types.global.overview\n"
+    "publishing:\n"
+    "  entries:\n"
+    "    - {entry_type}\n"
+    "  aspects:\n"
+    "    - dataplex-types.global.generic\n"
+    "    - dataplex-types.global.overview\n"
+)
+
+# Manifest for the context-overlay mode. The `scope:` is the editable
+# entry group where the NEW overlay entries are created/pushed (generic entry
+# type + overview aspect). The `reference:` section pulls the read-only 1P
+# BigQuery table entries (with schema + any existing overview) into `reference/`
+# via `kcmd reference` — these ground the overlays but are never pushed.
+_OVERLAY_MANIFEST = (
+    "scope: entryGroup.{project}.{location}.{eg}\n"
+    "snapshot:\n"
+    "  entries:\n"
+    "    - {entry_type}\n"
+    "  aspects:\n"
+    "    - dataplex-types.global.generic\n"
+    "    - dataplex-types.global.overview\n"
+    "    - dataplex-types.global.queries\n"
+    "publishing:\n"
+    "  entries:\n"
+    "    - {entry_type}\n"
+    "  aspects:\n"
+    "    - dataplex-types.global.generic\n"
+    "    - dataplex-types.global.overview\n"
+    "    - dataplex-types.global.queries\n"
+    "reference:\n"
+    "  scope: bq-dataset.{ref_project}.{ref_dataset}\n"
+    "  snapshot:\n"
+    "    entries:\n"
+    "      - dataplex-types.global.bigquery-table\n"
+    "    aspects:\n"
+    "      - dataplex-types.global.schema\n"
+    "      - dataplex-types.global.overview\n"
+)
+
+def _run(
+    args: list[str], cwd: str, project: str | None = None, timeout: int = 300
+) -> tuple[bool, str]:
+  if not os.path.exists(KCMD_BIN):
+    return False, (
+        f"kcmd not found. Build it: `cd agents/mdcode && npm install "
+        f"&& npm run build`, or set $KCMD_BIN / npm install -g kcmd."
+    )
+  env = os.environ.copy()
+  if project:
+    env.setdefault("CLOUDSDK_CORE_PROJECT", project)
+  # Echo the real command we shell out to (transparency: these are genuine kcmd
+  # subprocess calls, not status messages).
+  print(f"[kcmd] $ kcmd {' '.join(args)}", flush=True)
+  try:
+    pr = subprocess.run(
+        [KCMD_BIN, *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return pr.returncode == 0, (pr.stdout + pr.stderr).strip()[-600:]
+  except Exception as e:  # noqa: BLE001
+    return False, str(e)
+
+
+# --------------------------------------------------------------------------- #
+# table_mode: bq-dataset discovery via init + pull
+# --------------------------------------------------------------------------- #
+def init_pull_dataset(
+    output_dir: str,
+    project: str,
+    dataset: str,
+    with_glossary_links: bool = False,
+) -> tuple[bool, str]:
+  """`kcmd init --bigquery-dataset` (scope) -> write the schema-declaring
+
+  manifest -> `kcmd pull` (entries + schema). No Dataplex API.
+
+  When `with_glossary_links=True`, the manifest also declares entryLinks
+  config so `pull` brings down existing column-level links and `push` can
+  publish agent-added links. Callers also need to invoke
+  `pull_glossary_as_reference(...)` to bring glossary terms into the
+  workspace for the LinkingAgent's `terms_context`.
+  """
+  os.makedirs(output_dir, exist_ok=True)
+  ok_init, msg_init = _run(
+      ["init", "--bigquery-dataset", f"{project}.{dataset}"],
+      output_dir,
+      project,
+      120,
+  )
+  with open(os.path.join(output_dir, "catalog.yaml"), "w") as f:
+    f.write(_build_bq_manifest(project, dataset, with_glossary_links))
+  ok_pull, msg_pull = _run(["pull"], output_dir, project, 300)
+  return (ok_pull, (msg_init + "\n" + msg_pull).strip()[-600:])
+
+
+def pull_glossary_as_reference(
+    output_dir: str,
+    project: str,
+    dataset: str,
+    glossary_scope: str,
+) -> tuple[bool, str]:
+  """Side-channel pull of glossary terms into the workspace as a one-off
+
+  reference fetch. Temporarily swaps `catalog.yaml` to point the reference
+  scope at the glossary, runs `kcmd reference` (writes
+  `catalog/glossaries/.../*.ref.yaml`), then restores the original
+  `catalog.yaml` so subsequent `kcmd pull`/`push`/`reference` runs see the
+  caller's manifest unchanged.
+
+  `dataset` is only needed because the main `scope:` line must be a valid
+  parseable scope — we use the caller's BQ dataset as a no-op main scope.
+  """
+  manifest_path = os.path.join(output_dir, "catalog.yaml")
+  with open(manifest_path) as f:
+    original = f.read()
+  try:
+    with open(manifest_path, "w") as f:
+      f.write(
+          f"scope: bq-dataset.{project}.{dataset}\n"
+          "reference:\n"
+          f"  scope: {glossary_scope}\n"
+      )
+    return _run(["reference"], output_dir, project, 300)
+  finally:
+    with open(manifest_path, "w") as f:
+      f.write(original)
+
+
+def build_glossary_scope(glossaries: list[str]) -> tuple[str | None, str]:
+  """Convert a list of `project.location.glossaryId` strings to the kcmd
+
+  glossary scope string `glossary.<project>.<location>.<id1,id2,...>`.
+
+  Returns (scope, warning_msg). When glossaries span multiple
+  project/location pairs, the first one is used and a warning is returned
+  (kcmd glossary source today takes a single project.location prefix).
+  Returns (None, error_msg) when the input is empty or malformed.
+  """
+  groups: dict[str, list[str]] = {}
+  for g in glossaries:
+    parts = g.split(".")
+    if len(parts) < 3:
+      continue
+    pl = ".".join(parts[:2])
+    gid = parts[2]
+    groups.setdefault(pl, []).append(gid)
+
+  if not groups:
+    return (
+        None,
+        "Invalid glossary formats. Expected project.location.glossaryId.",
+    )
+
+  pl = next(iter(groups))
+  gids = ",".join(groups[pl])
+  warning = ""
+  if len(groups) > 1:
+    warning = (
+        f"Multiple project/locations for glossaries found. Only using {pl}"
+        " due to kcmd limits."
+    )
+  return f"glossary.{pl}.{gids}", warning
+
+
+def list_glossaries(output_dir: str) -> list[dict]:
+  """Read all Glossary and Term YAMLs under `<output_dir>/catalog/glossaries/`.
+
+  Returns:
+    [{id, type, display_name, description, parent}, ...]
+  """
+  glossary_dir = os.path.join(output_dir, "catalog", "glossaries")
+  if not os.path.isdir(glossary_dir):
+    return []
+  entries = []
+  for yaml_path in sorted(
+      glob.glob(os.path.join(glossary_dir, "**", "*.yaml"), recursive=True)
+  ):
+    if os.path.basename(yaml_path) == "catalog.yaml":
+      continue
+    try:
+      with open(yaml_path) as f:
+        entry = yaml.safe_load(f) or {}
+    except Exception:  # noqa: BLE001
+      continue
+
+    resource = entry.get("resource", {}) or {}
+    # Strip .ref or .yaml from the end
+    basename = os.path.basename(yaml_path)
+    if basename.endswith(".ref.yaml"):
+      eid = basename[:-9]
+    else:
+      eid = basename[:-5]
+
+    eid = entry.get("name") or eid
+    fqn = resource.get("name", "")
+
+    # If FQN is missing, try to synthesize it from the path
+    if not fqn:
+      # Path pattern: .../glossaries/Glossary (ID)/[Category (ID)/]terms/Term (ID).yaml
+      # Or simpler for kcmd layout
+      parts = yaml_path.split(os.sep)
+      try:
+        # Find the 'glossaries' segment
+        g_idx = parts.index("glossaries")
+
+        # Extract IDs from "DisplayName (ID)" format if present
+        def extract_id(s):
+          import re
+
+          m = re.search(r"\(([^)]+)\)$", s)
+          return m.group(1) if m else s
+
+        # This is a bit complex due to kcmd layout variety,
+        # but let's try a best-effort based on typical kcmd layout
+        # For now, let's trust kcmd pull to have the resource.name
+        # or at least the top-level name being usable if we prepend projects/
+        pass
+      except ValueError:
+        pass
+
+    entries.append({
+        "id": eid,
+        "fqn": fqn,
+        "type": entry.get("type"),
+        "display_name": resource.get("displayName", ""),
+        "description": resource.get("description", ""),
+        "parent": resource.get("parent", ""),
+    })
+  return entries
+
+
+def _dataset_dir(output_dir: str, project: str, dataset: str) -> str:
+  return os.path.join(output_dir, "catalog", "bigquery", project, dataset)
+
+
+def list_tables(output_dir: str, project: str, dataset: str) -> list[str]:
+  d = _dataset_dir(output_dir, project, dataset)
+  return [
+      os.path.basename(y)[:-5]
+      for y in sorted(glob.glob(os.path.join(d, "*.yaml")))
+      if os.path.basename(y) != "catalog.yaml" and not y.endswith(".ref.yaml")
+  ]
+
+
+def _aspect(entry: dict, suffix: str) -> dict:
+  """Aspect by last name segment -- accepts short alias keys ("schema") and full
+
+  `dataplex-types.global.schema` keys, nested under `aspects:` or top level.
+  """
+  for container in ((entry or {}).get("aspects", {}) or {}, entry or {}):
+    for k, v in (container or {}).items():
+      if isinstance(k, str) and k.split(".")[-1] == suffix:
+        return v or {}
+  return {}
+
+
+def _read_table_meta_path(
+    path: str, project: str, dataset: str, table: str
+) -> dict:
+  """Read a table entry YAML at `path` into the meta dict the agents use.
+
+  Shared by `read_table_meta` (pulled `catalog/`) and
+  `read_reference_table_meta`
+  (read-only `reference/`).
+  """
+  entry = {}
+  if os.path.exists(path):
+    try:
+      with open(path) as f:
+        entry = yaml.safe_load(f) or {}
+    except Exception:  # noqa: BLE001
+      entry = {}
+  res = entry.get("resource", {}) or {}
+  schema_fields = []
+  for f in _aspect(entry, "schema").get("fields", []) or []:
+    if isinstance(f, dict):
+      schema_fields.append({
+          "name": f.get("name", ""),
+          "dataType": f.get("dataType", f.get("type", "")),
+          "metadataType": f.get("metadataType", ""),
+          "mode": f.get("mode", ""),
+          "description": f.get("description", ""),
+      })
+  return {
+      "name": entry.get("name", f"{project}.{dataset}/{table}"),
+      "table": table,
+      "entry_id": entry.get("name", f"{project}.{dataset}/{table}"),
+      "entry_type_3part": entry.get(
+          "type", "dataplex-types.global.bigquery-table"
+      ),
+      "display_name": res.get("displayName", table),
+      "description": res.get("description", ""),
+      "schema_fields": schema_fields,
+      "existing_overview": _aspect(entry, "overview").get("content", ""),
+      "resource_name": (entry.get("resource", {}) or {}).get("name", ""),
+  }
+
+
+def read_table_meta(
+    output_dir: str, project: str, dataset: str, table: str
+) -> dict:
+  """Read one pulled table entry into the meta dict the table agent uses."""
+  path = os.path.join(
+      _dataset_dir(output_dir, project, dataset), f"{table}.yaml"
+  )
+  return _read_table_meta_path(path, project, dataset, table)
+
+
+def flatten_table_for_prompt(meta: dict, max_fields: int = 300) -> str:
+  """Render a meta dict into a compact, LLM-friendly block."""
+  lines = [
+      f"TABLE: {meta.get('table', '')}",
+      f"Entry id: {meta.get('entry_id', '')}",
+      f"Entry type: {meta.get('entry_type_3part', '')}",
+  ]
+  if meta.get("display_name"):
+    lines.append(f"Display name: {meta['display_name']}")
+  if meta.get("description"):
+    lines.append(f"Existing description: {meta['description']}")
+  if meta.get("existing_overview"):
+    lines.append(f"Existing overview:\n{meta['existing_overview']}")
+  fields = meta.get("schema_fields", [])
+  lines.append(f"\nSCHEMA ({len(fields)} columns):")
+  for f in fields[:max_fields]:
+    desc = f" — {f['description']}" if f.get("description") else ""
+    mode = f" [{f['mode']}]" if f.get("mode") else ""
+    lines.append(
+        f"  - {f.get('name','')}: {f.get('dataType','')}"
+        f"{mode} (metadataType={f.get('metadataType','')}){desc}"
+    )
+  if len(fields) > max_fields:
+    lines.append(f"  ... ({len(fields) - max_fields} more columns omitted)")
+  return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# doc_mode: entry-group manifest scaffold via init --entry-group
+# --------------------------------------------------------------------------- #
+def init_entry_group(
+    output_dir: str,
+    entry_group: str,
+    entry_type: str = "dataplex-types.global.generic",
+) -> tuple[bool, str]:
+  """Scaffold the catalog.yaml with `kcmd init --entry-group <proj>.<loc>.<eg>`.
+
+  Always writes the complete manifest afterward (init can't reach the catalog
+  for a brand-new entry group, and its bare `scope:` output lacks
+  snapshot/publishing). `entry_group` is `project.location.eg`; `entry_type` is
+  the full `project.location.entryTypeId` for the entries.
+  """
+  os.makedirs(output_dir, exist_ok=True)
+  parts = entry_group.split(".")
+  project = parts[0] if parts else ""
+  # Run init --entry-group for validation/auth, but always overwrite catalog.yaml
+  # with the complete manifest below — init's bare `scope:` output lacks the
+  # snapshot/publishing config that `kcmd push` needs to load entry types and
+  # publish the overview aspect (without it push silently no-ops).
+  ok, msg = _run(
+      ["init", "--entry-group", entry_group], output_dir, project, 120
+  )
+  if not ok:
+    return False, msg
+
+  manifest_path = os.path.join(output_dir, "catalog.yaml")
+  if len(parts) == 3:
+    with open(manifest_path, "w") as f:
+      f.write(
+          _EG_MANIFEST.format(
+              project=parts[0],
+              location=parts[1],
+              eg=parts[2],
+              entry_type=entry_type,
+          )
+      )
+    return True, msg or "wrote entry-group manifest"
+  return False, msg
+
+
+def init_pull_entry_group(
+    output_dir: str,
+    entry_group: str,
+    entry_type: str = "dataplex-types.global.generic",
+) -> tuple[bool, str]:
+  """init_entry_group + `kcmd pull`.
+
+  Pulls any pre-existing entries in this entry group so the agent can treat them
+  as seeds (must-preserve) and use their existing overview content as additional
+  grounding for the per-entry writer.
+
+  Returns (ok, message).
+  """
+  ok, msg = init_entry_group(output_dir, entry_group, entry_type)
+  if not ok:
+    return False, msg
+  parts = entry_group.split(".")
+  project = parts[0] if parts else ""
+  ok_pull, msg_pull = _run(["pull"], output_dir, project, 300)
+
+  combined_msg = (msg + "\n" + msg_pull).strip()[-600:]
+
+  # If it failed but the reason is simply that the group doesn't exist yet,
+  # that's OK for an initial setup. We treat it as success and move on.
+  if not ok_pull and (
+      "NOT_FOUND" in combined_msg or "does not exist" in combined_msg
+  ):
+    return (
+        True,
+        (
+            "(Note: Entry Group not found on cloud; proceeding with empty local"
+            " state)"
+        ),
+    )
+
+  return ok_pull, combined_msg
+
+
+def list_kb_entries(output_dir: str) -> list[dict]:
+  """Read all KB entry YAMLs (+ adjacent `.overview.md` sidecars) under
+  `<output_dir>/catalog/` into structured dicts.
+
+  Used by doc_mode AFTER `init_pull_entry_group` to discover what entries
+  already exist in the KC entry group. Returns:
+    [{id, display_name, description, existing_overview}, ...]
+
+  The STANDARD layout puts entry YAMLs at `catalog/<id>.yaml` and any
+  overview sidecar at `catalog/<id>.overview.md`. We also fall back to reading
+  the overview aspect's `content` field on the YAML in case the layout doesn't
+  use sidecars.
+  """
+  catalog_dir = os.path.join(output_dir, "catalog")
+  if not os.path.isdir(catalog_dir):
+    return []
+  entries = []
+  # Use recursive glob to find nested entries (namespace/project/location/id)
+  for yaml_path in sorted(
+      glob.glob(os.path.join(catalog_dir, "**", "*.yaml"), recursive=True)
+  ):
+    if os.path.basename(yaml_path) == "catalog.yaml" or yaml_path.endswith(
+        ".ref.yaml"
+    ):
+      continue
+    try:
+
+      with open(yaml_path) as f:
+        entry = yaml.safe_load(f) or {}
+    except Exception:  # noqa: BLE001
+      continue
+    sidecar = yaml_path[: -len(".yaml")] + ".overview.md"
+    overview = ""
+    if os.path.exists(sidecar):
+      try:
+        with open(sidecar) as f:
+          overview = f.read()
+      except OSError:
+        pass
+    if not overview:
+      overview = _aspect(entry, "overview").get("content", "") or ""
+    resource = entry.get("resource", {}) or {}
+    raw_name = (
+        entry.get("name")
+        or entry.get("id")
+        or os.path.basename(yaml_path)[: -len(".yaml")]
+    )
+    # Pulled entry-group entries carry their FULL nested name
+    # (`<eg>/<project>/<location>/<entryId>`). Use only the last segment as the
+    # local id so it is a valid filename stem and a correct local `name:` when
+    # the entry is re-emitted (kcmd's entrygroup source re-prepends the EG path
+    # at push time — see sources/entrygroup.ts).
+    eid = raw_name.split("/")[-1]
+    entries.append({
+        "id": eid,
+        "display_name": resource.get(
+            "displayName", entry.get("displayName", eid)
+        ),
+        "description": resource.get("description", ""),
+        "existing_overview": overview,
+        "yaml_path": yaml_path,
+    })
+  return entries
+
+
+# --------------------------------------------------------------------------- #
+# context_overlay_mode: read-only 1P table pull via `kcmd reference`
+# --------------------------------------------------------------------------- #
+def init_reference(
+    output_dir: str,
+    entry_group: str,
+    ref_project: str,
+    ref_dataset: str,
+    entry_type: str = "dataplex-types.global.generic",
+) -> tuple[bool, str]:
+  """Write the overlay manifest (editable `scope:` EG + `reference:` bq-dataset)
+
+  and run `kcmd reference` to pull the read-only 1P table entries into
+  `catalog/bigquery/<proj>/<dataset>/<table>.ref.yaml`. No Dataplex API
+  directly.
+
+  `entry_group` is `project.location.eg` (where overlays will be pushed);
+  `ref_project.ref_dataset` is the BigQuery dataset whose tables are referenced.
+  """
+  os.makedirs(output_dir, exist_ok=True)
+  parts = entry_group.split(".")
+  if len(parts) != 3:
+    return False, (
+        "entry_group must be `project.location.entryGroupId` (got"
+        f" '{entry_group}')."
+    )
+  project, location, eg = parts
+  with open(os.path.join(output_dir, "catalog.yaml"), "w") as f:
+    f.write(
+        _OVERLAY_MANIFEST.format(
+            project=project,
+            location=location,
+            eg=eg,
+            entry_type=entry_type,
+            ref_project=ref_project,
+            ref_dataset=ref_dataset,
+        )
+    )
+  return _run(["reference"], output_dir, ref_project, 300)
+
+
+def _reference_dir(output_dir: str, project: str, dataset: str) -> str:
+  # `kcmd reference` writes the read-only 1P entries straight into the main
+  # catalog tree as `catalog/bigquery/<project>/<dataset>/<table>.ref.yaml`
+  # (StandardLayout name `bigquery/<project>/<dataset>/<table>.ref`); there is no
+  # separate `reference/` folder.
+  return os.path.join(output_dir, "catalog", "bigquery", project, dataset)
+
+
+def list_reference_tables(
+    output_dir: str, project: str, dataset: str
+) -> list[str]:
+  d = _reference_dir(output_dir, project, dataset)
+  return [
+      os.path.basename(y)[: -len(".ref.yaml")]
+      for y in sorted(glob.glob(os.path.join(d, "*.ref.yaml")))
+  ]
+
+
+def read_reference_table_meta(
+    output_dir: str, project: str, dataset: str, table: str
+) -> dict:
+  """Read one read-only reference table entry (`<table>.ref.yaml`) into a meta
+
+  dict.
+
+  The 1P overview is pulled to a `.ref.overview.md` sidecar (not the YAML), so
+  fill `existing_overview` from there to ground the overlay writer with the
+  table's real overview when one exists.
+  """
+  path = os.path.join(
+      _reference_dir(output_dir, project, dataset), f"{table}.ref.yaml"
+  )
+  meta = _read_table_meta_path(path, project, dataset, table)
+  if not (meta.get("existing_overview") or "").strip():
+    meta["existing_overview"] = read_reference_overview(
+        output_dir, project, dataset, table
+    )
+  return meta
+
+
+def read_reference_overview(
+    output_dir: str, project: str, dataset: str, table: str
+) -> str:
+  """Read the 1P table's REAL overview from the `kcmd reference` sidecar.
+
+  `kcmd reference` (StandardLayout) writes a pulled overview aspect to the
+  sidecar `catalog/bigquery/<project>/<dataset>/<table>.ref.overview.md` (and
+  strips it from the YAML), so this is the only place the genuine 1P overview
+  lives. Returns the Markdown body (frontmatter stripped) or "" when the table
+  has no overview in the catalog — callers must NOT fabricate one in that case.
+  """
+  path = os.path.join(
+      _reference_dir(output_dir, project, dataset), f"{table}.ref.overview.md"
+  )
+  if not os.path.exists(path):
+    return ""
+  try:
+    with open(path) as f:
+      text = f.read()
+  except OSError:
+    return ""
+  # Strip a leading `---\n...\n---` YAML frontmatter block if present.
+  if text.startswith("---\n"):
+    end = text.find("\n---", 4)
+    if end != -1:
+      text = text[end + len("\n---") :].lstrip("\n")
+  return text.strip()

--- a/agents/mdcode/.gitignore
+++ b/agents/mdcode/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+node_modules/

--- a/agents/mdcode/README.md
+++ b/agents/mdcode/README.md
@@ -1,0 +1,444 @@
+# Metadata as Code
+
+Metadata as Code is a Knowledge Catalog (Dataplex) provides data stewards and
+data producers and AI agents with a source code artifact-based UX for metadata
+management and context engineering.
+
+Users and agents can author, manage, and enrich metadata artifacts using
+developer-friendly workflows with version control and CI/CD. It provides a
+standard metadata format can be used by a variety of tools and agents.
+
+More details are in the [docs/concept.md](docs/concept.md).
+
+## Key Features
+
+`kcmd` (Metadata as Code) provides a developer-friendly UX for Dataplex metadata management, enabling data stewards and AI agents to author and enrich metadata using version-controlled workflows.
+
+#### 1. Core Metadata Management
+
+*   **Metadata as Source Code**: Manage catalog entries as local YAML and Markdown files, organized in a hierarchy that mirrors your cloud resources.
+*   **Bi-directional Sync**: Seamlessly sync local changes with the Catalog service via `pull` and `push` operations.
+
+#### 2. Grounding & Safe Publishing
+
+*   **Contextual Reference Layers**: Pull read-only system metadata (like schemas) into `.ref.yaml` files. This provides an authoritative baseline for enrichment without risking accidental overwrites.
+*   **Automatic Provisioning**: Create missing Entry Groups and Entries directly from your local filesystem during a `push`.
+
+#### 3. Content Flexibility
+
+*   **Optimized Layouts**: Automatically switches between **YAML Layout** (for data assets) and **Markdown Layout** (for human-centric Knowledge Bases).
+*   **Markdown Sidecars**: Detach long-form text (like overviews) into sidecar `.md` files to maintain clean and manageable YAML files.
+
+#### 4. Integration & Extensibility
+
+*   **Agent-Ready (MCP)**: Includes a built-in **Model Context Protocol (MCP)** server, allowing AI agents to list, lookup, and modify metadata autonomously.
+*   **Unified Interface**: Supports BigQuery Datasets, Dataplex Entry Groups,
+    BigLake namespaces, and Business Glossaries through a single command-line
+    tool and library.
+
+#### 5. Linked Metadata & Glossary
+
+*   **EntryLinks**: Catalog relationships (e.g., `definition` linking a BQ
+    column to a business term, or `schema-join` between BQ tables) are
+    first-class artifacts in `pull` and `push`. Declare `entryLinks` in your
+    manifest and they sync alongside entries.
+*   **Column-level Linking**: Links that carry a `Schema.<field>` source path
+    are inlined under `aspects.schema.fields[].links` on the table YAML —
+    per-column governance lives right next to the column definition.
+*   **Glossary as a Source**: `scope:
+    glossary.<project>.<location>.<glossary-id>` manages Business Glossaries
+    (terms, categories, nested structure) using the same `pull`/`push` workflow
+    as other source types. Targets in pulled YAML resolve to the human-readable
+    `project.location.glossary.term` form (display-name based) with the full UID
+    preserved in `id` for round-trip.
+*   **Safe Push Reconciliation**: `push` matches local vs remote links by
+    normalized target + path (project ID/Number agnostic, `@dataplex` proxy
+    unwrapped), so existing links are detected and kept in place — no spurious
+    delete-and-recreate cycles.
+
+## What's New
+
+*   **Multi-dataset Support**: `kcmd init` now accepts multiple `--bigquery-dataset` flags, enabling a single workspace to manage metadata across multiple BQ datasets.
+*   **Knowledge Base (Wiki) Mode**: Use the `--kb` flag to manage human-authored content via the **Markdown Layout**. It automatically organizes pages as `.md` files with YAML frontmatter.
+*   **AI-Native Reference Layers**: Use `kcmd reference` to pull read-only system metadata. This creates a distinct `.ref.yaml` layer, allowing AI agents to ground their enrichments on authoritative schemas without modifying them.
+*   **Built-in MCP Server**: Native support for the Model Context Protocol, allowing seamless integration with AI agents for automated metadata tasks.
+*   **EntryLinks Sync**: `pull` and `push` now manage `EntryLink` resources as
+    first-class artifacts. Declare link types in `snapshot.entryLinks` to fetch
+    them, in `publishing.entryLinks` to reconcile them on push, and (optionally)
+    in `reference.snapshot.entryLinks` so `.ref.yaml` baselines include the
+    pre-edit link state for clean diffs.
+*   **Glossary Source**: A Business Glossary can be the primary `scope`
+    (`glossary.<project>.<location>.<glossary-id>`), enabling local CRUD of
+    glossary terms and categories via the same `pull`/`push` workflow.
+    Glossaries also work as a `reference.scope` so other workspaces can ground
+    enrichment in glossary terms without owning them.
+
+## Usage
+
+### 1. Initialization (`kcmd init`)
+The initialization flag defines the **Mode** (Source Type) of your workspace. This selection is mandatory and determines how `kcmd` communicates with GCP and how files are structured locally. You must choose **exactly one** primary source type.
+
+Source Type (Mode) | CLI Flag              | Required ID Format                            | Target Resource & Layout
+:----------------- | :-------------------- | :-------------------------------------------- | :-----------------------
+**BigQuery**       | `--bigquery-dataset`  | `my-project-id.my-dataset-id`                 | Manages tables, views, and schemas (**YAML** Layout).
+**Knowledge Base** | `--kb`                | `my-project-id.my-location.my-entry-group-id` | Manages human-authored Wiki/Doc content (**Markdown** Layout).
+**Entry Group**    | `--entry-group`       | `my-project-id.my-location.my-entry-group-id` | Manages custom or user-defined catalog entries (**YAML** Layout).
+**BigLake**        | `--biglake-namespace` | `my-project-id.my-catalog-id.my-namespace-id` | Manages Iceberg/BigLake table metadata (**YAML** Layout).
+**Glossary**       | `--glossary`          | `my-project-id.my-location.my-glossary-id`    | Manages a Business Glossary — terms and categories under `catalog/glossaries/` (**YAML** Layout).
+
+**Note on BigQuery:** While you must pick one mode, the BigQuery mode allows you to specify multiple datasets by repeating the flag (e.g., `--bigquery-dataset ds1 --bigquery-dataset ds2`).
+
+**Note on Glossary:** The glossary scope is flexible — you can specify one or
+more glossaries by ID or display name in a single `--glossary` flag using a
+comma-separated list, or omit the glossary ID entirely to operate in "location
+mode":
+
+*   **By ID (single or multiple)**: `--glossary
+    my-project.us-central1.glossary-a,glossary-b`
+*   **By display name (exact match)**: `--glossary my-project.us-central1.My
+    Business Glossary` (falls back from ID lookup automatically)
+*   **Location mode** (all glossaries in a location): `--glossary
+    my-project.us-central1`
+
+**Examples:**
+
+```bash
+# Data Mode: Initialize with one or more BigQuery datasets
+kcmd init --bigquery-dataset my-project-id.my-dataset-id
+
+# Wiki Mode: Initialize a human-authored Knowledge Base (uses .md files)
+kcmd init --kb my-project-id.us-central1.my-knowledge-base-id
+
+# BigLake Mode: Requires the --iceberg flag
+kcmd init --biglake-namespace my-project-id.my-catalog-id.my-namespace-id --iceberg
+
+# Glossary Mode: Initialize a workspace rooted at a Business Glossary
+kcmd init --glossary my-project-id.us-central1.my-glossary-id
+
+# Glossary Mode: Multiple glossaries (comma-separated, in the same project/location)
+kcmd init --glossary my-project-id.us-central1.glossary-a,glossary-b
+
+# Glossary Mode: Location mode — all glossaries in a given location
+kcmd init --glossary my-project-id.us-central1
+```
+
+### 2. Synchronization
+
+#### Pulling Metadata
+
+*   **`kcmd pull`**: Downloads editable metadata into the `catalog/` directory.
+    *   Generates `.yaml` files in **YAML** mode or `.md` files in **Markdown** mode.
+    *   **Entry Links**: When `snapshot.entryLinks` is declared, `pull` also
+        calls `lookupEntryLinks` for every fetched entry and inlines the results
+        into the entry YAML — column-level links (those with a `Schema.<field>`
+        source path) land under `aspects.schema.fields[].links`, others under
+        the top-level `links` block. Omit `snapshot.entryLinks` to skip the link
+        fetch entirely.
+*   **`kcmd reference`**: Downloads read-only reference data defined in the
+    `reference:` block of your manifest.
+    *   Generates **`.ref.yaml`** files as siblings to your editable files. These are used for grounding and are never pushed.
+    *   Honors `reference.snapshot.entryLinks` the same way as `pull` honors
+        `snapshot.entryLinks`, so a `.ref.yaml` baseline can include the
+        pre-edit link state for clean `diff`s.
+
+#### Pushing Changes
+
+*   **`kcmd push`**: Uploads local edits from `catalog/` to the Catalog service.
+    *   **Skip Reference Layers**: Files ending in `.ref.yaml` are strictly read-only and **skipped** during push.
+    *   **Auto-Creation**: If an entry (or its parent Entry Group) does not exist in the service, `kcmd` will attempt to create it using parameters derived from your local workspace:
+        *   **Project & Location**: Derived from the workspace context.
+        *   **Entry Group**: Determined by your workspace mode (e.g., `@bigquery` for BigQuery mode, or your custom ID for Knowledge Base/Entry Group modes).
+        *   **Entry ID**: Derived from your local file path. For example, a file at `catalog/bigquery/my-project/my-dataset/my-new-table.yaml` will result in an **Entry ID** of `bigquery.googleapis.com/projects/my-project/datasets/my-dataset/tables/my-new-table`.
+    *   **Entry Link Reconciliation**: When `publishing.entryLinks` is declared,
+        `push` reconciles local vs remote `EntryLink` resources of those types
+        per entry. Matching is symmetrical and project ID/Number agnostic
+        (`@dataplex` proxy unwrapped, both sides normalized to project ID before
+        comparison), so unchanged links are preserved (no delete-then-create).
+        New local links are created; remote links of the configured types with
+        no local match are deleted. Omit (or leave empty)
+        `publishing.entryLinks` to disable link mutations entirely — useful when
+        a workspace only reads links.
+    *   `--force`: Overwrites service metadata, ignoring potential conflicts.
+    *   `--validate-only`: Validates the local snapshot against the service without performing a push.
+
+> [!IMPORTANT] **`kcmd push` does NOT create Glossary, GlossaryCategory, or
+> GlossaryTerm resources.**
+>
+> These three resource kinds are Dataplex **control-plane** resources — they
+> govern catalog *structure* (which terms are sanctioned business vocabulary,
+> how the vocabulary is organized) rather than describing data assets. Their
+> lifecycle is intentionally controlled by humans: a glossary should reflect a
+> deliberate governance decision, not appear as a side effect of an enrichment
+> agent's run.
+>
+> Concretely: * A missing `Glossary`, `GlossaryCategory`, or `GlossaryTerm`
+> referenced by your local snapshot causes `kcmd push` to fail fast with a clear
+> error pointing at the missing resource. * To use a glossary, **create the
+> glossary (and any categories/terms you need) yourself first** — via the
+> Dataplex console or `gcloud dataplex glossaries create …` / `gcloud dataplex
+> glossary-terms create …` — then run `kcmd pull` followed by `kcmd push` to
+> manage metadata (e.g., descriptions, labels) on the existing resources. *
+> `kcmd push` **is allowed to update** the description, labels, and other
+> metadata of an *already-existing* glossary/category/term. This update path is
+> the only mutation kcmd performs against the glossary hierarchy; it never adds
+> or removes a node. * EntryLinks that *reference* glossary terms (e.g.,
+> `definition` links from a BQ column to a term) are catalog metadata and ARE
+> created/deleted normally by `kcmd push` — the no-create rule applies only to
+> the glossary tree itself, not to the relationships pointing at it.
+>
+> If your workflow needs to bootstrap an empty glossary, do it once out-of-band
+> and treat the result as a stable input to `kcmd`.
+
+### 3. AI Agent Integration (MCP)
+To use `kcmd` as a Model Context Protocol (MCP) server for agents like the Gemini CLI:
+
+```json
+{
+  "mcpServers": {
+    "kcmd": {
+      "command": "npx",
+      "args": ["-y", "kcmd", "mcp", "--path", "/absolute/path/to/workspace"]
+    }
+  }
+}
+```
+
+The server provides tools like `list-entries`, `lookup-entry`, and `modify-entry` for automated context engineering and metadata enrichment.
+
+### 4. Authentication
+The CLI and MCP server use `gcloud` to obtain authentication tokens. Ensure you are authenticated:
+
+```bash
+gcloud auth application-default login
+```
+
+## Metadata Artifacts
+
+### Directory Layout
+
+`kcmd` organizes metadata based on the resource hierarchy. Each entry (e.g., a table) is managed as a standalone YAML file, potentially with a Markdown sidecar for long-form content.
+
+#### YAML Layout (Data Assets)
+Entries are files named `<entry-id>.yaml`. Sidecars use the format `<entry-id>.<aspect-alias>.md`. Reference layers co-exist as `*.ref.yaml` files.
+
+```text
+/
+├── catalog.yaml
+└── catalog/
+    └── bigquery/
+        └── my-project-id/
+            ├── my-dataset-id.yaml      # Dataset entry file
+            └── my-dataset-id/          # Directory for entries within this dataset
+                ├── table1.yaml         # Table 1 entry file (editable)
+                ├── table1.ref.yaml     # Table 1 reference layer (read-only system metadata)
+                ├── table2.yaml         # Table 2 entry file
+                └── table2.overview.md  # Sidecar for table2's overview aspect
+```
+
+#### Markdown Layout (Knowledge Base)
+Entries are `.md` files containing both metadata and content.
+
+```text
+/
+├── catalog.yaml
+└── catalog/
+    └── my-namespace/
+        └── my-project-id/
+            └── my-location-id/
+                ├── page1.md            # Page 1 (Frontmatter + Markdown)
+                └── page2.md            # Page 2
+```
+
+## Catalog Manifest (`catalog.yaml`)
+
+The manifest defines the synchronization scope, the types of metadata to manage, and optional reference layers for grounding.
+### Example Manifest
+
+```yaml
+# The primary resource(s) to manage. Format: <mode-id>.<project-id>.<resource-id>
+scope: bigquery-mode-id.my-project-id.my-dataset-id
+
+# Defines which entry, aspect, and link types are managed locally.
+snapshot:
+  entries:
+    - dataplex-types.global.bigquery-table
+  aspects:
+    - dataplex-types.global.schema
+    - dataplex-types.global.bigquery-table
+    - dataplex-types.global.storage
+    - dataplex-types.global.overview
+  entryLinks:
+    - definition          # system alias: dataplex-types.global.definition
+    - synonym
+
+# Defines which aspects and links are pushed back to the service.
+publishing:
+  aspects:
+    - dataplex-types.global.overview
+  entryLinks:
+    - definition          # delete remote links of this type that aren't present locally; create new local ones
+
+# Optional: pull read-only metadata for grounding (never pushed).
+reference:
+  scope: bq-dataset.my-project-id.my-dataset-id
+  snapshot:
+    entries:
+      - dataplex-types.global.bigquery-table
+    aspects:
+      - dataplex-types.global.schema
+      - dataplex-types.global.overview
+    entryLinks:
+      - definition        # include pre-edit links in .ref.yaml so diffs surface only the changes
+      - synonym
+```
+
+*   **`scope`** — The "Source of Truth" for your workspace. It defines which GCP
+    resources `kcmd` connects to for pulling metadata and where it deploys
+    changes during a push. It also determines the directory hierarchy within
+    your `catalog/` folder. Supported types include `bq-dataset.*`,
+    `entryGroup.*`, `kb.*`, `biglake-namespace.*`, and
+    `glossary.<project>.<location>.<glossary-id>`.
+*   **`snapshot`** — The entry, aspect, and link types to manage locally.
+    *   `entryLinks` (optional) — short aliases (`definition`, `synonym`,
+        `related`, `schema-join`) or fully-qualified link type refs. When set,
+        `pull` calls `lookupEntryLinks` for every pulled entry and routes
+        results into the entry YAML (top-level `links` for entry-level links,
+        `aspects.schema.fields[].links` for column-level links carrying a
+        `Schema.<field>` path). Omit to skip link sync entirely.
+*   **`publishing`** — The subset of aspects `kcmd push` writes back to the
+    catalog.
+    *   `entryLinks` (optional) — must be a subset of `snapshot.entryLinks`. On
+        `push`, the engine compares local vs remote links of these types (after
+        unwrapping `@dataplex` proxies and normalizing project IDs) and
+        reconciles: existing matches are kept, missing-remote links are created,
+        missing-local links are deleted. Omit (or leave empty) to skip link
+        mutations entirely — useful when you want to read links without taking
+        responsibility for them.
+*   **`reference`** — A read-only resource to pull as a reference layer (saved
+    as `*.ref.yaml`).
+    *   `reference.snapshot.entryLinks` (optional) — when present, `.ref.yaml`
+        files include the pre-edit link state, so diffing live `.yaml` vs
+        `.ref.yaml` surfaces only what your enrichment added or removed.
+
+## Entry Artifacts
+
+### Standard Entry (YAML)
+
+**catalog/bigquery/my-project-id/my-dataset-id/my-table-id.yaml**
+
+```yaml
+name: bigquery/my-project-id/my-dataset-id/my-table-id
+type: dataplex-types.global.bigquery-table
+
+resource:
+  name: projects/my-project-id/datasets/my-dataset-id/tables/my-table-id
+  displayName: my-table-id
+  description: A descriptive summary of this table
+  labels:
+    env: prod
+  location: us-central1
+  ancestors:
+    - name: projects/my-project-id/datasets/my-dataset-id
+      type: dataplex-types.global.bigquery-dataset
+  createTime: 2024-09-18 00:01:34.230000+00:00
+  updateTime: 2024-10-23 22:55:17.063000+00:00
+
+aspects:
+  schema:
+    fields:
+      - name: my-column
+        dataType: STRING
+        metadataType: STRING
+        mode: NULLABLE
+  storage:
+    service: BIGQUERY
+    resourceName: //bigquery.googleapis.com/projects/my-project-id/datasets/my-dataset-id/tables/my-table-id
+
+category: miscellaneous
+```
+
+### Document Entry (Markdown)
+
+**catalog/my-namespace/my-project-id/my-location-id/my-page-id.md**
+
+```markdown
+---
+type: dataplex-types.global.entry
+title: My Page Title
+catalogEntry:
+  id: my-page-id
+  resource:
+    name: projects/my-project-id/locations/my-location-id/entryGroups/my-eg-id/entries/my-page-id
+---
+# Welcome to My Knowledge Base Page
+This is the human-authored content of the page.
+```
+
+### Entry with EntryLinks
+
+Column-level links live under `aspects.schema.fields[].links` and are produced
+automatically when the link's source reference carries a `Schema.<field>` path
+on `pull`. Entry-level links (no `Schema.<field>` path) appear at the top level
+under `links`. The `target` value is the human-readable
+`<project>.<location>.<glossary-display-name>.<term-display-name>` form, and the
+full UID resource path is preserved in `id` so `push` can reconstruct the exact
+catalog reference.
+
+**catalog/bigquery/my-project-id/my-dataset-id/orders.yaml** (excerpt)
+
+```yaml
+aspects:
+  schema:
+    fields:
+      - name: customer_id
+        dataType: STRING
+        mode: NULLABLE
+        links:
+          definition:
+            - target: my-project-id.global.business-glossary.customer-id
+              id: projects/my-project-id/locations/global/glossaries/biz/terms/customer-id
+      - name: total_amount
+        dataType: NUMERIC
+        mode: NULLABLE
+        links:
+          definition:
+            - target: my-project-id.global.business-glossary.transaction-amount
+              id: projects/my-project-id/locations/global/glossaries/biz/terms/transaction-amount
+
+# Top-level links (entry-level relationships without a column path)
+links:
+  related:
+    - target: my-other-project.us.docs-eg.runbook-page
+```
+
+### Glossary Term (YAML)
+
+When the workspace `scope` is `glossary.<project>.<location>.<glossary-id>`, the
+local hierarchy mirrors the glossary's "glossary → category → term" tree.
+
+**catalog/glossaries/Business Glossary (biz)/terms/customer-id.yaml**
+
+```yaml
+name: glossaries/Business Glossary (biz)/terms/customer-id
+type: glossaryTerm
+displayName: customer-id
+description: Unique identifier for a customer record.
+parent: projects/my-project-id/locations/global/glossaries/biz
+```
+
+## Developer Workflow
+
+### Setup
+
+```bash
+git clone https://github.com/googlecloudplatform/knowledge-catalog
+cd agents/mdcode
+npm install
+```
+
+### Build & Test
+
+```bash
+npm run build
+npm run test
+```

--- a/agents/mdcode/demo/.gitignore
+++ b/agents/mdcode/demo/.gitignore
@@ -1,0 +1,2 @@
+catalog/
+catalog.yaml

--- a/agents/mdcode/demo/README.md
+++ b/agents/mdcode/demo/README.md
@@ -1,0 +1,123 @@
+# Demo
+
+## Configuration
+
+You will need a cloud project with permissions to use BigQuery and Knowledge
+Catalog APIs.
+
+```bash
+export DEMO_CLOUD_PROJECT=<GCP_PROJECT_ID>
+```
+
+Ensure that gcloud is installed and configured.
+
+```bash
+gcloud auth application-default login
+gcloud config set compute/region us-central1
+gcloud config set project $DEMO_CLOUD_PROJECT
+```
+
+## BigQuery Dataset
+
+This demo demonstrates working with metadata for BigQuery resources (dataset and
+table).
+
+**Setup**
+
+*   Creates a BigQuery dataset (`demo_ecommerce`) and a table (`events`) based
+    on BigQuery sample data in your cloud project.
+*   Creates a `catalog.yaml` manifest to specify the local catalog snapshot.
+
+```bash
+bun setup.ts
+cat catalog.yaml
+```
+
+**Create Metadata Snapshot**
+
+*   Pull metadata from Knowledge Catalog
+
+```bash
+../../dist/kcmd pull
+ls -R catalog
+cat catalog/$DEMO_CLOUD_PROJECT.demo_ecommerce.yaml
+```
+
+**Modify Metadata Snapshot**
+
+*   Either manually edit the file, or use the following command which adds a
+    dummy overview aspect.
+
+```bash
+bun update.ts catalog/$DEMO_CLOUD_PROJECT.demo_ecommerce.yaml
+cat catalog/$DEMO_CLOUD_PROJECT.demo_ecommerce.yaml
+```
+
+**Publish Metadata Snapshot**
+
+*   Push metadata to Knowledge Catalog
+
+```bash
+../../dist/kcmd push
+```
+
+**Cleanup**
+
+*   Deletes the BigQuery resources created for the demo
+
+```bash
+bun cleanup.ts
+```
+
+## Knowledge Base
+
+This demo demonstrates working with a Knowledge Base managed in Knowledge
+Catalog.
+
+**Setup**
+
+*   Creates a Dataplex EntryGroup (`demo_kb`) and a set of document entries
+    within it.
+*   Creates a `catalog.yaml` manifest to specify the local catalog snapshot.
+
+```bash
+bun setup.ts
+cat catalog.yaml
+```
+
+**Create Metadata Snapshot**
+
+*   Pull metadata from Knowledge Catalog
+
+```bash
+../../dist/kcmd pull
+ls -R catalog
+cat catalog/index.md
+```
+
+**Modify Metadata Snapshot**
+
+*   Either manually edit the file, or use the following command which creates a
+    placeholder demo update to the content of the `index` entry using the `kcmd`
+    (metadata as code) library.
+
+```bash
+bun update.ts
+cat catalog/index.md
+```
+
+**Publish Metadata Snapshot**
+
+*   Push metadata to Knowledge Catalog
+
+```bash
+../../dist/kcmd push
+```
+
+**Cleanup**
+
+*   Deletes the Dataplex EntryGroup
+
+```bash
+bun cleanup.ts
+```

--- a/agents/mdcode/demo/bq/cleanup.ts
+++ b/agents/mdcode/demo/bq/cleanup.ts
@@ -1,0 +1,17 @@
+import * as cp from 'child_process';
+import * as kcmd from 'kcmd';
+
+const context = kcmd.gcp.ApiContext.default();
+const project = context.project;
+const dataset = `${project}.demo_ecommerce`;
+const sql = `
+DROP SCHEMA IF EXISTS \`${dataset}\` CASCADE;
+`;
+
+cp.execSync('bq query --use_legacy_sql=false', {
+  encoding: 'utf8',
+  input: sql,
+  stdio: 'inherit',
+});
+console.log(`Deleted demo BigQuery resources in dataset ${dataset}`);
+console.log();

--- a/agents/mdcode/demo/bq/setup.ts
+++ b/agents/mdcode/demo/bq/setup.ts
@@ -1,0 +1,60 @@
+import {YAML} from 'bun';
+import * as cp from 'child_process';
+import * as kcmd from 'kcmd';
+import * as path from 'node:path';
+
+const context = kcmd.gcp.ApiContext.default();
+const project = context.project;
+const dataset = `${project}.demo_ecommerce`;
+const sql = `
+CREATE SCHEMA IF NOT EXISTS \`${dataset}\`
+OPTIONS (
+  location = 'US',
+  labels = [('usage', 'demo')]
+);
+
+
+CREATE TABLE IF NOT EXISTS \`${dataset}.events\`
+PARTITION BY event_date_dt
+AS
+SELECT
+  *,
+  PARSE_DATE('%Y%m%d', event_date) AS event_date_dt
+FROM
+  \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\`;
+`;
+
+cp.execSync('bq query --use_legacy_sql=false', {
+  encoding: 'utf8',
+  input: sql,
+  stdio: 'inherit',
+});
+console.log(`Created demo BigQuery resources in dataset ${dataset}`);
+console.log();
+
+await Bun.file(path.join(process.cwd(), 'catalog.yaml')).write(
+  YAML.stringify(
+    {
+      scope: `bq-dataset.${dataset}`,
+      snapshot: {
+        entries: [
+          'dataplex-types.global.bigquery-dataset',
+          'dataplex-types.global.bigquery-table',
+          'dataplex-types.global.bigquery-view',
+        ],
+        aspects: ['dataplex-types.global.overview'],
+      },
+      publishing: {
+        entries: [
+          'dataplex-types.global.bigquery-dataset',
+          'dataplex-types.global.bigquery-table',
+          'dataplex-types.global.bigquery-view',
+        ],
+        aspects: ['dataplex-types.global.overview'],
+      },
+    },
+    null,
+    2,
+  ),
+);
+console.log('Created catalog.yaml manifest');

--- a/agents/mdcode/demo/bq/update.ts
+++ b/agents/mdcode/demo/bq/update.ts
@@ -1,0 +1,15 @@
+import {YAML} from 'bun';
+import path from 'node:path';
+
+const filePath = path.join(process.cwd(), process.argv[2]);
+const file = Bun.file(filePath);
+const content = await file.text();
+const metadata = YAML.parse(content) as Record<string, any>;
+
+metadata['aspects']['dataplex-types.global.overview'] = {
+  content: 'sample updated documentation',
+  contentType: 'MARKDOWN',
+};
+
+const updatedContent = YAML.stringify(metadata, null, 2);
+file.write(updatedContent);

--- a/agents/mdcode/demo/kb/cleanup.ts
+++ b/agents/mdcode/demo/kb/cleanup.ts
@@ -1,0 +1,23 @@
+import * as cp from 'child_process';
+import * as kcmd from 'kcmd';
+
+const context = kcmd.gcp.ApiContext.default();
+const project = context.project;
+const location = context.location;
+const entryGroup = 'demo_kb';
+
+function dataplex(cmd: string, data: string | null = null) {
+  cmd =
+    'gcloud -q dataplex ' +
+    cmd +
+    ` --project ${project} --location ${location}`;
+  cp.execSync(cmd, {
+    encoding: 'utf8',
+    input: data ?? undefined,
+    stdio: 'inherit',
+  });
+}
+
+dataplex(`entry-groups delete ${entryGroup}`);
+console.log('Deleted catalog knowledge base entries');
+console.log();

--- a/agents/mdcode/demo/kb/setup.ts
+++ b/agents/mdcode/demo/kb/setup.ts
@@ -1,0 +1,90 @@
+import {YAML} from 'bun';
+import * as cp from 'child_process';
+import * as kcmd from 'kcmd';
+import * as path from 'node:path';
+
+const context = kcmd.gcp.ApiContext.default();
+const project = context.project;
+const location = context.location;
+const entryGroup = 'demo_kb';
+const genericResource =
+  'projects/dataplex-types/locations/global/entryTypes/generic';
+
+function dataplex(cmd: string, data: string | null = null) {
+  cmd =
+    'gcloud dataplex ' + cmd + ` --project ${project} --location ${location}`;
+  cp.execSync(cmd, {
+    encoding: 'utf8',
+    input: data ?? undefined,
+    stdio: 'inherit',
+  });
+}
+
+function createEntry(name: string, displayName: string, description: string) {
+  dataplex(
+    `entries create --entry-group ${entryGroup} ` +
+      `--entry-type ${genericResource} ` +
+      `--entry-source-display-name "${displayName}" ` +
+      `--entry-source-description "${description}" ` +
+      `--entry-source-labels usage=demo,sample=true ` +
+      `--aspects /tmp/aspects.json ` +
+      name,
+  );
+}
+
+const aspectsFile = Bun.file('/tmp/aspects.json');
+await aspectsFile.write(
+  JSON.stringify({
+    'dataplex-types.global.generic': {
+      aspectType: 'dataplex-types.global.generic',
+      data: {},
+    },
+    'dataplex-types.global.overview': {
+      aspectType: 'dataplex-types.global.overview',
+      data: {
+        content: '# Placeholder Content\n\nLorem ipsum dolor met',
+        contentType: 'MARKDOWN',
+      },
+    },
+  }),
+);
+
+try {
+  dataplex(`entry-groups create ${entryGroup}`);
+  createEntry(
+    'index',
+    'Index',
+    'Demo knowledge base index of top-level sections',
+  );
+  createEntry('tags/tag1', 'Tag 1', 'First tag');
+  createEntry('tags/tag2', 'Tag 2', 'Second tag');
+  createEntry('topic1', 'Topic 1', 'Initial placeholder topic');
+  createEntry('dir/index', 'Index', 'Some contents in a directory');
+  createEntry('dir/topic1', 'Topic 1', 'Some topic 1');
+  createEntry('dir/topic2', 'Topic 2', 'Some topic 2');
+  createEntry('dir/topic3', 'Topic 3', 'Some topic 3');
+
+  console.log('Created catalog knowledge base entries');
+  console.log();
+} catch {
+  // Might already exist
+}
+
+await Bun.file(path.join(process.cwd(), 'catalog.yaml')).write(
+  YAML.stringify(
+    {
+      scope: `kb.${project}.${location}.${entryGroup}`,
+      snapshot: {
+        entries: ['dataplex-types.global.generic'],
+        aspects: ['dataplex-types.global.overview'],
+      },
+      publishing: {
+        entries: ['dataplex-types.global.generic'],
+        aspects: ['dataplex-types.global.overview'],
+      },
+    },
+    null,
+    2,
+  ),
+);
+console.log('Created catalog.yaml manifest');

--- a/agents/mdcode/demo/kb/update.ts
+++ b/agents/mdcode/demo/kb/update.ts
@@ -1,0 +1,14 @@
+import * as kcmd from 'kcmd';
+
+const context = kcmd.gcp.ApiContext.default();
+const catalogSnapshot = await kcmd.CatalogSnapshot.fromPath('.', context);
+
+const entry = await catalogSnapshot.lookupEntry('index');
+if (!entry.aspects) {
+  entry.aspects = {};
+}
+entry.aspects['dataplex-types.global.overview'] = {
+  content: 'New updated content\n',
+  contentType: 'MARKDOWN',
+};
+await catalogSnapshot.updateEntry(entry, ['dataplex-types.global.overview']);

--- a/agents/mdcode/docs/concept.md
+++ b/agents/mdcode/docs/concept.md
@@ -1,0 +1,566 @@
+# Metadata as Code
+
+## Overview
+
+This document details Metadata as Code, a core Knowledge Catalog capability
+designed to provide agent builders, data stewards and data producers, a source
+code artifact-based UX for metadata management and context engineering. Metadata
+as Code enables users and agents to author, manage, and consume metadata
+artifacts using developer-friendly practices such as versioning and CI/CD as
+part of their developer repository, and activate context enrichment agents on a
+standardized metadata format.
+
+This approach described in this document builds on top of broadly supported
+markdown and YAML, and simple file organization structure that enables
+bi-directional sync capability with Knowledge Catalog service by layering on top
+of existing Import/Export capabilities, and factors in extensibility that is a
+core tenet of the Catalog platform.
+
+**High-level Plan** We will pick a YAML representation that largely aligns with
+the Entry/EntryLink
+
++   Aspect data model in Knowledge Catalog to represent both 1st party and 3rd
+    party metadata. Unstructured text content in aspects will be represented as
+    sidecar markdown files. Local files are organized in a directory structure
+    aligned with the resource hierarchy of assets represented by the metadata.
+    Users can provide configurations to sync (download/snapshot and
+    publish/deploy) metadata from and to the service.
+
+### Tenets
+
+*   **Optimized for consumption by users and agents alike.** Metadata as code
+    artifacts should be easy to read and modify as well as naturally fit as
+    files within a developer's repository and support use-cases such as
+    versioning, diffing, CI/CD etc. In support of ease of consumption, users
+    should be able to organize their metadata in logical and modular slices,
+    while the layout of metadata facilitates organization and navigation.
+
+*   **Optimized for tools ecosystem** The code artifacts should benefit from
+    existing IDE and tool capabilities such as previews, navigation, etc.
+
+*   **Enable bi-directional sync with Knowledge Catalog and metadata fidelity**
+    The code artifacts should be amenable to serving as authoring and management
+    source of truth. They should enable a user to fully inspect and author
+    metadata that exists in the Catalog service. Metadata as code artifacts
+    should be able to represent 1st and 3rd party entries, aspects and the links
+    between them.
+
+*   **Embeddable and Consistent Representation** Users may operate on the
+    metadata in a standalone manner in their workspace for example, in the
+    context of an enrichment workflow. Alternatively, the metadata may be part
+    of a larger project, such as a Dataform/DBT pipeline, a BigQuery semantic
+    graph etc. We should strive for a format and representation that can largely
+    be consistent across these use-cases, and be used independently or embedded.
+
+### Goals
+
+**Source artifact for agents and human-in-the-loop review workflows** We will
+offer an agentic capability for metadata curation and enrichment. The agent will
+operate over the code representation of metadata to read it, and update it.
+Users can also track changes, review it, and if needed, directly modify it in an
+interactive loop.
+
+Metadata as Code is a pre-requisite capability to allow such agents to be built
+and integrated into a standardized workflow and UX.
+
+**Source artifact for metadata sidecars** Similar to the above, we are also
+collectively building agents to streamline building Semantic Graphs or LookML
+models, and Data Pipelines. These efforts are building their use-case specific
+code artifacts and agent flows.
+
+Metadata as code artifacts should naturally live within a larger project. This
+allows users to work with a standard representation. It allows the enrichment
+agents to be plugged into the larger agent flow as a sub-agent or agent tool.
+
+**Context versioning** Context engineering is central to agent building. Agent
+builders will need to be able to operate on their context as source code, evolve
+it in a versioned manner, and deploy it as versioned resources.
+
+Metadata as code provides the source code UX and workflows (by virtue of being
+hostable within a source control repository and using the existing versioning
+capabilities). Developers can then deploy the context to co-existing deployed
+versions to be able to run a/b tests and evals, and have agents pick the
+appropriate version.
+
+### Non-Goals
+
+**Hierarchical Context Serving Store or Index** The metadata as code model
+described in this document is aligned with the data model of metadata within
+Knowledge Catalog that organizes metadata to mirror resources in the integrated
+source systems. Specifically this means metadata organized as Entries and
+EntryLinks with aspects, within an EntryGroup (both system and user-managed) in
+a specific project.
+
+Context serving or searching use-cases would benefit from a different
+organization of metadata (eg. arbitrary hierarchy of content organized by data
+stores, use-cases, etc.). Conceivably, we might find such hierarchies naturally
+present in Document repositories such as Drive, or g3doc/wikis, or process
+metadata in Knowledge Catalog to produce a serving-ready version of metadata.
+
+## Use-cases
+
+This is a high-level mention of some of the use-cases where Metadata-as-Code
+should help with context engineering for agents.
+
+**Knowledge Catalog Enrichment Agent** Knowledge Catalog will offer an
+off-the-shelf enrichment agent that is pluggable with user-provided
+instructions, skills and tools. This will allow users to plug in their
+organizational data sources, including code repositories, queries, documentation
+in wikis, drive etc., internal Q&A channels etc.
+
+The enrichment agent operates on code artifacts, providing a mechanism for users
+to iterate on enrichment, as well as apply human review steps, and integration
+with git-based version control and CI/CD mechanisms for deployment to make the
+updates live.
+
+**Semantic Graph Business/Semantic Enrichment** We are introducing Semantic
+Graphs as the mechanism for users to build semantic models - defining entities
+and their relationships - that will be consumed by CA agents to ground their
+behavior and resulting queries in the organizational truth.
+
+The graph will allow users to define entities as nodes and relationships as
+edges along with additional properties, including computed values and measures.
+Users will want to attach additional meaning such as glossary term definitions
+as part of their graph authoring UX. Metadata-as-Code will provide a mechanism
+for users to co-locate their graph definition and catalog augmentations, and
+deploy them collectively.
+
+**Metadata propagation and curation in Data Pipelines** We are building a Data
+Engineering agent to streamline the creation and productionization of data
+pipelines. Data engineers should be able to leverage as well as publish metadata
+along with the deployment of their pipelines and data sources and sinks. This
+will ensure the resulting data is more ready for agentic consumption and allow
+for co-locating and unifying the UX for the transforms and the metadata flow
+within a pipeline project.
+
+**Database Context Set** We are introducing ContextSet and related functionality
+(Query Templates, Examples, etc.) to enable database admins and developers to
+engineer context for their NLD and NLA agents.
+
+This discussion is early. The observation is Metadata-as-Code offers a potential
+mechanism to unify the UX for context authoring, while supporting different
+service models (EntryGroup and ContextSetGroup) for purposes of storage, search
+and serving.
+
+## File Organization
+
+Metadata is organized within a directory. The directory represents a local
+snapshot of a subset of metadata in Catalog. It is the unit of synchronization
+with the metadata within the service.
+
+This directory contains a manifest file, named catalog.yaml, that provides
+structured configuration that can direct tools on handling the individual
+artifacts contained within the directory. It contains sub-directories that
+contain individual entries and entry links.
+
+Depending on the **scope** (see manifest below), files are organized in one of
+two layout formats (and potentially extendable to other formats in future):
+
+**Standard Layout:** Used for `bq-dataset` and `entryGroup` scopes. This is a
+hybrid disk organization where the metadata structure is stored in a main YAML
+file per entry, and unstructured aspects (like Overview) are placed in sidecar
+Markdown files.
+
+```
+path/to/root/
+├── catalog.yaml                      # Catalog metadata, processing config/directives
+└── catalog/                          # Contains all the Entries and EntryLinks
+    └── <dir1>/<dir2>
+        ├── <entry-id1>.yaml          # Single-file entry with all metadata contained within
+        ├── <entry-id2>.yaml          # Multi-file entry with unstructured metadata split into
+        └── <entry-id2>.<aspect>.md   # markdown sidecar files for unstructured aspects
+```
+
+**Documents Layout:** Used for `kb` scopes. This is a Markdown-first disk
+organization where the main entry is represented as a single Markdown file, with
+metadata structured in the YAML frontmatter and the main overview aspect
+promoted to the Markdown body.
+
+```
+path/to/root/
+├── catalog.yaml                      # Catalog metadata, processing config/directives
+└── catalog/                          # Contains all the Entries and EntryLinks
+    └── <dir1>/<dir2>
+        └── <entry-id1>.md            # Single markdown file: structured metadata in
+                                      # frontmatter, Overview in body
+```
+
+**NOTE: IDE Workspace** An IDE workspace, like the one in Antigravity, can
+include one or more such directories, organized according to the user's
+preferences.
+
+### Manifest - Catalog.yaml
+
+The manifest file captures all configuration related information. This includes:
+
+*   The resource that the metadata snapshot corresponds to (the `scope`). This
+    resource can either be a resource identified in a source system such as
+    BigQuery (e.g. a Dataset, or a set of Tables, whose metadata is managed in
+    Catalog in a system EntryGroup, such as @bigquery), a user-managed
+    EntryGroup containing user created entries, or a user-managed EntryGroup
+    representing a knowledge base containing markdown-based documentation
+    entries.
+
+*   The physical layout of the catalog snapshot on disk is automatically
+    determined by the type of the scope:
+
+    *   A `bq-dataset` or `entryGroup` scope uses the standard layout.
+    *   A `kb` scope uses the wiki layout.
+
+*   A set of type aliases to make it easy to refer to various catalog constructs
+    such as entry-types, aspect-types, link-types, glossaries, glossary-terms,
+    etc.
+
+*   The type of entries, aspects, and links to include into the local snapshot
+    when downloading metadata from the service.
+
+*   The subset of entries, aspects, and links to publish back to the service.
+
+**catalog.yaml** ``` scope: <type>.<name> # The resources in the snapshot.
+Examples: # scope: entryGroup.<projectId>.<locationId>.<entryGroupId> # scope:
+bq-dataset.<projectId>.<datasetId> # scope:
+kb.<projectId>.<locationId>.<entryGroupId> # Or multiple BigQuery datasets in
+array list format: # scope: # - bq-dataset.<projectId>.<datasetId1> # -
+bq-dataset.<projectId>.<datasetId2>
+
+aliases: # Optional. Can always use 3-part fully qualified references. # NOTE:
+All built-in types have predefined simple aliases. ca-guidelines: aspect:
+data-agents-project.global.ca-guidelines ecommerce: glossary:
+data-gov-project.global.ecommerce-glossary
+
+# Defines the specific metadata to be retrieved locally from Knowledge Catalog.
+
+# NOTE: Required aspects of listed entry types are implicitly included.
+
+snapshot: entries: - bigquery-dataset - bigquery-table aspects: - overview -
+descriptions - queries - ca-guidelines entryLinks: - definition
+
+# Optional configuration to identify which types should be published.
+
+# This must be a subset of the types specified in the snapshot configuration.
+
+publishing: entries: aspects: - ca-guidelines entryLinks: - definition ```
+
+**NOTE: Type References** Metadata content has several references to either the
+meta-model resources (entry, aspect, and link types) or other catalog constructs
+(such as glossaries). Syntax is provided to streamline these references.
+
+*   References take the form of `<projectId>.<locationId>.<resourceId>`. There
+    is no need for referring to the verbose collection names themselves
+    (projects/<projectId>/locations/<locationId>/<collection>/<resourceId>)
+*   Aliases can be defined to create single identifier names that are resolved
+    when metadata is processed.
+    *   These are optional. Users can choose to use the fully-qualified
+        references if that is the preference.
+    *   All built-in Dataplex types have pre-defined aliases without requiring
+        the user to declare them. Eg. bigquery-table resolves to
+        dataplex-types.global.bigquery-table.
+*   Use project IDs, not project numbers when generating metadata.
+
+### Entry File Names
+
+The name of the file is used to identify the Entry uniquely. The following rules
+are followed to derive file names from EntryIds.
+
+**Ingested Entries** use the service-qualified full resource name as EntryId.
+Inferrable segments (Service name and Location from EntryGroup) and Collection
+names (where possible) will be stripped out.
+
+| bigquery.googleapis.com/ projects/projectId/ datasets/datasetId/
+tables/tableId | projectId.datasetId/tableId.yaml | Aligns with physical
+hierarchy. Common case for context use-cases. Avoid a type segment in directory
+path to optimize for most common resource when a collection has multiple types
+of sub-resources | | bigquery.googleapis.com/ projects/projectId/
+datasets/datasetId/ routines/routineId |
+routines/projectId.datasetId/routineId.yaml | Moved into sub-directory to avoid
+potential conflicts between table and routine names | | cloudsql.googleapis.com/
+projects/projectId/ locations/locationId/ instances/instanceId/
+databases/databaseId | instanceId/databaseId/tableId.yaml | Example included to
+demonstrate how EntryIds and corresponding file names treat control plane and
+dataplane ids together |
+
+**3rd party Custom Entries** may use a similar REST API name of the resource
+(recommended when applicable) or arbitrary path-identifier (more likely
+scenario); We align the metadata file path to the Entry Id as there are no
+conventions to apply here.
+
+| Entry Id              | File Path                  | NOTES                   |
+| :-------------------- | :------------------------- | :---------------------- |
+| hive.walmart.com/     | hive.walmart.com/          |                         |
+: services/serviceId/   : services/serviceId/        :                         :
+: databases/databaseId/ : databases/databaseId/      :                         :
+: tables/tableId        : tables/tableId.yaml        :                         :
+| name-part1/name-part2 | name-part1/name-part2.yaml | Likely the common       |
+:                       :                            : pattern for custom      :
+:                       :                            : context overlays and    :
+:                       :                            : bundles. We ensure that :
+:                       :                            : it is clean in          :
+:                       :                            : directory layout.       :
+| simple-name           | simple-name.yaml           |                         |
+
+### File Extensions
+
+*   **Standard Layout (for `bq-dataset` and `entryGroup` scopes)**: Entry files
+    use the `.yaml` extension (e.g., `tableId.yaml`), with unstructured aspects
+    optionally stored in sidecar `.md` files (e.g., `tableId.overview.md`).
+
+*   **Document Layout (for `kb` scopes)**: Entry files use the `.md` extension
+    (e.g., `tableId.md`), where the main YAML entry is replaced with a single
+    markdown file containing YAML frontmatter and the promoted unstructured
+    aspect (`Overview.content`) as its body.
+
+### Entry File Layouts
+
+Metadata files are primarily structured representations of entry catalog info
+and aspects. Depending on the scope, the organization of these files differs:
+
+*   **Standard Layout (YAML + Markdown sidecars)**: Used for `bq-dataset` and
+    `entryGroup` scopes. Every entry is represented by at least a single YAML
+    file (`<entry-id>.yaml`) that captures entry metadata, information about
+    associated resource, and all aspects and links. Aspects containing
+    unstructured rich-text fields (like `overview`) are split into sidecar
+    markdown files (e.g., `<entry-id>.overview.md`).
+
+*   **Document Layout (Markdown Only)**: Used for `kb` scopes. The main YAML
+    file is replaced with a single markdown file (`<entry-id>.md`). The
+    structured YAML metadata moves entirely to the YAML frontmatter of this
+    markdown file, and the unstructured text of the `overview.content` aspect
+    becomes the main markdown body of the file.
+
+#### Standard Layout
+
+**Entry Resource Info + Entry Source + Aspects (`entry.yaml`)**
+
+```yaml
+id: <id>                                # Entry metadata
+type: <entryType>
+resource:                               # Entry.EntrySource
+  name: <entrySource.name>
+  displayName: <entrySource.displayName>
+  description: <entrySource.description>
+  labels:
+    key: value
+  location: <entrySource.location>
+  parent: <entry.parent>
+  ancestors: <entrySource.ancestors>
+  createTime: <entrySource.createTime>
+  updateTime: <entrySource.updateTime>
+
+schema:
+  fields:
+  - name1: <schemaField.name>
+    dataType: <schemaField.dataType>
+    mode: <schemaField.mode>
+    …
+    links:                              # EntryLinks associated with Schema.path are inlined
+      definition:                       # into a Schema field to leverage context of field
+      - target: glossary.term           # specification
+
+<aspect-type>:                          # In the general-case, each top-level field is an
+  [aspect.data]                         # aspect. Nested field represents aspect.data
+
+links:                                  # EntryLinks with this entry as source listed here
+  <entryLink-type>:
+  - target: <target-entry-reference>
+    <aspect-type>:
+      [aspect.data]
+```
+
+**Sidecar File per Aspect with Unstructured Text (`entry.overview.md`)**
+
+```markdown
+---
+field: value                            # YAML frontmatter used to capture structured metadata
+---
+[aspect.data.rich-text-field]
+```
+
+#### Wiki Layout
+
+In the wiki layout, the YAML content is placed in the YAML frontmatter of a
+`.md` file, and the unstructured overview text (`overview.content`) is promoted
+to the markdown body.
+
+**Entry with Inlined Unstructured Text (`entry.md`)**
+
+```markdown
+---
+id: <id>                                # Entry metadata in frontmatter
+type: <entryType>
+resource:                               # Entry.EntrySource
+  name: <entrySource.name>
+  displayName: <entrySource.displayName>
+  description: <entrySource.description>
+  labels:
+    key: value
+  location: <entrySource.location>
+  parent: <entry.parent>
+  ancestors: <entrySource.ancestors>
+  createTime: <entrySource.createTime>
+  updateTime: <entrySource.updateTime>
+
+schema:
+  fields:
+  - name1: <schemaField.name>
+    dataType: <schemaField.dataType>
+    mode: <schemaField.mode>
+    …
+    links:
+      definition:
+      - target: glossary.term
+
+<aspect-type>:                          # Other structured aspects
+  [aspect.data]
+
+overview:                               # Unstructured aspect's metadata
+  userManaged: true
+  links:
+  - title: <title>
+    url: <url>
+
+links:                                  # EntryLinks with this entry as source
+  <entryLink-type>:
+  - target: <target-entry-reference>
+    <aspect-type>:
+      [aspect.data]
+---
+# <displayName or entry-id>
+
+This is the main markdown body representing `overview.content` aspect data.
+```
+
+## Examples
+
+### Enrichment Agent
+
+This is an example for a BigQuery dataset and a table. For purposes of
+illustration, the user is interested in working the metadata that is used in
+Conversational Analytics, to enrich Overview documentation, Generated
+descriptions, Suggested Queries, Agent Guidelines and Glossary associations, and
+publish them back to Knowledge Catalog.
+
+**workspace/catalog.yaml** ``` scope:
+bq-dataset.ecommerce-prod.ecommerce-dataset
+
+resourceAliases: guidelines: aspect: data-agents-project.global.guidelines
+ecommerce: glossary: data-gov-project.global.ecommerce-glossary
+
+snapshot: entries: - bigquery-dataset - bigquery-table aspects: - overview -
+descriptions - queries - guidelines - data-profile # Included as local context,
+but not published - query-usage # Same as above entryLinks: - definition
+
+publishing: aspects: - overview - descriptions - queries - guidelines
+entryLinks: - definition ```
+
+**workspace/catalog/ecommerce-prod.ecommerce-dataset.yaml** ``` id:
+bigquery.googleapis.com/projects/ecommerce-prod/datasets/ecommerce-dataset type:
+bigquery-dataset createTime: <createTime> updateTime: <updateTime>
+
+resource: name: projects/ecommerce-prod/datasets/ecommerce-dataset displayName:
+E-commerce Production Dataset description: ... labels: env: prod createTime:
+<entrySource.createTime> updateTime: <entrySource.updateTime>
+
+bigquery-dataset: ...
+
+descriptions: description: <generated dataset description> ```
+
+**workspace/catalog/ecommerce-prod.ecommerce-dataset/orders.yaml** ``` id:
+bigquery.googleapis.com/projects/ecommerce-prod/datasets/ecommerce-dataset/tables/orders
+type: bigquery-table createTime: <createTime> updateTime: <updateTime>
+
+resource: name: projects/ecommerce-prod/datasets/ecommerce-dataset/tables/orders
+displayName: E-commerce Orders description: ... labels: env: prod createTime:
+<entrySource.createTime> updateTime: <entrySource.updateTime>
+
+bigquery-table: ... storage: ...
+
+schema: fields: - name: id dataType: string mode: required links: definition: -
+target: ecommerce.order-number - name: status dataType: integer mode: required
+
+dataProfile: [data-profile-data]
+
+queryUsage: [top-fields and other usage aggregations]
+
+descriptions: description: <generated table description> fields: - name: id
+description: ... - name: status description: ...
+
+queries: queries: - description: ... sql: | [SQL Text]
+
+links: definition: target: ecommerce.transaction ```
+
+**workspace/catalog/ecommerce-prod.ecommerce-dataset/orders.overview.md**
+
+## ```
+
+userManaged: true links: - title: <title>
+
+## url: <url>
+
+[overview.content] ```
+
+**workspace/catalog/ecommerce-prod.ecommerce-dataset/orders.guidelines.md**
+
+```markdown
+---
+userManaged: false
+---
+[guidelines.instructions]
+```
+
+### Knowledge Base
+
+Assume the user is managing a knowledge base of information managed in a
+hierarchical structure. Or alternatively, an agent is building this knowledge
+base from previously aggregated or enriched metadata.
+
+**workspace/catalog.yaml**
+
+```yaml
+scope: kb.ecommerce-prod.global.mbr-kb
+
+snapshot:
+  entries:
+  - document
+  aspects:
+  - overview
+
+publishing:
+  aspects:
+  - overview
+```
+
+**workspace/catalog/products.md**
+
+```markdown
+---
+id: products
+type: document
+createTime: <createTime>
+updateTime: <updateTime>
+
+resource:
+  name: products
+  displayName: Products
+  description: ...
+---
+# Products Data
+
+This is the markdown body representing `overview.content` for the document.
+```
+
+**workspace/catalog/playbooks/mbr.md**
+
+```markdown
+---
+id: playbooks/mbr
+type: document
+
+resource:
+  name: playbooks/mbr
+  displayName: MBR Playbook
+  description: ...
+---
+# Ecommerce Monthly Business Review Playbook
+
+[overview.content]
+```

--- a/agents/mdcode/docs/design.md
+++ b/agents/mdcode/docs/design.md
@@ -1,0 +1,197 @@
+# Metadata as Code Design Specification
+
+This document details the overall design for the Metadata as Code project,
+factoring in the sub-system breakdown, API surfaces, CLI and MCP structures,
+technical stack, and key technical decisions. It builds upon the initial context
+provided in:
+
+-   [readme.md](../README.md)
+-   [concept.md](concept.md)
+-   [spec.md](spec.md)
+-   [plan.md](plan.md)
+
+## 1. Sub-system / Module Breakdown
+
+The system is divided into two public interface layers and a core library
+foundation.
+
+### 1.1 Public Interfaces
+
+-   **CLI (`kcmd`)**: A single binary built using **Bun** that handles user
+    interaction and parses commands using the `cac` framework.
+-   **MCP Server**: Hosted within the same `kcmd` binary, triggered by the `mcp`
+    command argument (e.g., `kcmd mcp`). It exposes sync operations as tools to
+    external agents.
+
+### 1.2 Core Library Foundation (`kc-mac`)
+
+The brain of the operation, containing the following modules:
+
+-   **`CatalogManifest`**: Handles loading, validating, and parsing the
+    `catalog.yaml` project manifest, including parsing the unified `scope`
+    specification (which determines the layout style).
+-   **`CatalogSnapshot`**: Manages local catalog entries and coordinates
+    high-level read/write/list logic by delegating physical file representation
+    and layout-specific tasks to `CatalogLayout`.
+-   **`CatalogLayout`**: Abstract class defining the operations to list, read,
+    write, and delete files on the local disk. Standard and Wiki layouts
+    implement this interface, automatically selected based on the scope type.
+-   **`CatalogSync`**: Orchestrates pull and push sync directions, handles
+    pagination, fail-fast conflict detection, and manages tool state in a
+    separate state file (`.catalog.state`).
+-   **`CatalogService`**: Wrapper for raw HTTP API calls, handling Application
+    Default Credentials (ADC) auth and LRO polling.
+
+## 2. Project Directory Structure
+
+This section describes the directory structure for the project source code,
+reflecting the merge of interfaces, TypeScript library naming for future
+expansion, and the `gcp` subfolder for API functionality:
+
+-   **`src/`**
+    -   **`tool/`**: The unified layer for CLI and MCP.
+    -   **`main.ts`**: The entry point for the unified binary (`kcmd`). Handles
+        argument parsing to direct to either CLI commands or MCP server.
+        Defines/handles CLI surface.
+    -   **`commands.ts`**: Contains functionality for CLI commands.
+    -   **`mcp.ts`**: Contains functionality for the MCP server and tools.
+    -   **`libts/`**: The TypeScript core library.
+    -   **`index.ts`**: The main entry point exporting public APIs.
+    -   **`manifest.ts`**: Contains the `CatalogManifest` class logic.
+    -   **`layout.ts`**: Contains the `CatalogLayout` interface.
+    -   **`source.ts`**: Contains the `CatalogSource` interface.
+    -   **`snapshot.ts`**: Contains the `CatalogSnapshot` class logic.
+    -   **`sync.ts`**: Contains the `CatalogSync` class logic.
+    -   **`gcp/`**: Subfolder for GCP-specific functionality.
+        -   **`api.ts`**: Contains the `Api` base class with polling and
+            retries.
+        -   **`context.ts`**: Contains the `ApiContext` class.
+        -   **`dataplex.ts`**: Contains the API client for Knowledge Catalog.
+    -   **`sources/`**: Subfolder containing source-specific implementations.
+        -   **`entrygroup.ts`**: Encapsulates behavior for Dataplex EntryGroups.
+        -   **`bq-dataset.ts`**: Encapsulates behavior for BigQuery datasets.
+        -   **`wiki.ts`**: Encapsulates behavior for Wikis.
+    -   **`layouts/`**: Subfolder containing layout-specific implementations.
+        -   **`standard.ts`**: Encapsulates behavior for Standard layout.
+        -   **`documents.ts`**: Encapsulates behavior for Wiki layout.
+
+## 3. Public API, CLI, and MCP Structure
+
+### 2.1 Library API Surface
+
+**`CatalogManifest`**
+
+-   `static initWithEntryGroup(entryGroup: string, ctx: ApiContext):
+    CatalogManifest`
+-   `static initWithBigQuery(dataset: string, ctx: ApiContext): CatalogManifest`
+-   `static initWithKB(kb: string, ctx: ApiContext): CatalogManifest`
+-   `static load(path: string, ctx: ApiContext): Promise<CatalogManifest>`
+-   `save(path: string): void`
+
+**`CatalogLayout` (Abstract Class)**
+
+-   `abstract list(snapshotPath: string): Promise<string[]>`
+-   `abstract readEntry(snapshotPath: string, entryId: string): Promise<Entry>`
+-   `abstract writeEntry(snapshotPath: string, entryId: string, entry: Entry):
+    Promise<void>`
+-   `abstract deleteEntry(snapshotPath: string, entryId: string): Promise<void>`
+
+**`StandardLayout` (extends `CatalogLayout`)**
+
+-   Implements filesystem storage using a main `.yaml` file per entry and
+    optional sidecar `.overview.md` files for unstructured aspects.
+
+**`WikiLayout` (extends `CatalogLayout`)**
+
+-   Implements filesystem storage using a single `.md` file per entry with the
+    metadata in the YAML frontmatter and the overview content as the markdown
+    body.
+
+**`CatalogSnapshot`**
+
+-   `static fromPath(path: string): CatalogSnapshot`
+-   `layout: CatalogLayout`: The layout strategy instance initialized based on
+    the manifest scope.
+-   `list(): Promise<string[]>`: Returns a list of entry IDs in the snapshot by
+    delegating to `layout.list(snapshotPath)`.
+-   `lookupEntry(entryId: string): Promise<Entry>`: Returns structured metadata
+    for a specific entry by delegating to `layout.readEntry(snapshotPath,
+    entryId)`.
+-   `updateEntry(entryId: string, updates: Record<string, any>): Promise<void>`:
+    Merges updates into the entry metadata and aspect values, and commits the
+    result via `layout.writeEntry(snapshotPath, entryId, entry)`.
+-   `createEntry(entryId: string, data: Entry): Promise<void>`: Creates an entry
+    locally by delegating to `layout.writeEntry(snapshotPath, entryId, data)`.
+-   `deleteEntry(entryId: string): Promise<void>`: Deletes files associated with
+    the entry by delegating to `layout.deleteEntry(snapshotPath, entryId)`.
+
+**`CatalogSync`**
+
+-   `pull(): Promise<SyncResult>`
+-   `push(options?: { force?: boolean, validateOnly?: boolean }):
+    Promise<SyncResult>`
+-   `validate(): Promise<ValidationResult>`: Fetches fresh definitions and
+    performs pre-push validation.
+-   `status(): Promise<StatusResult>`: Checks for local modifications against
+    the saved checksum state.
+
+### 2.2 CLI Command Structure (`kcmd`)
+
+-   `kcmd init [--bigquery-dataset <id>] [--entry-group <id>] [--kb <id>]`
+-   `kcmd pull [--dry-run]`
+-   `kcmd push [--dry-run] [--force] [--validate-only]`
+-   `kcmd status`
+-   `kcmd mcp` (Triggers the MCP server)
+
+### 2.3 MCP Tools and Params
+
+-   **`pull`**: Params: None.
+-   **`push`**: Params: `force?: boolean`.
+-   **`list-entries`**: Params: None.
+-   **`lookup-entry`**: Params: `entryId: string`.
+-   **`update-entry`**: Params: `entryId: string`, and key/value pairs for each
+    field and aspect being updated.
+
+## 4. API Client Design & Context
+
+### 3.1 `ApiContext` (Class)
+
+-   `project: string`
+-   `token: string`
+-   `static default(): Promise<ApiContext>`: Uses `gcloud` to read project and
+    token defaults.
+-   `refresh(): Promise<void>`: Updates token via `gcloud auth
+    print-access-token`.
+
+### 3.2 `Api` (Base Class)
+
+-   `constructor(endpoint: string, pathPrefix: string, context: ApiContext)`
+-   **Methods**: `get`, `post`, `patch`, `delete` take relative resource names.
+-   **Polishing**:
+    -   Fully encapsulates Long Running Operation (LRO) polling and returns only
+        the completed result or error.
+    -   Implements transient error retries with exponential backoff
+        (configurable defaults).
+    -   Automatically calls `context.refresh()` on token expiry (401).
+
+## 5. Technical Stack and Key Dependencies
+
+-   **Language**: TypeScript.
+-   **Runtime/Build**: **Bun** for standalone binary creation and fast startup.
+-   **Frameworks & Libraries**:
+    -   **CLI**: `cac` (minimal size).
+    -   **Schema Validation**: `zod` (TypeScript-first).
+    -   **Parsing**: `yaml`.
+    -   **HTTP Client**: Native `fetch` (in Bun) or `node-fetch` fallback.
+
+## 6. Key Technical Decisions
+
+1.  **Bun Unified Binary**: The CLI and MCP server will be distributed as the
+    same single binary to reduce complexity for the end-user.
+2.  **Thin HTTP Client**: We use native raw HTTP requests rather than Google
+    SDKs to control code execution path and support environment workarounds.
+3.  **Validation Before Action**: Fresh type definitions are pulled at
+    publishing time, and full validation completes *before* the first change
+    payload hits the cloud.
+4.  **Fail-Fast Overwrites**: Overwrite protection fails fast when remote drift
+    is identified.

--- a/agents/mdcode/docs/features/entrylinks.md
+++ b/agents/mdcode/docs/features/entrylinks.md
@@ -1,0 +1,10 @@
+# EntryLinks Feature
+
+This feature adds support for EntryLinks to the `kcmd` tool, allowing for bi-directional synchronization of linkages between entries in Dataplex.
+
+## Key Capabilities
+- **Pull Synchronization**: Fetches EntryLinks from Dataplex and saves them in the local YAML metadata.
+- **Push Synchronization**: Publishes local EntryLinks back to Dataplex, including creation and deletion of links.
+- **Schema-Inlined Links**: Supports links associated with specific columns/fields within an entry's schema.
+- **Dry-Run Mode**: Allows previewing sync operations without making changes.
+- **Alias Resolution**: Maps fully qualified EntryLink types to human-readable aliases.

--- a/agents/mdcode/docs/features/entrylinks_plan.md
+++ b/agents/mdcode/docs/features/entrylinks_plan.md
@@ -1,0 +1,25 @@
+# Design & Implementation Specification: EntryLinks Support in `kcmd`
+
+This document defines the authoritative design and step-by-step implementation specification for adding comprehensive bi-directional synchronization and local layout support for **EntryLinks** (both top-level and schema-inlined linkages) to the `kcmd` tool. 
+
+To ensure complete data integrity, usability, and reliability, the architecture incorporates native **data loss prevention (safe push mutations)**, dynamic **project number vs. project ID normalization**, a robust **alias resolution system (supporting both system and custom user-defined aliases)**, **selective pull filtering**, and a safe **dry-run simulation mode**.
+
+---
+
+## Phase 1: Core Data Models & Manifest Extension
+
+Update the base TypeScript definitions, the manifest configuration parser, and type validation logic to cleanly handle EntryLinks and aliases.
+
+### 1.1. Manifest Schema & Alias Support
+
+1. **Manifest Schema Parsing:**
+   * Update `manifestSchema` (Zod object) to recognize optional `aliases` or `resourceAliases` and map them dynamically.
+   * Add `entryLinks` as an optional array of strings to both `snapshot` and `publishing` schemas.
+   * Update interfaces `SnapshotConfig` and `PublishingConfig` to include `entryLinks?: string[]`.
+
+2. **System and Custom Alias Registration:**
+   * Add a built-in map for global/system link aliases.
+   * Update the manifest class to store custom user-defined aliases loaded from `catalog.yaml`.
+
+3. **Alias Resolution and Validation:**
+   * Implement an internal type resolver helper.

--- a/agents/mdcode/docs/plan.md
+++ b/agents/mdcode/docs/plan.md
@@ -1,0 +1,87 @@
+# Phased Delivery Plan
+
+This document outlines the phased delivery plan for building the Metadata as
+Code foundation.
+
+## Phase 1: MVP - Read-Only Snapshot & Consumption
+
+Establish the local file structure by pulling metadata using the TypeScript
+library, and enable reading that snapshot via MCP. Support early distribution.
+
+*   **Key Features & Work:**
+    *   **Library (TS)**: Fetch metadata for a BigQuery dataset or Dataplex
+        EntryGroup; create local directory structure mirroring the resource
+        hierarchy; generate main YAML file per entry (Standard layout);
+        paginated pull; ADC authentication.
+    *   **CLI (TS-based)**: Implement `kcmd init` and a basic read-only `kcmd
+        pull`.
+    *   **MCP (TS-based)**: Implement an MCP server with tools: `list-entries`
+        and `lookup-entry` (reading from the local snapshot).
+    *   **Distribution**: Support installation from source repository or local
+        package for early access.
+    *   **Testing**: Implement test cases for snapshot creation and directory
+        layout for BigQuery datasets and EntryGroups.
+
+## Phase 2: MVP - Basic Push (Publish)
+
+Complete the bi-directional sync by enabling local modifications to be pushed
+back to the catalog using the TypeScript library.
+
+*   **Key Features & Work:**
+    *   **Library (TS)**: Read local YAML files and reconstruct API payloads;
+        push updates individually per entry; support parsing and filtering via
+        `publishing` configuration in `catalog.yaml`.
+    *   **CLI (TS-based)**: Implement a basic `kcmd push`.
+    *   **Distribution**: Update early access packages with push capability.
+    *   **Testing**: Implement test cases for basic push operation and
+        publishing configuration filtering.
+
+## Phase 3: Enhanced Representation
+
+Optimize the file format for human and agent editing. Update interfaces to
+support the new formats and layout options.
+
+*   **Key Features & Work:**
+    *   **Library (TS)**: Support `kb` scope type alongside `bq-dataset` and
+        `entryGroup` in `catalog.yaml`; implement the `CatalogLayout`
+        abstraction (`layout.ts`) and its concrete layouts (`StandardLayout` and
+        `DocumentsLayout`); refactor `CatalogSnapshot` to delegate filesystem
+        list, read, and write operations to the active layout strategy
+        (automatically instantiated based on the scope); support type aliases in
+        `catalog.yaml`, including built-in aliases for built-in types.
+    *   **CLI (TS-based)**: Update `pull` and `push` operations to handle
+        sidecars, aliases, and different layout scopes correctly.
+    *   **MCP (TS-based)**: Ensure `list-entries` and `lookup-entry` tools
+        correctly handle layouts (by delegating via `CatalogSnapshot` to
+        `CatalogLayout` strategy).
+    *   **Testing**: Implement test cases for format mapping, including Standard
+        layout (YAML + sidecars) and Documents layout (Markdown + frontmatter),
+        and validate that `CatalogSnapshot` interacts correctly with both
+        layouts based on the active scope type. Implement test cases for
+        aliases.
+
+## Phase 4: Robust Sync and State Management
+
+Ensure data integrity and efficient updates.
+
+*   **Key Features & Work:**
+    *   **Library (TS)**: Store checksums of local state in a separate file; use
+        checksums to detect changes; treat missing files as intent to delete;
+        fail fast on remote modification; fetch type definitions dynamically for
+        validation.
+    *   **CLI (TS-based)**: Add `kcmd status` to check for local modifications;
+        update `kcmd push` to use checksums and report conflicts; support
+        **force override** flag; implement `--dry-run` option for `pull` and
+        `push` commands.
+    *   **Testing**: Implement test cases for checksum validation, intent to
+        delete, validation against dynamic schema, and `--dry-run` behavior.
+
+## Phase 5: Future / Other
+
+Other workstreams to consider.
+
+*   **Key Features & Work:**
+    *   **Library (TS)**: Support for EntryLinks
+    *   **Python Library**: Implement the equivalent library in Python to
+        support Python-based agents and workflows.
+    *   **MCP (TS-based)**: Implement `pull` and `push` tools in the MCP server.

--- a/agents/mdcode/docs/spec.md
+++ b/agents/mdcode/docs/spec.md
@@ -1,0 +1,179 @@
+# Metadata as Code Specification
+
+This specification builds upon the concepts in `docs/concept.md` and
+`readme.md`, detailing the agreed-upon design decisions, critical user journeys,
+glossary, and test cases for the Metadata as Code project.
+
+## 1. Overview
+
+Metadata as Code provides a source code artifact-based UX for metadata
+management and context engineering in Knowledge Catalog (Dataplex). It is
+designed for agent builders, data stewards, data producers, and AI agents to
+author, manage, and enrich metadata using developer-friendly workflows with
+version control and CI/CD.
+
+### 1.1. Primary Use Case
+
+The primary driver for the initial design is the **Knowledge Catalog Enrichment
+Agent**, focusing on automating metadata curation with human-in-the-loop review.
+However, the library is designed to be flexible and usable by any developer
+building agents or custom tools.
+
+## 2. Glossary of Terms
+
+To ensure consistency, the following terms are used:
+
+*   **Catalog Snapshot**: A directory on the local filesystem containing a
+    subset of Knowledge Catalog metadata.
+*   **Manifest (catalog.yaml)**: A file in the snapshot root that captures sync
+    configuration and directives.
+*   **Scope**: A unified identifier format (`<type>.<name>`) that establishes
+    the single target resource for the snapshot in the manifest.
+*   **Standard Layout**: A hybrid disk organization automatically used for
+    `bq-dataset` and `entryGroup` scopes where metadata structure is stored in a
+    YAML file per entry, and unstructured aspects are placed in sidecar Markdown
+    files.
+*   **Documents Layout**: A Markdown-only disk organization automatically used
+    for `kb` scopes where the main entry is represented as a single Markdown
+    file, with metadata structured in the YAML frontmatter and the main overview
+    aspect promoted to the Markdown body.
+*   **Entry**: A representation of a resource (like a table or dataset) in the
+    Knowledge Catalog.
+*   **Aspect**: A specific type of metadata attached to an entry (e.g.,
+    description, profile).
+*   **Sidecar File**: An auxiliary file (e.g., Markdown) used for aspects with
+    unstructured text.
+*   **Source**: A backend metadata repository referenced by a scope (e.g.,
+    Dataplex EntryGroup or BigQuery Dataset).
+
+## 3. Key Design Decisions
+
+The following core decisions have been established:
+
+### 3.1. Metadata Representation
+
+The disk organization layout is automatically determined by the scope type:
+
+*   **Standard Layout** (used for `bq-dataset` and `entryGroup` scopes):
+    Structured data (entry metadata, resource info, aspects like schema and
+    profile) is stored in a main YAML file per entry, while unstructured
+    rich-text fields (like Overview) are stored in dedicated sidecar Markdown
+    files.
+*   **Documents Layout** (used for `kb` scopes): Structured metadata is stored
+    within the YAML frontmatter of a single `.md` file per entry, and the
+    primary unstructured aspect (`overview.content`) is promoted to serve as the
+    main Markdown body of that file. Other unstructured aspects may still use
+    sidecars.
+
+### 3.2. Synchronization Model
+
+We will support a bi-directional sync (Pull and Push) with the following rules:
+
+*   **Publishing is a subset** of the snapshot list.
+*   While required aspects may be implicitly included in the snapshot, all entry
+    types and aspect types that should be published **must be explicitly
+    listed** in the manifest.
+
+### 3.3. Conflict Handling
+
+To prevent data loss during a `push` operation:
+
+*   The tool will **fail fast** if it detects that the metadata has been
+    modified in the catalog in the interim.
+*   It will abort the push, report the conflict, and require a `pull` to
+    resolve.
+*   A **force override** option will be provided to bypass this check if
+    necessary.
+
+### 3.4. Aliases Strategy
+
+To maintain consistency and steer users toward simpler names:
+
+*   If an alias is defined in `catalog.yaml`, it **must be used consistently**
+    in metadata files.
+*   Otherwise, the full reference takes the form of
+    `<projectId>.<locationId>.<resourceId>`.
+
+### 3.5. Scale and Performance
+
+*   **Paginated Pull**: Pull operations will be paginated to handle large
+    resources.
+*   **Individual Push**: Push operations will be performed individually per
+    entry for now, with bulk import operations considered later.
+*   **Scale Assumption**: Users are managing this as code artifacts in a
+    repository and should not be operating at hyperscale/unbounded scale in this
+    workflow.
+
+### 3.6. Extensibility and Validation
+
+*   **Dynamic Schema Fetching**: The tool will fetch type definitions from the
+    Catalog service dynamically to validate local files against the actual
+    registered schema.
+
+### 3.7. Checksum Storage
+
+*   **Separate State File**: Checksums for entries and aspects will be stored in
+    a separate state file (e.g., `.catalog.state`) to separate user content from
+    tool state.
+
+### 3.8. Sync Deletions
+
+*   **Intent to Delete**: If an entry type is listed in the publish config,
+    treat missing files compared to state as intent to delete.
+*   **Skip for Managed Entries**: Deletions are skipped for Dataplex managed
+    entries (like BigQuery resources) which cannot be deleted.
+
+### 3.9. Unified Scope Mapping
+
+*   **Single String Identifier**: Snapshot resources are specified using a
+    unified `scope` property formatted as `<type>.<name>` (e.g.
+    `bq-dataset.<id>` or `entryGroup.<id>`). This unifies target definition
+    logic and enables future extension to other resource types easily.
+
+## 4. Critical User Journeys (CUJs)
+
+We focus on the following core journeys:
+
+*   **CUJ 1: Initial Setup and Snapshot Creation** User runs `kcmd init` to
+    create a local snapshot of a BigQuery dataset or Dataplex EntryGroup.
+*   **CUJ 2: Metadata Sync (Pull and Push)** User pulls updates from the catalog
+    service, makes modifications to local files, and pushes changes back to the
+    catalog.
+
+*Note: Advanced workflows like Automated Curation with Human Review (CUJ 3
+candidates) are built on top of this foundation using external tools (IDE, git,
+custom agents) and are out of scope for this base library.*
+
+## 5. Key Test Cases
+
+To validate the design, we will implement test cases covering the following
+areas, including user feedback:
+
+### 5.1. Resource Types
+
+*   **Snapshots for different resource types**: BigQuery datasets and Dataplex
+    EntryGroups.
+*   **Entry and aspect varieties**: Both Dataplex-defined entries/aspects (where
+    required aspects are read-only) and user-defined ones (where required
+    aspects are modifiable).
+
+### 5.2. Format Mapping
+
+*   **Standard Layout** (for `bq-dataset` and `entryGroup` scopes): Aspects
+    managed correctly within the main YAML file, and unstructured text mapped
+    correctly to/from sidecar Markdown files.
+*   **Documents Layout** (for `kb` scopes): Metadata mapped correctly to/from
+    YAML frontmatter, and the `overview.content` aspect promoted to/from the
+    Markdown file body.
+
+### 5.3. Directory Organization
+
+*   **BQ Resource Hierarchy**: Testing layout for BigQuery datasets.
+*   **EntryGroup Hierarchy**: Testing layout for EntryGroups based on path
+    segments in the entry ID.
+
+### 5.4. Data Integrity
+
+*   **Checksum validation**: Verifying that checksums are updated and validated
+    for entries and aspects during both pull and push operations to detect
+    conflicts.

--- a/agents/mdcode/package-lock.json
+++ b/agents/mdcode/package-lock.json
@@ -1,0 +1,4859 @@
+{
+  "name": "kcmd",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kcmd",
+      "version": "0.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "cac": "^7.0.0",
+        "glob": "^13.0.6",
+        "yaml": "^2.8.4",
+        "zod": "^4.4.2"
+      },
+      "bin": {
+        "kcmd": "dist/kcmd"
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/inspector": "^0.21.2",
+        "@types/bun": "^1.3.14",
+        "@types/node": "^25.6.0",
+        "bun": "^1.3.14",
+        "bun-types": "^1.3.14",
+        "memfs": "^4.57.2",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/buffers": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/codegen": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.6.tgz",
+      "integrity": "sha512-uI++Wx6VkBJqVmkb4ZeExwAVpZiA2Do5NrEtXoDk0Pdvce3ytFXJoviT1sLOj16+qDIMnD5nWPfOhVpnDmRJKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.6.tgz",
+      "integrity": "sha512-pKkw/yC5CzSZKhIIUIsH1przOa+K5jGmZIg1sWaSF24JojyrUFbjcQv7QrcGAudriei6HQ6R0BFj+V8NbQinJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.57.6",
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.6.tgz",
+      "integrity": "sha512-Kbn1jdkvDN4F2+BhoB6mMu7NCbhP0bgA5NcI1aJj/Q5UcU+I1JLLW+dEQean33iV4tXv35AzBVKPICnDltBpxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.57.6",
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "@jsonjoy.com/fs-print": "4.57.6",
+        "@jsonjoy.com/fs-snapshot": "4.57.6",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.6.tgz",
+      "integrity": "sha512-V4DgEFT3Cg5S9fCMOZSCVdTxdJWWLBO0WnAazV7hnCM96u5zXHyW/ubDAfcSVwqjkMJ50W1Y44IXtxRoIwaCVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.6.tgz",
+      "integrity": "sha512-+JptNw3iifihxH2rEXrninDzX4FFVW8JD/wPR8GbJPAeL9CQUSblrlumOPB5gZuS7tYRX+PJPLtT7XzKoRhv/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.57.6",
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.6.tgz",
+      "integrity": "sha512-foyUrfS7WmYEUzqYXSNxmJBcSj04TABrkpFabwO9SCDCpVCfJ+qG+2sk5FjfiflG2n0SDFZDCJ6vYlJAEpxJFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.57.6"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.6.tgz",
+      "integrity": "sha512-96eAn4Dudtt67LTeuU47yUD+pg9/G/oKpI10zei9ljk3X3WK4lYKc+n3cpaPCAbKPzoyfxl0mXm8f8Y7BOSFXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.6.tgz",
+      "integrity": "sha512-V57CMzbOgTzUWGOWQ8GzHQdpJP6JnrYVNCtTBNxVYEnlVRvo4uEJqHhtAT8vhDFrIuJOXLrTL1Fki4h5oI7xxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^17.65.0",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.67.0",
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0",
+        "@jsonjoy.com/json-pointer": "17.67.0",
+        "@jsonjoy.com/util": "17.67.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.2",
+        "@jsonjoy.com/buffers": "^1.2.0",
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/json-pointer": "^1.0.2",
+        "@jsonjoy.com/util": "^1.9.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pointer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/util": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@mcp-ui/client": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@mcp-ui/client/-/client-6.1.1.tgz",
+      "integrity": "sha512-kN5io7ouEpVfOTloEEGrnuWio3ZzYOVgTk4o8ULleACdKEw7VgOTozPl9aj9qVl/UBh7rXlvKH0JbBm6Tw52LQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.2.0",
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
+    "node_modules/@mcp-ui/client/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
+      "integrity": "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-0.21.2.tgz",
+      "integrity": "sha512-f/zIzl6ccYjIxSTgmol9EKvd8AXsXkIaZX16kLGhrYwxrApvU3IL6IzgOqATKP/2kgyKdFUOVLlHMxX9e6BZZA==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "workspaces": [
+        "client",
+        "server",
+        "cli"
+      ],
+      "dependencies": {
+        "@modelcontextprotocol/inspector-cli": "^0.21.2",
+        "@modelcontextprotocol/inspector-client": "^0.21.2",
+        "@modelcontextprotocol/inspector-server": "^0.21.2",
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "concurrently": "^9.2.0",
+        "node-fetch": "^3.3.2",
+        "open": "^10.2.0",
+        "shell-quote": "^1.8.3",
+        "spawn-rx": "^5.1.2",
+        "ts-node": "^10.9.2",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "mcp-inspector": "cli/build/cli.js"
+      },
+      "engines": {
+        "node": ">=22.7.5"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-cli": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-cli/-/inspector-cli-0.21.2.tgz",
+      "integrity": "sha512-Om2ApfIbkbfR7+PqJX0bO2Qwg0z55MgxquC+G0YL6x80ElpZMfxITsWQ1238kh3bv1zlwPSePc2kvDnCcU5tXw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "commander": "^13.1.0",
+        "express": "^5.2.1",
+        "spawn-rx": "^5.1.2"
+      },
+      "bin": {
+        "mcp-inspector-cli": "build/cli.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-client": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-client/-/inspector-client-0.21.2.tgz",
+      "integrity": "sha512-8us3hVXDgMHGb5jF1bBE/a6rRRlEaS+SKjbDFB56oE6+mNcAP9JgL8h6T0fYd3XQ3vL/CYxjVeQE+5yRdvhsVg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@mcp-ui/client": "^6.0.0",
+        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@radix-ui/react-checkbox": "^1.1.4",
+        "@radix-ui/react-dialog": "^1.1.3",
+        "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-label": "^2.1.0",
+        "@radix-ui/react-popover": "^1.1.3",
+        "@radix-ui/react-select": "^2.1.2",
+        "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.1",
+        "@radix-ui/react-toast": "^1.2.6",
+        "@radix-ui/react-tooltip": "^1.1.8",
+        "ajv": "^6.12.6",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.1",
+        "cmdk": "^1.0.4",
+        "lucide-react": "^0.523.0",
+        "pkce-challenge": "^4.1.0",
+        "prismjs": "^1.30.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-simple-code-editor": "^0.14.1",
+        "serve-handler": "^6.1.6",
+        "tailwind-merge": "^2.5.3",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "mcp-inspector-client": "bin/start.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-client/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-server": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-server/-/inspector-server-0.21.2.tgz",
+      "integrity": "sha512-ASFNPFMnT0Vn5u6aYRwwMrwA/0qpxb1lg3sE5GjWii5bUfPNXuIaLOXuXKSOFIMG4o82RxpuipdqX1ZdsmTPUw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "cors": "^2.8.5",
+        "express": "^5.1.0",
+        "express-rate-limit": "^8.2.1",
+        "shell-quote": "^1.8.3",
+        "shx": "^0.3.4",
+        "spawn-rx": "^5.1.2",
+        "ws": "^8.18.0",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "mcp-inspector-server": "build/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-server/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@oven/bun-darwin-aarch64": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.14.tgz",
+      "integrity": "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.14.tgz",
+      "integrity": "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-darwin-x64-baseline": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.14.tgz",
+      "integrity": "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oven/bun-freebsd-aarch64": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-freebsd-aarch64/-/bun-freebsd-aarch64-1.3.14.tgz",
+      "integrity": "sha512-LIKrXaFxAHybVO5Pf+9XP2FHUj/5APvXTUKk9dqHm5iFz4oH+W24cmhjkJirNujh9hKeTyrpWSe3no9JZKowIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oven/bun-freebsd-x64": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-freebsd-x64/-/bun-freebsd-x64-1.3.14.tgz",
+      "integrity": "sha512-uwD+fGUH1ADpIF3B1U2jWzzb20QwRLZfj5QZ28GUCGrAJ/nTmWrD6YYGsblCY1wuhldRez3lU40AyuvSCyLYmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.14.tgz",
+      "integrity": "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64-android": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-android/-/bun-linux-aarch64-android-1.3.14.tgz",
+      "integrity": "sha512-y4kq5b85lsrmFb9Xvi4w9mA5IEFJkLMrSmYn06q24KjL9rUWDWO3VFZEtteZxUN5+ec3Zm5S8OnJw1umaCbVjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oven/bun-linux-aarch64-musl": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.14.tgz",
+      "integrity": "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.3.14.tgz",
+      "integrity": "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-android": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-android/-/bun-linux-x64-android-1.3.14.tgz",
+      "integrity": "sha512-qe9e1d+3VAEU7nAA2ol9Jvmy/o99PVMSgZhHn7Q/9O3YcDrfEqyQ8zm4zoe5qTEo8HZH0dN03Le0Ys2eQPs7eg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-baseline": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.14.tgz",
+      "integrity": "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.14.tgz",
+      "integrity": "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-linux-x64-musl-baseline": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.14.tgz",
+      "integrity": "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oven/bun-windows-aarch64": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-aarch64/-/bun-windows-aarch64-1.3.14.tgz",
+      "integrity": "sha512-T7s3x/BsVKQObGU6QDkZeI6wKynzqGbBH1yI77jrrj5siElclxr3DQrDIk8CV4G5/SJq2HHq4kpLyYY2DKCSmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.3.14.tgz",
+      "integrity": "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64-baseline": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.14.tgz",
+      "integrity": "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-aB6GVd42x1Y5ie1K16SF+oLGtgSkwX9hgoDdIW88pjvfTccU8F1vfpoOt34QLv0dZ1v3XimtaxPlZUG81Gx9Zg==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "android",
+        "freebsd",
+        "win32"
+      ],
+      "bin": {
+        "bun": "bin/bun.exe",
+        "bunx": "bin/bunx.exe"
+      },
+      "optionalDependencies": {
+        "@oven/bun-darwin-aarch64": "1.3.14",
+        "@oven/bun-darwin-x64": "1.3.14",
+        "@oven/bun-darwin-x64-baseline": "1.3.14",
+        "@oven/bun-freebsd-aarch64": "1.3.14",
+        "@oven/bun-freebsd-x64": "1.3.14",
+        "@oven/bun-linux-aarch64": "1.3.14",
+        "@oven/bun-linux-aarch64-android": "1.3.14",
+        "@oven/bun-linux-aarch64-musl": "1.3.14",
+        "@oven/bun-linux-x64": "1.3.14",
+        "@oven/bun-linux-x64-android": "1.3.14",
+        "@oven/bun-linux-x64-baseline": "1.3.14",
+        "@oven/bun-linux-x64-musl": "1.3.14",
+        "@oven/bun-linux-x64-musl-baseline": "1.3.14",
+        "@oven/bun-windows-aarch64": "1.3.14",
+        "@oven/bun-windows-x64": "1.3.14",
+        "@oven/bun-windows-x64-baseline": "1.3.14"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-to-regex.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.523.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.523.0.tgz",
+      "integrity": "sha512-rUjQoy7egZT9XYVXBK1je9ckBnNp7qzRZOhLQx5RcEp2dCGlXo+mv6vf7Am4LimEcFBJIIZzSGfgTqc9QCrPSw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "4.57.6",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.6.tgz",
+      "integrity": "sha512-WQK+DGjKCnPdpSyJUXphz+COF2uEhhsxQ3VIWBSbzpbbXuch3h4FePMqXrXGdLjsTgo4JFzBFsP6AWd9pVazGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.57.6",
+        "@jsonjoy.com/fs-fsa": "4.57.6",
+        "@jsonjoy.com/fs-node": "4.57.6",
+        "@jsonjoy.com/fs-node-builtins": "4.57.6",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.6",
+        "@jsonjoy.com/fs-node-utils": "4.57.6",
+        "@jsonjoy.com/fs-print": "4.57.6",
+        "@jsonjoy.com/fs-snapshot": "4.57.6",
+        "@jsonjoy.com/json-pack": "^1.11.0",
+        "@jsonjoy.com/util": "^1.9.0",
+        "glob-to-regex.js": "^1.0.1",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.0.3",
+        "tslib": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
+      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-simple-code-editor": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.14.1.tgz",
+      "integrity": "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.5",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve-handler/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-handler/node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/serve-handler/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve-handler/node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shelljs/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/shelljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/shelljs/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/spawn-rx": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-5.1.2.tgz",
+      "integrity": "sha512-/y7tJKALVZ1lPzeZZB9jYnmtrL7d0N2zkorii5a7r7dhHkWIuLTzZpZzMJLK1dmYRgX/NCc4iarTO3F7BS2c/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7",
+        "rxjs": "^7.8.1"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/thingies": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
+      "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-dump": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/agents/mdcode/package.json
+++ b/agents/mdcode/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "kcmd",
+  "version": "0.1.0",
+  "description": "Google Knowledge Catalog Metadata as Code Library, CLI and MCP Server",
+  "main": "index.js",
+  "bin": {
+    "kcmd": "./dist/kcmd"
+  },
+  "types": "./build/ts/kcmd/index.d.ts",
+  "exports": {
+    ".": "./build/ts/kcmd/index.js"
+  },
+  "scripts": {
+    "build:libts": "npx tsc -p src/libts/tsconfig.json",
+    "build:tool": "npx bun build --compile --outfile dist/kcmd src/tool/main.ts",
+    "build": "npm run build:libts && npm run build:tool",
+    "compile": "npx tsc --noEmit",
+    "test:libts": "npx bun test ./tests/libts/scenarios.ts",
+    "test": "npm run test:libts",
+    "x:mcp": "npx @modelcontextprotocol/inspector dist/kcmd mcp"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "cac": "^7.0.0",
+    "glob": "^13.0.6",
+    "yaml": "^2.8.4",
+    "zod": "^4.4.2"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/inspector": "^0.21.2",
+    "@types/bun": "^1.3.14",
+    "@types/node": "^25.6.0",
+    "bun": "^1.3.14",
+    "bun-types": "^1.3.14",
+    "memfs": "^4.57.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/agents/mdcode/src/libts/gcp/api.ts
+++ b/agents/mdcode/src/libts/gcp/api.ts
@@ -1,0 +1,123 @@
+// API Client base class
+//
+
+import * as context from './context';
+
+export interface ApiResult<T> {
+  status: number;
+  result?: T;
+  message?: string;
+}
+
+export class ApiClient {
+  private readonly _endpoint: string;
+  private readonly _pathPrefix: string;
+  private readonly _context: context.ApiContext;
+
+  constructor(
+    endpoint: string,
+    pathPrefix: string,
+    context: context.ApiContext,
+  ) {
+    this._endpoint = endpoint;
+    this._pathPrefix = pathPrefix;
+    this._context = context;
+  }
+
+  get context(): context.ApiContext {
+    return this._context;
+  }
+
+  async _get<T>(
+    resourceName: string,
+    queryParams?: Record<string, any>,
+  ): Promise<ApiResult<T>> {
+    const url = `${this._endpoint}/${this._pathPrefix}/${resourceName}`;
+    return this._requestRetry('GET', url, queryParams);
+  }
+
+  async _post<T>(
+    resourceName: string,
+    body: any,
+    queryParams?: Record<string, any>,
+  ): Promise<ApiResult<T>> {
+    const url = `${this._endpoint}/${this._pathPrefix}/${resourceName}`;
+    return this._requestRetry('POST', url, queryParams, body);
+  }
+
+  async _patch<T>(
+    resourceName: string,
+    body: any,
+    queryParams?: Record<string, any>,
+  ): Promise<ApiResult<T>> {
+    const url = `${this._endpoint}/${this._pathPrefix}/${resourceName}`;
+    return this._requestRetry('PATCH', url, queryParams, body);
+  }
+
+  async _delete<T>(
+    resourceName: string,
+    queryParams?: Record<string, any>,
+  ): Promise<ApiResult<T>> {
+    const url = `${this._endpoint}/${this._pathPrefix}/${resourceName}`;
+    return this._requestRetry('DELETE', url, queryParams);
+  }
+
+  private async _requestRetry<T>(
+    method: string,
+    url: string,
+    queryParams?: Record<string, any>,
+    body?: any,
+  ): Promise<ApiResult<T>> {
+    if (queryParams) {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(queryParams)) {
+        if (value !== undefined) {
+          if (Array.isArray(value)) {
+            value.forEach((v) => params.append(key, String(v)));
+          } else {
+            params.append(key, String(value));
+          }
+        }
+      }
+      const queryString = params.toString();
+      if (queryString) {
+        url += `?${queryString}`;
+      }
+    }
+
+    this._context.log(`${method} ${url}{body ? '\n' : ''}`, body);
+
+    let response = await this._requestCore(url, {method, body});
+    if (response.status === 401) {
+      this.context.refresh();
+      response = await this._requestCore(url, {method, body});
+    }
+
+    const result: ApiResult<T> = {status: response.status};
+    if (!response.ok) {
+      result.message = await response.text();
+    } else {
+      result.result = (await response.json()) as T;
+    }
+
+    this._context.log(
+      `${response.status}:${result.message ?? ''}\n`,
+      result.result,
+    );
+    return result;
+  }
+
+  private async _requestCore(url: string, options: any): Promise<Response> {
+    const headers = {
+      ...options.headers,
+      'Authorization': `Bearer ${this._context.token}`,
+      'Content-Type': 'application/json',
+    };
+
+    return fetch(url, {
+      ...options,
+      headers,
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+  }
+}

--- a/agents/mdcode/src/libts/gcp/biglake.ts
+++ b/agents/mdcode/src/libts/gcp/biglake.ts
@@ -1,0 +1,49 @@
+// API client for BigLake Metastore Service
+//
+
+import * as api from './api';
+import * as context from './context';
+
+export interface BigLakeTable {
+  name: string;
+  [key: string]: any;
+}
+
+interface TableList {
+  tables?: BigLakeTable[];
+  nextPageToken?: string;
+}
+
+export class BigLakeClient extends api.ApiClient {
+  constructor(ctx: context.ApiContext, catalogType: 'iceberg') {
+    const pathPrefix =
+      catalogType === 'iceberg' ? 'iceberg/v1/restcatalog/v1' : '';
+    super('https://biglake.googleapis.com', pathPrefix, ctx);
+  }
+
+  async *listTables(
+    project: string,
+    location: string,
+    catalog: string,
+    namespace: string,
+  ): AsyncGenerator<BigLakeTable> {
+    const name = `projects/${project}/catalogs/${catalog}/namespaces/${namespace}/tables`;
+
+    const params: Record<string, any> = {};
+    const res = await this._get<{
+      identifiers?: Array<{namespace: string[]; name: string}>;
+    }>(name, params);
+    if (res.status !== 200) {
+      throw new Error(
+        `Failed to list BigLake Iceberg tables: ${res.message || res.status}`,
+      );
+    }
+
+    const tables = res.result?.identifiers || [];
+    for (const table of tables) {
+      yield {
+        name: `projects/${project}/locations/${location}/catalogs/${catalog}/namespaces/${namespace}/tables/${table.name}`,
+      };
+    }
+  }
+}

--- a/agents/mdcode/src/libts/gcp/bigquery.ts
+++ b/agents/mdcode/src/libts/gcp/bigquery.ts
@@ -1,0 +1,70 @@
+// API client for BigQuery
+//
+
+import * as api from './api';
+import * as context from './context';
+
+export interface Dataset {
+  id: string;
+  datasetReference: {
+    projectId: string;
+    datasetId: string;
+  };
+  location: string;
+  [key: string]: any;
+}
+
+export interface Table {
+  id: string;
+  tableReference: {
+    projectId: string;
+    datasetId: string;
+    tableId: string;
+  };
+  [key: string]: any;
+}
+
+interface TableList {
+  tables: Table[];
+  nextPageToken?: string;
+}
+
+export class BigQueryClient extends api.ApiClient {
+  constructor(ctx: context.ApiContext) {
+    super('https://bigquery.googleapis.com', 'bigquery/v2', ctx);
+  }
+
+  async getDataset(
+    project: string,
+    dataset: string,
+  ): Promise<api.ApiResult<Dataset>> {
+    const name = `projects/${project}/datasets/${dataset}`;
+    const params: Record<string, any> = {datasetView: 'METADATA'};
+
+    return await this._get(name, params);
+  }
+
+  async *listTables(project: string, dataset: string): AsyncGenerator<Table> {
+    const name = `projects/${project}/datasets/${dataset}/tables`;
+
+    let pageToken: string | undefined = undefined;
+    do {
+      const params: Record<string, any> = {maxResults: 500};
+      if (pageToken) {
+        params.pageToken = pageToken;
+      }
+
+      const res = await this._get<TableList>(name, params);
+      if (res.status !== 200) {
+        throw new Error(`Failed to list tables: ${res.message || res.status}`);
+      }
+
+      const tables = res.result?.tables || [];
+      for (const table of tables) {
+        yield table;
+      }
+
+      pageToken = res.result?.nextPageToken;
+    } while (pageToken);
+  }
+}

--- a/agents/mdcode/src/libts/gcp/context.ts
+++ b/agents/mdcode/src/libts/gcp/context.ts
@@ -1,0 +1,50 @@
+// Context variables for GCP API requests
+//
+
+import * as cp from 'child_process';
+
+const GCLOUD_PROJECT_CMD = 'gcloud -q config get-value project';
+const GCLOUD_LOCATION_CMD = 'gcloud -q config get-value compute/region';
+const GCLOUD_TOKEN_CMD =
+  'gcloud -q auth application-default print-access-token';
+
+export class ApiContext {
+  readonly project: string;
+  readonly location: string;
+  private _token: string;
+
+  constructor(project: string, location: string, token: string) {
+    this.project = project;
+    this.location = location;
+    this._token = token;
+  }
+
+  get token(): string {
+    return this._token;
+  }
+
+  log(message: string, data?: any) {
+    if (process.env.GCP_LOG) {
+      console.log(`[GCP_LOG] ${message}`, data ? JSON.stringify(data) : '');
+    }
+  }
+
+  static default(): ApiContext {
+    // Creates an ApiContext instance using gcloud configuration
+
+    const project = cp.execSync(GCLOUD_PROJECT_CMD).toString().trim();
+    const location = cp.execSync(GCLOUD_LOCATION_CMD).toString().trim();
+    const token = cp.execSync(GCLOUD_TOKEN_CMD).toString().trim();
+    if (!project || !location || !token) {
+      throw new Error(
+        'Unable to retrieve project, location, or token. Ensure gcloud is configured.',
+      );
+    }
+
+    return new ApiContext(project, location, token);
+  }
+
+  refresh() {
+    this._token = cp.execSync(GCLOUD_TOKEN_CMD).toString().trim();
+  }
+}

--- a/agents/mdcode/src/libts/gcp/crm.ts
+++ b/agents/mdcode/src/libts/gcp/crm.ts
@@ -1,0 +1,95 @@
+// API client for Cloud Resource Manager
+//
+
+import * as api from './api';
+import * as context from './context';
+
+export interface Project {
+  name: string;
+  projectId: string;
+  projectNumber: string;
+  [key: string]: any;
+}
+
+const PROJECT_NUM_TO_ID_CACHE = new Map<string, string>();
+PROJECT_NUM_TO_ID_CACHE.set('655216118709', 'dataplex-types');
+
+const PROJECT_ID_TO_NUM_CACHE = new Map<string, string>();
+PROJECT_ID_TO_NUM_CACHE.set('dataplex-types', '655216118709');
+
+export class ResourceManagerClient extends api.ApiClient {
+  constructor(ctx: context.ApiContext) {
+    // USE V1 because V3 Project resource does NOT contain projectNumber field.
+    super('https://cloudresourcemanager.googleapis.com', 'v1', ctx);
+  }
+
+  async getProject(project: string): Promise<api.ApiResult<Project>> {
+    const name = `projects/${project}`;
+    return await this._get(name);
+  }
+}
+
+export async function projectNumber(
+  id: string,
+  ctx: context.ApiContext,
+): Promise<string> {
+  const cached = PROJECT_ID_TO_NUM_CACHE.get(id);
+  if (cached) {
+    return cached;
+  }
+  if (/^\d+$/.test(id)) {
+    return id;
+  }
+  const res = await new ResourceManagerClient(ctx).getProject(id);
+  const num = res.status === 200 ? res.result?.projectNumber : '';
+  if (num) {
+    PROJECT_ID_TO_NUM_CACHE.set(id, num.toString());
+    PROJECT_NUM_TO_ID_CACHE.set(num.toString(), id);
+    return num.toString();
+  }
+  return id;
+}
+
+export async function fixProject(
+  resource: string,
+  ctx: context.ApiContext,
+): Promise<string> {
+  // projects/<project_id> or projects/<project_number> -> projects/<project_id>
+
+  if (!resource.startsWith('projects/')) {
+    return resource;
+  }
+
+  const parts = resource.split('/');
+  if (/^\d+$/.test(parts[1])) {
+    let id = PROJECT_NUM_TO_ID_CACHE.get(parts[1]);
+    if (!id) {
+      const res = await new ResourceManagerClient(ctx).getProject(parts[1]);
+      id = res.status == 200 ? res.result?.projectId : '';
+    }
+
+    if (id) {
+      PROJECT_NUM_TO_ID_CACHE.set(parts[1], id);
+      parts[1] = id;
+    }
+  }
+
+  return parts.join('/');
+}
+
+export async function fixProjectToNumber(
+  resource: string,
+  ctx: context.ApiContext,
+): Promise<string> {
+  // projects/<project_id> or projects/<project_number> -> projects/<project_number>
+
+  if (!resource.startsWith('projects/')) {
+    return resource;
+  }
+
+  const parts = resource.split('/');
+  const num = await projectNumber(parts[1], ctx);
+  parts[1] = num;
+
+  return parts.join('/');
+}

--- a/agents/mdcode/src/libts/gcp/dataplex.ts
+++ b/agents/mdcode/src/libts/gcp/dataplex.ts
@@ -1,0 +1,790 @@
+// API client for Knowledge Catalog (Dataplex)
+//
+
+import * as api from './api';
+import * as context from './context';
+import * as crm from './crm';
+
+export interface EntryGroup {
+  name: string;
+  [key: string]: any;
+}
+
+export interface EntryType {
+  name: string;
+  requiredAspects: {type: string}[];
+  [key: string]: any;
+}
+
+export interface AspectType {
+  name: string;
+  [key: string]: any;
+}
+
+export interface Aspect {
+  aspectType?: string;
+  data?: Record<string, any>;
+}
+
+export interface Entry {
+  name: string;
+  entryType: string;
+  parentEntry?: string;
+  createTime?: string;
+  updateTime?: string;
+  entrySource?: {
+    resource?: string;
+    ancestors?: {
+      name: string;
+      type: string;
+    }[];
+    displayName?: string;
+    description?: string;
+    labels?: Record<string, string>;
+    location?: string;
+    createTime?: string;
+    updateTime?: string;
+  };
+  aspects?: Record<string, Aspect>;
+}
+
+export interface EntryReference {
+  name: string;
+  type: string;
+  path?: string;
+}
+
+export interface EntryLink {
+  name: string;
+  entryLinkType: string;
+  entryReferences: EntryReference[];
+  aspects?: Record<string, Aspect>;
+}
+
+export interface LookupEntryLinksResponse {
+  entryLinks: EntryLink[];
+  nextPageToken?: string;
+}
+
+export interface Glossary {
+  name: string;
+  displayName?: string;
+  description?: string;
+  labels?: Record<string, string>;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface GlossaryTerm {
+  name: string;
+  displayName?: string;
+  description?: string;
+  labels?: Record<string, string>;
+  parent: string;
+  createTime?: string;
+  updateTime?: string;
+}
+
+export interface GlossaryCategory {
+  name: string;
+  displayName?: string;
+  description?: string;
+  labels?: Record<string, string>;
+  parent: string;
+  createTime?: string;
+  updateTime?: string;
+}
+
+interface EntryList {
+  entries: Entry[];
+  nextPageToken?: string;
+}
+
+interface GlossaryList {
+  glossaries: Glossary[];
+  nextPageToken?: string;
+}
+
+interface GlossaryTermList {
+  terms: GlossaryTerm[];
+  nextPageToken?: string;
+}
+
+interface GlossaryCategoryList {
+  categories: GlossaryCategory[];
+  nextPageToken?: string;
+}
+
+export class CatalogClient extends api.ApiClient {
+  constructor(ctx: context.ApiContext) {
+    super('https://dataplex.googleapis.com', 'v1', ctx);
+  }
+
+  async getEntryGroup(
+    project: string,
+    location: string,
+    entryGroup: string,
+  ): Promise<api.ApiResult<EntryGroup>> {
+    const name = catalogContainer(project, location, entryGroup);
+    return await this._get(name);
+  }
+
+  async getEntryType(
+    project: string,
+    location: string,
+    type: string,
+  ): Promise<api.ApiResult<EntryType>> {
+    const name = `${catalogContainer(project, location)}/entryTypes/${type}`;
+    return await this._get(name);
+  }
+
+  async getAspectType(
+    project: string,
+    location: string,
+    type: string,
+  ): Promise<api.ApiResult<AspectType>> {
+    const name = `${catalogContainer(project, location)}/aspectTypes/${type}`;
+    return await this._get(name);
+  }
+
+  async getEntry(
+    project: string,
+    location: string,
+    entryGroup: string,
+    entry: string,
+    aspects?: string[],
+  ): Promise<api.ApiResult<Entry>> {
+    const name = `${catalogContainer(project, location, entryGroup)}/entries/${entry}`;
+    const params: Record<string, any> = {view: 'BASIC'};
+    if (aspects && aspects.length) {
+      params.view = 'CUSTOM';
+      params.aspectTypes = aspects;
+    }
+
+    const res = await this._get<Entry>(name, params);
+    if (res.status == 200 && res.result) {
+      await _fixEntry(res.result, this.context);
+    }
+
+    return res;
+  }
+
+  async lookupEntry(
+    project: string,
+    location: string,
+    name: string,
+    aspects?: string[],
+  ): Promise<api.ApiResult<Entry>> {
+    const container = `${catalogContainer(project, location)}:lookupEntry`;
+    const params: Record<string, any> = {entry: name, view: 'BASIC'};
+    if (aspects && aspects.length) {
+      params.view = 'CUSTOM';
+      params.aspectTypes = aspects;
+    }
+
+    const res = await this._get<Entry>(container, params);
+    if (res.status == 200 && res.result) {
+      await _fixEntry(res.result, this.context);
+    }
+
+    return res;
+  }
+
+  async modifyEntry(
+    project: string,
+    location: string,
+    entry: Entry,
+    updateMask?: string[],
+    aspectKeys?: string[],
+  ): Promise<api.ApiResult<Entry>> {
+    const container = `${catalogContainer(project, location)}:modifyEntry`;
+    const body: Record<string, any> = {
+      entry: entry,
+      updateMask: updateMask ? updateMask.join(',') : undefined,
+      aspectKeys: aspectKeys ?? undefined,
+    };
+
+    const res = await this._post<Entry>(container, body);
+    if (res.status == 200 && res.result) {
+      await _fixEntry(res.result, this.context);
+    }
+
+    return res;
+  }
+
+  async updateEntry(
+    entry: Entry,
+    updateMask?: string[],
+    aspectKeys?: string[],
+  ): Promise<api.ApiResult<Entry>> {
+    const params: Record<string, any> = {};
+    if (updateMask && updateMask.length) {
+      params.updateMask = updateMask.join(',');
+    }
+    if (aspectKeys && aspectKeys.length) {
+      params.aspectKeys = aspectKeys;
+    }
+
+    const res = await this._patch<Entry>(entry.name, entry, params);
+    if (res.status == 200 && res.result) {
+      await _fixEntry(res.result, this.context);
+    }
+
+    return res;
+  }
+
+  async *listEntries(
+    project: string,
+    location: string,
+    entryGroup: string,
+  ): AsyncGenerator<Entry, void, unknown> {
+    const parent = catalogContainer(project, location, entryGroup);
+    const resourceName = `${parent}/entries`;
+
+    let pageToken: string | undefined = undefined;
+    do {
+      const params: Record<string, string | number> = {pageSize: 1000};
+      if (pageToken) {
+        params.pageToken = pageToken;
+      }
+
+      const res = await this._get<EntryList>(resourceName, params);
+      if (res.status !== 200) {
+        throw new Error(`Failed to list entries: ${res.message || res.status}`);
+      }
+
+      const entries = res.result?.entries || [];
+      for (const entry of entries) {
+        await _fixEntry(entry, this.context);
+        yield entry;
+      }
+
+      pageToken = res.result?.nextPageToken;
+    } while (pageToken);
+  }
+
+  async lookupEntryLinks(
+    project: string,
+    location: string,
+    entryName: string,
+    entryLinkTypes?: string[],
+  ): Promise<api.ApiResult<LookupEntryLinksResponse>> {
+    const container = `${catalogContainer(project, location)}:lookupEntryLinks`;
+    const params: Record<string, any> = {
+      entry: entryName,
+    };
+    if (entryLinkTypes && entryLinkTypes.length) {
+      // Send as a REPEATED query param (`?entryLinkTypes=A&entryLinkTypes=B`).
+      // `api._get` expands arrays into repeated params; a comma-joined string
+      // gets parsed by the server as one resource name and fails with
+      // INVALID_ARGUMENT once there are 2+ types in the list.
+      params.entryLinkTypes = entryLinkTypes;
+    }
+    const res = await this._get<LookupEntryLinksResponse>(container, params);
+    if (res.status === 200 && res.result?.entryLinks) {
+      for (const link of res.result.entryLinks) {
+        await _fixEntryLink(link, this.context);
+      }
+    }
+    return res;
+  }
+
+  async createEntryLink(
+    project: string,
+    location: string,
+    entryGroup: string,
+    entryLinkId: string,
+    entryLink: EntryLink,
+  ): Promise<api.ApiResult<EntryLink>> {
+    const parent = catalogContainer(project, location, entryGroup);
+    const container = `${parent}/entryLinks`;
+    const params: Record<string, any> = {entryLinkId};
+    const res = await this._post<EntryLink>(container, entryLink, params);
+    if (res.status === 200 && res.result) {
+      await _fixEntryLink(res.result, this.context);
+    }
+    return res;
+  }
+
+  async deleteEntryLink(
+    project: string,
+    location: string,
+    entryGroup: string,
+    entryLinkId: string,
+  ): Promise<api.ApiResult<{}>> {
+    const parent = catalogContainer(project, location, entryGroup);
+    const name = `${parent}/entryLinks/${entryLinkId}`;
+    return await this._delete<{}>(name);
+  }
+
+  async *listEntryLinks(
+    project: string,
+    location: string,
+    entryGroup: string,
+    filter?: string,
+  ): AsyncGenerator<EntryLink, void, unknown> {
+    const parent = catalogContainer(project, location, entryGroup);
+    const resourceName = `${parent}/entryLinks`;
+
+    let pageToken: string | undefined = undefined;
+    do {
+      const params: Record<string, string | number> = {pageSize: 1000};
+      if (filter) {
+        params.filter = filter;
+      }
+      if (pageToken) {
+        params.pageToken = pageToken;
+      }
+
+      const res = await this._get<{
+        entryLinks: EntryLink[];
+        nextPageToken?: string;
+      }>(resourceName, params);
+      if (res.status !== 200) {
+        throw new Error(
+          `Failed to list entry links: ${res.message || res.status}`,
+        );
+      }
+
+      const links = res.result?.entryLinks || [];
+      for (const link of links) {
+        await _fixEntryLink(link, this.context);
+        yield link;
+      }
+
+      pageToken = res.result?.nextPageToken;
+    } while (pageToken);
+  }
+
+  async createEntry(
+    project: string,
+    location: string,
+    entryGroup: string,
+    entryId: string,
+    entry?: Entry,
+  ): Promise<api.ApiResult<Entry>> {
+    const parent = catalogContainer(project, location, entryGroup);
+    const resourceName = `${parent}/entries`;
+
+    const params: Record<string, any> = {entryId};
+
+    const res = await this._post<Entry>(resourceName, entry, params);
+
+    if (res.status == 200 && res.result) {
+      await _fixEntry(res.result, this.context);
+    }
+
+    return res;
+  }
+
+  async createEntryGroup(
+    project: string,
+    location: string,
+    entryGroupId: string,
+    entryGroup?: EntryGroup,
+  ): Promise<api.ApiResult<EntryGroup>> {
+    const parent = catalogContainer(project, location);
+    const resourceName = `${parent}/entryGroups`;
+
+    const params: Record<string, any> = {entryGroupId};
+
+    const res = await this._post<EntryGroup>(resourceName, entryGroup, params);
+
+    return res;
+  }
+
+  async getGlossary(
+    project: string,
+    location: string,
+    glossary: string,
+  ): Promise<api.ApiResult<Glossary>> {
+    const name = `${catalogContainer(project, location)}/glossaries/${glossary}`;
+    const res = await this._get<Glossary>(name);
+    if (res.status == 200 && res.result) {
+      await _fixGlossary(res.result, this.context);
+    }
+    return res;
+  }
+
+  async *listGlossaries(
+    project: string,
+    location: string,
+  ): AsyncGenerator<Glossary, void, unknown> {
+    const parent = catalogContainer(project, location);
+    const resourceName = `${parent}/glossaries`;
+
+    let pageToken: string | undefined = undefined;
+    do {
+      const params: Record<string, string | number> = {pageSize: 1000};
+      if (pageToken) {
+        params.pageToken = pageToken;
+      }
+
+      const res = await this._get<GlossaryList>(resourceName, params);
+      if (res.status !== 200) {
+        throw new Error(
+          `Failed to list glossaries: ${res.message || res.status}`,
+        );
+      }
+
+      const glossaries = res.result?.glossaries || [];
+      for (const glossary of glossaries) {
+        await _fixGlossary(glossary, this.context);
+        yield glossary;
+      }
+
+      pageToken = res.result?.nextPageToken;
+    } while (pageToken);
+  }
+
+  async createGlossary(
+    project: string,
+    location: string,
+    glossaryId: string,
+    glossary?: Glossary,
+  ): Promise<api.ApiResult<Glossary>> {
+    const parent = catalogContainer(project, location);
+    const resourceName = `${parent}/glossaries`;
+    const params: Record<string, any> = {glossaryId};
+    const res = await this._post<Glossary>(resourceName, glossary, params);
+    if (res.status == 200 && res.result) {
+      await _fixGlossary(res.result, this.context);
+    }
+    return res;
+  }
+
+  async updateGlossary(
+    glossary: Glossary,
+    updateMask?: string[],
+  ): Promise<api.ApiResult<Glossary>> {
+    const params: Record<string, any> = {};
+    if (updateMask && updateMask.length) {
+      params.updateMask = updateMask.join(',');
+    }
+    const res = await this._patch<Glossary>(glossary.name, glossary, params);
+    if (res.status == 200 && res.result) {
+      await _fixGlossary(res.result, this.context);
+    }
+    return res;
+  }
+
+  async deleteGlossary(
+    project: string,
+    location: string,
+    glossary: string,
+  ): Promise<api.ApiResult<void>> {
+    const name = `${catalogContainer(project, location)}/glossaries/${glossary}`;
+    return await this._delete(name);
+  }
+
+  async getGlossaryTerm(
+    project: string,
+    location: string,
+    glossary: string,
+    term: string,
+  ): Promise<api.ApiResult<GlossaryTerm>> {
+    const name = `${catalogContainer(project, location)}/glossaries/${glossary}/terms/${term}`;
+    const res = await this._get<GlossaryTerm>(name);
+    if (res.status == 200 && res.result) {
+      await _fixGlossaryTerm(res.result, this.context);
+    }
+    return res;
+  }
+
+  async *listGlossaryTerms(
+    project: string,
+    location: string,
+    glossary: string,
+  ): AsyncGenerator<GlossaryTerm, void, unknown> {
+    const parent = `${catalogContainer(project, location)}/glossaries/${glossary}`;
+    const resourceName = `${parent}/terms`;
+
+    let pageToken: string | undefined = undefined;
+    do {
+      const params: Record<string, string | number> = {pageSize: 1000};
+      if (pageToken) {
+        params.pageToken = pageToken;
+      }
+
+      const res = await this._get<GlossaryTermList>(resourceName, params);
+      if (res.status !== 200) {
+        throw new Error(
+          `Failed to list glossary terms: ${res.message || res.status}`,
+        );
+      }
+
+      const terms = res.result?.terms || [];
+      for (const term of terms) {
+        await _fixGlossaryTerm(term, this.context);
+        yield term;
+      }
+
+      pageToken = res.result?.nextPageToken;
+    } while (pageToken);
+  }
+
+  async createGlossaryTerm(
+    project: string,
+    location: string,
+    glossary: string,
+    termId: string,
+    term?: GlossaryTerm,
+  ): Promise<api.ApiResult<GlossaryTerm>> {
+    const parent = `${catalogContainer(project, location)}/glossaries/${glossary}`;
+    const resourceName = `${parent}/terms`;
+    const params: Record<string, any> = {termId};
+    const res = await this._post<GlossaryTerm>(resourceName, term, params);
+    if (res.status == 200 && res.result) {
+      await _fixGlossaryTerm(res.result, this.context);
+    }
+    return res;
+  }
+
+  async updateGlossaryTerm(
+    term: GlossaryTerm,
+    updateMask?: string[],
+  ): Promise<api.ApiResult<GlossaryTerm>> {
+    const params: Record<string, any> = {};
+    if (updateMask && updateMask.length) {
+      params.updateMask = updateMask.join(',');
+    }
+    const res = await this._patch<GlossaryTerm>(term.name, term, params);
+    if (res.status == 200 && res.result) {
+      await _fixGlossaryTerm(res.result, this.context);
+    }
+    return res;
+  }
+
+  async deleteGlossaryTerm(
+    project: string,
+    location: string,
+    glossary: string,
+    term: string,
+  ): Promise<api.ApiResult<void>> {
+    const name = `${catalogContainer(project, location)}/glossaries/${glossary}/terms/${term}`;
+    return await this._delete(name);
+  }
+
+  async getGlossaryCategory(
+    project: string,
+    location: string,
+    glossary: string,
+    category: string,
+  ): Promise<api.ApiResult<GlossaryCategory>> {
+    const name = `${catalogContainer(project, location)}/glossaries/${glossary}/categories/${category}`;
+    const res = await this._get<GlossaryCategory>(name);
+    if (res.status == 200 && res.result) {
+      await _fixGlossaryCategory(res.result, this.context);
+    }
+    return res;
+  }
+
+  async *listGlossaryCategories(
+    project: string,
+    location: string,
+    glossary: string,
+  ): AsyncGenerator<GlossaryCategory, void, unknown> {
+    const parent = `${catalogContainer(project, location)}/glossaries/${glossary}`;
+    const resourceName = `${parent}/categories`;
+
+    let pageToken: string | undefined = undefined;
+    do {
+      const params: Record<string, string | number> = {pageSize: 1000};
+      if (pageToken) {
+        params.pageToken = pageToken;
+      }
+
+      const res = await this._get<GlossaryCategoryList>(resourceName, params);
+      if (res.status !== 200) {
+        throw new Error(
+          `Failed to list glossary categories: ${res.message || res.status}`,
+        );
+      }
+
+      const categories = res.result?.categories || [];
+      for (const category of categories) {
+        await _fixGlossaryCategory(category, this.context);
+        yield category;
+      }
+
+      pageToken = res.result?.nextPageToken;
+    } while (pageToken);
+  }
+
+  async createGlossaryCategory(
+    project: string,
+    location: string,
+    glossary: string,
+    categoryId: string,
+    category?: GlossaryCategory,
+  ): Promise<api.ApiResult<GlossaryCategory>> {
+    const parent = `${catalogContainer(project, location)}/glossaries/${glossary}`;
+    const resourceName = `${parent}/categories`;
+    const params: Record<string, any> = {categoryId};
+    const res = await this._post<GlossaryCategory>(
+      resourceName,
+      category,
+      params,
+    );
+    if (res.status == 200 && res.result) {
+      await _fixGlossaryCategory(res.result, this.context);
+    }
+    return res;
+  }
+
+  async updateGlossaryCategory(
+    category: GlossaryCategory,
+    updateMask?: string[],
+  ): Promise<api.ApiResult<GlossaryCategory>> {
+    const params: Record<string, any> = {};
+    if (updateMask && updateMask.length) {
+      params.updateMask = updateMask.join(',');
+    }
+    const res = await this._patch<GlossaryCategory>(
+      category.name,
+      category,
+      params,
+    );
+    if (res.status == 200 && res.result) {
+      await _fixGlossaryCategory(res.result, this.context);
+    }
+    return res;
+  }
+
+  async deleteGlossaryCategory(
+    project: string,
+    location: string,
+    glossary: string,
+    category: string,
+  ): Promise<api.ApiResult<void>> {
+    const name = `${catalogContainer(project, location)}/glossaries/${glossary}/categories/${category}`;
+    return await this._delete(name);
+  }
+}
+
+// Fix all entries and aspects to consistently use project id. Its currently a mess with an
+// inconsistent mix of project ids and unusable project numbers.
+async function _fixEntry(entry: Entry, ctx: context.ApiContext): Promise<void> {
+  entry.name = await crm.fixProject(entry.name, ctx);
+  entry.entryType = await crm.fixProject(entry.entryType, ctx);
+  if (entry.entrySource?.resource) {
+    entry.entrySource.resource = await crm.fixProject(
+      entry.entrySource.resource,
+      ctx,
+    );
+  }
+
+  if (entry.aspects) {
+    const fixedAspects: Record<string, Aspect> = {};
+    for (const [aspectKey, aspectValue] of Object.entries(entry.aspects)) {
+      let aspectType = '';
+      if (!aspectValue || Object.keys(aspectValue).length) {
+        aspectType = _typeRefToName(aspectKey, 'aspect');
+      } else {
+        aspectType = aspectValue['aspectType'] as string;
+      }
+      aspectType = await crm.fixProject(aspectType, ctx);
+
+      fixedAspects[_nameToTypeRef(aspectType)] = {
+        aspectType: aspectType,
+        data: aspectValue['data'] ?? {},
+      };
+    }
+    entry.aspects = fixedAspects;
+  }
+}
+
+async function _fixGlossary(
+  glossary: Glossary,
+  ctx: context.ApiContext,
+): Promise<void> {
+  glossary.name = await crm.fixProject(glossary.name, ctx);
+}
+
+async function _fixGlossaryTerm(
+  term: GlossaryTerm,
+  ctx: context.ApiContext,
+): Promise<void> {
+  term.name = await crm.fixProject(term.name, ctx);
+  term.parent = await crm.fixProject(term.parent, ctx);
+}
+
+async function _fixGlossaryCategory(
+  category: GlossaryCategory,
+  ctx: context.ApiContext,
+): Promise<void> {
+  category.name = await crm.fixProject(category.name, ctx);
+  category.parent = await crm.fixProject(category.parent, ctx);
+}
+
+// Constructs canonical names for catalog container resources, identified by project, location and
+// optionally, depending on use-case, the entry group.
+export function catalogContainer(
+  project: string,
+  location: string,
+  entryGroup: string = '',
+): string {
+  let container = `projects/${project}/locations/${location}`;
+  if (entryGroup) {
+    container += `/entryGroups/${entryGroup}`;
+  }
+
+  return container;
+}
+
+// Converts project.location.type to projects/${project}/locations/${location}/typeTypes/${type}
+export function _typeRefToName(ref: string, type: string): string {
+  const refParts = ref.split('.');
+  if (refParts.length !== 3) {
+    throw new Error(`Invalid type reference: ${ref}`);
+  }
+  return `projects/${refParts[0]}/locations/${refParts[1]}/${type}Types/${refParts[2]}`;
+}
+
+// Converts projects/${project}/locations/${location}/typeTypes/${type} -> project.location.type
+export function _nameToTypeRef(name: string): string {
+  const nameParts = name.split('/');
+  if (nameParts.length < 6) {
+    throw new Error(`Invalid type name: ${name}`);
+  }
+  return `${nameParts[1]}.${nameParts[3]}.${nameParts[5]}`;
+}
+
+export function wrapAsProxyEntry(resourceName: string): string {
+  if (!resourceName.startsWith('projects/')) {
+    return resourceName;
+  }
+  if (resourceName.includes('/entryGroups/')) {
+    return resourceName;
+  }
+  const parts = resourceName.split('/');
+  if (parts.length >= 4 && parts[2] === 'locations') {
+    const project = parts[1];
+    const location = parts[3];
+    return `projects/${project}/locations/${location}/entryGroups/@dataplex/entries/${resourceName}`;
+  }
+  return resourceName;
+}
+
+export function unwrapProxyEntry(entryName: string): string {
+  const match = entryName.match(
+    /\/entryGroups\/@dataplex\/entries\/(projects\/.+)$/,
+  );
+  if (match) {
+    return match[1];
+  }
+  return entryName;
+}
+
+export async function _fixEntryLink(
+  link: EntryLink,
+  ctx: context.ApiContext,
+): Promise<void> {
+  link.name = await crm.fixProject(link.name, ctx);
+  link.entryLinkType = await crm.fixProject(link.entryLinkType, ctx);
+  if (link.entryReferences) {
+    for (const ref of link.entryReferences) {
+      ref.name = await crm.fixProject(ref.name, ctx);
+    }
+  }
+}

--- a/agents/mdcode/src/libts/gcp/index.ts
+++ b/agents/mdcode/src/libts/gcp/index.ts
@@ -1,0 +1,7 @@
+// GCP Client Library and Helpers
+//
+
+export * from './api';
+export * from './biglake';
+export * from './context';
+export * from './dataplex';

--- a/agents/mdcode/src/libts/index.ts
+++ b/agents/mdcode/src/libts/index.ts
@@ -1,0 +1,7 @@
+export * from './manifest';
+export * from './metadata';
+export * from './snapshot';
+export * from './sync';
+
+export * as gcp from './gcp/context';
+export * as dataplex from './gcp/dataplex';

--- a/agents/mdcode/src/libts/layout.ts
+++ b/agents/mdcode/src/libts/layout.ts
@@ -1,0 +1,38 @@
+// Defines the Catalog metadata layout abstraction.
+//
+
+import {DocumentsLayout} from './layouts/documents';
+import {StandardLayout} from './layouts/standard';
+import {CatalogManifest} from './manifest';
+import * as md from './metadata';
+
+export enum Layouts {
+  STANDARD = 'standard',
+  DOCUMENTS = 'documents',
+}
+
+export interface CatalogLayout {
+  init(): Promise<void>;
+
+  entryExists(name: string): boolean;
+  listEntries(): string[];
+  loadEntry(name: string): Promise<md.Entry>;
+  saveEntry(name: string, entry: md.Entry): Promise<void>;
+  deleteEntry(name: string): Promise<void>;
+  getEntryPaths(name: string): {local?: string; ref?: string} | undefined;
+}
+
+export function createLayout(
+  layout: Layouts,
+  catalogPath: string,
+  manifest?: CatalogManifest,
+): CatalogLayout {
+  switch (layout) {
+    case Layouts.STANDARD:
+      return new StandardLayout(catalogPath, manifest);
+    case Layouts.DOCUMENTS:
+      return new DocumentsLayout(catalogPath);
+    default:
+      throw new Error(`Unknown layout type: ${layout}`);
+  }
+}

--- a/agents/mdcode/src/libts/layouts/documents.ts
+++ b/agents/mdcode/src/libts/layouts/documents.ts
@@ -1,0 +1,196 @@
+// Implements the documents layout (markdown files in directory)
+//
+
+import * as glob from 'glob';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'yaml';
+import {CatalogLayout} from '../layout';
+import * as md from '../metadata';
+
+const OVERVIEW_ASPECT_KEY = 'dataplex-types.global.overview';
+
+export class DocumentsLayout implements CatalogLayout {
+  private _catalogPath: string = '';
+
+  private readonly _index = new Map<string, string>();
+
+  constructor(catalogPath: string) {
+    this._catalogPath = catalogPath;
+  }
+
+  async init(): Promise<void> {
+    this._index.clear();
+
+    if (!fs.existsSync(this._catalogPath)) {
+      return;
+    }
+
+    const matches = await glob.glob('**/*.md', {
+      cwd: this._catalogPath,
+      absolute: true,
+      nodir: true,
+    });
+
+    for (const localPath of matches) {
+      try {
+        const content = await fs.promises.readFile(localPath, 'utf8');
+        const {entry} = parseMarkdown(content);
+        if (entry && entry.name) {
+          this._index.set(entry.name, localPath);
+        }
+      } catch (err) {
+        // Skip unreadable/invalid files during indexing
+      }
+    }
+  }
+
+  entryExists(name: string): boolean {
+    const entryPath = this._index.get(name);
+    return !!entryPath && fs.existsSync(entryPath);
+  }
+
+  listEntries(): string[] {
+    return Array.from(this._index.keys());
+  }
+
+  async loadEntry(name: string): Promise<md.Entry> {
+    const entryPath = this._index.get(name);
+    if (!entryPath || !fs.existsSync(entryPath)) {
+      throw new Error(`Entry not found: ${name}`);
+    }
+    const content = await fs.promises.readFile(entryPath, 'utf8');
+    const {entry, body} = parseMarkdown(content);
+
+    if (!entry) {
+      throw new Error(
+        `Missing YAML frontmatter in Markdown file: ${entryPath}`,
+      );
+    }
+
+    const bodyTrimmed = body.trim();
+    if (bodyTrimmed) {
+      if (!entry.aspects) {
+        entry.aspects = {};
+      }
+      if (!entry.aspects[OVERVIEW_ASPECT_KEY]) {
+        entry.aspects[OVERVIEW_ASPECT_KEY] = {};
+      }
+      entry.aspects[OVERVIEW_ASPECT_KEY].content = bodyTrimmed;
+      entry.aspects[OVERVIEW_ASPECT_KEY].contentType = 'MARKDOWN';
+    }
+    return entry;
+  }
+
+  async saveEntry(name: string, entry: md.Entry): Promise<void> {
+    const entryPath = path.join(this._catalogPath, `${name}.md`);
+    await fs.promises.mkdir(path.dirname(entryPath), {recursive: true});
+
+    // Clone to avoid mutating original entry aspects
+    const clonedEntry = JSON.parse(JSON.stringify(entry)) as md.Entry;
+    let body = '';
+
+    if (clonedEntry.aspects?.[OVERVIEW_ASPECT_KEY]) {
+      const aspect = clonedEntry.aspects[OVERVIEW_ASPECT_KEY];
+      if (aspect.content !== undefined) {
+        body = aspect.content;
+        delete aspect.content;
+        delete aspect.contentType;
+      }
+    }
+
+    const fileContent = toMarkdown(clonedEntry, body);
+
+    await fs.promises.writeFile(entryPath, fileContent, 'utf8');
+    this._index.set(name, entryPath);
+  }
+
+  async deleteEntry(name: string): Promise<void> {
+    const entryPath = this._index.get(name);
+    if (!entryPath || !fs.existsSync(entryPath)) {
+      throw new Error(`Entry not found: ${name}`);
+    }
+
+    await fs.promises.unlink(entryPath);
+    this._index.delete(name);
+  }
+
+  getEntryPaths(name: string): {local?: string; ref?: string} | undefined {
+    const entryPath = this._index.get(name);
+    return entryPath ? {local: entryPath} : undefined;
+  }
+}
+
+export function parseMarkdown(content: string): {
+  entry: md.Entry | null;
+  body: string;
+} {
+  const lines = content.split(/\r?\n/);
+  if (lines[0] !== '---') {
+    return {entry: null, body: content};
+  }
+  const endIndex = lines.indexOf('---', 1);
+  if (endIndex === -1) {
+    return {entry: null, body: content};
+  }
+
+  const frontmatter = lines.slice(1, endIndex).join('\n');
+  const metadata = yaml.parse(frontmatter);
+  const body = lines.slice(endIndex + 1).join('\n');
+
+  const entry = (metadata.catalogEntry ?? {}) as md.Entry;
+  entry.type = metadata.type;
+  entry.resource = entry.resource ?? {};
+  entry.resource.displayName = metadata.title;
+  entry.resource.description = metadata.description;
+  if (metadata.tags) {
+    entry.resource.labels = entry.resource.labels ?? {};
+    for (const tag of metadata.tags) {
+      entry.resource.labels[tag] = 'true';
+    }
+  }
+  if (metadata.timeStamp) {
+    entry.resource.updateTime = metadata.timeStamp;
+    if (!entry.resource.createTime) {
+      entry.resource.createTime = metadata.timeStamp;
+    }
+  }
+
+  return {entry, body};
+}
+
+export function toMarkdown(entry: md.Entry, body: string): string {
+  // Clone to be able to make modifications
+  const entryClone = JSON.parse(JSON.stringify(entry)) as Record<string, any>;
+
+  const tags = [];
+  if (entry.resource.labels) {
+    for (const [k, v] of Object.entries(entryClone.resource.labels ?? {})) {
+      if (v == 'true') {
+        tags.push(k);
+      }
+    }
+  }
+
+  const metadata = {
+    type: entry.type,
+    title: entry.resource.displayName ?? entry.resource.name,
+    description: entry.resource.description ?? undefined,
+    tags: tags.length ? tags : undefined,
+    timeStamp:
+      entry.resource.updateTime ?? entry.resource.createTime ?? undefined,
+    catalogEntry: entryClone,
+  };
+
+  delete entryClone.resource.displayName;
+  delete entryClone.resource.description;
+  delete entryClone.resource.updateTime;
+  delete entryClone.resource.createTime;
+  delete entryClone.type;
+  for (const tag of tags) {
+    delete entryClone.resource.labels[tag];
+  }
+
+  const frontmatter = yaml.stringify(metadata).trim();
+  return `---\n${frontmatter}\n---\n${body}`;
+}

--- a/agents/mdcode/src/libts/layouts/standard.ts
+++ b/agents/mdcode/src/libts/layouts/standard.ts
@@ -1,0 +1,350 @@
+// Implements the standard layout (yaml files in directory)
+//
+
+import * as glob from 'glob';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'yaml';
+import {CatalogLayout} from '../layout';
+import {CatalogManifest} from '../manifest';
+import * as md from '../metadata';
+
+export class StandardLayout implements CatalogLayout {
+  private readonly _catalogPath: string;
+  private readonly _manifest?: CatalogManifest;
+
+  // Maps entry name to its file paths (modifiable and reference)
+  private readonly _index = new Map<string, {local?: string; ref?: string}>();
+
+  constructor(catalogPath: string, manifest?: CatalogManifest) {
+    this._catalogPath = catalogPath;
+    this._manifest = manifest;
+  }
+
+  async init(): Promise<void> {
+    this._index.clear();
+
+    if (!fs.existsSync(this._catalogPath)) {
+      return;
+    }
+
+    const matches = await walkDir(this._catalogPath, '.yaml');
+
+    for (const localPath of matches) {
+      try {
+        const content = await fs.promises.readFile(localPath, 'utf8');
+        const metadata = yaml.parse(content);
+        if (metadata && metadata.name) {
+          const entryName = metadata.name;
+          const entryPaths = this._index.get(entryName) || {};
+          if (localPath.endsWith('.ref.yaml')) {
+            entryPaths.ref = localPath;
+          } else {
+            entryPaths.local = localPath;
+          }
+          this._index.set(entryName, entryPaths);
+        }
+      } catch (err) {
+        // Skip unreadable/invalid yaml files during indexing
+      }
+    }
+  }
+
+  entryExists(name: string): boolean {
+    const entryPaths = this._index.get(name);
+    return (
+      !!entryPaths &&
+      ((!!entryPaths.local && fs.existsSync(entryPaths.local)) ||
+        (!!entryPaths.ref && fs.existsSync(entryPaths.ref)))
+    );
+  }
+
+  listEntries(): string[] {
+    return Array.from(this._index.keys());
+  }
+
+  async loadEntry(name: string): Promise<md.Entry> {
+    const entryPaths = this._index.get(name);
+    if (!entryPaths) {
+      throw new Error(`Entry not found: ${name}`);
+    }
+
+    let mergedEntry: md.Entry | undefined;
+
+    // Load reference layer first
+    if (entryPaths.ref && fs.existsSync(entryPaths.ref)) {
+      mergedEntry = await this._loadLayer(entryPaths.ref);
+    }
+
+    // Load local layer and merge
+    if (entryPaths.local && fs.existsSync(entryPaths.local)) {
+      const localEntry = await this._loadLayer(entryPaths.local);
+      if (!mergedEntry) {
+        mergedEntry = localEntry;
+      } else {
+        // Merge logic: local overrides ref
+        mergedEntry.type = localEntry.type;
+        mergedEntry.resource = {
+          ...mergedEntry.resource,
+          ...localEntry.resource,
+        };
+
+        if (localEntry.aspects) {
+          if (!mergedEntry.aspects) {
+            mergedEntry.aspects = {};
+          }
+          for (const [key, value] of Object.entries(localEntry.aspects)) {
+            mergedEntry.aspects[key] = value;
+          }
+        }
+      }
+    }
+
+    if (!mergedEntry) {
+      throw new Error(`Entry files missing for: ${name}`);
+    }
+
+    return mergedEntry;
+  }
+
+  private async _loadLayer(entryPath: string): Promise<md.Entry> {
+    const content = await fs.promises.readFile(entryPath, 'utf8');
+    const entry = yaml.parse(content) as md.Entry;
+
+    // Load and merge any markdown sidecar files
+    const dir = path.dirname(entryPath);
+    const baseName = path.basename(entryPath, '.yaml');
+    try {
+      const files = await fs.promises.readdir(dir);
+      // Sidecars must start with baseName followed by a dot
+      const sidecarFiles = files.filter(
+        (f) => f.startsWith(`${baseName}.`) && f.endsWith('.md'),
+      );
+
+      for (const sidecarFile of sidecarFiles) {
+        const aspectSuffix = sidecarFile.substring(
+          baseName.length + 1,
+          sidecarFile.length - 3,
+        );
+        let matchedKey = aspectSuffix;
+
+        if (this._manifest) {
+          const snapshotAspects = this._manifest.snapshotConfig?.aspects || [];
+          const publishingAspects =
+            this._manifest.publishingConfig?.aspects || [];
+          const allAspects = Array.from(
+            new Set([...snapshotAspects, ...publishingAspects]),
+          );
+
+          for (const key of allAspects) {
+            if (key === aspectSuffix || key.endsWith(`.${aspectSuffix}`)) {
+              matchedKey = key;
+              break;
+            }
+          }
+        } else if (aspectSuffix === 'overview') {
+          matchedKey = 'dataplex-types.global.overview';
+        }
+
+        const sidecarPath = path.join(dir, sidecarFile);
+        const sidecarContent = await fs.promises.readFile(sidecarPath, 'utf8');
+        const parsed = parseSidecarMarkdown(sidecarContent);
+
+        if (!entry.aspects) {
+          entry.aspects = {};
+        }
+        if (!entry.aspects[matchedKey]) {
+          entry.aspects[matchedKey] = {};
+        }
+
+        Object.assign(entry.aspects[matchedKey], parsed.data);
+        // Only inject the Markdown body as `content` when it's non-empty.
+        // Some aspect types (e.g. `dataplex-types.global.queries`) have no
+        // `content` field in their schema; injecting an empty string causes
+        // Dataplex to reject the push with "Unknown property: content". A
+        // sidecar with no body is treated as pure-frontmatter — the
+        // frontmatter IS the entire aspect payload.
+        const body = parsed.body.trim();
+        if (body) {
+          entry.aspects[matchedKey].content = body;
+        }
+
+        if (
+          !entry.aspects[matchedKey].contentType &&
+          matchedKey.endsWith('.overview')
+        ) {
+          entry.aspects[matchedKey].contentType = 'MARKDOWN';
+        }
+      }
+    } catch (err) {
+      // Ignore reading directory errors
+    }
+
+    return entry;
+  }
+
+  async saveEntry(name: string, entry: md.Entry): Promise<void> {
+    const entryPath = path.join(this._catalogPath, `${name}.yaml`);
+    await fs.promises.mkdir(path.dirname(entryPath), {recursive: true});
+
+    // Clone the entry to avoid modifying the original entry aspects
+    const entryClone = JSON.parse(JSON.stringify(entry)) as md.Entry;
+
+    if (entryClone.aspects) {
+      const dir = path.dirname(entryPath);
+      const baseName = path.basename(entryPath, '.yaml');
+
+      for (const key in entryClone.aspects) {
+        const aspectData = entryClone.aspects[key];
+        if (isMarkdownAspect(key, aspectData)) {
+          const suffix = key.split('.').pop() || key;
+          const sidecarPath = path.join(dir, `${baseName}.${suffix}.md`);
+          const sidecarContent = toSidecarMarkdown(aspectData);
+          await fs.promises.writeFile(sidecarPath, sidecarContent, 'utf8');
+
+          delete entryClone.aspects[key];
+        }
+      }
+
+      if (Object.keys(entryClone.aspects).length === 0) {
+        delete entryClone.aspects;
+      }
+    }
+
+    await fs.promises.writeFile(entryPath, yaml.stringify(entryClone), 'utf8');
+
+    // Update index
+    const entryName = entryClone.name;
+    const entryPaths = this._index.get(entryName) || {};
+    if (name.endsWith('.ref')) {
+      entryPaths.ref = entryPath;
+    } else {
+      entryPaths.local = entryPath;
+    }
+    this._index.set(entryName, entryPaths);
+  }
+
+  async deleteEntry(name: string): Promise<void> {
+    const entryPaths = this._index.get(name);
+    // Note: deleteEntry as implemented only handles one path at a time currently
+    // because 'name' in layout context usually refers to the local path name.
+    // However, the interface says 'name', which is the resource name.
+    // This part might need more thought if we want to delete both layers.
+    // For now, we'll keep it simple and try to delete the local one if it exists.
+
+    const entryPath = entryPaths?.local || entryPaths?.ref;
+    if (!entryPath || !fs.existsSync(entryPath)) {
+      throw new Error(`Entry not found: ${name}`);
+    }
+
+    // Delete the entry YAML file
+    await fs.promises.unlink(entryPath);
+    this._index.delete(name);
+
+    // Delete any associated markdown sidecar files
+    const dir = path.dirname(entryPath);
+    const baseName = path.basename(entryPath, '.yaml');
+    try {
+      const files = await fs.promises.readdir(dir);
+      const sidecars = files.filter(
+        (f) => f.startsWith(`${baseName}.`) && f.endsWith('.md'),
+      );
+      for (const sidecar of sidecars) {
+        await fs.promises.unlink(path.join(dir, sidecar));
+      }
+    } catch (err) {
+      // Ignore reading directory errors
+    }
+  }
+
+  getEntryPaths(name: string): {local?: string; ref?: string} | undefined {
+    return this._index.get(name);
+  }
+}
+
+function parseSidecarMarkdown(content: string): {
+  data: Record<string, any>;
+  body: string;
+} {
+  const lines = content.split(/\r?\n/);
+  if (lines[0] !== '---') {
+    return {data: {}, body: content};
+  }
+  const endIndex = lines.indexOf('---', 1);
+  if (endIndex === -1) {
+    return {data: {}, body: content};
+  }
+
+  const frontmatter = lines.slice(1, endIndex).join('\n');
+  const data = yaml.parse(frontmatter) || {};
+  const body = lines.slice(endIndex + 1).join('\n');
+
+  return {data, body};
+}
+
+function toSidecarMarkdown(aspectData: Record<string, any>): string {
+  const cloned = JSON.parse(JSON.stringify(aspectData));
+  const body = cloned.content || '';
+  delete cloned.content;
+  delete cloned.contentType;
+
+  // Drop empty fields (e.g. an overview aspect's `links: []`) so they don't get
+  // written as spurious frontmatter; only real, non-empty metadata is kept.
+  for (const key of Object.keys(cloned)) {
+    if (isEmptyValue(cloned[key])) {
+      delete cloned[key];
+    }
+  }
+
+  if (Object.keys(cloned).length === 0) {
+    return body;
+  }
+
+  const frontmatter = yaml.stringify(cloned).trim();
+  return `---\n${frontmatter}\n---\n${body}`;
+}
+
+function isEmptyValue(value: any): boolean {
+  if (value === null || value === undefined || value === '') {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (typeof value === 'object') {
+    return Object.keys(value).length === 0;
+  }
+  return false;
+}
+
+function isMarkdownAspect(key: string, data: any): boolean {
+  if (
+    key === 'overview' ||
+    key === 'dataplex-types.global.overview' ||
+    key.endsWith('.overview')
+  ) {
+    return true;
+  }
+  if (data && typeof data === 'object' && data.contentType === 'MARKDOWN') {
+    return true;
+  }
+  return false;
+}
+
+async function walkDir(dir: string, ext: string): Promise<string[]> {
+  const files: string[] = [];
+  try {
+    const entries = await fs.promises.readdir(dir, {withFileTypes: true});
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...(await walkDir(fullPath, ext)));
+      } else if (entry.isFile() && entry.name.endsWith(ext)) {
+        files.push(fullPath);
+      }
+    }
+  } catch (err) {
+    // Ignore errors reading directories
+  }
+  return files;
+}

--- a/agents/mdcode/src/libts/manifest.ts
+++ b/agents/mdcode/src/libts/manifest.ts
@@ -1,0 +1,406 @@
+// Implements support for creating and loading catalog manifests.
+//
+
+import * as fs from 'node:fs';
+import * as yaml from 'yaml';
+import * as z from 'zod';
+import * as gcp from './gcp';
+import {ResourceAlias, ResourceType} from './resourcealias';
+import {CatalogSource, createSource, Sources} from './source';
+
+export interface LocalEntryLink {
+  type: string;
+  references: string[];
+}
+
+const manifestSchema = z.object({
+  scope: z.union([z.string(), z.array(z.string())]),
+  resourceAlias: z
+    .record(z.string(), z.record(z.string(), z.string()))
+    .optional(),
+  entryLinkTypes: z.array(z.string()).optional(),
+  snapshot: z
+    .object({
+      entries: z.array(z.string()).optional(),
+      aspects: z.array(z.string()).optional(),
+      entryLinks: z.array(z.string()).optional(),
+    })
+    .optional(),
+  publishing: z
+    .object({
+      entries: z.array(z.string()).optional(),
+      aspects: z.array(z.string()).optional(),
+      entryLinks: z.array(z.string()).optional(),
+    })
+    .optional(),
+  reference: z
+    .object({
+      scope: z.union([z.string(), z.array(z.string())]),
+      snapshot: z
+        .object({
+          entries: z.array(z.string()).optional(),
+          aspects: z.array(z.string()).optional(),
+          entryLinks: z.array(z.string()).optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+export interface SnapshotConfig {
+  entries?: string[];
+  aspects?: string[];
+  entryLinks?: string[];
+}
+
+export interface PublishingConfig {
+  entries?: string[];
+  aspects?: string[];
+  entryLinks?: string[];
+}
+
+export interface Scope {
+  type: string;
+  name: string;
+}
+
+export interface ReferenceConfig {
+  scope: string | string[];
+  snapshot?: SnapshotConfig;
+}
+
+export class ReferenceManifest {
+  readonly source: CatalogSource;
+  readonly snapshotConfig?: SnapshotConfig;
+
+  constructor(source: CatalogSource, snapshotConfig?: SnapshotConfig) {
+    this.source = source;
+    this.snapshotConfig = snapshotConfig;
+  }
+}
+
+export class CatalogManifest {
+  readonly source: CatalogSource;
+  readonly context: gcp.ApiContext;
+  readonly snapshotConfig?: SnapshotConfig;
+  readonly publishingConfig?: PublishingConfig;
+  readonly referenceManifest?: ReferenceManifest;
+  readonly aliasMap: ResourceAlias;
+  readonly entryLinkTypes?: string[];
+
+  private constructor(
+    source: CatalogSource,
+    context: gcp.ApiContext,
+    aliasMap = new ResourceAlias(),
+    snapshotConfig?: SnapshotConfig,
+    publishingConfig?: PublishingConfig,
+    referenceManifest?: ReferenceManifest,
+    entryLinkTypes?: string[],
+  ) {
+    this.source = source;
+    this.context = context;
+    this.aliasMap = aliasMap;
+    this.snapshotConfig = snapshotConfig;
+    this.publishingConfig = publishingConfig;
+    this.referenceManifest = referenceManifest;
+    this.entryLinkTypes = entryLinkTypes;
+  }
+
+  static async initWithEntryGroup(
+    name: string,
+    ctx: gcp.ApiContext,
+  ): Promise<CatalogManifest> {
+    const source = await createSource(Sources.ENTRYGROUP, name, ctx);
+    return new CatalogManifest(source, ctx);
+  }
+
+  static async initWithBigQuery(
+    dataset: string,
+    ctx: gcp.ApiContext,
+  ): Promise<CatalogManifest> {
+    const source = await createSource(Sources.BIGQUERY_DATASET, dataset, ctx);
+    return new CatalogManifest(source, ctx);
+  }
+
+  static async initWithKnowledgeBase(
+    name: string,
+    ctx: gcp.ApiContext,
+  ): Promise<CatalogManifest> {
+    const source = await createSource(Sources.KB, name, ctx);
+    return new CatalogManifest(source, ctx);
+  }
+
+  static async initWithGlossary(
+    name: string,
+    ctx: gcp.ApiContext,
+  ): Promise<CatalogManifest> {
+    const source = await createSource(Sources.GLOSSARY, name, ctx);
+    return new CatalogManifest(source, ctx);
+  }
+
+  static async initWithBigLakeNamespace(
+    name: string,
+    catalogType: 'iceberg',
+    ctx: gcp.ApiContext,
+  ): Promise<CatalogManifest> {
+    const source = await createSource(
+      catalogType === 'iceberg'
+        ? Sources.BIGLAKE_ICEBERG_NAMESPACE
+        : Sources.BIGLAKE_NAMESPACE,
+      name,
+      ctx,
+    );
+    return new CatalogManifest(source, ctx);
+  }
+
+  static async parseScope(
+    scope: string | string[],
+    ctx: gcp.ApiContext,
+  ): Promise<CatalogSource> {
+    let source: CatalogSource;
+    if (Array.isArray(scope)) {
+      if (scope.length === 0) {
+        throw new Error('Manifest error: scope array cannot be empty.');
+      }
+
+      const datasets: string[] = [];
+      for (const s of scope) {
+        const dotIndex = s.indexOf('.');
+        if (dotIndex === -1) {
+          throw new Error(`Manifest error: scope '${s}' is invalid.`);
+        }
+        const type = s.substring(0, dotIndex);
+        const name = s.substring(dotIndex + 1);
+        if (type !== Sources.BIGQUERY_DATASET) {
+          throw new Error(
+            `Manifest error: Unsupported scope type in multiple scopes: '${type}'.`,
+          );
+        }
+        datasets.push(name);
+      }
+
+      source = await createSource(
+        Sources.BIGQUERY_DATASET,
+        datasets.join(','),
+        ctx,
+      );
+    } else {
+      const dotIndex = scope.indexOf('.');
+      if (dotIndex === -1) {
+        throw new Error(`Manifest error: scope '${scope}' is invalid.`);
+      }
+      source = await createSource(
+        scope.substring(0, dotIndex),
+        scope.substring(dotIndex + 1),
+        ctx,
+      );
+    }
+    return source;
+  }
+
+  static parseAlias(
+    aliasList?: Record<string, Record<string, string>>,
+  ): ResourceAlias {
+    let aliasMap = new ResourceAlias();
+    if (aliasList) {
+      for (const [alias, resource] of Object.entries(aliasList)) {
+        if (Object.keys(resource).length != 1) {
+          throw Error(`Alias ${alias} has multiple mappings.`);
+        }
+        const [resourceType, resourceId] = Object.entries(resource)[0];
+        aliasMap.add(alias, resourceType, resourceId);
+      }
+    }
+    return aliasMap;
+  }
+
+  static parseSnapshot(
+    snapshot?: SnapshotConfig,
+    aliasMap?: ResourceAlias,
+  ): SnapshotConfig | undefined {
+    if (snapshot) {
+      if (snapshot.entries) {
+        for (const entryType of snapshot.entries) {
+          const parts = entryType.split('.');
+          if (parts.length !== 3) {
+            throw new Error(
+              `Manifest error: Invalid Entry Type '${entryType}'`,
+            );
+          }
+        }
+      }
+
+      if (snapshot.aspects) {
+        for (const aspectType of snapshot.aspects) {
+          let formalName = aliasMap
+            ? aliasMap.lookupAlias(aspectType, ResourceType.ASPECT)
+            : aspectType;
+          const parts = formalName.split('.');
+          if (parts.length !== 3) {
+            throw new Error(
+              `Manifest error: Invalid Aspect Type '${aspectType}'`,
+            );
+          }
+        }
+      }
+
+      if (snapshot.entryLinks) {
+        for (const linkType of snapshot.entryLinks) {
+          let formalName = aliasMap
+            ? aliasMap.lookupAlias(linkType, ResourceType.ENTRYLINK)
+            : linkType;
+          const parts = formalName.split('.');
+          if (parts.length !== 3) {
+            throw new Error(
+              `Manifest error: Invalid EntryLink Type '${linkType}'`,
+            );
+          }
+        }
+      }
+      return snapshot;
+    }
+    return undefined;
+  }
+
+  static parsePublishingConfig(
+    snapshot?: SnapshotConfig,
+    publishing?: PublishingConfig,
+    aliasMap?: ResourceAlias,
+  ): PublishingConfig | undefined {
+    if (publishing) {
+      if (publishing.entries) {
+        for (const entryType of publishing.entries) {
+          const parts = entryType.split('.');
+          if (parts.length !== 3) {
+            throw new Error(
+              `Manifest error: Invalid Entry Type '${entryType}'`,
+            );
+          }
+          if (!snapshot?.entries?.includes(entryType)) {
+            throw new Error(
+              `Manifest error: Publishing entry type '${entryType}' is not listed in snapshot entries.`,
+            );
+          }
+        }
+      }
+
+      if (publishing.aspects) {
+        for (const aspectType of publishing.aspects) {
+          let formalName = aliasMap
+            ? aliasMap.lookupAlias(aspectType, ResourceType.ASPECT)
+            : aspectType;
+          const parts = formalName.split('.');
+          if (parts.length !== 3) {
+            throw new Error(
+              `Manifest error: Invalid Aspect Type '${aspectType}'`,
+            );
+          }
+          if (!snapshot?.aspects?.includes(aspectType)) {
+            throw new Error(
+              `Manifest error: Publishing aspect type '${aspectType}' is not listed in snapshot aspects.`,
+            );
+          }
+        }
+      }
+
+      if (publishing.entryLinks) {
+        for (const linkType of publishing.entryLinks) {
+          let formalName = aliasMap
+            ? aliasMap.lookupAlias(linkType, ResourceType.ENTRYLINK)
+            : linkType;
+          const parts = formalName.split('.');
+          if (parts.length !== 3) {
+            throw new Error(
+              `Manifest error: Invalid EntryLink Type '${linkType}'`,
+            );
+          }
+          if (!snapshot?.entryLinks?.includes(linkType)) {
+            throw new Error(
+              `Manifest error: Publishing entryLink type '${linkType}' is not listed in snapshot entryLinks.`,
+            );
+          }
+        }
+      }
+      return publishing;
+    }
+    return undefined;
+  }
+
+  static async parseReference(
+    reference: ReferenceConfig | undefined,
+    ctx: gcp.ApiContext,
+    aliasMap?: ResourceAlias,
+  ): Promise<ReferenceManifest | undefined> {
+    if (reference) {
+      const referenceSource = await this.parseScope(reference.scope, ctx);
+      const referenceSnapshot = this.parseSnapshot(
+        reference.snapshot,
+        aliasMap,
+      );
+      return new ReferenceManifest(referenceSource, referenceSnapshot);
+    }
+
+    return undefined;
+  }
+
+  static async load(
+    path: string,
+    ctx: gcp.ApiContext,
+  ): Promise<CatalogManifest> {
+    const content = fs.readFileSync(path, 'utf8');
+    const parsed = yaml.parse(content);
+
+    const result = manifestSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(`Manifest error: ${result.error.message}`);
+    }
+
+    const source = await this.parseScope(result.data.scope, ctx);
+
+    const aliasMap = await this.parseAlias(result.data.resourceAlias);
+
+    const snapshot = this.parseSnapshot(result.data.snapshot, aliasMap);
+
+    const publishing = this.parsePublishingConfig(
+      snapshot,
+      result.data.publishing,
+      aliasMap,
+    );
+
+    const reference = await this.parseReference(
+      result.data.reference,
+      ctx,
+      aliasMap,
+    );
+
+    const entryLinkTypes = result.data.entryLinkTypes;
+
+    return new CatalogManifest(
+      source,
+      ctx,
+      aliasMap,
+      snapshot,
+      publishing,
+      reference,
+      entryLinkTypes,
+    );
+  }
+
+  save(path: string): void {
+    let scope: string | string[];
+    const names = this.source.name.split(',');
+    if (names.length > 1) {
+      scope = names.map((n) => `${this.source.type}.${n}`);
+    } else {
+      scope = `${this.source.type}.${this.source.name}`;
+    }
+
+    const data: any = {
+      scope: scope,
+      snapshot: this.snapshotConfig ?? undefined,
+      publishing: this.publishingConfig ?? undefined,
+      entryLinkTypes: this.entryLinkTypes ?? undefined,
+    };
+    fs.writeFileSync(path, yaml.stringify(data), 'utf8');
+  }
+}

--- a/agents/mdcode/src/libts/metadata.ts
+++ b/agents/mdcode/src/libts/metadata.ts
@@ -1,0 +1,33 @@
+// Defines metadata objects provided by the catalog snapshot
+//
+
+export interface Aspect {
+  [key: string]: any;
+}
+
+export interface Entry {
+  name: string;
+  type: string;
+  resource: {
+    name?: string;
+    displayName?: string;
+    description?: string;
+    labels?: Record<string, string>;
+    location?: string;
+    parent?: string;
+    ancestors?: {
+      name: string;
+      type: string;
+    }[];
+    createTime?: string;
+    updateTime?: string;
+  };
+  aspects?: Record<string, Aspect>;
+  links?: Record<string, EntryLink[]>;
+}
+
+export interface EntryLink {
+  target: string;
+  id?: string;
+  aspects?: Record<string, Aspect>;
+}

--- a/agents/mdcode/src/libts/resourcealias.ts
+++ b/agents/mdcode/src/libts/resourcealias.ts
@@ -1,0 +1,110 @@
+export enum ResourceType {
+  ASPECT = 'aspect',
+  GLOSSARY = 'glossary',
+  ENTRYLINK = 'entryLink',
+}
+
+// Provides 1:1 mapping between alias and resource.
+export class ResourceAlias {
+  readonly _defaultAlias: ReadonlyMap<string, string> = new Map([
+    ['bigquery-dataset', 'aspect: dataplex-types.global.bigquery-dataset'],
+    ['bigquery-table', 'aspect: dataplex-types.global.bigquery-table'],
+    ['schema', 'aspect: dataplex-types.global.schema'],
+    ['storage', 'aspect: dataplex-types.global.storage'],
+    ['overview', 'aspect: dataplex-types.global.overview'],
+    ['definition', 'entryLink: dataplex-types.global.definition'],
+    ['synonym', 'entryLink: dataplex-types.global.synonym'],
+    ['related', 'entryLink: dataplex-types.global.related'],
+    ['schema-join', 'entryLink: dataplex-types.global.schema-join'],
+  ]);
+  readonly _defaultResource: ReadonlyMap<string, string> = new Map([
+    ['aspect: dataplex-types.global.bigquery-dataset', 'bigquery-dataset'],
+    ['aspect: dataplex-types.global.bigquery-table', 'bigquery-table'],
+    ['aspect: dataplex-types.global.schema', 'schema'],
+    ['aspect: dataplex-types.global.storage', 'storage'],
+    ['aspect: dataplex-types.global.overview', 'overview'],
+    ['entryLink: dataplex-types.global.definition', 'definition'],
+    ['entryLink: dataplex-types.global.synonym', 'synonym'],
+    ['entryLink: dataplex-types.global.related', 'related'],
+    ['entryLink: dataplex-types.global.schema-join', 'schema-join'],
+  ]);
+
+  private customAlias: Map<string, string>;
+  private customResource: Map<string, string>;
+
+  constructor() {
+    this.customAlias = new Map();
+    this.customResource = new Map();
+  }
+
+  add(alias: string, resourceType: string, resource: string) {
+    if (this._defaultAlias.has(alias)) {
+      throw new Error(
+        `Cannot define predefined alias ${alias}, which is predefined for ${this._defaultAlias.get(alias)!}`,
+      );
+    }
+
+    if (this.customAlias.has(alias)) {
+      throw new Error(
+        `Duplicate alias defined: ${alias}, which has a definition for ${this.customAlias.get(alias)!}`,
+      );
+    }
+
+    if (!Object.values(ResourceType).includes(resourceType as ResourceType)) {
+      throw new Error(
+        `Unrecognized resource type ${resourceType}, supported types are [ ${Object.values(ResourceType).join(', ')} ]`,
+      );
+    }
+
+    const resourceTypeName = `${resourceType}: ${resource}`;
+
+    if (
+      this._defaultResource.has(resourceTypeName) ||
+      this.customResource.has(resourceTypeName)
+    ) {
+      const duplicate = this._defaultResource.has(resourceTypeName)
+        ? this._defaultResource.get(resourceTypeName)!
+        : this.customResource.get(resourceTypeName)!;
+      throw new Error(
+        `Cannot re-define resource ${resource}, which has an alias as ${duplicate}`,
+      );
+    }
+
+    this.customAlias.set(alias, resourceTypeName);
+    this.customResource.set(resourceTypeName, alias);
+  }
+
+  // Return the resource name, only when resourceType matches alias config.
+  lookupAlias(alias: string, resourceType: ResourceType): string {
+    if (
+      this._defaultAlias.has(alias) &&
+      this._defaultAlias.get(alias)!.startsWith(resourceType)
+    ) {
+      const resourceTypeName = this._defaultAlias.get(alias)!;
+      const [_, name] = resourceTypeName.split(':').map((part) => part.trim());
+      return name;
+    }
+    if (this.customAlias.has(alias)) {
+      const resourceTypeName = this.customAlias.get(alias)!;
+      const [_, name] = resourceTypeName.split(':').map((part) => part.trim());
+      return name;
+    }
+    // Couldn't find, return the original.
+    return alias;
+  }
+
+  // Return the alias.
+  lookupResource(resource: string, resourceType: ResourceType): string {
+    const resourceTypeName = `${resourceType}: ${resource}`;
+    if (this._defaultResource.has(resourceTypeName)) {
+      return this._defaultResource.get(resourceTypeName)!;
+    }
+
+    if (this.customResource.has(resourceTypeName)) {
+      return this.customResource.get(resourceTypeName)!;
+    }
+
+    // Couldn't find, return the original.
+    return resource;
+  }
+}

--- a/agents/mdcode/src/libts/snapshot.ts
+++ b/agents/mdcode/src/libts/snapshot.ts
@@ -1,0 +1,1012 @@
+// Implements a local catalog interface
+//
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import * as gcp from './gcp/context';
+import * as crm from './gcp/crm';
+import * as dataplex from './gcp/dataplex';
+import {CatalogLayout, createLayout} from './layout';
+import {CatalogManifest} from './manifest';
+import * as md from './metadata';
+import {ResourceAlias, ResourceType} from './resourcealias';
+
+export class CatalogSnapshot {
+  public readonly manifest: CatalogManifest;
+  public readonly basePath: string;
+
+  private readonly _entryTypes: Map<string, dataplex.EntryType> = new Map();
+  private readonly _aspectTypes: Map<string, dataplex.AspectType> = new Map();
+
+  private readonly _referenceEntryTypes: Map<string, dataplex.EntryType> =
+    new Map();
+  private readonly _referenceAspectTypes: Map<string, dataplex.AspectType> =
+    new Map();
+
+  private readonly _layout: CatalogLayout;
+
+  private constructor(basePath: string, manifest: CatalogManifest) {
+    this.basePath = basePath;
+    this.manifest = manifest;
+
+    const catalogPath = path.join(this.basePath, 'catalog');
+    this._layout = createLayout(manifest.source.layout, catalogPath, manifest);
+  }
+
+  static async fromPath(
+    basePath: string,
+    ctx: gcp.ApiContext,
+    isReference: boolean = false,
+  ): Promise<CatalogSnapshot> {
+    const manifestPath = path.join(basePath, 'catalog.yaml');
+    if (!fs.existsSync(manifestPath)) {
+      throw new Error(`Cannot find catalog manifest at '${manifestPath}'`);
+    }
+
+    const manifest = await CatalogManifest.load(manifestPath, ctx);
+    if (isReference && !manifest.referenceManifest) {
+      throw new Error(`Cannot find reference config in manifest`);
+    }
+
+    const snapshot = new CatalogSnapshot(basePath, manifest);
+
+    await snapshot._buildTypes(manifest, ctx);
+    await snapshot._buildReferenceTypes(manifest, ctx);
+    await snapshot._layout.init();
+    return snapshot;
+  }
+
+  get entryTypes(): Map<string, dataplex.EntryType> {
+    return this._entryTypes;
+  }
+
+  get aspectTypes(): Map<string, dataplex.AspectType> {
+    return this._aspectTypes;
+  }
+
+  get referenceEntryTypes(): Map<string, dataplex.EntryType> {
+    return this._referenceEntryTypes;
+  }
+
+  get referenceAspectTypes(): Map<string, dataplex.AspectType> {
+    return this._referenceAspectTypes;
+  }
+
+  // Retrieves the list of locally (pulled and/or created) managed entries
+  async listEntries(): Promise<string[]> {
+    return this._layout.listEntries();
+  }
+
+  // Retrieves the local copy of the entry using its local name
+  async lookupEntry(name: string): Promise<md.Entry> {
+    return await this._layout.loadEntry(name);
+  }
+
+  isModifiable(name: string): boolean {
+    const paths = this._layout.getEntryPaths(name);
+    return !!paths?.local;
+  }
+
+  // Updates the locally managed entry, referenced by its local name.
+  // The list of fields can either be "resource" to update the resource-level metadata
+  // (which is relevant in case of non-ingested entries) or an aspect identified by it
+  // key (project.location.type).
+  async updateEntry(entry: md.Entry, fields: string[]): Promise<void> {
+    const existingEntry = await this._layout.loadEntry(entry.name);
+
+    for (const f of fields) {
+      if (f == 'resource') {
+        if (!existingEntry.resource) {
+          existingEntry.resource = {};
+        }
+        if (!entry.resource) {
+          entry.resource = {};
+        }
+        existingEntry.resource.description = entry.resource.description;
+      } else {
+        const aspectType = dataplex._typeRefToName(f, 'aspect');
+        if (!this._aspectTypes.has(aspectType)) {
+          throw new Error(
+            `The aspect '${f}' is not registered in the snapshot.`,
+          );
+        }
+
+        if (this.manifest.source.ingestedEntries) {
+          const entryType = this._entryTypes.get(existingEntry.type);
+          if (
+            !entryType ||
+            entryType.requiredAspects?.find((a) => a.type == aspectType)
+          ) {
+            throw new Error(
+              `The aspect '${f}' is not modifiable on the entry.`,
+            );
+          }
+        }
+
+        if (!existingEntry.aspects) {
+          existingEntry.aspects = {};
+        }
+        if (entry.aspects && entry.aspects[f]) {
+          existingEntry.aspects[f] = entry.aspects[f];
+        } else {
+          delete existingEntry.aspects[f];
+        }
+      }
+    }
+
+    await this._layout.saveEntry(entry.name, existingEntry);
+  }
+
+  // Creates an entry within the locally catalog snapshot. This capabilitiy is only supported
+  // when the associated EntryGroup is user-managed, i.e. not contain ingested metadata.
+  async createEntry(name: string, entry: md.Entry): Promise<void> {
+    if (this.manifest.source.ingestedEntries) {
+      throw new Error(`Entry cannot be created as entries are ingested.`);
+    }
+
+    // TODO: Validate aspect and other things
+
+    if (this._layout.entryExists(name)) {
+      throw new Error(`Entry '${name}' already exists`);
+    }
+
+    await this._layout.saveEntry(name, entry);
+  }
+
+  // Deletes an entry within the locally catalog snapshot. This capabilitiy is only supported
+  // when the associated EntryGroup is user-managed, i.e. not contain ingested metadata.
+  async deleteEntry(name: string): Promise<void> {
+    if (this.manifest.source.ingestedEntries) {
+      throw new Error(`Entry cannot be deleted as entries are ingested.`);
+    }
+
+    await this._layout.deleteEntry(name);
+  }
+
+  // Build the map of types supported within the locally managed catalog snapshot
+  // Types are stored using two keys: the resource name and the 3-part type name.
+  private async _buildTypes(
+    manifest: CatalogManifest,
+    ctx: gcp.ApiContext,
+  ): Promise<void> {
+    const catalog = new dataplex.CatalogClient(ctx);
+
+    for (const entryType of manifest.snapshotConfig?.entries || []) {
+      const parts = entryType.split('.');
+      const res = await catalog.getEntryType(parts[0], parts[1], parts[2]);
+      if (!res.result) {
+        if (res.status === 403) {
+          console.warn(
+            `Warning: Permission denied loading type information for entry type ${entryType}. Proceeding...`,
+          );
+          const placeholderType: dataplex.EntryType = {
+            name: `projects/${parts[0]}/locations/${parts[1]}/entryTypes/${parts[2]}`,
+            requiredAspects: [],
+          };
+          this._entryTypes.set(placeholderType.name, placeholderType);
+          this._entryTypes.set(entryType, placeholderType);
+          continue;
+        }
+        throw new Error(
+          `Unable to load type information for entry type ${entryType}`,
+        );
+      }
+
+      this._entryTypes.set(res.result.name, res.result);
+      this._entryTypes.set(entryType, res.result);
+
+      for (const requiredAspect of res.result.requiredAspects ?? []) {
+        if (!this._aspectTypes.has(requiredAspect.type)) {
+          const parts = requiredAspect.type.split('/');
+          const res = await catalog.getAspectType(parts[1], parts[3], parts[5]);
+          if (!res.result) {
+            if (res.status === 403) {
+              console.warn(
+                `Warning: Permission denied loading type information for required aspect type ${requiredAspect.type}. Proceeding...`,
+              );
+              const placeholderAspect: dataplex.AspectType = {
+                name: requiredAspect.type,
+              };
+              this._aspectTypes.set(placeholderAspect.name, placeholderAspect);
+              this._aspectTypes.set(
+                `${parts[0]}.${parts[3]}.${parts[5]}`,
+                placeholderAspect,
+              );
+              continue;
+            }
+            throw new Error(
+              `Unable to load type information for aspect type ${requiredAspect.type}`,
+            );
+          }
+          this._aspectTypes.set(res.result.name, res.result);
+          this._aspectTypes.set(
+            `${parts[0]}.${parts[3]}.${parts[5]}`,
+            res.result,
+          );
+        }
+      }
+    }
+
+    for (const aspectType of manifest.snapshotConfig?.aspects || []) {
+      const aspectTypeResourceName = manifest.aliasMap.lookupAlias(
+        aspectType,
+        ResourceType.ASPECT,
+      );
+      if (this._aspectTypes.has(aspectTypeResourceName)) {
+        continue;
+      }
+
+      const parts = aspectTypeResourceName.split('.');
+      const res = await catalog.getAspectType(parts[0], parts[1], parts[2]);
+      if (!res.result) {
+        if (res.status === 403) {
+          const placeholderAspect: dataplex.AspectType = {
+            name: `projects/${parts[0]}/locations/${parts[1]}/aspectTypes/${parts[2]}`,
+          };
+          this._aspectTypes.set(placeholderAspect.name, placeholderAspect);
+          this._aspectTypes.set(aspectType, placeholderAspect);
+          this._aspectTypes.set(aspectTypeResourceName, placeholderAspect);
+          continue;
+        }
+        throw new Error(
+          `Unable to load type information for aspect type ${aspectTypeResourceName}`,
+        );
+      }
+      this._aspectTypes.set(res.result.name, res.result);
+      this._aspectTypes.set(aspectTypeResourceName, res.result);
+    }
+  }
+
+  // Build the map of types supported within the locally managed catalog reference snapshot
+  // Types are stored using two keys: the resource name and the 3-part type name.
+  private async _buildReferenceTypes(
+    manifest: CatalogManifest,
+    ctx: gcp.ApiContext,
+  ): Promise<void> {
+    if (!manifest.referenceManifest) {
+      return;
+    }
+
+    const catalog = new dataplex.CatalogClient(ctx);
+
+    for (const entryType of manifest.referenceManifest!.snapshotConfig
+      ?.entries || []) {
+      const parts = entryType.split('.');
+      const res = await catalog.getEntryType(parts[0], parts[1], parts[2]);
+      if (!res.result) {
+        throw new Error(
+          `Unable to load type information for reference entry type ${entryType}`,
+        );
+      }
+
+      this._referenceEntryTypes.set(res.result.name, res.result);
+      this._referenceEntryTypes.set(entryType, res.result);
+
+      for (const requiredAspect of res.result.requiredAspects ?? []) {
+        if (!this._referenceAspectTypes.has(requiredAspect.type)) {
+          const parts = requiredAspect.type.split('/');
+          const res = await catalog.getAspectType(parts[1], parts[3], parts[5]);
+          if (!res.result) {
+            throw new Error(
+              `Unable to load type information for reference aspect type ${requiredAspect.type}`,
+            );
+          }
+          this._referenceAspectTypes.set(res.result.name, res.result);
+          this._referenceAspectTypes.set(
+            `${parts[0]}.${parts[3]}.${parts[5]}`,
+            res.result,
+          );
+        }
+      }
+    }
+
+    for (const aspectType of manifest.referenceManifest!.snapshotConfig
+      ?.aspects || []) {
+      const aspectTypeResourceName = manifest.aliasMap.lookupAlias(
+        aspectType,
+        ResourceType.ASPECT,
+      );
+      if (this._referenceAspectTypes.has(aspectTypeResourceName)) {
+        continue;
+      }
+
+      const parts = aspectTypeResourceName.split('.');
+      const res = await catalog.getAspectType(parts[0], parts[1], parts[2]);
+      if (!res.result) {
+        throw new Error(
+          `Unable to load type information for reference aspect type ${aspectTypeResourceName}`,
+        );
+      }
+      this._referenceAspectTypes.set(res.result.name, res.result);
+      this._referenceAspectTypes.set(aspectTypeResourceName, res.result);
+    }
+  }
+
+  // Stores a Dataplex resource into the locally managed catalog snapshot. This will internally map
+  // The service representation into the local metadata representation.
+  // This is only meant to be used within the syncing process (as part of pull operations).
+  async _storeResource(
+    resource: any,
+    isReference: boolean = false,
+    entryLinks?: dataplex.EntryLink[],
+  ): Promise<void> {
+    const source = isReference
+      ? this.manifest.referenceManifest!.source
+      : this.manifest.source;
+    const localName = source.localName(resource, isReference);
+    // When storing a reference entry, the internal name within the yaml file
+    // should not contain the .ref suffix, to allow merging with the modifiable
+    // entry.
+    const internalName = isReference
+      ? source.localName(resource, false)
+      : localName;
+
+    let localResource: md.Entry;
+    if (resource.entryType) {
+      localResource = await toLocalEntry(
+        resource,
+        internalName,
+        this.manifest.aliasMap,
+        entryLinks,
+        this.manifest,
+      );
+    } else if (resource.name.includes('/terms/')) {
+      localResource = toLocalGlossaryTerm(resource, internalName);
+    } else if (resource.name.includes('/categories/')) {
+      localResource = toLocalGlossaryCategory(resource, internalName);
+    } else {
+      localResource = toLocalGlossary(resource, internalName);
+    }
+
+    await this._layout.saveEntry(localName, localResource);
+  }
+
+  // Fetches a Dataplex resource from its local metadata representation.
+  // This is only meant to be used within the syncing process (as part of push operations).
+  async _fetchResource(name: string): Promise<any | undefined> {
+    const entry = await this._layout.loadEntry(name);
+
+    if (
+      entry.type === 'glossary' ||
+      entry.type === 'glossaryTerm' ||
+      entry.type === 'glossaryCategory'
+    ) {
+      const serviceName = this.manifest.source.serviceName(name);
+      if (entry.type === 'glossary') {
+        return toServiceGlossary(entry, serviceName);
+      } else if (entry.type === 'glossaryTerm') {
+        return toServiceGlossaryTerm(entry, serviceName);
+      } else {
+        return toServiceGlossaryCategory(entry, serviceName);
+      }
+    }
+
+    if (
+      this.manifest.publishingConfig?.entries?.length &&
+      !this.manifest.publishingConfig.entries.includes(entry.type)
+    ) {
+      return undefined;
+    }
+
+    const serviceName = this.manifest.source.serviceName(name);
+    return toServiceEntry(
+      entry,
+      serviceName,
+      this.manifest,
+      this._entryTypes,
+      this._aspectTypes,
+      this.manifest.aliasMap,
+    );
+  }
+
+  async _fetchEntryLinks(name: string): Promise<dataplex.EntryLink[]> {
+    const entry = await this._layout.loadEntry(name);
+    const serviceName = this.manifest.source.serviceName(name);
+    return await toServiceEntryLinks(entry, serviceName, this.manifest);
+  }
+}
+
+// Module-level caches for glossary display-name resolution. Keyed by the
+// fully-normalized (project ID) resource path so a single pull only fetches
+// each glossary / term once, no matter how many entries link to it.
+const _glossaryDisplayNameCache = new Map<string, string>();
+const _glossaryTermDisplayNameCache = new Map<string, string>();
+
+async function getGlossaryDisplayName(
+  catalog: dataplex.CatalogClient,
+  project: string,
+  location: string,
+  glossaryId: string,
+): Promise<string> {
+  const key = `${project}/${location}/${glossaryId}`;
+  const cached = _glossaryDisplayNameCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const res = await catalog.getGlossary(project, location, glossaryId);
+  const name = (res.status === 200 && res.result?.displayName) || glossaryId;
+  _glossaryDisplayNameCache.set(key, name);
+  return name;
+}
+
+async function getGlossaryTermDisplayName(
+  catalog: dataplex.CatalogClient,
+  project: string,
+  location: string,
+  glossaryId: string,
+  termId: string,
+): Promise<string> {
+  const key = `${project}/${location}/${glossaryId}/${termId}`;
+  const cached = _glossaryTermDisplayNameCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const res = await catalog.getGlossaryTerm(
+    project,
+    location,
+    glossaryId,
+    termId,
+  );
+  const name = (res.status === 200 && res.result?.displayName) || termId;
+  _glossaryTermDisplayNameCache.set(key, name);
+  return name;
+}
+
+// Converts a Dataplex entry into the local metadata representation.
+async function toLocalEntry(
+  entry: dataplex.Entry,
+  localName: string,
+  aliasMap: ResourceAlias,
+  entryLinks?: dataplex.EntryLink[],
+  manifest?: CatalogManifest,
+): Promise<md.Entry> {
+  const aspects: Record<string, md.Aspect> = {};
+  if (entry.aspects) {
+    for (const key in entry.aspects) {
+      const keyAlias = aliasMap.lookupResource(key, ResourceType.ASPECT);
+      aspects[keyAlias] = entry.aspects[key].data ?? {};
+    }
+  }
+
+  const links: Record<string, md.EntryLink[]> = {};
+  if (entryLinks) {
+    for (const link of entryLinks) {
+      const sourceRef =
+        link.entryReferences.find(
+          (ref) =>
+            ref.type === 'SOURCE' ||
+            !ref.type ||
+            ref.type === 'UNSPECIFIED' ||
+            ref.name === entry.name,
+        ) || link.entryReferences[0];
+
+      const targetRef =
+        link.entryReferences.find(
+          (ref) =>
+            ref !== sourceRef &&
+            (ref.type === 'TARGET' ||
+              !ref.type ||
+              ref.type === 'UNSPECIFIED' ||
+              ref.name !== entry.name),
+        ) || link.entryReferences[1];
+
+      if (sourceRef && targetRef) {
+        const unwrappedTargetName = dataplex.unwrapProxyEntry(targetRef.name);
+        // `_fixEntryLink` only normalizes the OUTER project segment; the inner
+        // nested `projects/<num>/...` (e.g. the glossary's host project) stays
+        // in Number form. Sources match against Project IDs (their scope is
+        // configured by ID), so normalize once more after unwrap or every
+        // `tryGetLocalName` call against a glossary target misses and we fall
+        // back to the raw API name in the YAML.
+        const normalizedTargetName = manifest
+          ? await crm.fixProject(unwrappedTargetName, manifest.context)
+          : unwrappedTargetName;
+        let targetLocalName = normalizedTargetName;
+        if (manifest) {
+          // Glossary terms get a human-readable target via display-name lookup:
+          // `<targetProject>.<targetLocation>.<glossaryDisplayName>.<termDisplayName>`.
+          // The full UID path is preserved in `localLink.id` (set below), so
+          // push round-trips exactly via `toServiceEntryLinks` (which prefers
+          // `link.id` when set). Display names are cached for the duration of
+          // the run so each glossary/term is only fetched once.
+          const glossaryTermMatch = normalizedTargetName.match(
+            /^projects\/([^/]+)\/locations\/([^/]+)\/glossaries\/([^/]+)\/terms\/([^/]+)$/,
+          );
+          if (glossaryTermMatch) {
+            const [, gProject, gLocation, gid, tid] = glossaryTermMatch;
+            const catalog = new dataplex.CatalogClient(manifest.context);
+            const gDisplay = await getGlossaryDisplayName(
+              catalog,
+              gProject,
+              gLocation,
+              gid,
+            );
+            const tDisplay = await getGlossaryTermDisplayName(
+              catalog,
+              gProject,
+              gLocation,
+              gid,
+              tid,
+            );
+            targetLocalName = `${gProject}.${gLocation}.${gDisplay}.${tDisplay}`;
+          } else {
+            const resolved =
+              manifest.source.tryGetLocalName(normalizedTargetName);
+            if (resolved) {
+              targetLocalName = resolved;
+            } else if (manifest.referenceManifest) {
+              const refResolved =
+                manifest.referenceManifest.source.tryGetLocalName(
+                  normalizedTargetName,
+                );
+              if (refResolved) {
+                targetLocalName = refResolved;
+              }
+            }
+          }
+        }
+
+        const linkTypeRef = dataplex._nameToTypeRef(link.entryLinkType);
+        const linkTypeAlias = aliasMap.lookupResource(
+          linkTypeRef,
+          ResourceType.ENTRYLINK,
+        );
+
+        const localLink: md.EntryLink = {
+          target: targetLocalName,
+          id: normalizedTargetName,
+          aspects: link.aspects
+            ? Object.fromEntries(
+                Object.entries(link.aspects).map(([k, v]) => [
+                  aliasMap.lookupResource(k, ResourceType.ASPECT),
+                  v.data ?? {},
+                ]),
+              )
+            : undefined,
+        };
+
+        if (sourceRef.path) {
+          const pathParts = sourceRef.path.split('.');
+          // Path head is case-insensitive: push writes `Schema.<field>` (capital
+          // S, required by the Dataplex API), but historical data and other
+          // writers may use `schema.<field>`. Accept both.
+          if (pathParts[0]?.toLowerCase() === 'schema' && pathParts[1]) {
+            const schemaAspect = aspects['schema'];
+            if (schemaAspect && Array.isArray(schemaAspect.fields)) {
+              const field = schemaAspect.fields.find(
+                (f: any) => f.name === pathParts[1],
+              );
+              if (field) {
+                if (!field.links) {
+                  field.links = {};
+                }
+                if (!field.links[linkTypeAlias]) {
+                  field.links[linkTypeAlias] = [];
+                }
+                field.links[linkTypeAlias].push(localLink);
+                continue;
+              }
+            }
+          }
+        }
+
+        if (!links[linkTypeAlias]) {
+          links[linkTypeAlias] = [];
+        }
+        links[linkTypeAlias].push(localLink);
+      }
+    }
+  }
+
+  const entrySource = entry.entrySource ?? {};
+
+  return {
+    name: localName,
+    type: dataplex._nameToTypeRef(entry.entryType),
+    resource: {
+      name: entrySource.resource ?? undefined,
+      displayName: entrySource.displayName ?? undefined,
+      description: entrySource.description ?? undefined,
+      labels: entrySource.labels ?? undefined,
+      location: entrySource.location ?? undefined,
+      ancestors: entrySource.ancestors ?? undefined,
+      createTime: entrySource.createTime ?? undefined,
+      updateTime: entrySource.updateTime ?? undefined,
+    },
+    aspects: aspects ?? undefined,
+    links: Object.keys(links).length ? links : undefined,
+  };
+}
+
+// Converts a Dataplex glossary into the local metadata representation.
+function toLocalGlossary(
+  glossary: dataplex.Glossary,
+  localName: string,
+): md.Entry {
+  return {
+    name: localName,
+    type: 'glossary',
+    resource: {
+      name: glossary.name,
+      displayName: glossary.displayName,
+      description: glossary.description,
+      labels: glossary.labels,
+      createTime: glossary.createTime,
+      updateTime: glossary.updateTime,
+    },
+  };
+}
+
+// Converts a Dataplex glossary term into the local metadata representation.
+function toLocalGlossaryTerm(
+  term: dataplex.GlossaryTerm,
+  localName: string,
+): md.Entry {
+  return {
+    name: localName,
+    type: 'glossaryTerm',
+    resource: {
+      name: term.name,
+      displayName: term.displayName,
+      description: term.description,
+      labels: term.labels,
+      parent: term.parent,
+      createTime: term.createTime,
+      updateTime: term.updateTime,
+    },
+  };
+}
+
+// Converts a Dataplex glossary category into the local metadata representation.
+function toLocalGlossaryCategory(
+  category: dataplex.GlossaryCategory,
+  localName: string,
+): md.Entry {
+  return {
+    name: localName,
+    type: 'glossaryCategory',
+    resource: {
+      name: category.name,
+      displayName: category.displayName,
+      description: category.description,
+      labels: category.labels,
+      parent: category.parent,
+      createTime: category.createTime,
+      updateTime: category.updateTime,
+    },
+  };
+}
+
+// Converts a local metadata representation into a Dataplex Entry
+function toServiceEntry(
+  entry: md.Entry,
+  serviceName: string,
+  manifest: CatalogManifest,
+  entryTypes: Map<string, dataplex.EntryType>,
+  aspectTypes: Map<string, dataplex.AspectType>,
+  aliasMap: ResourceAlias,
+): dataplex.Entry {
+  const entryType = entryTypes.get(entry.type);
+  if (!entryType) {
+    throw new Error(`Unknown entry type ${entry.type} in snapshot`);
+  }
+
+  const aspects: Record<string, dataplex.Aspect> = {};
+  if (entry.aspects) {
+    for (const key in entry.aspects) {
+      const keyResourceName = aliasMap.lookupAlias(key, ResourceType.ASPECT);
+      if (
+        manifest.publishingConfig &&
+        !manifest.publishingConfig.aspects?.includes(keyResourceName)
+      ) {
+        continue;
+      }
+
+      const aspectType = dataplex._typeRefToName(keyResourceName, 'aspect');
+      if (
+        manifest.source.ingestedEntries &&
+        entryType.requiredAspects?.find(
+          (aspectInfo) => aspectInfo.type == aspectType,
+        )
+      ) {
+        continue;
+      }
+
+      aspects[keyResourceName] = {aspectType, data: entry.aspects[key]};
+    }
+  }
+
+  const resource = entry.resource ?? {};
+  const entryTypeName = dataplex._typeRefToName(entry.type, 'entry');
+
+  if (
+    manifest.source.ingestedEntries ||
+    !entry.resource ||
+    !Object.keys(entry.resource).length
+  ) {
+    return {
+      name: serviceName,
+      entryType: entryTypeName,
+      aspects: aspects,
+    };
+  }
+
+  return {
+    name: serviceName,
+    entryType: entryTypeName,
+    parentEntry: resource.parent,
+    entrySource: {
+      resource: resource.name,
+      ancestors: resource.ancestors,
+      displayName: resource.displayName,
+      description: resource.description,
+      labels: resource.labels,
+      location: resource.location,
+      createTime: resource.createTime,
+      updateTime: resource.updateTime,
+    },
+    aspects: aspects,
+  };
+}
+async function toServiceEntryLinks(
+  entry: md.Entry,
+  serviceName: string,
+  manifest: CatalogManifest,
+): Promise<dataplex.EntryLink[]> {
+  const links: dataplex.EntryLink[] = [];
+  const ctx = manifest.context;
+
+  if (entry.links) {
+    for (const [linkTypeAlias, entryLinks] of Object.entries(entry.links)) {
+      const linkTypeRef = manifest.aliasMap.lookupAlias(
+        linkTypeAlias,
+        ResourceType.ENTRYLINK,
+      );
+      if (manifest.publishingConfig) {
+        const publishingLinks =
+          manifest.publishingConfig.entryLinks?.map((l) =>
+            manifest.aliasMap.lookupAlias(l, ResourceType.ENTRYLINK),
+          ) ?? [];
+        if (!publishingLinks.includes(linkTypeRef)) {
+          continue;
+        }
+      }
+
+      const entryLinkType = dataplex._typeRefToName(linkTypeRef, 'entryLink');
+      for (const link of entryLinks) {
+        let targetName = link.id ? link.id : link.target;
+        if (!targetName.startsWith('projects/')) {
+          // Try main source
+          try {
+            const mainResolved = manifest.source.serviceName(targetName);
+            // Heuristic: if it's a glossary term link in a BQ dataset, the BQ source
+            // will produce a very long /entries/biglake... string.
+            // Glossary terms usually don't have '/entries/' in their FQN.
+            if (
+              mainResolved.startsWith('projects/') &&
+              !mainResolved.includes('/entries/')
+            ) {
+              targetName = mainResolved;
+            } else if (manifest.referenceManifest) {
+              targetName =
+                manifest.referenceManifest.source.serviceName(targetName);
+            } else {
+              targetName = mainResolved;
+            }
+          } catch (e) {
+            if (manifest.referenceManifest) {
+              try {
+                targetName =
+                  manifest.referenceManifest.source.serviceName(targetName);
+              } catch (e2) {
+                // Keep as is
+              }
+            }
+          }
+        }
+
+        links.push({
+          name: '',
+          entryLinkType,
+          entryReferences: [
+            {
+              // BQ SOURCE: Outer is Number, Inner (if proxy) is ID.
+              // fixProjectToNumber already handles the outer.
+              // Main source serviceName produces the inner with ID.
+              name: await crm.fixProjectToNumber(serviceName, ctx),
+              type: 'SOURCE',
+            },
+            {
+              // Glossary TARGET: Both MUST be Number for proxy entries.
+              name: await crm.fixProjectToNumber(
+                dataplex.wrapAsProxyEntry(
+                  await crm.fixProjectToNumber(targetName, ctx),
+                ),
+                ctx,
+              ),
+              type: 'TARGET',
+            },
+          ],
+
+          aspects: link.aspects
+            ? Object.fromEntries(
+                Object.entries(link.aspects).map(([k, v]) => {
+                  const aspectTypeRef = manifest.aliasMap.lookupAlias(
+                    k,
+                    ResourceType.ASPECT,
+                  );
+                  const aspectType = dataplex._typeRefToName(
+                    aspectTypeRef,
+                    'aspect',
+                  );
+                  return [aspectTypeRef, {aspectType, data: v}];
+                }),
+              )
+            : undefined,
+        });
+      }
+    }
+  }
+
+  const schemaAlias = manifest.aliasMap.lookupResource(
+    'dataplex-types.global.schema',
+    ResourceType.ASPECT,
+  );
+  const schemaAspect = entry.aspects?.[schemaAlias];
+  if (schemaAspect && Array.isArray(schemaAspect.fields)) {
+    for (const field of schemaAspect.fields) {
+      if (field.links) {
+        for (const [linkTypeAlias, entryLinks] of Object.entries(
+          field.links as Record<string, md.EntryLink[]>,
+        )) {
+          const linkTypeRef = manifest.aliasMap.lookupAlias(
+            linkTypeAlias,
+            ResourceType.ENTRYLINK,
+          );
+          if (manifest.publishingConfig) {
+            const publishingLinks =
+              manifest.publishingConfig.entryLinks?.map((l) =>
+                manifest.aliasMap.lookupAlias(l, ResourceType.ENTRYLINK),
+              ) ?? [];
+            if (!publishingLinks.includes(linkTypeRef)) {
+              continue;
+            }
+          }
+
+          const entryLinkType = dataplex._typeRefToName(
+            linkTypeRef,
+            'entryLink',
+          );
+          for (const link of entryLinks) {
+            let targetName = link.id ? link.id : link.target;
+            if (!targetName.startsWith('projects/')) {
+              // Try main source
+              try {
+                const mainResolved = manifest.source.serviceName(targetName);
+                if (
+                  mainResolved.startsWith('projects/') &&
+                  !mainResolved.includes('/entries/')
+                ) {
+                  targetName = mainResolved;
+                } else if (manifest.referenceManifest) {
+                  targetName =
+                    manifest.referenceManifest.source.serviceName(targetName);
+                } else {
+                  targetName = mainResolved;
+                }
+              } catch (e) {
+                if (manifest.referenceManifest) {
+                  try {
+                    targetName =
+                      manifest.referenceManifest.source.serviceName(targetName);
+                  } catch (e2) {
+                    // Keep as is
+                  }
+                }
+              }
+            }
+
+            links.push({
+              name: '',
+              entryLinkType,
+              entryReferences: [
+                {
+                  // BQ SOURCE: Outer is Number, Inner (if proxy) is ID.
+                  name: await crm.fixProjectToNumber(serviceName, ctx),
+                  type: 'SOURCE',
+                  path: `Schema.${field.name}`,
+                },
+                {
+                  // Glossary TARGET: Both MUST be Number for proxy entries.
+                  name: await crm.fixProjectToNumber(
+                    dataplex.wrapAsProxyEntry(
+                      await crm.fixProjectToNumber(targetName, ctx),
+                    ),
+                    ctx,
+                  ),
+                  type: 'TARGET',
+                },
+              ],
+              aspects: link.aspects
+                ? Object.fromEntries(
+                    Object.entries(link.aspects).map(([k, v]) => {
+                      const aspectTypeRef = manifest.aliasMap.lookupAlias(
+                        k,
+                        ResourceType.ASPECT,
+                      );
+                      const aspectType = dataplex._typeRefToName(
+                        aspectTypeRef,
+                        'aspect',
+                      );
+                      return [aspectTypeRef, {aspectType, data: v}];
+                    }),
+                  )
+                : undefined,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return links;
+}
+
+// Converts a local metadata representation into a Dataplex Glossary
+function toServiceGlossary(
+  entry: md.Entry,
+  serviceName: string,
+): dataplex.Glossary {
+  const resource = entry.resource ?? {};
+  return {
+    name: resource.name || serviceName,
+    displayName: resource.displayName,
+    description: resource.description,
+    labels: resource.labels,
+    createTime: resource.createTime,
+    updateTime: resource.updateTime,
+  };
+}
+
+// Converts a local metadata representation into a Dataplex GlossaryTerm
+function toServiceGlossaryTerm(
+  entry: md.Entry,
+  serviceName: string,
+): dataplex.GlossaryTerm {
+  const resource = entry.resource ?? {};
+  if (!resource.parent) {
+    throw new Error(`Glossary term ${entry.name} is missing parent glossary.`);
+  }
+  return {
+    name: resource.name || serviceName,
+    displayName: resource.displayName,
+    description: resource.description,
+    labels: resource.labels,
+    parent: resource.parent,
+    createTime: resource.createTime,
+    updateTime: resource.updateTime,
+  };
+}
+
+// Converts a local metadata representation into a Dataplex GlossaryCategory
+function toServiceGlossaryCategory(
+  entry: md.Entry,
+  serviceName: string,
+): dataplex.GlossaryCategory {
+  const resource = entry.resource ?? {};
+  if (!resource.parent) {
+    throw new Error(
+      `Glossary category ${entry.name} is missing parent glossary.`,
+    );
+  }
+  return {
+    name: resource.name || serviceName,
+    displayName: resource.displayName,
+    description: resource.description,
+    labels: resource.labels,
+    parent: resource.parent,
+    createTime: resource.createTime,
+    updateTime: resource.updateTime,
+  };
+}

--- a/agents/mdcode/src/libts/source.ts
+++ b/agents/mdcode/src/libts/source.ts
@@ -1,0 +1,207 @@
+// Defines a Catalog metadata source abstraction
+//
+
+import * as gcp from './gcp';
+import * as bq from './gcp/bigquery';
+import * as dataplex from './gcp/dataplex';
+import {Layouts} from './layout';
+import {BigLakeNamespaceSource} from './sources/biglake-namespace';
+import {BigQueryDatasetSource} from './sources/bq-dataset';
+import {EntryGroupSource} from './sources/entrygroup';
+import {GlossarySource} from './sources/glossary';
+import {KnowledgeBaseSource} from './sources/kb';
+
+export enum Sources {
+  ENTRYGROUP = 'entryGroup',
+  BIGQUERY_DATASET = 'bq-dataset',
+  KB = 'kb',
+  BIGLAKE_NAMESPACE = 'biglake-namespace',
+  BIGLAKE_ICEBERG_NAMESPACE = 'biglake-iceberg-namespace',
+  GLOSSARY = 'glossary',
+}
+
+export interface CatalogSource {
+  readonly type: string;
+  readonly name: string;
+  readonly namespace: string;
+  readonly ingestedEntries: boolean;
+  readonly layout: Layouts;
+
+  entries(ctx: gcp.ApiContext): AsyncGenerator<any, void, unknown>;
+  localName(resource: any, isReference?: boolean): string;
+  serviceName(localName: string): string;
+  tryGetLocalName(serviceName: string): string | undefined;
+}
+
+async function getEntryGroup(
+  name: string,
+  ctx: gcp.ApiContext,
+): Promise<dataplex.EntryGroup> {
+  const [project, location, entryGroup] = name.split('.');
+  if (!project || !location || !entryGroup) {
+    throw new Error(
+      'EntryGroup must be in format <projectId>.<locationId>.<entryGroupId>',
+    );
+  }
+
+  const catalog = new gcp.CatalogClient(ctx);
+  const res = await catalog.getEntryGroup(project, location, entryGroup);
+  if (!res.result) {
+    console.log(
+      `[kcmd] ℹ️ EntryGroup '${name}' not found. It will be created during push if needed.`,
+    );
+    // Return a minimal EntryGroup object so the source can be initialized locally
+    return {
+      name: `projects/${project}/locations/${location}/entryGroups/${entryGroup}`,
+    };
+  }
+
+  return res.result;
+}
+
+async function resolveGlossaries(
+  name: string,
+  ctx: gcp.ApiContext,
+): Promise<dataplex.Glossary[]> {
+  const parts = name.split('.');
+  if (parts.length < 2) {
+    throw new Error(
+      'Glossary scope must be in format <projectId>.<locationId> or <projectId>.<locationId>.<glossaryIdOrDisplayName>',
+    );
+  }
+
+  const [project, location] = parts;
+  const searchTermsRaw = parts.slice(2).join('.');
+
+  // If no search terms, it's location mode
+  if (!searchTermsRaw) {
+    return [];
+  }
+
+  // Split by comma or newline
+  const searchTerms = searchTermsRaw
+    .split(/[,\n]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const catalog = new gcp.CatalogClient(ctx);
+  const resolved: dataplex.Glossary[] = [];
+
+  for (const term of searchTerms) {
+    // 1. Try to get by ID directly
+    const res = await catalog.getGlossary(project, location, term);
+    if (res.result) {
+      resolved.push(res.result);
+      continue;
+    }
+
+    // 2. Search by Display Name (exact match)
+    let foundByName = false;
+    for await (const glossary of catalog.listGlossaries(project, location)) {
+      if (glossary.displayName === term) {
+        resolved.push(glossary);
+        foundByName = true;
+      }
+    }
+
+    if (!foundByName) {
+      throw new Error(
+        `Glossary '${term}' not found in ${project}.${location} (tried ID and Display Name).`,
+      );
+    }
+  }
+
+  return resolved;
+}
+
+async function getBigQueryDatasets(
+  name: string,
+  ctx: gcp.ApiContext,
+): Promise<Map<string, bq.Dataset>> {
+  const datasets = new Map<string, bq.Dataset>();
+  const names = name.split(',');
+
+  const bigQuery = new bq.BigQueryClient(ctx);
+  for (const n of names) {
+    const [project, dataset] = n.split('.');
+    if (!project || !dataset) {
+      throw new Error(
+        `BigQuery dataset must be in format <projectId>.<datasetId>: ${n}`,
+      );
+    }
+
+    const res = await bigQuery.getDataset(project, dataset);
+    if (!res.result) {
+      throw new Error(`Failed to locate BigQuery dataset '${n}'.`);
+    }
+
+    datasets.set(n, res.result);
+  }
+
+  return datasets;
+}
+
+async function getBigLakeNamespace(
+  name: string,
+  ctx: gcp.ApiContext,
+): Promise<{location: string}> {
+  const [project, catalog, namespace] = name.split('.');
+  if (!project || !catalog || !namespace) {
+    throw new Error(
+      `BigLake namespace must be in format <projectId>.<catalogId>.<namespaceId>: ${name}`,
+    );
+  }
+
+  const bigQuery = new bq.BigQueryClient(ctx);
+  const res = await bigQuery.getDataset(project, `${catalog}.${namespace}`);
+  if (!res.result) {
+    throw new Error(
+      `Failed to locate BigLake namespace '${name}'. Ensure it physically exists.`,
+    );
+  }
+
+  return {location: res.result.location || ctx.location};
+}
+
+export async function createSource(
+  type: string,
+  name: string,
+  ctx: gcp.ApiContext,
+): Promise<CatalogSource> {
+  switch (type) {
+    case Sources.ENTRYGROUP:
+      const entryGroup = await getEntryGroup(name, ctx);
+      return new EntryGroupSource(Sources.ENTRYGROUP, name, entryGroup);
+    case Sources.BIGQUERY_DATASET:
+      const datasets = await getBigQueryDatasets(name, ctx);
+      return new BigQueryDatasetSource(
+        Sources.BIGQUERY_DATASET,
+        name,
+        datasets,
+      );
+    case Sources.KB:
+      const knowledgeBase = await getEntryGroup(name, ctx);
+      return new KnowledgeBaseSource(Sources.KB, name, knowledgeBase);
+    case Sources.BIGLAKE_NAMESPACE:
+      const nsInfo = await getBigLakeNamespace(name, ctx);
+      return new BigLakeNamespaceSource(
+        Sources.BIGLAKE_NAMESPACE,
+        name,
+        nsInfo.location,
+        'iceberg',
+      );
+    case Sources.BIGLAKE_ICEBERG_NAMESPACE:
+      const icebergNsInfo = await getBigLakeNamespace(name, ctx);
+      return new BigLakeNamespaceSource(
+        Sources.BIGLAKE_ICEBERG_NAMESPACE,
+        name,
+        icebergNsInfo.location,
+        'iceberg',
+      );
+    case Sources.GLOSSARY:
+      const glossaries = await resolveGlossaries(name, ctx);
+      return new GlossarySource(Sources.GLOSSARY, name, glossaries);
+    default:
+      throw new Error(`Unknown source type: ${type}`);
+  }
+}

--- a/agents/mdcode/src/libts/sources/biglake-namespace.ts
+++ b/agents/mdcode/src/libts/sources/biglake-namespace.ts
@@ -1,0 +1,96 @@
+// BigLake Metastore Namespace as Metadata Source
+//
+
+import * as gcp from '../gcp';
+import {Layouts} from '../layout';
+import {CatalogSource} from '../source';
+
+export class BigLakeNamespaceSource implements CatalogSource {
+  readonly type: string;
+  readonly name: string;
+  readonly namespace: string = 'biglake';
+  readonly ingestedEntries = true;
+  readonly layout = Layouts.STANDARD;
+
+  private readonly _project: string;
+  private readonly _location: string;
+  readonly _catalogId: string;
+  private readonly _namespaceId: string;
+  private readonly _catalogType: 'iceberg';
+
+  constructor(
+    type: string,
+    name: string,
+    location: string,
+    catalogType: 'iceberg',
+  ) {
+    this.type = type;
+    this.name = name;
+    this._catalogType = catalogType;
+
+    const parts = name.split('.');
+    if (parts.length !== 3) {
+      throw new Error(
+        'BigLake namespace must be in format <projectId>.<catalogId>.<namespaceId>',
+      );
+    }
+    this._project = parts[0];
+    this._location = location.toLowerCase();
+    this._catalogId = parts[1];
+    this._namespaceId = parts[2];
+  }
+
+  async *entries(
+    ctx: gcp.ApiContext,
+  ): AsyncGenerator<gcp.Entry, void, unknown> {
+    const bigLake = new gcp.BigLakeClient(ctx, this._catalogType);
+    const catalog = new gcp.CatalogClient(ctx);
+
+    for await (const table of bigLake.listTables(
+      this._project,
+      this._location,
+      this._catalogId,
+      this._namespaceId,
+    )) {
+      const tableId = table.name.substring(table.name.lastIndexOf('/') + 1);
+      const tableEntryName = `projects/${this._project}/locations/${this._location}/entryGroups/@biglake/entries/biglake.googleapis.com/projects/${this._project}/catalogs/${this._catalogId}/namespaces/${this._namespaceId}/tables/${tableId}`;
+
+      const tableEntryResult = await catalog.lookupEntry(
+        this._project,
+        this._location,
+        tableEntryName,
+      );
+      if (tableEntryResult.status === 200 && tableEntryResult.result) {
+        yield tableEntryResult.result;
+      }
+    }
+  }
+
+  localName(entry: gcp.Entry, isReference?: boolean): string {
+    const match = entry.name.match(/\/tables\/([^/]+)$/);
+    if (!match) {
+      throw new Error(`Invalid entry name for BigLake: ${entry.name}`);
+    }
+    const localPath = `${this.namespace}/${this._project}/${this._catalogId}/${this._namespaceId}/${match[1]}`;
+    return isReference ? `${localPath}.ref` : localPath;
+  }
+
+  serviceName(localName: string): string {
+    const cleanName = localName.endsWith('.ref')
+      ? localName.slice(0, -4)
+      : localName;
+    const parts = cleanName.split('/');
+    // parts[0] is namespace, parts[1] is project, parts[2] is catalog, parts[3] is namespaceId, parts[4] is tableId
+    const tableId = parts[4];
+    return `projects/${this._project}/locations/${this._location}/entryGroups/@biglake/entries/biglake.googleapis.com/projects/${this._project}/catalogs/${this._catalogId}/namespaces/${this._namespaceId}/tables/${tableId}`;
+  }
+
+  tryGetLocalName(serviceName: string): string | undefined {
+    const prefix = `projects/${this._project}/locations/${this._location}/entryGroups/@biglake/entries/biglake.googleapis.com/projects/${this._project}/catalogs/${this._catalogId}/namespaces/${this._namespaceId}/tables/`;
+    if (!serviceName.startsWith(prefix)) {
+      return undefined;
+    }
+    const tableId = serviceName.substring(prefix.length);
+    return `${this.namespace}/${this._project}/${this._catalogId}/${this._namespaceId}/${tableId}`;
+  }
+}

--- a/agents/mdcode/src/libts/sources/bq-dataset.ts
+++ b/agents/mdcode/src/libts/sources/bq-dataset.ts
@@ -1,0 +1,172 @@
+// BigQuery Dataset as Metadata Source
+//
+
+import * as gcp from '../gcp';
+import * as bq from '../gcp/bigquery';
+import {Layouts} from '../layout';
+import {CatalogSource} from '../source';
+
+export class BigQueryDatasetSource implements CatalogSource {
+  readonly type: string;
+  readonly name: string;
+  readonly namespace: string = 'bigquery';
+  readonly ingestedEntries = true;
+  readonly layout = Layouts.STANDARD;
+
+  private readonly _datasets: Map<string, bq.Dataset>;
+
+  constructor(type: string, name: string, datasets: Map<string, bq.Dataset>) {
+    this.type = type;
+    this.name = name;
+
+    this._datasets = datasets;
+  }
+
+  async *entries(
+    ctx: gcp.ApiContext,
+  ): AsyncGenerator<gcp.Entry, void, unknown> {
+    const bigQuery = new bq.BigQueryClient(ctx);
+    const catalog = new gcp.CatalogClient(ctx);
+
+    for (const [_, dsResource] of this._datasets.entries()) {
+      const project = dsResource.datasetReference.projectId;
+      const dataset = dsResource.datasetReference.datasetId;
+
+      // Fetch the dataset entry
+      const location = dsResource.location.toLowerCase();
+      const dsEntryId = `bigquery.googleapis.com/projects/${project}/datasets/${dataset}`;
+      const dsEntryName = `${gcp.catalogContainer(project, location, '@bigquery')}/entries/${dsEntryId}`;
+      const dsEntryResult = await catalog.lookupEntry(
+        project,
+        location,
+        dsEntryName,
+      );
+      if (!dsEntryResult.result) {
+        throw new Error(
+          `Failed to get Entry for dataset ${project}.${dataset}`,
+        );
+      }
+      yield dsEntryResult.result;
+
+      // Fetch the table entries
+      for await (const table of bigQuery.listTables(project, dataset)) {
+        const tableId = table.tableReference.tableId;
+        const tableEntryName = `${dsEntryName}/tables/${tableId}`;
+        const tableEntryResult = await catalog.lookupEntry(
+          project,
+          location,
+          tableEntryName,
+        );
+        if (!tableEntryResult.result) {
+          throw new Error(
+            `Failed to get Entry for table ${project}.${dataset}.${tableId}`,
+          );
+        }
+
+        yield tableEntryResult.result;
+      }
+    }
+
+    // TODO: Add support for routines, models
+  }
+
+  localName(entry: gcp.Entry, isReference?: boolean): string {
+    // The local catalog uses simplified path scheme:
+    // dataset -> bigquery/<project id>/<dataset id>
+    // table -> bigquery/<project id>/<dataset id>/<table id>
+    // routine -> bigquery/<project id>/<dataset id>/routines/<routine id>
+
+    let localPath = '';
+    let match = entry.name.match(
+      /\/projects\/([^/]+)\/datasets\/([^/]+)\/(tables|models|routines)\/(.+)$/,
+    );
+    if (match) {
+      const [, project, dataset, type, id] = match;
+      if (type === 'tables') {
+        localPath = `${this.namespace}/${project}/${dataset}/${id}`;
+      } else {
+        localPath = `${this.namespace}/${project}/${dataset}/${type}/${id}`;
+      }
+    } else {
+      match = entry.name.match(/\/projects\/([^/]+)\/datasets\/([^/]+)$/);
+      if (match) {
+        const [, project, dataset] = match;
+        localPath = `${this.namespace}/${project}/${dataset}`;
+      }
+    }
+
+    if (!localPath) {
+      throw new Error(`Invalid BigQuery entry: ${entry.name}`);
+    }
+
+    return isReference ? `${localPath}.ref` : localPath;
+  }
+
+  serviceName(localName: string): string {
+    const cleanName = localName.endsWith('.ref')
+      ? localName.slice(0, -4)
+      : localName;
+    const parts = cleanName.split('/');
+
+    // parts[0] is 'bigquery'
+    if (parts[0] !== this.namespace) {
+      throw new Error(`Invalid namespace in local name: ${localName}`);
+    }
+
+    const projectId = parts[1];
+    const datasetId = parts[2];
+
+    const dsKey = `${projectId}.${datasetId}`;
+    const dsResource = this._datasets.get(dsKey);
+    if (!dsResource) {
+      throw new Error(`Failed to find dataset for ${dsKey}`);
+    }
+
+    const project = dsResource.datasetReference.projectId;
+    const location = dsResource.location.toLowerCase();
+    const dataset = dsResource.datasetReference.datasetId;
+
+    const entryGroup = `${gcp.catalogContainer(project, location, '@bigquery')}`;
+    const entryName = `${entryGroup}/entries/bigquery.googleapis.com/projects/${project}/datasets/${dataset}`;
+
+    if (parts.length === 3) {
+      return entryName;
+    }
+
+    if (parts.length === 4) {
+      // Table: bigquery/project/dataset/tableId
+      return `${entryName}/tables/${parts[3]}`;
+    }
+
+    // Others: bigquery/project/dataset/type/id
+    return `${entryName}/${parts[3]}/${parts[4]}`;
+  }
+
+  tryGetLocalName(serviceName: string): string | undefined {
+    const match = serviceName.match(
+      /\/projects\/([^/]+)\/datasets\/([^/]+)(\/(tables|models|routines)\/(.+))?$/,
+    );
+    if (!match) {
+      return undefined;
+    }
+    const [, project, dataset, , type, id] = match;
+    const datasetKey = `${project}.${dataset}`;
+    if (!this._datasets.has(datasetKey)) {
+      return undefined;
+    }
+    const dsResource = this._datasets.get(datasetKey)!;
+    const location = dsResource.location.toLowerCase();
+    const prefix = `${gcp.catalogContainer(project, location, '@bigquery')}/entries/bigquery.googleapis.com/projects/${project}/datasets/${dataset}`;
+    if (!serviceName.startsWith(prefix)) {
+      return undefined;
+    }
+
+    if (type === 'tables') {
+      return `${this.namespace}/${project}/${dataset}/${id}`;
+    }
+    if (type) {
+      return `${this.namespace}/${project}/${dataset}/${type}/${id}`;
+    }
+    return `${this.namespace}/${project}/${dataset}`;
+  }
+}

--- a/agents/mdcode/src/libts/sources/entrygroup.ts
+++ b/agents/mdcode/src/libts/sources/entrygroup.ts
@@ -1,0 +1,79 @@
+// Dataplex EntryGroup as Metadata Source
+//
+
+import * as gcp from '../gcp';
+import * as dataplex from '../gcp/dataplex';
+import {Layouts} from '../layout';
+import {CatalogSource} from '../source';
+
+export class EntryGroupSource implements CatalogSource {
+  readonly type: string;
+  readonly name: string;
+  readonly namespace: string;
+  readonly ingestedEntries: boolean;
+  readonly layout = Layouts.STANDARD;
+
+  private readonly _name: string[];
+  private readonly _entryGroup: dataplex.EntryGroup;
+
+  constructor(type: string, name: string, entryGroup: dataplex.EntryGroup) {
+    this.type = type;
+    this.name = name;
+
+    this._name = name.split('.');
+    this._entryGroup = entryGroup;
+
+    this.namespace = this._name[2].startsWith('@')
+      ? this._name[2].substring(1)
+      : this._name[2];
+    this.ingestedEntries = this._name[2].startsWith('@');
+  }
+
+  async *entries(
+    ctx: gcp.ApiContext,
+  ): AsyncGenerator<gcp.Entry, void, unknown> {
+    // Enumerate all entries in the EntryGroup
+
+    const catalog = new gcp.CatalogClient(ctx);
+    for await (const entry of catalog.listEntries(
+      this._name[0],
+      this._name[1],
+      this._name[2],
+    )) {
+      yield entry;
+    }
+  }
+
+  localName(entry: gcp.Entry, isReference?: boolean): string {
+    // The local catalog uses the entry id as is, nested under namespace/project/location
+    const match = entry.name.match(/entryGroups\/([^/]+)\/entries\/(.+)$/);
+    if (!match) {
+      throw new Error(`Invalid entry name for entry: ${entry.name}`);
+    }
+
+    const entryId = match[2];
+    const localPath = `${this.namespace}/${this._name[0]}/${this._name[1]}/${entryId}`;
+    return isReference ? `${localPath}.ref` : localPath;
+  }
+
+  serviceName(localName: string): string {
+    const cleanName = localName.endsWith('.ref')
+      ? localName.slice(0, -4)
+      : localName;
+    const parts = cleanName.split('/');
+    // parts[0] is namespace, parts[1] is project, parts[2] is location, parts[3+] is entryId
+    // If the path is shorter (e.g. category/id), we assume the last part is the entryId
+    // and use the existing entry group name.
+    const entryId =
+      parts.length >= 4 ? parts.slice(3).join('/') : parts[parts.length - 1];
+    return `${this._entryGroup.name}/entries/${entryId}`;
+  }
+
+  tryGetLocalName(serviceName: string): string | undefined {
+    if (!serviceName.startsWith(this._entryGroup.name + '/entries/')) {
+      return undefined;
+    }
+    const entryId = serviceName.substring(this._entryGroup.name.length + 9);
+    return `${this.namespace}/${this._name[0]}/${this._name[1]}/${entryId}`;
+  }
+}

--- a/agents/mdcode/src/libts/sources/glossary.ts
+++ b/agents/mdcode/src/libts/sources/glossary.ts
@@ -1,0 +1,265 @@
+// Dataplex Business Glossary as Metadata Source
+//
+
+import * as gcp from '../gcp';
+import * as dataplex from '../gcp/dataplex';
+import {Layouts} from '../layout';
+import {CatalogSource} from '../source';
+
+export class GlossarySource implements CatalogSource {
+  readonly type: string;
+  readonly name: string;
+  readonly namespace: string;
+  readonly ingestedEntries = false;
+  readonly layout = Layouts.STANDARD;
+
+  private readonly _parts: string[];
+  private readonly _glossaries: dataplex.Glossary[];
+  private readonly _displayNames = new Map<string, string>();
+
+  constructor(
+    type: string,
+    name: string,
+    glossaries: dataplex.Glossary[] = [],
+  ) {
+    this.type = type;
+    this.name = name;
+
+    this._parts = name.split('.');
+    this._glossaries = glossaries;
+    for (const g of glossaries) {
+      this._displayNames.set(g.name, g.displayName || '');
+    }
+
+    this.namespace = 'glossaries';
+  }
+
+  async *entries(ctx: gcp.ApiContext): AsyncGenerator<any, void, unknown> {
+    const catalog = new gcp.CatalogClient(ctx);
+    const [project, location] = this._parts;
+
+    if (this._glossaries.length > 0) {
+      // Specific Glossaries mode
+      for (const glossary of this._glossaries) {
+        this._displayNames.set(glossary.name, glossary.displayName || '');
+        yield glossary;
+
+        const glossaryId = glossary.name.split('/').pop()!;
+
+        for await (const category of catalog.listGlossaryCategories(
+          project,
+          location,
+          glossaryId,
+        )) {
+          this._displayNames.set(category.name, category.displayName || '');
+          yield category;
+        }
+        for await (const term of catalog.listGlossaryTerms(
+          project,
+          location,
+          glossaryId,
+        )) {
+          yield term;
+        }
+      }
+    } else {
+      // Location mode: list all glossaries, their categories and terms
+      for await (const glossary of catalog.listGlossaries(project, location)) {
+        this._displayNames.set(glossary.name, glossary.displayName || '');
+        yield glossary;
+        const gId = glossary.name.split('/').pop()!;
+        for await (const category of catalog.listGlossaryCategories(
+          project,
+          location,
+          gId,
+        )) {
+          this._displayNames.set(category.name, category.displayName || '');
+          yield category;
+        }
+        for await (const term of catalog.listGlossaryTerms(
+          project,
+          location,
+          gId,
+        )) {
+          yield term;
+        }
+      }
+    }
+  }
+
+  localName(resource: any, isReference?: boolean): string {
+    const name = resource.name as string;
+    const displayName = resource.displayName as string;
+
+    let localPath = '';
+    if (name.includes('/terms/')) {
+      const match = name.match(/glossaries\/([^/]+)\/terms\/(.+)$/);
+      if (!match) {
+        throw new Error(`Invalid glossary term name for resource: ${name}`);
+      }
+      const glossaryId = match[1];
+      const termId = match[2];
+
+      const glossaryName = name.split('/terms/')[0];
+      const gDisplayName = this._displayNames.get(glossaryName);
+      const gFolderName = gDisplayName
+        ? `${gDisplayName} (${glossaryId})`
+        : glossaryId;
+
+      // Check if term belongs to a category
+      const categoryName = (resource as dataplex.GlossaryTerm).parent;
+      if (categoryName && categoryName.includes('/categories/')) {
+        const cMatch = categoryName.match(/\/categories\/(.+)$/);
+        const categoryId = cMatch ? cMatch[1] : categoryName;
+        const cDisplayName = this._displayNames.get(categoryName);
+        const cFolderName = cDisplayName
+          ? `${cDisplayName} (${categoryId})`
+          : categoryId;
+
+        localPath = `${this.namespace}/${gFolderName}/${cFolderName}/terms/${displayName || termId}`;
+      } else {
+        localPath = `${this.namespace}/${gFolderName}/terms/${displayName || termId}`;
+      }
+    } else if (name.includes('/categories/')) {
+      const match = name.match(/glossaries\/([^/]+)\/categories\/(.+)$/);
+      if (!match) {
+        throw new Error(`Invalid glossary category name for resource: ${name}`);
+      }
+      const glossaryId = match[1];
+      const categoryId = match[2];
+
+      const glossaryName = name.split('/categories/')[0];
+      const gDisplayName = this._displayNames.get(glossaryName);
+      const gFolderName = gDisplayName
+        ? `${gDisplayName} (${glossaryId})`
+        : glossaryId;
+
+      const cFolderName = displayName
+        ? `${displayName} (${categoryId})`
+        : categoryId;
+      const cFileName = displayName || categoryId;
+
+      localPath = `${this.namespace}/${gFolderName}/${cFolderName}/${cFileName}`;
+    } else {
+      const match = name.match(/glossaries\/([^/]+)$/);
+      if (!match) {
+        throw new Error(`Invalid glossary name for resource: ${name}`);
+      }
+      const glossaryId = match[1];
+      const gFolderName = displayName
+        ? `${displayName} (${glossaryId})`
+        : glossaryId;
+      const gFileName = displayName || glossaryId;
+      localPath = `${this.namespace}/${gFolderName}/${gFileName}`;
+    }
+
+    return isReference ? `${localPath}.ref` : localPath;
+  }
+
+  serviceName(localName: string): string {
+    const cleanName = localName.endsWith('.ref')
+      ? localName.slice(0, -4)
+      : localName;
+
+    const project = this._parts[0];
+    const location = this._parts[1];
+
+    if (cleanName.startsWith(`${this.namespace}/`)) {
+      const relativePath = cleanName.substring(this.namespace.length + 1);
+      const parts = relativePath.split('/');
+
+      // parts[0] is always "GlossaryName (ID)"
+      const gPathPart = parts[0];
+      const gMatch = gPathPart.match(/\(([^)]+)\)$/);
+      const glossaryId = gMatch ? gMatch[1] : gPathPart;
+
+      const termIndex = relativePath.indexOf('/terms/');
+      if (termIndex !== -1) {
+        // It's a glossary term.
+        const termId = relativePath.substring(termIndex + 7);
+        // Does it have a category folder? e.g. "G (id)/C (id)/terms/T" vs "G (id)/terms/T"
+        if (parts.length >= 4 && parts[parts.length - 2] === 'terms') {
+          const cPathPart = parts[1];
+          const cMatch = cPathPart.match(/\(([^)]+)\)$/);
+          const categoryId = cMatch ? cMatch[1] : cPathPart;
+          return `projects/${project}/locations/${location}/glossaries/${glossaryId}/terms/${termId}`;
+          // Note: In Dataplex, terms are addressed directly under glossary,
+          // but they reference their parent category in the resource.
+          // However, serviceName's job is to return the REST resource name.
+          // For terms, that is always glossaries/{gid}/terms/{tid}.
+        }
+        return `projects/${project}/locations/${location}/glossaries/${glossaryId}/terms/${termId}`;
+      } else {
+        // It's a glossary or a category
+        if (parts.length >= 3) {
+          // It's a category: G (id)/C (id)/C
+          const cPathPart = parts[1];
+          const cMatch = cPathPart.match(/\(([^)]+)\)$/);
+          const categoryId = cMatch ? cMatch[1] : cPathPart;
+          return `projects/${project}/locations/${location}/glossaries/${glossaryId}/categories/${categoryId}`;
+        }
+        // It's the glossary itself
+        return `projects/${project}/locations/${location}/glossaries/${glossaryId}`;
+      }
+    }
+
+    throw new Error(`Invalid local name for glossary source: ${localName}`);
+  }
+
+  tryGetLocalName(serviceName: string): string | undefined {
+    // This is a complex mapping due to display names.
+    // We try to match by the resource ID parts.
+    const project = this._parts[0];
+    const location = this._parts[1];
+
+    const termMatch = serviceName.match(
+      /\/glossaries\/([^/]+)\/terms\/([^/]+)$/,
+    );
+    if (termMatch) {
+      const glossaryId = termMatch[1];
+      const termId = termMatch[2];
+      const prefix = `projects/${project}/locations/${location}`;
+      if (!serviceName.startsWith(prefix)) {
+        return undefined;
+      }
+
+      const glossaryName = serviceName.split('/terms/')[0];
+      const gDisplayName = this._displayNames.get(glossaryName);
+      const gFolderName = gDisplayName
+        ? `${gDisplayName} (${glossaryId})`
+        : glossaryId;
+
+      // Note: We might not have the category info here without more context.
+      // For now, return a path without category or with raw ID.
+      return `${this.namespace}/${gFolderName}/terms/${termId}`;
+    }
+
+    const catMatch = serviceName.match(
+      /\/glossaries\/([^/]+)\/categories\/([^/]+)$/,
+    );
+    if (catMatch) {
+      const glossaryId = catMatch[1];
+      const categoryId = catMatch[2];
+      const glossaryName = serviceName.split('/categories/')[0];
+      const gDisplayName = this._displayNames.get(glossaryName);
+      const gFolderName = gDisplayName
+        ? `${gDisplayName} (${glossaryId})`
+        : glossaryId;
+
+      return `${this.namespace}/${gFolderName}/${categoryId}/${categoryId}`;
+    }
+
+    const glossaryMatch = serviceName.match(/\/glossaries\/([^/]+)$/);
+    if (glossaryMatch) {
+      const glossaryId = glossaryMatch[1];
+      const gDisplayName = this._displayNames.get(serviceName);
+      const gFolderName = gDisplayName
+        ? `${gDisplayName} (${glossaryId})`
+        : glossaryId;
+
+      return `${this.namespace}/${gFolderName}/${glossaryId}`;
+    }
+
+    return undefined;
+  }
+}

--- a/agents/mdcode/src/libts/sources/kb.ts
+++ b/agents/mdcode/src/libts/sources/kb.ts
@@ -1,0 +1,75 @@
+// Dataplex Wiki managed as an EntryGroup as Metadata Source
+//
+
+import * as gcp from '../gcp';
+import * as dataplex from '../gcp/dataplex';
+import {Layouts} from '../layout';
+import {CatalogSource} from '../source';
+
+export class KnowledgeBaseSource implements CatalogSource {
+  readonly type: string;
+  readonly name: string;
+  readonly namespace: string;
+  readonly ingestedEntries = false;
+  readonly layout = Layouts.DOCUMENTS;
+
+  private readonly _name: string[];
+  private readonly _entryGroup: dataplex.EntryGroup;
+
+  constructor(type: string, name: string, entryGroup: dataplex.EntryGroup) {
+    this.type = type;
+    this.name = name;
+
+    this._name = name.split('.');
+    this._entryGroup = entryGroup;
+
+    this.namespace = this._name[2].startsWith('@')
+      ? this._name[2].substring(1)
+      : this._name[2];
+  }
+
+  async *entries(
+    ctx: gcp.ApiContext,
+  ): AsyncGenerator<gcp.Entry, void, unknown> {
+    // Enumerate all entries in the EntryGroup
+
+    const catalog = new gcp.CatalogClient(ctx);
+    for await (const entry of catalog.listEntries(
+      this._name[0],
+      this._name[1],
+      this._name[2],
+    )) {
+      yield entry;
+    }
+  }
+
+  localName(entry: gcp.Entry, isReference?: boolean): string {
+    // The local catalog uses the entry id as is, nested under kb/project/location
+    const match = entry.name.match(/entryGroups\/([^/]+)\/entries\/(.+)$/);
+    if (!match) {
+      throw new Error(`Invalid entry name for entry: ${entry.name}`);
+    }
+
+    const entryId = match[2];
+    const localPath = `${this.namespace}/${this._name[0]}/${this._name[1]}/${entryId}`;
+    return isReference ? `${localPath}.ref` : localPath;
+  }
+
+  serviceName(localName: string): string {
+    const cleanName = localName.endsWith('.ref')
+      ? localName.slice(0, -4)
+      : localName;
+    const parts = cleanName.split('/');
+    // parts[0] is namespace, parts[1] is project, parts[2] is location, parts[3+] is entryId
+    const entryId = parts.slice(3).join('/');
+    return `${this._entryGroup.name}/entries/${entryId}`;
+  }
+
+  tryGetLocalName(serviceName: string): string | undefined {
+    if (!serviceName.startsWith(this._entryGroup.name + '/entries/')) {
+      return undefined;
+    }
+    const entryId = serviceName.substring(this._entryGroup.name.length + 9);
+    return `${this.namespace}/${this._name[0]}/${this._name[1]}/${entryId}`;
+  }
+}

--- a/agents/mdcode/src/libts/sync.ts
+++ b/agents/mdcode/src/libts/sync.ts
@@ -1,0 +1,640 @@
+// Implements catalog sync logic for pull and push operations
+//
+
+import * as gcp from './gcp';
+import * as crm from './gcp/crm';
+import {ResourceType} from './resourcealias';
+import {CatalogSnapshot} from './snapshot';
+
+// Glossary, GlossaryCategory, and GlossaryTerm are Dataplex *control-plane*
+// resources, not catalog metadata. By policy `kcmd push` never creates them —
+// the user must provision the glossary hierarchy in the Dataplex console or
+// via `gcloud` first, and only then push catalog metadata that references it.
+// Modifying descriptions/labels on EXISTING glossary resources is still
+// allowed (handled by `updateGlossary*` further below).
+const GLOSSARY_NO_CREATE_NOTICE =
+  'kcmd does not create glossary resources. Glossary, GlossaryCategory, and ' +
+  'GlossaryTerm are Dataplex control-plane resources that must be created by ' +
+  'the user (Dataplex console or `gcloud`) before pushing. See README for ' +
+  'rationale.';
+
+export interface SyncResult {
+  success: boolean;
+  details?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+}
+
+export interface StatusResult {
+  modified: boolean;
+}
+
+export class CatalogSync {
+  private _catalog: gcp.CatalogClient;
+  private _snapshot: CatalogSnapshot;
+  private _verifiedEntryGroups: Set<string> = new Set();
+  private _verifiedGlossaries: Set<string> = new Set();
+  private _verifiedCategories: Set<string> = new Set();
+
+  constructor(catalog: gcp.CatalogClient, snapshot: CatalogSnapshot) {
+    this._catalog = catalog;
+    this._snapshot = snapshot;
+  }
+
+  // Lists metadata in the Catalog service to create or update the local snapshot.
+  async pull(options?: {dryRun?: boolean}): Promise<SyncResult> {
+    try {
+      const resources = this._snapshot.manifest.source.entries(
+        this._catalog.context,
+      );
+
+      const snapshotLinks = this._snapshot.manifest.snapshotConfig?.entryLinks;
+      const hasSnapshotLinks = snapshotLinks && snapshotLinks.length > 0;
+
+      const entryLinkTypes = snapshotLinks?.map((linkTypeAlias) => {
+        const linkTypeRef = this._snapshot.manifest.aliasMap.lookupAlias(
+          linkTypeAlias,
+          ResourceType.ENTRYLINK,
+        );
+        return gcp._typeRefToName(linkTypeRef, 'entryLink');
+      });
+
+      for await (const resource of resources) {
+        let fullResource = resource;
+        let entryLinks: gcp.EntryLink[] = [];
+
+        if (resource.entryType) {
+          if (
+            this._snapshot.entryTypes.size &&
+            !this._snapshot.entryTypes.has(resource.entryType)
+          ) {
+            continue;
+          }
+
+          // TODO: Need to populate type info if its a type we haven't seen.
+          // TODO: Handle local modification conflicts.
+          // TODO: Handle config changes or service deletions that require removing local entries.
+
+          const nameParts = resource.name.split('/');
+          const res = await this._catalog.lookupEntry(
+            nameParts[1],
+            nameParts[3],
+            resource.name,
+            [...this._snapshot.aspectTypes.keys()],
+          );
+          // The server will respond with 403 permission denied for both resource not exist or
+          // insufficient permission. We cannot tell if a resource not exist or user does not
+          // have the access. Thus using 200 for an ensured result.
+          if (res.status != 200 || !res.result) {
+            continue;
+          }
+          fullResource = res.result;
+
+          if (hasSnapshotLinks) {
+            const linksRes = await this._catalog.lookupEntryLinks(
+              nameParts[1],
+              nameParts[3],
+              resource.name,
+              entryLinkTypes,
+            );
+            if (linksRes.status === 200 && linksRes.result?.entryLinks) {
+              entryLinks = linksRes.result.entryLinks;
+            }
+          }
+        }
+
+        if (options?.dryRun) {
+          console.log(`[DRY-RUN] Pull Resource: ${resource.name}`);
+        } else {
+          await this._snapshot._storeResource(
+            fullResource,
+            false,
+            entryLinks.length ? entryLinks : undefined,
+          );
+        }
+      }
+      return {success: true};
+    } catch (e: any) {
+      return {success: false, details: e.message};
+    }
+  }
+
+  async reference(): Promise<SyncResult> {
+    try {
+      const resources =
+        this._snapshot.manifest!.referenceManifest!.source.entries(
+          this._catalog.context,
+        );
+
+      // Reference pull also fetches entry links when `reference.snapshot.entryLinks`
+      // is declared, so `.ref.yaml` files include the pre-enrichment link state.
+      // Without this, diffing live `.yaml` (post-enrichment) vs `.ref.yaml`
+      // (baseline) would surface every existing link as a fake addition.
+      const referenceSnapshotLinks =
+        this._snapshot.manifest!.referenceManifest!.snapshotConfig?.entryLinks;
+      const hasReferenceSnapshotLinks =
+        referenceSnapshotLinks && referenceSnapshotLinks.length > 0;
+      const referenceEntryLinkTypes = referenceSnapshotLinks?.map(
+        (linkTypeAlias) => {
+          const linkTypeRef = this._snapshot.manifest.aliasMap.lookupAlias(
+            linkTypeAlias,
+            ResourceType.ENTRYLINK,
+          );
+          return gcp._typeRefToName(linkTypeRef, 'entryLink');
+        },
+      );
+
+      for await (const resource of resources) {
+        let fullResource = resource;
+        let entryLinks: gcp.EntryLink[] = [];
+
+        if (resource.entryType) {
+          if (
+            this._snapshot.referenceEntryTypes.size &&
+            !this._snapshot.referenceEntryTypes.has(resource.entryType)
+          ) {
+            continue;
+          }
+
+          const nameParts = resource.name.split('/');
+          const res = await this._catalog.lookupEntry(
+            nameParts[1],
+            nameParts[3],
+            resource.name,
+            [...this._snapshot.referenceAspectTypes.keys()],
+          );
+          if (res.status != 200 || !res.result) {
+            continue;
+          }
+          fullResource = res.result;
+
+          if (hasReferenceSnapshotLinks) {
+            const linksRes = await this._catalog.lookupEntryLinks(
+              nameParts[1],
+              nameParts[3],
+              resource.name,
+              referenceEntryLinkTypes,
+            );
+            if (linksRes.status === 200 && linksRes.result?.entryLinks) {
+              entryLinks = linksRes.result.entryLinks;
+            }
+          }
+        }
+
+        await this._snapshot._storeResource(
+          fullResource,
+          true,
+          entryLinks.length ? entryLinks : undefined,
+        );
+      }
+      return {success: true};
+    } catch (e: any) {
+      return {success: false, details: e.message};
+    }
+  }
+
+  // Pushes local metadata to the Catalog service to publish/deploy it.
+  async push(options?: {
+    force?: boolean;
+    validateOnly?: boolean;
+    dryRun?: boolean;
+  }): Promise<SyncResult> {
+    const entries = await this._snapshot.listEntries();
+
+    const publishingLinks =
+      this._snapshot.manifest.publishingConfig?.entryLinks;
+    const entryLinkTypes = publishingLinks?.map((linkTypeAlias) => {
+      const linkTypeRef = this._snapshot.manifest.aliasMap.lookupAlias(
+        linkTypeAlias,
+        ResourceType.ENTRYLINK,
+      );
+      return gcp._typeRefToName(linkTypeRef, 'entryLink');
+    });
+
+    for (const name of entries) {
+      if (!this._snapshot.isModifiable(name)) {
+        continue;
+      }
+
+      const resource = await this._snapshot._fetchResource(name);
+      if (!resource) {
+        // If this was filtered out based on publishing config
+        continue;
+      }
+
+      // TODO: Track what has changed and do minimal update.
+      // TODO: Handle creates and deletes, as well as partial updates.
+      // TODO: Handle conflicts.
+
+      const nameParts = resource.name.split('/');
+      const project = nameParts[1];
+      const location = nameParts[3];
+
+      if (resource.entryType) {
+        // Handle Entry push
+        const entry = resource as gcp.Entry;
+        const exist = await this._catalog.lookupEntry(
+          project,
+          location,
+          entry.name,
+        );
+        if (exist.status != 200 || !exist.result) {
+          if (options?.dryRun) {
+            console.log(`[DRY-RUN] Create Entry ${entry.name}`);
+          } else {
+            console.log(
+              `entry ${name} does not exist, will try to create the entry.`,
+            );
+
+            const entryGroup = nameParts[5];
+            const entryId = nameParts.slice(7).join('/');
+
+            const groupKey = `${project}:${location}:${entryGroup}`;
+            if (!this._verifiedEntryGroups.has(groupKey)) {
+              const groupRes = await this._catalog.getEntryGroup(
+                project,
+                location,
+                entryGroup,
+              );
+              if (groupRes.status !== 200 || !groupRes.result) {
+                console.log(
+                  `Entry group ${entryGroup} does not exist, creating it...`,
+                );
+                const createGroupRes = await this._catalog.createEntryGroup(
+                  project,
+                  location,
+                  entryGroup,
+                );
+                if (createGroupRes.status !== 200 || !createGroupRes.result) {
+                  return {
+                    success: false,
+                    details: `Failed to create entry group ${entryGroup}: ${createGroupRes.message || createGroupRes.status}`,
+                  };
+                }
+              }
+              this._verifiedEntryGroups.add(groupKey);
+            }
+
+            const createEntryRes = await this._catalog.createEntry(
+              project,
+              location,
+              entryGroup,
+              entryId,
+              entry,
+            );
+            if (createEntryRes.status != 200 || !createEntryRes.result) {
+              console.error(
+                `Failed to push entry ${entry.name}: Failed to create new entry.`,
+              );
+              return {
+                success: false,
+                details: `Failed to create entry ${entry.name}: ${createEntryRes.message || createEntryRes.status}`,
+              };
+            }
+            console.log(`Successfully created and pushed entry ${entry.name}`);
+          }
+        } else {
+          const updateMask = [];
+          const aspectKeys = Object.keys(entry.aspects || {});
+          if (aspectKeys.length) {
+            updateMask.push('aspects');
+          }
+
+          if (!this._snapshot.manifest.source.ingestedEntries) {
+            if (entry.entrySource) {
+              updateMask.push('entry_source');
+            }
+          }
+
+          if (updateMask.length) {
+            if (options?.dryRun) {
+              console.log(
+                `[DRY-RUN] Modify Entry ${entry.name} (updateMask: ${updateMask.join(',')}, aspects: ${aspectKeys.join(',')})`,
+              );
+            } else {
+              const res = await this._catalog.modifyEntry(
+                project,
+                location,
+                entry,
+                updateMask,
+                aspectKeys,
+              );
+              if (res.status !== 200 || !res.result) {
+                return {
+                  success: false,
+                  details: `Failed to update entry ${name}: ${res.message || res.status}`,
+                };
+              }
+            }
+          }
+        }
+
+        // Update EntryLinks
+        const localLinks = await this._snapshot._fetchEntryLinks(name);
+        const existingLinksRes = await this._catalog.lookupEntryLinks(
+          project,
+          location,
+          entry.name,
+          entryLinkTypes,
+        );
+
+        if (existingLinksRes.status === 200 && existingLinksRes.result) {
+          const existingLinks = existingLinksRes.result.entryLinks || [];
+
+          // Normalize existing links in place so debug logs and downstream
+          // `delete`s see the same project-ID form as the rest of the system.
+          for (const existingLink of existingLinks) {
+            await gcp._fixEntryLink(existingLink, this._catalog.context);
+          }
+
+          // Build comparison keys via the Unwrap-and-Normalize strategy:
+          // `toServiceEntryLinks` emits TARGET as `projects/<num>/.../entries/projects/<num>/.../terms/...`
+          // while remote links come back with the outer segment as project ID
+          // (after `_fixEntryLink`) and the inner segment still in Number form
+          // — so a raw string compare always diverges and triggers a spurious
+          // DELETE+CREATE every push. Stripping the `@dataplex` proxy shell
+          // and normalizing the project segment to ID on both sides makes the
+          // two forms compare equal.
+          const ctx = this._catalog.context;
+          const existingByKey = new Map<string, gcp.EntryLink>();
+          for (const el of existingLinks) {
+            existingByKey.set(await this._entryLinkKey(el, ctx), el);
+          }
+          const localByKey = new Map<string, gcp.EntryLink>();
+          for (const ll of localLinks) {
+            localByKey.set(await this._entryLinkKey(ll, ctx), ll);
+          }
+
+          // Delete links that are no longer in local metadata.
+          for (const [key, existingLink] of existingByKey) {
+            const targetRef = existingLink.entryReferences.find(
+              (r) => r.type === 'TARGET',
+            )?.name;
+            const sourcePath = existingLink.entryReferences.find(
+              (r) => r.type === 'SOURCE',
+            )?.path;
+            if (localByKey.has(key)) {
+              console.log(
+                `[DEBUG] Existing link to ${targetRef} (path: ${sourcePath}) matches local metadata. Keeping.`,
+              );
+              continue;
+            }
+            console.log(
+              `[DEBUG] No local match found for existing link to ${targetRef} (path: ${sourcePath}). DELETING.`,
+            );
+            if (options?.dryRun) {
+              console.log(`[DRY-RUN] Delete EntryLink ${existingLink.name}`);
+            } else {
+              const linkNameParts = existingLink.name.split('/');
+              const entryGroup = linkNameParts[5];
+              const linkId = linkNameParts[7];
+              const res = await this._catalog.deleteEntryLink(
+                project,
+                location,
+                entryGroup,
+                linkId,
+              );
+              console.log(
+                `[DEBUG] DELETE EntryLink result: ${res.status} ${res.message || ''}`,
+              );
+            }
+          }
+
+          // Create links that don't exist remotely yet.
+          for (const [key, localLink] of localByKey) {
+            const targetRef = localLink.entryReferences.find(
+              (r) => r.type === 'TARGET',
+            )?.name;
+            const sourcePath = localLink.entryReferences.find(
+              (r) => r.type === 'SOURCE',
+            )?.path;
+            if (existingByKey.has(key)) {
+              // TODO: Support EntryLink updates if aspects differ.
+              continue;
+            }
+            console.log(
+              `[DEBUG] No existing match found for local link to ${targetRef} (path: ${sourcePath}). CREATING.`,
+            );
+            if (options?.dryRun) {
+              console.log(
+                `[DRY-RUN] Create EntryLink of type ${localLink.entryLinkType}`,
+              );
+            } else {
+              const linkNameParts = entry.name.split('/');
+              const entryGroup = linkNameParts[5];
+              const linkId =
+                'link-' + Math.random().toString(36).substring(2, 12);
+              const res = await this._catalog.createEntryLink(
+                project,
+                location,
+                entryGroup,
+                linkId,
+                localLink,
+              );
+              console.log(
+                `[DEBUG] CREATE EntryLink result: ${res.status} ${res.message || ''}`,
+              );
+              if (res.status !== 200) {
+                throw new Error(
+                  `Failed to create EntryLink: ${res.message || res.status}`,
+                );
+              }
+            }
+          }
+        }
+      } else if (resource.name.includes('/terms/')) {
+        // Handle GlossaryTerm push
+        const term = resource as gcp.GlossaryTerm;
+        const glossaryId = nameParts[5];
+        const termId = nameParts[7];
+
+        const glossaryKey = `${project}:${location}:${glossaryId}`;
+        if (!this._verifiedGlossaries.has(glossaryKey)) {
+          const glossaryRes = await this._catalog.getGlossary(
+            project,
+            location,
+            glossaryId,
+          );
+          if (glossaryRes.status !== 200 || !glossaryRes.result) {
+            return {
+              success: false,
+              details:
+                `Parent glossary '${glossaryId}' does not exist in ` +
+                `${project}/${location} (required by term ${name}). ` +
+                GLOSSARY_NO_CREATE_NOTICE,
+            };
+          }
+          this._verifiedGlossaries.add(glossaryKey);
+        }
+
+        // If the term has a category, ensure the category exists
+        if (term.parent && term.parent.includes('/categories/')) {
+          const catParts = term.parent.split('/');
+          const categoryId = catParts[7];
+          const categoryKey = `${project}:${location}:${glossaryId}:${categoryId}`;
+
+          if (!this._verifiedCategories.has(categoryKey)) {
+            const catRes = await this._catalog.getGlossaryCategory(
+              project,
+              location,
+              glossaryId,
+              categoryId,
+            );
+            if (catRes.status !== 200 || !catRes.result) {
+              return {
+                success: false,
+                details:
+                  `Parent category '${categoryId}' does not exist in ` +
+                  `glossary '${glossaryId}' (required by term ${name}). ` +
+                  GLOSSARY_NO_CREATE_NOTICE,
+              };
+            }
+            this._verifiedCategories.add(categoryKey);
+          }
+        }
+
+        const exist = await this._catalog.getGlossaryTerm(
+          project,
+          location,
+          glossaryId,
+          termId,
+        );
+        if (exist.status !== 200 || !exist.result) {
+          return {
+            success: false,
+            details:
+              `Glossary term '${name}' does not exist. ` +
+              GLOSSARY_NO_CREATE_NOTICE,
+          };
+        } else {
+          if (options?.dryRun) {
+            console.log(`[DRY-RUN] Update Glossary Term ${name}`);
+          } else {
+            const res = await this._catalog.updateGlossaryTerm(term);
+            if (res.status !== 200 || !res.result) {
+              return {
+                success: false,
+                details: `Failed to update glossary term ${name}: ${res.message || res.status}`,
+              };
+            }
+          }
+        }
+      } else if (resource.name.includes('/categories/')) {
+        // Handle GlossaryCategory push
+        const category = resource as gcp.GlossaryCategory;
+        const glossaryId = nameParts[5];
+        const categoryId = nameParts[7];
+
+        const glossaryKey = `${project}:${location}:${glossaryId}`;
+        if (!this._verifiedGlossaries.has(glossaryKey)) {
+          const glossaryRes = await this._catalog.getGlossary(
+            project,
+            location,
+            glossaryId,
+          );
+          if (glossaryRes.status !== 200 || !glossaryRes.result) {
+            return {
+              success: false,
+              details:
+                `Parent glossary '${glossaryId}' does not exist in ` +
+                `${project}/${location} (required by category ${name}). ` +
+                GLOSSARY_NO_CREATE_NOTICE,
+            };
+          }
+          this._verifiedGlossaries.add(glossaryKey);
+        }
+
+        const exist = await this._catalog.getGlossaryCategory(
+          project,
+          location,
+          glossaryId,
+          categoryId,
+        );
+        if (exist.status !== 200 || !exist.result) {
+          return {
+            success: false,
+            details:
+              `Glossary category '${name}' does not exist. ` +
+              GLOSSARY_NO_CREATE_NOTICE,
+          };
+        } else {
+          if (options?.dryRun) {
+            console.log(`[DRY-RUN] Update Glossary Category ${name}`);
+          } else {
+            const res = await this._catalog.updateGlossaryCategory(category);
+            if (res.status !== 200 || !res.result) {
+              return {
+                success: false,
+                details: `Failed to update glossary category ${name}: ${res.message || res.status}`,
+              };
+            }
+          }
+        }
+      } else {
+        // Handle Glossary push
+        const glossary = resource as gcp.Glossary;
+        const glossaryId = nameParts[5];
+
+        const exist = await this._catalog.getGlossary(
+          project,
+          location,
+          glossaryId,
+        );
+        if (exist.status !== 200 || !exist.result) {
+          return {
+            success: false,
+            details:
+              `Glossary '${name}' does not exist. ` + GLOSSARY_NO_CREATE_NOTICE,
+          };
+        } else {
+          if (options?.dryRun) {
+            console.log(`[DRY-RUN] Update Glossary ${name}`);
+          } else {
+            const res = await this._catalog.updateGlossary(glossary);
+            if (res.status !== 200 || !res.result) {
+              return {
+                success: false,
+                details: `Failed to update glossary ${name}: ${res.message || res.status}`,
+              };
+            }
+          }
+        }
+      }
+    }
+
+    return {success: true};
+  }
+
+  async validate(): Promise<ValidationResult> {
+    throw new Error('Not yet implemented');
+  }
+
+  async status(): Promise<StatusResult> {
+    throw new Error('Not yet implemented');
+  }
+
+  // Builds a comparison key for an EntryLink that's stable across the two
+  // forms we have to reconcile during push:
+  //   - existing remote links: `@dataplex` proxy wrapping intact, outer project
+  //     normalized to ID by `_fixEntryLink`, inner project still in Number form.
+  //   - local links from `toServiceEntryLinks`: both outer and inner project
+  //     in Number form.
+  // Unwrapping the proxy shell collapses the outer wrapper so both sides
+  // compare on the inner entry, and `crm.fixProject` canonicalizes any
+  // project segment to ID. Source path (e.g. `Schema.<field>`) round-trips
+  // verbatim and is included to keep field-level links distinct.
+  private async _entryLinkKey(
+    link: gcp.EntryLink,
+    ctx: gcp.ApiContext,
+  ): Promise<string> {
+    const target = link.entryReferences.find((r) => r.type === 'TARGET');
+    const source = link.entryReferences.find((r) => r.type === 'SOURCE');
+    const normalizedTarget = target
+      ? await crm.fixProject(gcp.unwrapProxyEntry(target.name), ctx)
+      : '';
+    const normalizedLinkType = await crm.fixProject(link.entryLinkType, ctx);
+    return `${normalizedLinkType}|${normalizedTarget}|${source?.path || ''}`;
+  }
+}

--- a/agents/mdcode/src/libts/tsconfig.json
+++ b/agents/mdcode/src/libts/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "outDir": "../../build/ts/kcmd",
+    "declaration": true,
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "**/*.test.ts"
+  ]
+}

--- a/agents/mdcode/src/tool/commands.ts
+++ b/agents/mdcode/src/tool/commands.ts
@@ -1,0 +1,142 @@
+// CLI command handlers
+//
+
+import * as fs from 'node:fs';
+
+import * as kcmd from '../libts';
+import * as context from '../libts/gcp/context';
+import * as dataplex from '../libts/gcp/dataplex';
+
+export interface InitOptions {
+  entryGroup?: string;
+  bigqueryDataset?: string | string[];
+  biglakeNamespace?: string;
+  iceberg?: boolean;
+  kb?: string;
+  glossary?: string;
+  pull?: boolean;
+}
+
+export interface PullOptions {
+  dryRun?: boolean;
+}
+
+export interface PushOptions {
+  force?: boolean;
+  validateOnly?: boolean;
+  dryRun?: boolean;
+}
+
+export async function init(options: InitOptions): Promise<number> {
+  const ctx = context.ApiContext.default();
+
+  let manifest: kcmd.CatalogManifest;
+  if (options.entryGroup) {
+    manifest = await kcmd.CatalogManifest.initWithEntryGroup(
+      options.entryGroup,
+      ctx,
+    );
+  } else if (options.kb) {
+    manifest = await kcmd.CatalogManifest.initWithKnowledgeBase(
+      options.kb,
+      ctx,
+    );
+  } else if (options.glossary) {
+    manifest = await kcmd.CatalogManifest.initWithGlossary(
+      options.glossary,
+      ctx,
+    );
+  } else if (options.bigqueryDataset) {
+    let datasets = '';
+    if (Array.isArray(options.bigqueryDataset)) {
+      datasets = options.bigqueryDataset.join(',');
+    } else {
+      datasets = options.bigqueryDataset!;
+    }
+    manifest = await kcmd.CatalogManifest.initWithBigQuery(datasets, ctx);
+  } else if (options.biglakeNamespace) {
+    if (!options.iceberg) {
+      console.error(
+        'Error: Must specify --iceberg when initializing a BigLake namespace (other metastores are not supported yet)',
+      );
+      return 1;
+    }
+    manifest = await kcmd.CatalogManifest.initWithBigLakeNamespace(
+      options.biglakeNamespace,
+      'iceberg',
+      ctx,
+    );
+  } else {
+    console.error(
+      'Error: Must provide either --entry-group, --bigquery-dataset, --biglake-namespace, --kb, or --glossary',
+    );
+    return 1;
+  }
+
+  manifest.save('catalog.yaml');
+  console.log(fs.readFileSync('catalog.yaml', 'utf8'));
+
+  if (options.pull) {
+    return await pull();
+  }
+
+  return 0;
+}
+
+export async function pull(options?: PullOptions): Promise<number> {
+  const ctx = context.ApiContext.default();
+  const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
+
+  const catalog = new dataplex.CatalogClient(ctx);
+  const sync = new kcmd.CatalogSync(catalog, snapshot);
+
+  console.log('Pulling catalog entries...');
+  const result = await sync.pull(options);
+
+  if (result.success) {
+    console.log('Successfully updated local snapshot.');
+    return 0;
+  } else {
+    console.error('Error pulling catalog entries:', result.details);
+    return 1;
+  }
+}
+
+export async function push(options: PushOptions): Promise<number> {
+  const ctx = context.ApiContext.default();
+  const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
+
+  const catalog = new dataplex.CatalogClient(ctx);
+  const sync = new kcmd.CatalogSync(catalog, snapshot);
+
+  console.log('Pushing catalog entries...');
+  const result = await sync.push(options);
+
+  if (result.success) {
+    console.log('Successfully pushed catalog entries.');
+    return 0;
+  } else {
+    console.error('Error pushing catalog entries:', result.details);
+    return 1;
+  }
+}
+
+export async function reference(): Promise<number> {
+  const ctx = context.ApiContext.default();
+
+  const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx, true);
+
+  const catalog = new dataplex.CatalogClient(ctx);
+  const sync = new kcmd.CatalogSync(catalog, snapshot);
+
+  console.log('Pulling reference entries...');
+  const result = await sync.reference();
+
+  if (result.success) {
+    console.log('Successfully updated local reference entries snapshot.');
+    return 0;
+  } else {
+    console.error('Error pulling reference entries:', result.details);
+    return 1;
+  }
+}

--- a/agents/mdcode/src/tool/main.ts
+++ b/agents/mdcode/src/tool/main.ts
@@ -1,0 +1,104 @@
+// Main CLI entrypoint
+//
+
+import * as cac from 'cac';
+import * as commands from './commands';
+import * as mcp from './mcp';
+
+const cli = cac.cac('kcmd').version('1.0.0').help();
+cli
+  .command('init', 'Initialize a new catalog snapshot')
+  .option(
+    '--entry-group <id>',
+    'Identifier of the EntryGroup (project.location.id)',
+  )
+  .option(
+    '--bigquery-dataset <id...>',
+    'Identifier of the BigQuery dataset(s) (project.datasetId)',
+  )
+  .option(
+    '--biglake-namespace <id>',
+    'Identifier of the BigLake namespace (project.catalog.namespace)',
+  )
+  .option(
+    '--iceberg',
+    'Specify that the BigLake namespace is an Iceberg catalog',
+  )
+  .option(
+    '--kb <id>',
+    'Identifier of the Knowledge Base EntryGroup (project.location.id)',
+  )
+  .option('--glossary <id>', 'Identifier of the Glossary (project.location.id)')
+  .option('--pull', 'Optionally pull catalog entries during initialization')
+  .action(async (options) => {
+    try {
+      await commands.init(options);
+    } catch (err: any) {
+      console.error('Error:', err.message || err);
+      process.exit(1);
+    }
+  });
+
+cli
+  .command('pull', 'Pull catalog entries')
+  .option('--dry-run', 'Perform a dry run without modifying local files')
+  .action(async (options) => {
+    let exitCode = 1;
+    try {
+      exitCode = await commands.pull(options);
+    } catch (err: any) {
+      console.error('Error:', err.message || err);
+      exitCode = 1;
+    }
+
+    process.exit(exitCode);
+  });
+
+cli
+  .command('push', 'Push catalog entries')
+  .option('--force', 'Force push changes')
+  .option('--validate-only', 'Only validate changes without applying')
+  .option('--dry-run', 'Perform a dry run without publishing to service')
+  .action(async (options) => {
+    let exitCode = 1;
+    try {
+      exitCode = await commands.push(options);
+    } catch (err: any) {
+      console.error('Error:', err.message || err);
+      exitCode = 1;
+    }
+
+    process.exit(exitCode);
+  });
+
+cli
+  .command('mcp', 'Run the Model Context Protocol (MCP) server')
+  .option('--path <path>', 'Path to the catalog snapshot root directory')
+  .action(async (options) => {
+    try {
+      await mcp.startServer(options.path);
+    } catch (err: any) {
+      console.error('Error starting MCP server:', err.message || err);
+      process.exit(1);
+    }
+  });
+
+cli.command('reference', 'Pull reference resource entries').action(async () => {
+  try {
+    await commands.reference();
+  } catch (err: any) {
+    console.error('Error:', err.message || err);
+    process.exit(1);
+  }
+});
+
+cli.parse();
+
+if (!cli.matchedCommand) {
+  if (cli.args.length > 0) {
+    console.error(`Error: Unknown command '${cli.args[0]}'`);
+  }
+
+  cli.outputHelp();
+  process.exit(1);
+}

--- a/agents/mdcode/src/tool/mcp.ts
+++ b/agents/mdcode/src/tool/mcp.ts
@@ -1,0 +1,108 @@
+// MCP Server implementation
+//
+
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
+import {z} from 'zod';
+
+import * as kcmd from '../libts';
+import * as gcp from '../libts/gcp';
+
+export async function startServer(basePath: string = '.') {
+  const server = new McpServer({
+    name: 'kcmd',
+    version: '1.0.0',
+  });
+
+  const ctx = gcp.ApiContext.default();
+  const snapshot = await kcmd.CatalogSnapshot.fromPath(basePath, ctx);
+
+  server.registerTool(
+    'list-entries',
+    {
+      description:
+        'List names of all catalog entries. ' +
+        'Each entry corresponds to a resource that has associated metadata.',
+    },
+    async () => {
+      const names = await snapshot.listEntries();
+      return {
+        content: [{type: 'text', text: JSON.stringify(names, null, 2)}],
+      };
+    },
+  );
+
+  server.registerTool(
+    'lookup-entry',
+    {
+      description: 'Lookup the metadata of a specific catalog entry by name',
+      inputSchema: {
+        name: z.string().describe('The name of the entry to lookup'),
+      },
+    },
+    async ({name}) => {
+      try {
+        const entry = await snapshot.lookupEntry(name);
+        return {
+          content: [{type: 'text', text: JSON.stringify(entry, null, 2)}],
+        };
+      } catch (error: any) {
+        return {
+          isError: true,
+          content: [
+            {type: 'text', text: `Error looking up entry: ${error.message}`},
+          ],
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    'modify-entry',
+    {
+      description:
+        'Modify (either "resource" or an aspect key field) of a catalog entry by name',
+      inputSchema: {
+        name: z.string().describe('The name of the entry to modify'),
+        field: z
+          .string()
+          .describe(
+            'The name of the field being updated. Either "resource" or an aspect key',
+          ),
+        updates: z
+          .record(z.string(), z.any())
+          .describe('A structured JSON data dictionary containing the updates'),
+      },
+    },
+    async ({name, field, updates}) => {
+      try {
+        const existingEntry = await snapshot.lookupEntry(name);
+        let updatedEntry: kcmd.Entry = {
+          name,
+          type: existingEntry.type,
+          resource: field === 'resource' ? updates : {},
+          aspects: field !== 'resource' ? {[field]: updates} : undefined,
+        };
+
+        await snapshot.updateEntry(updatedEntry, [field]);
+
+        updatedEntry = await snapshot.lookupEntry(name);
+        return {
+          content: [
+            {type: 'text', text: JSON.stringify(updatedEntry, null, 2)},
+          ],
+        };
+      } catch (error: any) {
+        return {
+          isError: true,
+          content: [
+            {type: 'text', text: `Error modifying entry: ${error.message}`},
+          ],
+        };
+      }
+    },
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/agents/mdcode/tests/libts/mocks.ts
+++ b/agents/mdcode/tests/libts/mocks.ts
@@ -1,0 +1,255 @@
+import * as gcp from '../../src/libts/gcp';
+import * as bigquery from '../../src/libts/gcp/bigquery';
+
+// Bypass actual gcloud CLI calls by using the explicit constructor
+export const TEST_API_CONTEXT = new gcp.ApiContext(
+  'test-project',
+  'test-location',
+  'test-token',
+);
+
+export class CatalogClientMock extends gcp.CatalogClient {
+  public mockEntries: gcp.Entry[] = [];
+  public mockEntryGroups: Map<string, gcp.EntryGroup> = new Map();
+  public mockEntryTypes: Map<string, gcp.EntryType> = new Map();
+  public mockAspectTypes: Map<string, gcp.AspectType> = new Map();
+
+  constructor() {
+    super(TEST_API_CONTEXT);
+  }
+
+  setMockEntries(entries: gcp.Entry[]) {
+    this.mockEntries = entries;
+  }
+
+  addMockEntryGroup(resource: gcp.EntryGroup) {
+    this.mockEntryGroups.set(resource.name, resource);
+  }
+
+  addMockEntryType(resource: gcp.EntryType) {
+    this.mockEntryTypes.set(resource.name, resource);
+  }
+
+  addMockAspectType(resource: gcp.AspectType) {
+    this.mockAspectTypes.set(resource.name, resource);
+  }
+
+  async getEntryGroup(
+    project: string,
+    location: string,
+    id: string,
+  ): Promise<gcp.ApiResult<gcp.EntryGroup>> {
+    const name = `projects/${project}/locations/${location}/entryGroups/${id}`;
+    const group = this.mockEntryGroups.get(name);
+    if (group) {
+      return {status: 200, result: group};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+
+  async getEntryType(
+    project: string,
+    location: string,
+    id: string,
+  ): Promise<gcp.ApiResult<gcp.EntryType>> {
+    const name = `projects/${project}/locations/${location}/entryTypes/${id}`;
+    const res = this.mockEntryTypes.get(name);
+    if (res) {
+      return {status: 200, result: res};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+
+  async getAspectType(
+    project: string,
+    location: string,
+    id: string,
+  ): Promise<gcp.ApiResult<gcp.AspectType>> {
+    const name = `projects/${project}/locations/${location}/aspectTypes/${id}`;
+    const res = this.mockAspectTypes.get(name);
+    if (res) {
+      return {status: 200, result: res};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+
+  async getEntry(
+    project: string,
+    location: string,
+    entryGroup: string,
+    id: string,
+    aspects?: string[],
+  ): Promise<gcp.ApiResult<gcp.Entry>> {
+    const name = `projects/${project}/locations/${location}/entryGroups/${entryGroup}/entries/${id}`;
+    const entry = this.mockEntries.find((e) => e.name == name);
+    if (entry) {
+      return {status: 200, result: entry};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+
+  async lookupEntry(
+    project: string,
+    location: string,
+    name: string,
+    aspects?: string[],
+  ): Promise<gcp.ApiResult<gcp.Entry>> {
+    const entry = this.mockEntries.find((e) => e.name == name);
+    if (entry) {
+      return {status: 200, result: entry};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+
+  async modifyEntry(
+    project: string,
+    location: string,
+    entry: gcp.Entry,
+    updateMask?: string[],
+    aspectKeys?: string[],
+  ): Promise<gcp.ApiResult<gcp.Entry>> {
+    const existingEntry = this.mockEntries.find((e) => e.name == entry.name);
+    if (existingEntry) {
+      if (updateMask?.find((m) => m == 'entry_source')) {
+        existingEntry.entrySource = entry.entrySource;
+      }
+      if (updateMask?.find((m) => m == 'aspects')) {
+        if (!existingEntry.aspects) {
+          existingEntry.aspects = {};
+        }
+        for (const aspectKey of aspectKeys ?? []) {
+          if (entry.aspects?.[aspectKey]) {
+            existingEntry.aspects[aspectKey] = entry.aspects[aspectKey];
+          } else {
+            delete existingEntry.aspects[aspectKey];
+          }
+        }
+      }
+      return {status: 200, result: existingEntry};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+
+  async *listEntries(
+    project: string,
+    location: string,
+    entryGroup: string,
+  ): AsyncGenerator<gcp.Entry, void, unknown> {
+    for (const entry of this.mockEntries) {
+      yield entry;
+    }
+  }
+
+  async updateEntry(
+    entry: gcp.Entry,
+    updateMask?: string[],
+    aspectKeys?: string[],
+  ): Promise<gcp.ApiResult<gcp.Entry>> {
+    const existingEntry = this.mockEntries.find((e) => e.name == entry.name);
+    if (existingEntry) {
+      if (updateMask?.find((m) => m == 'entry_source')) {
+        existingEntry.entrySource = entry.entrySource;
+      }
+      if (updateMask?.find((m) => m == 'aspects')) {
+        if (!existingEntry.aspects) {
+          existingEntry.aspects = {};
+        }
+        for (const f in aspectKeys ?? []) {
+          if (entry.aspects?.[f]) {
+            existingEntry.aspects[f] = entry.aspects[f];
+          } else {
+            delete existingEntry.aspects[f];
+          }
+        }
+      }
+      return {status: 200, result: existingEntry};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+
+  async createEntry(
+    project: string,
+    location: string,
+    entryGroup: string,
+    entryId: string,
+    entry?: gcp.Entry,
+  ): Promise<gcp.ApiResult<gcp.Entry>> {
+    const fakeEntry = entry;
+    if (fakeEntry) {
+      this.mockEntries.push(fakeEntry);
+      return {status: 200, result: entry};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+}
+
+export class BigQueryClientMock extends bigquery.BigQueryClient {
+  public mockDatasets: Map<string, any> = new Map();
+  public mockTables: Map<string, any> = new Map();
+
+  constructor() {
+    super(TEST_API_CONTEXT);
+  }
+
+  addMockDataset(resource: bigquery.Dataset) {
+    const name = `projects/${resource.datasetReference.projectId}/datasets/${resource.datasetReference.datasetId}`;
+    this.mockDatasets.set(name, resource);
+  }
+
+  addMockTable(resource: bigquery.Table) {
+    const name = `projects/${resource.tableReference.projectId}/datasets/${resource.tableReference.datasetId}/tables/${resource.tableReference.tableId}`;
+    this.mockTables.set(name, resource);
+  }
+
+  async getDataset(
+    project: string,
+    id: string,
+  ): Promise<gcp.ApiResult<bigquery.Dataset>> {
+    const name = `projects/${project}/datasets/${id}`;
+    const resource = this.mockDatasets.get(name);
+    if (resource) {
+      return {status: 200, result: resource};
+    }
+    return {status: 404, message: 'Not found'};
+  }
+
+  async *listTables(
+    project: string,
+    dataset: string,
+  ): AsyncGenerator<bigquery.Table> {
+    for (const table of this.mockTables.values()) {
+      if (
+        table.tableReference.projectId === project &&
+        table.tableReference.datasetId === dataset
+      ) {
+        yield table;
+      }
+    }
+  }
+}
+
+export class BigLakeClientMock extends gcp.BigLakeClient {
+  public mockTables: Map<string, any> = new Map();
+
+  constructor() {
+    super(TEST_API_CONTEXT, 'iceberg');
+  }
+
+  addMockTable(resource: gcp.BigLakeTable) {
+    this.mockTables.set(resource.name, resource);
+  }
+
+  async *listTables(
+    project: string,
+    location: string,
+    catalog: string,
+    database: string,
+  ): AsyncGenerator<gcp.BigLakeTable> {
+    const prefix = `projects/${project}/locations/${location}/catalogs/${catalog}/databases/${database}/tables/`;
+    for (const table of this.mockTables.values()) {
+      if (table.name.startsWith(prefix)) {
+        yield table;
+      }
+    }
+  }
+}

--- a/agents/mdcode/tests/libts/scenarios.ts
+++ b/agents/mdcode/tests/libts/scenarios.ts
@@ -1,0 +1,442 @@
+import * as realGlob from 'glob';
+import * as realFs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'yaml';
+
+// Load the scenario files NOW, using the real fs!
+const scenariosPath = path.join(__dirname, '..', 'scenarios');
+let globPattern = '**/*.yaml';
+if (process.env.TEST_GLOB) {
+  globPattern = process.env.TEST_GLOB;
+}
+const scenarioFiles = realGlob.globSync(globPattern, {
+  cwd: scenariosPath,
+  absolute: true,
+});
+const scenarios = scenarioFiles.map((file: string) =>
+  yaml.parse(realFs.readFileSync(file, 'utf-8') as string),
+);
+
+import {describe, expect, mock, spyOn, test} from 'bun:test';
+import {fs as memfs, vol} from 'memfs';
+import type * as mocksType from './mocks';
+
+mock.module('fs', () => memfs);
+mock.module('node:fs', () => memfs);
+
+import * as gcp from '../../src/libts/gcp';
+import * as bq from '../../src/libts/gcp/bigquery';
+
+const fs = memfs;
+const kcmac = require('../../src/libts');
+const {
+  CatalogClientMock,
+  BigQueryClientMock,
+  BigLakeClientMock,
+  TEST_API_CONTEXT,
+} = require('./mocks');
+
+let currentCatalogMock: mocksType.CatalogClientMock | null = null;
+let currentBigQueryMock: mocksType.BigQueryClientMock | null = null;
+let currentBigLakeMock: mocksType.BigLakeClientMock | null = null;
+
+function runScenario(scenario: any) {
+  describe(scenario.name, () => {
+    test('run', async () => {
+      const catalog = new CatalogClientMock();
+      const bigquery = new BigQueryClientMock();
+
+      // Reset state
+      vol.reset();
+      currentCatalogMock = catalog;
+      currentBigQueryMock = bigquery;
+      currentBigLakeMock = null;
+
+      // Setup state - Catalog Service
+      if (scenario.setup?.catalog?.entries) {
+        catalog.setMockEntries(scenario.setup.catalog.entries);
+      }
+      if (scenario.setup?.catalog?.entryGroups) {
+        for (const eg of scenario.setup.catalog.entryGroups) {
+          catalog.addMockEntryGroup(eg);
+        }
+      }
+      if (scenario.setup?.catalog?.entryTypes) {
+        for (const et of scenario.setup.catalog.entryTypes) {
+          catalog.addMockEntryType(et);
+        }
+      }
+      if (scenario.setup?.catalog?.aspectTypes) {
+        for (const at of scenario.setup.catalog.aspectTypes) {
+          catalog.addMockAspectType(at);
+        }
+      }
+
+      // Setup state - BigQuery Service
+      if (scenario.setup?.bigQuery?.datasets) {
+        for (const ds of scenario.setup.bigQuery.datasets) {
+          bigquery.addMockDataset(ds);
+        }
+      }
+      if (scenario.setup?.bigQuery?.tables) {
+        for (const table of scenario.setup.bigQuery.tables) {
+          bigquery.addMockTable(table);
+        }
+      }
+
+      // Setup state - BigLake Service
+      const biglake = new BigLakeClientMock();
+      currentBigLakeMock = biglake;
+      if (scenario.setup?.bigLake?.tables) {
+        for (const table of scenario.setup.bigLake.tables) {
+          biglake.addMockTable(table);
+        }
+      }
+
+      // Setup state - Filesystem
+      if (scenario.setup?.fileSystem) {
+        vol.fromJSON(scenario.setup.fileSystem, '/');
+      } else {
+        vol.fromJSON({}, '/');
+      }
+
+      // Execute - Manifest setup
+      if (scenario.init?.entryGroup) {
+        const mf = await kcmac.CatalogManifest.initWithEntryGroup(
+          scenario.init.entryGroup,
+          TEST_API_CONTEXT,
+        );
+        mf.save('/catalog.yaml');
+      }
+      if (scenario.init?.dataset) {
+        const mf = await kcmac.CatalogManifest.initWithBigQuery(
+          scenario.init.dataset,
+          TEST_API_CONTEXT,
+        );
+        mf.save('/catalog.yaml');
+      }
+      if (scenario.init?.kb) {
+        const mf = await kcmac.CatalogManifest.initWithKnowledgeBase(
+          scenario.init.kb,
+          TEST_API_CONTEXT,
+        );
+        mf.save('/catalog.yaml');
+      }
+      if (scenario.init?.biglakeNamespace) {
+        const mf = await kcmac.CatalogManifest.initWithBigLakeNamespace(
+          scenario.init.biglakeNamespace,
+          'iceberg',
+          TEST_API_CONTEXT,
+        );
+        mf.save('/catalog.yaml');
+      }
+      if (!fs.existsSync('/catalog.yaml')) {
+        throw new Error('Scenario did not include or initialize a manifest');
+      }
+      const snapshot = await kcmac.CatalogSnapshot.fromPath(
+        '/',
+        TEST_API_CONTEXT,
+      );
+      const sync = new kcmac.CatalogSync(catalog, snapshot);
+
+      // Execute - Snapshot actions
+      const actions = scenario.actions ?? [];
+      for (const actionStep of actions) {
+        const {action, ...params} = actionStep;
+        switch (action) {
+          case 'pull':
+            await sync.pull();
+            break;
+          case 'push':
+            await sync.push(params.options);
+            break;
+          case 'listEntries':
+            console.log(await snapshot.listEntries());
+            break;
+          case 'createEntry':
+            await snapshot.createEntry(params.name, params.entry);
+            break;
+          case 'updateEntry':
+            await snapshot.updateEntry(params.entry, params.fields);
+            break;
+          case 'deleteEntry':
+            await snapshot.deleteEntry(params.name);
+            break;
+          case 'reference':
+            const referenceSnapshot = await kcmac.CatalogSnapshot.fromPath(
+              '/',
+              TEST_API_CONTEXT,
+              true,
+            );
+            const refereneSync = new kcmac.CatalogSync(
+              catalog,
+              referenceSnapshot,
+            );
+            await refereneSync.reference();
+
+            break;
+          default:
+            throw new Error(`Unknown action: ${action}`);
+        }
+      }
+
+      // Assert expectations - Filesystem
+      if (scenario.assert?.fileSystem) {
+        for (const [fpath, rawCondition] of Object.entries(
+          scenario.assert.fileSystem,
+        )) {
+          const condition = rawCondition as any;
+          const absolutePath = path.resolve('/', fpath);
+
+          if (condition === null) {
+            expect(fs.existsSync(absolutePath)).toBe(false);
+          } else {
+            expect(fs.existsSync(absolutePath)).toBe(true);
+            if (typeof condition === 'string') {
+              const actualContent = fs.readFileSync(
+                absolutePath,
+                'utf8',
+              ) as string;
+              expect(actualContent.trim()).toBe(condition.trim());
+            } else if (Array.isArray(condition)) {
+              const actualContent = fs.readFileSync(
+                absolutePath,
+                'utf8',
+              ) as string;
+              for (const cond of condition) {
+                if (cond && typeof cond === 'object' && 'contains' in cond) {
+                  expect(actualContent).toContain(cond.contains);
+                }
+              }
+            } else if (
+              condition &&
+              typeof condition === 'object' &&
+              'contains' in condition
+            ) {
+              const actualContent = fs.readFileSync(
+                absolutePath,
+                'utf8',
+              ) as string;
+              expect(actualContent).toContain(condition.contains);
+            }
+          }
+        }
+      }
+
+      // Assert expectations - Catalog Service
+      if (scenario.assert?.catalog?.entries) {
+        expect(JSON.parse(JSON.stringify(catalog.mockEntries))).toEqual(
+          JSON.parse(JSON.stringify(scenario.assert.catalog.entries)),
+        );
+      }
+    });
+  });
+}
+
+function main() {
+  // Establish dynamic prototype spies to automatically connect inner-constructed
+  // API clients directly to the scenario mock data registries.
+  spyOn(gcp.CatalogClient.prototype, 'getEntryGroup').mockImplementation(
+    async function (project: string, location: string, id: string) {
+      if (currentCatalogMock) {
+        return await currentCatalogMock.getEntryGroup(project, location, id);
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(gcp.CatalogClient.prototype, 'getEntryType').mockImplementation(
+    async function (project: string, location: string, type: string) {
+      if (currentCatalogMock) {
+        return await currentCatalogMock.getEntryType(project, location, type);
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(gcp.CatalogClient.prototype, 'getAspectType').mockImplementation(
+    async function (project: string, location: string, type: string) {
+      if (currentCatalogMock) {
+        return await currentCatalogMock.getAspectType(project, location, type);
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(gcp.CatalogClient.prototype, 'getEntry').mockImplementation(
+    async function (
+      project: string,
+      location: string,
+      entryGroup: string,
+      entry: string,
+    ) {
+      if (currentCatalogMock) {
+        return await currentCatalogMock.getEntry(
+          project,
+          location,
+          entryGroup,
+          entry,
+        );
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(gcp.CatalogClient.prototype, 'lookupEntry').mockImplementation(
+    async function (project: string, location: string, entry: string) {
+      if (currentCatalogMock) {
+        return await currentCatalogMock.lookupEntry(project, location, entry);
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(gcp.CatalogClient.prototype, 'modifyEntry').mockImplementation(
+    async function (
+      project: string,
+      location: string,
+      entry: gcp.Entry,
+      updateMask?: string[],
+      aspectKeys?: string[],
+    ) {
+      if (currentCatalogMock) {
+        return await currentCatalogMock.modifyEntry(
+          project,
+          location,
+          entry,
+          updateMask,
+          aspectKeys,
+        );
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(gcp.CatalogClient.prototype, 'listEntries').mockImplementation(
+    async function* (project: string, location: string, entryGroup: string) {
+      if (currentCatalogMock) {
+        for await (const entry of currentCatalogMock.listEntries(
+          project,
+          location,
+          entryGroup,
+        )) {
+          yield entry;
+        }
+      }
+    },
+  );
+
+  spyOn(gcp.CatalogClient.prototype, 'updateEntry').mockImplementation(
+    async function (
+      entry: gcp.Entry,
+      updateMask?: string[],
+      aspectKeys?: string[],
+    ) {
+      if (currentCatalogMock) {
+        return await currentCatalogMock.updateEntry(
+          entry,
+          updateMask,
+          aspectKeys,
+        );
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(gcp.CatalogClient.prototype, 'createEntry').mockImplementation(
+    async function (
+      project: string,
+      location: string,
+      entryGroup: string,
+      entryId: string,
+      entry?: gcp.Entry,
+    ) {
+      if (currentCatalogMock) {
+        return await currentCatalogMock.createEntry(
+          project,
+          location,
+          entryGroup,
+          entryId,
+          entry,
+        );
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(bq.BigQueryClient.prototype, 'getDataset').mockImplementation(
+    async function (project: string, dataset: string) {
+      if (currentBigQueryMock) {
+        return await currentBigQueryMock.getDataset(project, dataset);
+      }
+      return {status: 404, message: 'Not found'};
+    },
+  );
+
+  spyOn(bq.BigQueryClient.prototype, 'listTables').mockImplementation(
+    async function* (project: string, dataset: string) {
+      if (currentBigQueryMock) {
+        for await (const table of currentBigQueryMock.listTables(
+          project,
+          dataset,
+        )) {
+          yield table;
+        }
+      }
+    },
+  );
+
+  spyOn(gcp.BigLakeClient.prototype, 'listTables').mockImplementation(
+    async function* (
+      project: string,
+      location: string,
+      catalog: string,
+      database: string,
+    ) {
+      if (currentBigLakeMock) {
+        for await (const table of currentBigLakeMock.listTables(
+          project,
+          location,
+          catalog,
+          database,
+        )) {
+          yield table;
+        }
+      }
+    },
+  );
+
+  // Globally mock fs and node:fs to direct file system calls to virtual volume
+  mock.module('fs', () => memfs);
+  mock.module('node:fs', () => memfs);
+
+  for (const scenario of scenarios) {
+    runScenario(scenario);
+  }
+
+  describe('BigLake Namespace Init Failure', () => {
+    test('should throw error on malformed coordinate', () => {
+      expect(
+        kcmac.CatalogManifest.initWithBigLakeNamespace(
+          'invalid-format',
+          'iceberg',
+          TEST_API_CONTEXT,
+        ),
+      ).rejects.toThrow(
+        'BigLake namespace must be in format <projectId>.<catalogId>.<namespaceId>',
+      );
+
+      expect(
+        kcmac.CatalogManifest.initWithBigLakeNamespace(
+          'proj.cat',
+          'iceberg',
+          TEST_API_CONTEXT,
+        ),
+      ).rejects.toThrow(
+        'BigLake namespace must be in format <projectId>.<catalogId>.<namespaceId>',
+      );
+    });
+  });
+}
+
+main();

--- a/agents/mdcode/tests/scenarios/create_entry_hierarchy.yaml
+++ b/agents/mdcode/tests/scenarios/create_entry_hierarchy.yaml
@@ -1,0 +1,24 @@
+name: create_entry_hierarchy
+description: Create entry with hierarchical name
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/project/locations/location/entryGroups/entryGroup
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/generic
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.project.location.entryGroup
+
+actions:
+  - action: createEntry
+    name: aaa/bbb
+    entry:
+      name: aaa/bbb
+      type: p.global.generic
+
+assert:
+  fileSystem:
+    catalog/aaa/bbb.yaml:
+      contains: "type: p.global.generic"

--- a/agents/mdcode/tests/scenarios/init_biglake.yaml
+++ b/agents/mdcode/tests/scenarios/init_biglake.yaml
@@ -1,0 +1,18 @@
+name: init_biglake
+description: Validate CatalogManifest dynamic initialization with a BigLake namespace source.
+setup:
+  bigQuery:
+    datasets:
+      - id: "test-proj:test-catalog.test-ns"
+        datasetReference:
+          projectId: test-proj
+          datasetId: test-catalog.test-ns
+        location: us-central1
+
+init:
+  biglakeNamespace: test-proj.test-catalog.test-ns
+
+assert:
+  fileSystem:
+    catalog.yaml:
+      contains: "scope: biglake-iceberg-namespace.test-proj.test-catalog.test-ns"

--- a/agents/mdcode/tests/scenarios/init_bqds.yaml
+++ b/agents/mdcode/tests/scenarios/init_bqds.yaml
@@ -1,0 +1,18 @@
+name: init_bqds
+description: Validate CatalogManifest initialization with BigQuery Dataset.
+setup:
+  bigQuery:
+    datasets:
+      - id: "test-proj:test_dataset"
+        datasetReference:
+          projectId: test-proj
+          datasetId: test_dataset
+        location: us
+
+init:
+  dataset: test-proj.test_dataset
+
+assert:
+  fileSystem:
+    catalog.yaml:
+      contains: "scope: bq-dataset.test-proj.test_dataset"

--- a/agents/mdcode/tests/scenarios/init_eg.yaml
+++ b/agents/mdcode/tests/scenarios/init_eg.yaml
@@ -1,0 +1,14 @@
+name: init_eg
+description: Validate CatalogManifest dynamic initialization with an explicit EntryGroup source.
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test-proj/locations/us/entryGroups/test-group
+
+init:
+  entryGroup: test-proj.us.test-group
+
+assert:
+  fileSystem:
+    catalog.yaml:
+      contains: "scope: entryGroup.test-proj.us.test-group"

--- a/agents/mdcode/tests/scenarios/init_kb.yaml
+++ b/agents/mdcode/tests/scenarios/init_kb.yaml
@@ -1,0 +1,14 @@
+name: init_kb
+description: Validate CatalogManifest dynamic initialization with a Wiki EntryGroup.
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test-proj/locations/us/entryGroups/test-kb
+
+init:
+  kb: test-proj.us.test-kb
+
+assert:
+  fileSystem:
+    catalog.yaml:
+      contains: "scope: kb.test-proj.us.test-kb"

--- a/agents/mdcode/tests/scenarios/manifest_simple.yaml
+++ b/agents/mdcode/tests/scenarios/manifest_simple.yaml
@@ -1,0 +1,15 @@
+name: manifest_simple
+description: Simple minimal manifest
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test/locations/us/entryGroups/g1
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.test.us.g1
+
+assert:
+  fileSystem:
+    catalog.yaml:
+      contains: "scope: entryGroup.test.us.g1"

--- a/agents/mdcode/tests/scenarios/manifest_snapshot.yaml
+++ b/agents/mdcode/tests/scenarios/manifest_snapshot.yaml
@@ -1,0 +1,25 @@
+name: manifest_snapshot
+description: Manifest with configured snapshot of entries and aspects
+setup:
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+    aspectTypes:
+      - name: projects/dataplex-types/locations/global/aspectTypes/overview
+    entryGroups:
+      - name: projects/test/locations/us/entryGroups/g1
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.test.us.g1
+      snapshot:
+        entries:
+          - dataplex-types.global.bigquery-dataset
+        aspects:
+          - dataplex-types.global.overview
+
+assert:
+  fileSystem:
+    catalog.yaml:
+      - contains: "scope: entryGroup.test.us.g1"
+      - contains: "dataplex-types.global.overview"

--- a/agents/mdcode/tests/scenarios/pull_basic.yaml
+++ b/agents/mdcode/tests/scenarios/pull_basic.yaml
@@ -1,0 +1,24 @@
+name: pull_basic
+description: EntryGroup with single entry
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test/locations/us/entryGroups/g1
+    entryTypes:
+      - name: projects/test/locations/global/entryTypes/et1
+    entries:
+      - name: projects/test/locations/us/entryGroups/g1/entries/e1
+        entryType: projects/test/locations/global/entryTypes/et1
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.test.us.g1
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/e1.yaml:
+      - contains: "name: e1"
+      - contains: "type: test.global.et1"

--- a/agents/mdcode/tests/scenarios/pull_basic_withalias.yaml
+++ b/agents/mdcode/tests/scenarios/pull_basic_withalias.yaml
@@ -1,0 +1,40 @@
+name: pull_basic_withalias.yaml
+description: EntryGroup with single entry with resource alias
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test/locations/us/entryGroups/g1
+    entryTypes:
+      - name: projects/test/locations/global/entryTypes/et1
+    aspectTypes:
+      - name: projects/test/locations/global/aspectTypes/at1
+    entries:
+      - name: projects/test/locations/us/entryGroups/g1/entries/e1
+        entryType: projects/test/locations/global/entryTypes/et1
+        aspects:
+          test.global.at1:
+            aspectType: projects/test/locations/global/aspectTypes/at1
+            data:
+              content: Fun
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.test.us.g1
+      resourceAlias:
+        alias1:
+          aspect: test.global.at1
+      snapshot:
+        entries:
+          - test.global.et1
+        aspects:
+          - alias1
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/e1.yaml:
+      - contains: "name: e1"
+      - contains: "alias1"
+      - contains: "content: Fun"

--- a/agents/mdcode/tests/scenarios/pull_biglake.yaml
+++ b/agents/mdcode/tests/scenarios/pull_biglake.yaml
@@ -1,0 +1,31 @@
+name: pull_biglake
+description: Validate CatalogManifest pull from a BigLake Metastore namespace.
+setup:
+  bigQuery:
+    datasets:
+      - id: "test-proj:test-catalog.test-ns"
+        datasetReference:
+          projectId: test-proj
+          datasetId: test-catalog.test-ns
+        location: us-central1
+  bigLake:
+    tables:
+      - name: projects/test-proj/locations/us-central1/catalogs/test-catalog/databases/test-ns/tables/table-1
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/biglake-table
+    entries:
+      - name: projects/test-proj/locations/us-central1/entryGroups/@biglake/entries/biglake.googleapis.com/projects/test-proj/catalogs/test-catalog/namespaces/test-ns/tables/table-1
+        entryType: projects/dataplex-types/locations/global/entryTypes/biglake-table
+
+  fileSystem:
+    catalog.yaml: |
+      scope: biglake-iceberg-namespace.test-proj.test-catalog.test-ns
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/test-proj.test-catalog.test-ns/table-1.yaml:
+      - contains: "type: dataplex-types.global.biglake-table"

--- a/agents/mdcode/tests/scenarios/pull_bq.yaml
+++ b/agents/mdcode/tests/scenarios/pull_bq.yaml
@@ -1,0 +1,41 @@
+name: pull_bq
+description: BigQuery dataset
+setup:
+  bigQuery:
+    datasets:
+      - id: p:d
+        datasetReference:
+          projectId: p
+          datasetId: d
+        location: US
+    tables:
+      - id: p:d.t1
+        tableReference:
+          projectId: p
+          datasetId: d
+          tableId: t1
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d/tables/t1
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+
+  fileSystem:
+    catalog.yaml: |
+      scope: bq-dataset.p.d
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/p.d.yaml:
+      - contains: "name: p.d"
+      - contains: "type: dataplex-types.global.bigquery-dataset"
+    catalog/p.d/t1.yaml:
+      - contains: "name: p.d/t1"
+      - contains: "type: dataplex-types.global.bigquery-table"

--- a/agents/mdcode/tests/scenarios/pull_bq_filtered.yaml
+++ b/agents/mdcode/tests/scenarios/pull_bq_filtered.yaml
@@ -1,0 +1,49 @@
+name: pull_bq_filtered
+description: BigQuery dataset with snapshot filtering
+setup:
+  bigQuery:
+    datasets:
+      - id: p:d
+        datasetReference:
+          projectId: p
+          datasetId: d
+        location: us
+    tables:
+      - id: p:d.t1
+        tableReference:
+          projectId: p
+          datasetId: d
+          tableId: t1
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+        requiredAspects:
+          - type: projects/dataplex-types/locations/global/aspectTypes/bigquery-dataset
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+        requiredAspects:
+          - type: projects/dataplex-types/locations/global/aspectTypes/bigquery-table
+    aspectTypes:
+      - name: projects/dataplex-types/locations/global/aspectTypes/bigquery-dataset
+      - name: projects/dataplex-types/locations/global/aspectTypes/bigquery-table
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d/tables/t1
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+
+  fileSystem:
+    catalog.yaml: |
+      scope: bq-dataset.p.d
+      snapshot:
+        entries:
+          - dataplex-types.global.bigquery-table
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/p.d.yaml: null
+    catalog/p.d/t1.yaml:
+      - contains: "name: p.d/t1"
+      - contains: "type: dataplex-types.global.bigquery-table"

--- a/agents/mdcode/tests/scenarios/pull_bq_multiple.yaml
+++ b/agents/mdcode/tests/scenarios/pull_bq_multiple.yaml
@@ -1,0 +1,63 @@
+name: pull_bq_multiple
+description: Multiple BigQuery datasets in list scope format
+setup:
+  bigQuery:
+    datasets:
+      - id: p:d1
+        datasetReference:
+          projectId: p
+          datasetId: d1
+        location: us
+      - id: p:d2
+        datasetReference:
+          projectId: p
+          datasetId: d2
+        location: us
+    tables:
+      - id: p:d1.t1
+        tableReference:
+          projectId: p
+          datasetId: d1
+          tableId: t1
+      - id: p:d2.t2
+        tableReference:
+          projectId: p
+          datasetId: d2
+          tableId: t2
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d1
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d1/tables/t1
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d2
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d2/tables/t2
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+
+  fileSystem:
+    catalog.yaml: |
+      scope:
+        - bq-dataset.p.d1
+        - bq-dataset.p.d2
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/p.d1.yaml:
+      - contains: "name: p.d1"
+      - contains: "type: dataplex-types.global.bigquery-dataset"
+    catalog/p.d1/t1.yaml:
+      - contains: "name: p.d1/t1"
+      - contains: "type: dataplex-types.global.bigquery-table"
+    catalog/p.d2.yaml:
+      - contains: "name: p.d2"
+      - contains: "type: dataplex-types.global.bigquery-dataset"
+    catalog/p.d2/t2.yaml:
+      - contains: "name: p.d2/t2"
+      - contains: "type: dataplex-types.global.bigquery-table"

--- a/agents/mdcode/tests/scenarios/pull_kb.yaml
+++ b/agents/mdcode/tests/scenarios/pull_kb.yaml
@@ -1,0 +1,52 @@
+name: pull_kb
+description: Knowledge Base with multiple entries
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/t/locations/u/entryGroups/g
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/generic
+    entries:
+      - name: projects/t/locations/u/entryGroups/g/entries/e0
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+        entrySource:
+          displayName: Sample entry
+          description: Sample entry description
+          labels:
+            aaa: bbb
+            xyz: 'true'
+      - name: projects/t/locations/u/entryGroups/g/entries/e1
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/e2
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/e3
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/dir/sub
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/dir/sub.xyz
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+
+  fileSystem:
+    catalog.yaml: |
+      scope: kb.t.u.g
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/e0.md:
+      - contains: "name: e0"
+      - contains: "title: Sample entry"
+      - contains: "description: Sample entry description"
+      - contains: "- xyz"
+    catalog/e1.md:
+      contains: "name: e1"
+    catalog/e2.md:
+      contains: "name: e2"
+    catalog/e3.md:
+      contains: "name: e3"
+    catalog/dir/sub.md:
+      contains: "name: dir/sub"
+    catalog/dir/sub.xyz.md:
+      contains: "name: dir/sub.xyz"

--- a/agents/mdcode/tests/scenarios/pull_multi.yaml
+++ b/agents/mdcode/tests/scenarios/pull_multi.yaml
@@ -1,0 +1,35 @@
+name: pull_multi
+description: EntryGroup with multiple entries
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/t/locations/u/entryGroups/g
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/generic
+    entries:
+      - name: projects/t/locations/u/entryGroups/g/entries/e0
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/e1
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/e2
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/e3
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.t.u.g
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/e0.yaml:
+      contains: "name: e0"
+    catalog/e1.yaml:
+      contains: "name: e1"
+    catalog/e2.yaml:
+      contains: "name: e2"
+    catalog/e3.yaml:
+      contains: "name: e3"

--- a/agents/mdcode/tests/scenarios/push_biglake.yaml
+++ b/agents/mdcode/tests/scenarios/push_biglake.yaml
@@ -1,0 +1,67 @@
+name: push_biglake
+description: Validate CatalogManifest push/deploy of local table aspect modifications back to a BigLake namespace.
+setup:
+  bigQuery:
+    datasets:
+      - id: "test-proj:test-catalog.test-ns"
+        datasetReference:
+          projectId: test-proj
+          datasetId: test-catalog.test-ns
+        location: us-central1
+  bigLake:
+    tables:
+      - name: projects/test-proj/locations/us-central1/catalogs/test-catalog/databases/test-ns/tables/table-1
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/biglake-table
+    aspectTypes:
+      - name: projects/dataplex-types/locations/global/aspectTypes/overview
+    entries:
+      - name: projects/test-proj/locations/us-central1/entryGroups/@biglake/entries/biglake.googleapis.com/projects/test-proj/catalogs/test-catalog/namespaces/test-ns/tables/table-1
+        entryType: projects/dataplex-types/locations/global/entryTypes/biglake-table
+        aspects:
+          dataplex-types.global.overview:
+            aspectType: projects/dataplex-types/locations/global/aspectTypes/overview
+            data:
+              content: Old aspect description
+              contentType: MARKDOWN
+
+  fileSystem:
+    catalog.yaml: |
+      scope: biglake-iceberg-namespace.test-proj.test-catalog.test-ns
+      snapshot:
+        entries:
+          - dataplex-types.global.biglake-table
+        aspects:
+          - dataplex-types.global.overview
+
+actions:
+  - action: pull
+  - action: updateEntry
+    entry:
+      name: test-proj.test-catalog.test-ns/table-1
+      type: dataplex-types.global.biglake-table
+      aspects:
+        dataplex-types.global.overview:
+          content: New aspect description
+          contentType: MARKDOWN
+    fields:
+      - dataplex-types.global.overview
+  - action: push
+
+assert:
+  fileSystem:
+    catalog/test-proj.test-catalog.test-ns/table-1.yaml:
+      - contains: "name: test-proj.test-catalog.test-ns/table-1"
+    catalog/test-proj.test-catalog.test-ns/table-1.dataplex-types.global.overview.md:
+      - contains: "New aspect description"
+  catalog:
+    entries:
+      - name: projects/test-proj/locations/us-central1/entryGroups/@biglake/entries/biglake.googleapis.com/projects/test-proj/catalogs/test-catalog/namespaces/test-ns/tables/table-1
+        entryType: projects/dataplex-types/locations/global/entryTypes/biglake-table
+        aspects:
+          dataplex-types.global.overview:
+            aspectType: projects/dataplex-types/locations/global/aspectTypes/overview
+            data:
+              content: New aspect description
+              contentType: MARKDOWN

--- a/agents/mdcode/tests/scenarios/push_bq.yaml
+++ b/agents/mdcode/tests/scenarios/push_bq.yaml
@@ -1,0 +1,64 @@
+name: push_bq
+description: Push BigQuery dataset modifications
+setup:
+  bigQuery:
+    datasets:
+      - id: p:d
+        datasetReference:
+          projectId: p
+          datasetId: d
+        location: us
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+    aspectTypes:
+      - name: projects/dataplex-types/locations/global/aspectTypes/overview
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+        aspects:
+          dataplex-types.global.overview:
+            aspectType: projects/dataplex-types/locations/global/aspectTypes/overview
+            data:
+              content: Old aspect description
+              contentType: MARKDOWN
+
+  fileSystem:
+    catalog.yaml: |
+      scope: bq-dataset.p.d
+      snapshot:
+        entries:
+          - dataplex-types.global.bigquery-dataset
+        aspects:
+          - dataplex-types.global.overview
+
+actions:
+  - action: pull
+  - action: updateEntry
+    entry:
+      name: p.d
+      type: dataplex-types.global.bigquery-dataset
+      aspects:
+        dataplex-types.global.overview:
+          content: New aspect description
+          contentType: MARKDOWN
+    fields:
+      - dataplex-types.global.overview
+  - action: push
+
+assert:
+  fileSystem:
+    catalog/p.d.yaml:
+      - contains: "name: p.d"
+    catalog/p.d.dataplex-types.global.overview.md:
+      - contains: "New aspect description"
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+        aspects:
+          dataplex-types.global.overview:
+            aspectType: projects/dataplex-types/locations/global/aspectTypes/overview
+            data:
+              content: New aspect description
+              contentType: MARKDOWN

--- a/agents/mdcode/tests/scenarios/push_bq_sidecar.yaml
+++ b/agents/mdcode/tests/scenarios/push_bq_sidecar.yaml
@@ -1,0 +1,58 @@
+name: push_bq_sidecar
+description: Push BQ dataset metadata with a local sidecar markdown file
+setup:
+  bigQuery:
+    datasets:
+      - id: p:d
+        datasetReference:
+          projectId: p
+          datasetId: d
+        location: us
+  catalog:
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+    aspectTypes:
+      - name: projects/dataplex-types/locations/global/aspectTypes/overview
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+
+  fileSystem:
+    catalog.yaml: |
+      scope: bq-dataset.p.d
+      snapshot:
+        entries:
+          - dataplex-types.global.bigquery-dataset
+        aspects:
+          - dataplex-types.global.overview
+      publishing:
+        entries:
+          - dataplex-types.global.bigquery-dataset
+        aspects:
+          - dataplex-types.global.overview
+    catalog/p.d.yaml: |
+      name: p.d
+      type: dataplex-types.global.bigquery-dataset
+      resource:
+        name: projects/p/datasets/d
+    catalog/p.d.dataplex-types.global.overview.md: |
+      ---
+      userManaged: true
+      ---
+      This is the brand new sidecar content!
+
+actions:
+  - action: push
+
+assert:
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+        aspects:
+          dataplex-types.global.overview:
+            aspectType: projects/dataplex-types/locations/global/aspectTypes/overview
+            data:
+              content: This is the brand new sidecar content!
+              contentType: MARKDOWN
+              userManaged: true

--- a/agents/mdcode/tests/scenarios/push_custom.yaml
+++ b/agents/mdcode/tests/scenarios/push_custom.yaml
@@ -1,0 +1,44 @@
+name: push_custom
+description: Push Custom entry modifications
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/p/locations/us/entryGroups/custom-group
+    entryTypes:
+      - name: projects/p/locations/global/entryTypes/custom-type
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/custom-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.p.us.custom-group
+      snapshot:
+        entries:
+          - p.global.custom-type
+
+actions:
+  - action: pull
+  - action: updateEntry
+    entry:
+      name: custom-entry
+      type: p.global.custom-type
+      resource:
+        description: New custom description
+    fields:
+      - resource
+  - action: push
+
+assert:
+  fileSystem:
+    catalog/custom-entry.yaml:
+      - contains: "name: custom-entry"
+      - contains: "description: New custom description"
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/custom-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: New custom description

--- a/agents/mdcode/tests/scenarios/push_filtered.yaml
+++ b/agents/mdcode/tests/scenarios/push_filtered.yaml
@@ -1,0 +1,101 @@
+name: push_filtered
+description: Push modifications with publishing configuration filtering
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/p/locations/us/entryGroups/custom-group
+    entryTypes:
+      - name: projects/p/locations/global/entryTypes/custom-type
+      - name: projects/p/locations/global/entryTypes/other-type
+    aspectTypes:
+      - name: projects/p/locations/global/aspectTypes/aspect1
+      - name: projects/p/locations/global/aspectTypes/aspect2
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/custom-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description
+        aspects:
+          p.global.aspect1:
+            aspectType: projects/p/locations/global/aspectTypes/aspect1
+            data:
+              content: Old aspect1
+          p.global.aspect2:
+            aspectType: projects/p/locations/global/aspectTypes/aspect2
+            data:
+              content: Old aspect2
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/other-entry
+        entryType: projects/p/locations/global/entryTypes/other-type
+        entrySource:
+          description: Old other description
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.p.us.custom-group
+      snapshot:
+        entries:
+          - p.global.custom-type
+          - p.global.other-type
+        aspects:
+          - p.global.aspect1
+          - p.global.aspect2
+      publishing:
+        entries:
+          - p.global.custom-type
+        aspects:
+          - p.global.aspect1
+
+actions:
+  - action: pull
+  - action: updateEntry
+    entry:
+      name: custom-entry
+      type: projects/p/locations/global/entryTypes/custom-type
+      resource:
+        description: New custom description
+      aspects:
+        p.global.aspect1:
+          content: New aspect1
+        p.global.aspect2:
+          content: New aspect2
+    fields:
+      - resource
+      - p.global.aspect1
+      - p.global.aspect2
+  - action: updateEntry
+    entry:
+      name: other-entry
+      type: projects/p/locations/global/entryTypes/other-type
+      resource:
+        description: New other description
+    fields:
+      - resource
+  - action: push
+
+assert:
+  fileSystem:
+    catalog/custom-entry.yaml:
+      - contains: "name: custom-entry"
+      - contains: "New custom description"
+    catalog/other-entry.yaml:
+      - contains: "name: other-entry"
+      - contains: "New other description"
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/custom-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: New custom description
+        aspects:
+          p.global.aspect1:
+            aspectType: projects/p/locations/global/aspectTypes/aspect1
+            data:
+              content: New aspect1
+          p.global.aspect2:
+            aspectType: projects/p/locations/global/aspectTypes/aspect2
+            data:
+              content: Old aspect2
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/other-entry
+        entryType: projects/p/locations/global/entryTypes/other-type
+        entrySource:
+          description: Old other description

--- a/agents/mdcode/tests/scenarios/push_kb.yaml
+++ b/agents/mdcode/tests/scenarios/push_kb.yaml
@@ -1,0 +1,70 @@
+name: push_kb
+description: Push KB entry modifications
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/p/locations/us/entryGroups/kb
+    entryTypes:
+      - name: projects/p/locations/global/entryTypes/kb-type
+    aspectTypes:
+      - name: projects/dataplex-types/locations/global/aspectTypes/overview
+    entries:
+      - name: projects/p/locations/us/entryGroups/kb/entries/kb-entry
+        entryType: projects/p/locations/global/entryTypes/kb-type
+        aspects:
+          dataplex-types.global.overview:
+            aspectType: projects/dataplex-types/locations/global/aspectTypes/overview
+            data:
+              content: Old custom description
+              contentType: MARKDOWN
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.p.us.kb
+      snapshot:
+        entries:
+          - p.global.kb-type
+        aspects:
+          - dataplex-types.global.overview
+      publishing:
+        entries:
+          - p.global.kb-type
+        aspects:
+          - dataplex-types.global.overview
+
+actions:
+  - action: pull
+  - action: updateEntry
+    entry:
+      name: kb-entry
+      type: p.global.kb-type
+      resource:
+        description: updated basic description
+      aspects:  
+        dataplex-types.global.overview:
+          content: New custom description
+          contentType: MARKDOWN
+    fields:
+      - dataplex-types.global.overview
+      - resource
+  - action: push
+
+assert:
+  fileSystem:
+    catalog/kb-entry.yaml:
+      - contains: "name: kb-entry"
+      - contains: "description: updated basic description"
+    catalog/kb-entry.dataplex-types.global.overview.md:
+      - contains: "New custom description"
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/kb/entries/kb-entry
+        entryType: projects/p/locations/global/entryTypes/kb-type
+        entrySource:
+          description: updated basic description
+        aspects:
+          dataplex-types.global.overview:
+            aspectType: projects/dataplex-types/locations/global/aspectTypes/overview
+            data:
+              content: New custom description
+              contentType: MARKDOWN

--- a/agents/mdcode/tests/scenarios/push_new_entry.yaml
+++ b/agents/mdcode/tests/scenarios/push_new_entry.yaml
@@ -1,0 +1,49 @@
+name: push_new_entry
+description: Push new entry from local workspace
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/p/locations/us/entryGroups/custom-group
+    entryTypes:
+      - name: projects/p/locations/global/entryTypes/custom-type
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/existing-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.p.us.custom-group
+      snapshot:
+        entries:
+          - p.global.custom-type
+
+
+actions:
+  - action: pull
+  - action: createEntry
+    name: custom-entry
+    entry:
+      name: custom-entry
+      type: p.global.custom-type
+      resource:
+        description: Hello world
+  - action: push
+
+assert:
+  fileSystem:
+    catalog/custom-entry.yaml:
+      - contains: "name: custom-entry"
+      - contains: "description: Hello world"
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/existing-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/custom-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: "Hello world"
+        aspects: {}

--- a/agents/mdcode/tests/scenarios/push_new_entry_withalias.yaml
+++ b/agents/mdcode/tests/scenarios/push_new_entry_withalias.yaml
@@ -1,0 +1,65 @@
+name: push_new_entry_withalias
+description: Push new entry from local workspace with alias
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/p/locations/us/entryGroups/custom-group
+    entryTypes:
+      - name: projects/p/locations/global/entryTypes/custom-type
+    aspectTypes:
+      - name: projects/p/locations/global/aspectTypes/at1
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/existing-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.p.us.custom-group
+      resourceAlias:
+        alias1:
+          aspect: p.global.at1
+      snapshot:
+        entries:
+          - p.global.custom-type
+        aspects:
+          - alias1
+      
+
+
+actions:
+  - action: pull
+  - action: createEntry
+    name: custom-entry
+    entry:
+      name: custom-entry
+      type: p.global.custom-type
+      resource:
+        description: Hello world
+      aspects:
+        alias1:
+          content: Chicken
+  - action: push
+
+assert:
+  fileSystem:
+    catalog/custom-entry.yaml:
+      - contains: "name: custom-entry"
+      - contains: "description: Hello world"
+      - contains: "content: Chicken"
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/existing-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/custom-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: "Hello world"
+        aspects:
+          p.global.at1:
+            aspectType: projects/p/locations/global/aspectTypes/at1
+            data:
+              content: Chicken

--- a/agents/mdcode/tests/scenarios/reference_bq.yaml
+++ b/agents/mdcode/tests/scenarios/reference_bq.yaml
@@ -1,0 +1,46 @@
+name: reference_bq
+description: Referencing a BQ dataset entries
+setup:
+  bigQuery:
+    datasets:
+      - id: p:d
+        datasetReference:
+          projectId: p
+          datasetId: d
+        location: US
+    tables:
+      - id: p:d.t1
+        tableReference:
+          projectId: p
+          datasetId: d
+          tableId: t1
+  catalog:
+    entryGroups:
+      - name: projects/p/locations/us/entryGroups/custom-group
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+    entries:
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-dataset
+      - name: projects/p/locations/us/entryGroups/@bigquery/entries/bigquery.googleapis.com/projects/p/datasets/d/tables/t1
+        entryType: projects/dataplex-types/locations/global/entryTypes/bigquery-table
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.p.us.custom-group
+      reference:
+        scope: bq-dataset.p.d
+
+
+actions:
+  - action: reference
+
+assert:
+  fileSystem:
+    reference/p.d.yaml:
+      - contains: "name: p.d"
+      - contains: "type: dataplex-types.global.bigquery-dataset"
+    reference/p.d/t1.yaml:
+      - contains: "name: p.d/t1"
+      - contains: "type: dataplex-types.global.bigquery-table"

--- a/agents/mdcode/tests/scenarios/reference_eg.yaml
+++ b/agents/mdcode/tests/scenarios/reference_eg.yaml
@@ -1,0 +1,27 @@
+name: reference_eg
+description: Referencing an EntryGroup entries
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test/locations/us/entryGroups/g1
+      - name: projects/test/locations/us/entryGroups/r1
+    entryTypes:
+      - name: projects/test/locations/global/entryTypes/rt1
+    entries:
+      - name: projects/test/locations/us/entryGroups/g1/entries/r1
+        entryType: projects/test/locations/global/entryTypes/rt1
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.test.us.g1
+      reference:
+        scope: entryGroup.test.us.r1
+
+actions:
+  - action: reference
+
+assert:
+  fileSystem:
+    reference/r1.yaml:
+      - contains: "name: r1"
+      - contains: "type: test.global.rt1"

--- a/agents/mdcode/tests/scenarios/reference_kb.yaml
+++ b/agents/mdcode/tests/scenarios/reference_kb.yaml
@@ -1,0 +1,55 @@
+name: reference_kb
+description: Reference Knowledge Base with multiple entries
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test/locations/us/entryGroups/g1
+      - name: projects/t/locations/u/entryGroups/g
+    entryTypes:
+      - name: projects/dataplex-types/locations/global/entryTypes/generic
+    entries:
+      - name: projects/t/locations/u/entryGroups/g/entries/e0
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+        entrySource:
+          displayName: Sample entry
+          description: Sample entry description
+          labels:
+            aaa: bbb
+            xyz: 'true'
+      - name: projects/t/locations/u/entryGroups/g/entries/e1
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/e2
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/e3
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/dir/sub
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+      - name: projects/t/locations/u/entryGroups/g/entries/dir/sub.xyz
+        entryType: projects/dataplex-types/locations/global/entryTypes/generic
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.test.us.g1
+      reference:
+        scope: kb.t.u.g
+
+actions:
+  - action: reference
+
+assert:
+  fileSystem:
+    reference/e0.md:
+      - contains: "name: e0"
+      - contains: "title: Sample entry"
+      - contains: "description: Sample entry description"
+      - contains: "- xyz"
+    reference/e1.md:
+      contains: "name: e1"
+    reference/e2.md:
+      contains: "name: e2"
+    reference/e3.md:
+      contains: "name: e3"
+    reference/dir/sub.md:
+      contains: "name: dir/sub"
+    reference/dir/sub.xyz.md:
+      contains: "name: dir/sub.xyz"

--- a/agents/mdcode/tsconfig.json
+++ b/agents/mdcode/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "types": [
+      "node",
+      "bun-types"
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ]
+}


### PR DESCRIPTION
Creates a new top-level `agents/` folder and adds, underneath it, the enrichment agent and mdcode tooling taken from the `dev` branch:

- `agents/enrichment/` — copied from `toolbox/enrichment/` on `dev`
- `agents/mdcode/` — copied from `toolbox/mdcode/` on `dev`

This consolidates the agent and its mdcode tooling under `agents/` on `main`. No existing files on `main` are modified.