### PR TITLE
Sync enrichment agent + evaluation harness into agents/enrichment

### DIFF
--- a/agents/enrichment/README.md
+++ b/agents/enrichment/README.md
@@ -77,11 +77,16 @@ agents/
     │       ├── bq_usage_tools.py # INFORMATION_SCHEMA query history + queries-aspect sidecar
     │       ├── feedback_tools.py # user-feedback proposal loader + per-table router
     │       └── github_tools.py   # agentic GitHub-repo code source via the GitHub MCP server
-    └── eval/                     # evaluation CLI (dynamic, golden-free)
-        ├── __main__.py          # `python -m eval --output-dir ...`
+    └── eval/                     # evaluation CLI (dynamic golden-free + golden-based)
+        ├── __main__.py          # `python -m eval --output-dir ... [--golden ...]` | `--run`
         ├── dynamic_eval.py      # golden-free scoring of a single run
+        ├── golden_eval.py       # golden-based scoring (concepts, facts, coverage)
+        ├── aggregate.py         # multi-run roll-up (per-run + averaged + consistency)
+        ├── runner.py            # `--run` case-runner (setup + N agent runs)
         ├── metrics.py           # metric library (deterministic + LLM-judge)
-        └── loaders.py           # read catalog/ + trajectory.json
+        ├── loaders.py           # read catalog/ + trajectory.json
+        ├── goldens/             # golden schema (TEMPLATE.json) + ready goldens
+        └── corpora/             # local markdown corpora the goldens ground on
 ```
 
 ## Prerequisites
@@ -137,7 +142,7 @@ export PYTHONPATH=agents/enrichment/src
 python3 agents/enrichment/src/agent_runner.py \
   --mode=table \
   --dataset=<project>.<dataset> \
-  --folder=<drive_folder_id_or_url> \
+  --folders=<drive_folder_id_or_url> \
   --topic="<your use case / instruction>" \
   --project=<your_gcp_project> \
   --location=<vertex_location> \
@@ -148,7 +153,7 @@ python3 agents/enrichment/src/agent_runner.py \
 python3 agents/enrichment/src/agent_runner.py \
   --mode=doc \
   --docs="https://docs.google.com/document/d/<id>,<id2>" \
-  --folder=<drive_folder_id_or_url> \
+  --folders=<drive_folder_id_or_url> \
   --topic="<your use case / instruction>" \
   --entry_group=<project>.<location>.<entryGroupId> \
   --project=<your_gcp_project> \
@@ -162,7 +167,7 @@ python3 agents/enrichment/src/agent_runner.py \
   --mode=context_overlay \
   --dataset=<project>.<dataset> \
   --entry_group=<project>.<location>.<entryGroupId> \
-  --folder=<drive_folder_id_or_url> \
+  --folders=<drive_folder_id_or_url> \
   --topic="<your use case / instruction>" \
   --project=<your_gcp_project> \
   --model=<vertex_model> \
@@ -214,7 +219,7 @@ list). `--project`, `--model`, and `--output_dir` are required in **every** mode
 | `--topic` | ✓ | ✓ | ✓ |
 | `--dataset` | — | R | R |
 | `--entry_group` | R | — | R |
-| `--folder` | ✓ | ✓ | ✓ |
+| `--folders` | ✓ | ✓ | ✓ |
 | `--docs` | ✓ | — | ✓ |
 | `--tables` | — | — | ✓ |
 | `--include_usage` | — | ✓ | ✓ |
@@ -250,8 +255,8 @@ list). `--project`, `--model`, and `--output_dir` are required in **every** mode
 #### Source context (what the agent reads)
 
 - **`--topic`** — *(optional, default `"Metadata enrichment"`)* Free-text use case/instruction that steers enrichment (and the doc-mode topic reduce). Example: `--topic="Customer 360 data"`.
-- **`--folder`** — *(optional)* Google Drive folder ID or URL to seed source documents from (Docs/Sheets/Slides/PDF). Works in all modes. Example: `--folder=https://drive.google.com/drive/folders/<id>`.
-- **`--docs`** — *(doc, context_overlay)* Comma-separated Google Doc URLs or IDs. In doc mode these are the authoritative depth-0 "spine"; in overlay mode they're routed to tables. **Not used in table mode** — use `--folder` there. Example: `--docs="https://docs.google.com/document/d/<id1>,<id2>"`.
+- **`--folders`** — *(optional)* Comma-separated, mixed list (routed per entry): Google Drive folder IDs/URLs (Docs/Sheets/Slides/PDF) **and/or local directories of `.md` files** (read recursively). Works in all modes. `--folder` (singular) is accepted as a deprecated alias. See [Local Markdown inputs](#local-markdown-inputs). Example: `--folders=https://drive.google.com/drive/folders/<id>,./local_md_corpus`.
+- **`--docs`** — *(doc, context_overlay)* Comma-separated, mixed list: Google Doc URLs/IDs **and/or local `.md` files**. In doc mode these are the authoritative depth-0 "spine"; in overlay mode they're routed to tables. **Not used in table mode** — use `--folders` there. Example: `--docs="https://docs.google.com/document/d/<id1>,./notes/x.md"`.
 - **`--tables`** — *(context_overlay only)* Restrict the overlay to specific tables — short names or `proj.ds.table` FQNs, comma-separated. Empty = every table in `--dataset`. Example: `--tables=orders,customers`.
 
 #### BigQuery usage signal — the `queries` aspect *(table, context_overlay)*
@@ -280,7 +285,62 @@ list). `--project`, `--model`, and `--output_dir` are required in **every** mode
 #### Refinement *(all modes, after a run)*
 
 - **`--interactive`** — *(default `false`)* After the initial run, stay in a `refine>` REPL for free-text changes — rewrite an overview, add/remove/recategorize entries, or ask a question. Reuses loaded context (no doc re-read). No-op on a non-TTY.
-- **`--refine_instruction`** — Apply ONE refinement turn to the saved session in `--output_dir`, then exit (the webapp's persist + re-invoke flow). Requires a prior run's `refine_session.json` in `--output_dir`. Example: `--refine_instruction="make the orders overview more concise"`.
+- **`--refine_instruction`** — Apply ONE refinement turn to the saved session in `--output_dir`, then exit (the report's persist + re-invoke flow). Requires a prior run's `refine_session.json` in `--output_dir`. Example: `--refine_instruction="make the orders overview more concise"`.
+
+## Local Markdown inputs
+
+You don't have to put your source material in Google Drive. `--docs` and
+`--folders` both accept **local Markdown** (`.md` / `.markdown`) alongside Google
+Docs / Drive folders — every entry in either flag is routed independently, so a
+single run can mix all four kinds of source.
+
+**How each entry is classified (format-first, so it never depends on your shell's
+working directory):**
+
+1. Starts with `http://` / `https://` → **Google Drive** (Doc or folder URL).
+2. Ends in `.md` / `.markdown` → **local Markdown file**.
+3. Path-shaped (`/abs/path`, `./rel`, `../rel`, `~/path`, or contains a `/`) →
+   **local** (a directory is read recursively; a file is read directly).
+4. A bare relative name that exists on disk → **local**.
+5. Otherwise (a bare opaque token) → **Google Drive ID**.
+
+Because Drive IDs are long opaque tokens and local paths/`.md` files trip rules
+1–3 first, there is no collision between the two. The agent logs how it routed
+each entry (`[Route] --docs '…' -> local md spine file`, etc.). Absolute paths
+are recommended; relative paths resolve from the agent's working directory.
+
+**What local Markdown maps to per mode:**
+
+- **doc mode** — a local `.md` file in `--docs` is a depth-0 *spine* doc (like an
+  authoritative Google Doc); a local directory in `--docs`/`--folders` contributes
+  its `.md` files as depth-1 children (like a Drive folder).
+- **table / context_overlay modes** — local `.md` files/folders join the
+  candidate pool that the relevance router grounds each table's overview in,
+  exactly like Drive documents.
+
+```bash
+# Doc mode mixing Google Docs + local Markdown (files and a folder):
+python3 agents/enrichment/src/agent_runner.py \
+  --mode=doc \
+  --docs="https://docs.google.com/document/d/<id>,./notes/data_model.md" \
+  --folders="<drive_folder_id_or_url>,./local_md_corpus" \
+  --topic="<your use case>" \
+  --entry_group=<project>.<location>.<entryGroupId> \
+  --project=<your_gcp_project> --model=<vertex_model> \
+  --output_dir=<local_output_dir>
+
+# Table mode grounded purely in a local Markdown folder (no Drive needed):
+python3 agents/enrichment/src/agent_runner.py \
+  --mode=table \
+  --dataset=<project>.<dataset> \
+  --folders=./local_md_corpus \
+  --project=<your_gcp_project> --model=<vertex_model> \
+  --output_dir=<local_output_dir>
+```
+
+Each source the agent reads is recorded in `trajectory.json` as its own tool call
+(`read_local_md` for local files, `fetch_gdoc` for Google Docs), so downstream
+evaluation counts and grounds on exactly what was read.
 
 ## Output
 
@@ -324,11 +384,18 @@ Flags (see `python -m eval --help`):
 
 | Flag | Required | Meaning |
 |------|----------|---------|
-| `--output-dir` | yes | The enrichment run's output dir (contains `catalog/` + `trajectory.json`). |
+| `--output-dir` | yes (score mode) | The enrichment run's output dir (contains `catalog/` + `trajectory.json`). |
+| `--golden` | no | Golden file → golden-based eval (adds concept_recall/precision, fact_recall, coverage). Omit for dynamic (golden-free) eval. See `eval/goldens/README.md`. |
+| `--run` | no | Run each golden as a CASE (generate the mdcode via the agent, then score) instead of scoring an existing dir. Requires `--project`. |
+| `--goldens` | no | Comma-separated golden files (run/score several cases at once). |
+| `--runs` | no | How many times to run each case (default 3 in `--run`). Reports per-run + averaged metrics, and enables the cross-run **consistency** metrics (need ≥2 runs). |
+| `--project` | with `--run` | GCP project the agent runs in (also sets `GOOGLE_CLOUD_PROJECT` for the judge). |
+| `--concurrency` | no | Max concurrent agent processes in `--run` (default 2, env `KC_EVAL_MAX_CONCURRENCY`). |
+| `--persona` | no | Persona id from the golden's `personas` (golden mode only). |
 | `--model` | no | Judge model — any Vertex AI model id you have access to. Defaults to `gemini-2.5-pro`. |
 | `--json` | no | Emit raw JSON instead of the formatted scorecard (for piping/automation). |
 
-It reports the following, each on a 0–1 scale (higher is better):
+It reports the following, each shown **out of 100** in the scorecard (higher is better):
 
 - **structural_validity** *(deterministic)* — the generated mdcode is well-formed:
   entry YAML parses, required fields are present, the entry type matches the mode,
@@ -338,16 +405,16 @@ It reports the following, each on a 0–1 scale (higher is better):
   visibility (not gated against a budget; does not affect pass/fail).
 - **hallucination_free** *(judge)* — is every factual claim in the overviews
   supported by what the agent actually retrieved? The score is the fraction of
-  extracted claims that are grounded; **1.0 = nothing fabricated**. Claims are
+  extracted claims that are grounded; **100 = nothing fabricated**. Claims are
   checked in parallel across chunks of the retrieved source.
 - **redundancy_index** *(judge)* — does the overview add **novel** context beyond
-  echoing column names/schema? **1 = rich synthesis, 0 = tautological restatement.**
+  echoing column names/schema? **100 = rich synthesis, 0 = tautological restatement.**
 - **disambiguation_efficacy** *(judge)* — is the enrichment enough to tell this
   entry apart from similar/overlapping ones (its grain and purpose made explicit)?
-  **1 = clearly distinct.**
+  **100 = clearly distinct.**
 - **absence_of_contradictions** *(judge)* — are there contradictions within or
   across the generated entries (join keys, enums, metric definitions, freshness)?
-  **1 = none, 0 = an explicit conflict.**
+  **100 = none, 0 = an explicit conflict.**
 
 ### Enabling the judge-based metrics
 
@@ -365,6 +432,99 @@ gcloud auth application-default login
 Without auth they are simply skipped and shown as `n/a`; the deterministic metrics
 still run. Choose the judge model with `--model` (default `gemini-2.5-pro`).
 
+### Golden-based eval (optional)
+
+A **golden** is an answer key you declare for a case — the expected facts, terms,
+and sections. Golden scoring runs the **full dynamic metric set**
+(`structural_validity`, `perf`, `hallucination_free`, `redundancy_index`,
+`disambiguation_efficacy`, `absence_of_contradictions`) **and adds** the
+golden-driven metrics below (each shown out of 100, higher is better):
+
+- **concept_recall** *(judge, doc mode)* — of the concepts the golden expects as
+  knowledge-base entries, what fraction did the agent produce (matched by meaning,
+  not exact name)? **100 = every expected concept covered.**
+- **concept_precision** *(judge, doc mode)* — of the entries the agent produced,
+  what fraction map to an expected concept? Spurious entries lower it; concepts
+  you list under `acceptable_extra_concepts` are exempt. **100 = no off-target
+  entries.**
+- **fact_recall** *(judge)* — of the `golden_facts` (per table in table mode),
+  what fraction are conveyed by the matched output? **100 = all expected facts
+  present.**
+- **business_terms_presence** *(judge)* — are the golden's `business_terms`
+  defined or used in the output (matched semantically)? **100 = all covered.**
+- **enrichment_diversity** *(deterministic)* — does the output contain the
+  sections the golden declares in `expected_headings`? A "Sample Queries" heading
+  is satisfied by a populated `<table>.queries.md` sidecar. **100 = all expected
+  sections present.**
+- **entry_grounding** *(deterministic, table mode)* — do all generated entries
+  correspond to real dataset tables, with none invented? **100 = nothing
+  fabricated.**
+- **persona_alignment** *(judge, with `--persona`)* — on the same source, does the
+  output emphasize this persona's focus areas while still retaining the shared
+  concepts? **100 = strong persona conditioning without dropping shared content.**
+- **business_terms_validity** *(judge, needs `business_terms`)* — beyond mere
+  presence, does each business term get a dedicated, correct definition (a
+  per-term MaC file)? Typically low today (the agent doesn't emit per-term files
+  yet) — included for parity with the reference design so scores are comparable.
+- **context_preservation** *(judge, needs `prebaked_facts`)* — if the golden
+  declares facts that already existed before enrichment, were they **preserved**
+  (not clobbered) through the run? Only scored when the golden has `prebaked_facts`.
+- **trajectory** *(deterministic, needs a `trajectory` block)* — input-conditioned
+  tool use: did the agent call the tools it should (`must_call`) and avoid those it
+  shouldn't (`must_not_call`)? Derived from `trajectory.json`. Only scored when the
+  golden declares a `trajectory` block (e.g. `{ "must_not_call": ["dataset_pull"] }`
+  for a doc case). **100 = tool use matched the inputs.**
+
+The simplest way is to let the eval **run the case end-to-end** — it does the
+setup (e.g. copying a public dataset into your project), runs the agent, and
+scores the result. You only pass your project and the golden:
+
+```bash
+# Runs theLook eCommerce table mode for you (copies the public dataset into
+# <project>, enriches it grounded by the local corpus, scores it) — 3 runs,
+# run-level + averaged metrics:
+python -m eval --run --goldens eval/goldens/thelook_ecommerce.json \
+    --project <your_gcp_project> --model gemini-2.5-pro --runs 3
+```
+
+`--run` repeats each case `--runs` times and writes per-run + averaged reports
+into a timestamped folder under `$TMPDIR/kc_golden_eval_reports/` (printed at the
+end). Add more cases with a comma-separated `--goldens`. Prereqs: ADC
+(`gcloud auth application-default login`) and a built `kcmd`
+(`cd agents/mdcode && npm run build`) — every mode shells out to it.
+
+### Multiple runs: averaged metrics + consistency
+
+With `--runs N` (N ≥ 2), each metric is reported as the **mean across runs** with
+its per-run scores and how many runs passed (`runs k/n`), the case rationale keeps
+the *real* per-metric explanation (a representative run's, preferring a failing
+one — not just "mean of N"), and the report appends a **per-run breakdown** you
+can drill into. Two extra **cross-run stability** metrics are added (informational
+— they don't gate the case or affect the average):
+
+- **concept_consistency** — does the agent produce the **same set of concepts**
+  every run? Each concept scores the fraction of runs it appears in, so producing
+  more/fewer concepts between runs lowers it (matched by meaning when the judge is
+  on, by name/word overlap otherwise). **100 = identical concept set each run.**
+- **content_consistency** — for concepts that recur across runs, are their
+  **facts consistent** (no drift/contradiction between runs)? **100 = same facts
+  every run.**
+
+Both measure stability *across* runs, so they only apply with **≥2 runs**; with a
+single run they're surfaced as `n/a` with a note to run the case 2–3× to assess
+stability.
+
+To score an output you already produced (no agent run), point `--golden` at it:
+
+```bash
+python -m eval --output-dir /tmp/enrich_out --golden eval/goldens/supply_chain.json
+```
+
+See `eval/goldens/README.md` for the golden/case schema (incl. the `run` block
+for your own cases), `--run`/`--runs`/`--goldens` usage, and three ways to build
+goldens — author them, work backward from already-documented data, or harvest
+them from human review.
+
 ## Publishing to the catalog
 
 The agent only **generates** mdcode and runs read-only `kcmd` commands. Pushing
@@ -373,7 +533,7 @@ to Dataplex is **your** step, with `kcmd push`:
 ```bash
 cd /tmp/enrich_out
 CLOUDSDK_CORE_PROJECT=<project> CLOUDSDK_COMPUTE_REGION=<region> \
-  kcmd push     # kcmd from the build step above (on your PATH); otherwise use the full path to agents/mdcode/dist/kcmd
+  ../agents/mdcode/dist/kcmd push     # or `kcmd push` if kcmd is on your PATH
 ```
 
 `kcmd` is the Metadata as Code tool from

--- a/agents/enrichment/eval/__main__.py
+++ b/agents/enrichment/eval/__main__.py
@@ -1,25 +1,41 @@
-"""CLI for dynamic (golden-free) enrichment evaluation.
+"""CLI for enrichment evaluation (dynamic golden-free + golden-based).
 
-Run from `agents/enrichment/`:
+Two ways to use it, run from `agents/enrichment/`:
 
-    python -m eval --output-dir /path/to/enrichment/output
-    python -m eval --output-dir /path/to/output --model gemini-2.5-pro --json
+  SCORE an output the agent already produced
+    python -m eval --output-dir /path/to/output                       # dynamic (golden-free)
+    python -m eval --output-dir /path/to/output --golden eval/goldens/supply_chain.json
 
-The output dir is what the enrichment agent wrote (contains `catalog/` and
-`trajectory.json`). Judge auth: Vertex AI — set GOOGLE_CLOUD_PROJECT and
-Application Default Credentials (`gcloud auth application-default login`), the
-same auth the enrichment agent uses. Each run also writes a full `eval_report.md`
-into the output dir with untruncated rationales.
+  RUN golden cases on the agent, then score (single agent — the golden's `run` block carries the agent inputs + setup):
+    python -m eval --run --goldens eval/goldens/thelook_ecommerce.json \
+        --project my-gcp-project --runs 3
+
+`--run` generates the Metadata-as-Code itself (you don't pre-run the agent),
+repeats each case `--runs` times, scores every run, and reports run-level +
+averaged metrics into a timestamped run folder. Agent processes are capped at
+`--concurrency` (default 2, env KC_EVAL_MAX_CONCURRENCY) on top of the agent's own
+per-mode LLM concurrency limits.
+
+Judge auth: Vertex AI — set GOOGLE_CLOUD_PROJECT (or pass --project, which sets it)
+and ADC (`gcloud auth application-default login`).
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
+import datetime
 import json
 import os
 import sys
+import tempfile
+import uuid
+from collections import defaultdict
 
-from .dynamic_eval import run_dynamic_eval, fmt_score
+from . import aggregate
+from . import runner
+from .dynamic_eval import run_dynamic_eval, fmt_score, write_report
+from .golden_eval import run_golden_eval
 
 
 def _has_judge_auth() -> bool:
@@ -29,24 +45,40 @@ def _has_judge_auth() -> bool:
 
 def _fmt(results: dict) -> str:
   metrics = results.get("metrics", [])
-  # Width the metric column to the longest name (e.g. absence_of_contradictions)
-  # so every score stays aligned.
+  golden = results.get("golden")
   w = max([len(m["name"]) for m in metrics] + [len("metric"), len("AVERAGE")])
-  lines = ["", f"Dynamic eval — {results.get('output_dir')}",
-           f"  mode: {results.get('mode')}  (agent_type={results.get('agent_type')})",
-           "",
-           f"  {'metric':{w}} {'score':>7}   rationale",
-           f"  {'-'*w} {'-'*7}   {'-'*40}"]
+  title = "Golden eval" if golden else "Dynamic eval"
+  n_runs = results.get("runs", 1)
+  head = f"{title} — {results.get('output_dir')}"
+  if n_runs and n_runs > 1:
+    head += f"  ({n_runs} runs, averaged)"
+  lines = ["", head]
+  if golden:
+    lines.append(f"  golden: {golden}")
+  lines.append(f"  mode: {results.get('mode')}  (agent_type={results.get('agent_type')})")
+  lines += ["",
+            f"  {'metric':{w}} {'score':>7}   rationale",
+            f"  {'-'*w} {'-'*7}   {'-'*40}"]
+  multi = bool(n_runs and n_runs > 1)
   for m in metrics:
-    sc = m["score"]
-    sc_s = fmt_score(sc)
     rat = (m.get("rationale") or "").replace("\n", " ")
-    if len(rat) > 90:
-      rat = rat[:90] + "…"
-    lines.append(f"  {m['name']:{w}} {sc_s:>7}   {rat}")
-  avg = results.get("average_score")
+    # On multi-run cases, lead the rationale with the per-run signal the report
+    # shows ("runs k/n [s1, s2]") so flaky/variant metrics are obvious.
+    rs = m.get("run_scores")
+    # Consistency metrics carry entry COUNTS in run_scores (not 0..1 scores) and
+    # explain them in their rationale — don't render them as percentages.
+    if multi and rs and not m["name"].endswith("_consistency"):
+      rp = m.get("runs_passed")
+      tag = (f"runs {rp} " if rp else "") + f"[{', '.join(fmt_score(s) for s in rs)}]"
+      rat = f"{tag}  {rat}".strip()
+    if len(rat) > 100:
+      rat = rat[:100] + "…"
+    lines.append(f"  {m['name']:{w}} {fmt_score(m['score']):>7}   {rat}")
   lines.append(f"  {'-'*w} {'-'*7}")
-  lines.append(f"  {'AVERAGE':{w}} {fmt_score(avg):>7}")
+  lines.append(f"  {'AVERAGE':{w}} {fmt_score(results.get('average_score')):>7}")
+  per_run = results.get("per_run_averages")
+  if per_run and len(per_run) > 1:
+    lines.append(f"  {'per-run':{w}} {', '.join(fmt_score(s) for s in per_run)}")
   t = results.get("telemetry", {})
   lat = t.get("latency_s")
   lines.append("")
@@ -55,39 +87,279 @@ def _fmt(results: dict) -> str:
                f"tool calls: {t.get('num_tool_calls', 0)}  ·  "
                f"latency: {('—' if not lat else f'{lat:.1f}s')}")
   lines.append("")
-  lines.append(f"  full report: {os.path.join(results.get('output_dir', ''), 'eval_report.md')}")
+  return "\n".join(lines)
+
+
+def _label(results: dict) -> str:
+  g = results.get("golden")
+  return os.path.basename(g) if g else os.path.basename(results.get("output_dir", ""))
+
+
+def _fmt_summary(results: list[dict], batch_dir: str | None) -> str:
+  w = max([len(_label(r)) for r in results] + [len("golden"), len("OVERALL")])
+  lines = ["", f"=== Summary — {len(results)} case(s) ===",
+           f"  {'golden':{w}} {'avg':>7}",
+           f"  {'-'*w} {'-'*7}"]
+  scores = []
+  for r in results:
+    avg = r.get("average_score")
+    if isinstance(avg, (int, float)):
+      scores.append(avg)
+    lines.append(f"  {_label(r):{w}} {fmt_score(avg):>7}")
+  if scores:
+    lines.append(f"  {'-'*w} {'-'*7}")
+    lines.append(f"  {'OVERALL':{w}} {fmt_score(sum(scores) / len(scores)):>7}")
+  if batch_dir:
+    lines.append("")
+    lines.append(f"  reports: {batch_dir}")
   lines.append("")
   return "\n".join(lines)
+
+
+def _aggregate_runs(run_results: list[dict], mode: str | None = None,
+                    model: str = "gemini-2.5-pro") -> dict:
+  """Aggregate N runs of one case → one result, matching the reference design
+  (per-metric mean + representative rationale + run_scores/runs_passed, per-run
+  drill-down, and the cross-run consistency metrics). See aggregate.py."""
+  return aggregate.aggregate_runs(run_results, mode=mode, model=model)
+
+
+# --------------------------- run mode (case-runner) ---------------------------
+
+async def _run_cases(goldens, project, model, runs, concurrency, batch_dir,
+                     persona, dry_run):
+  cases = []
+  for gp in goldens:
+    with open(gp, encoding="utf-8") as f:
+      golden = json.load(f)
+    if "run" not in golden:
+      print(f"error: {gp} has no `run` block — it's a score-only golden. Score it "
+            "with `--output-dir <existing> --golden`.", file=sys.stderr)
+      return None
+    cases.append((gp, golden))
+
+  if dry_run:
+    print(f"[dry-run] would run {len(cases)} case(s) x {runs} run(s), "
+          f"concurrency {concurrency}, into {batch_dir}:")
+    for gp, golden in cases:
+      print(f"  - {os.path.basename(gp)}: {json.dumps(golden['run'])}")
+    return []
+
+  sem = asyncio.Semaphore(concurrency)
+  # Resolve inputs (incl. copy-public-dataset setup) sequentially — bq calls.
+  jobs = []  # (gp, stem, inputs, run_idx, out_dir)
+  for gp, golden in cases:
+    inputs = runner.resolve_inputs(golden, project)
+    stem = os.path.splitext(os.path.basename(gp))[0]
+    for i in range(runs):
+      out = os.path.join(batch_dir, stem, f"run{i + 1}", "mdcode")
+      jobs.append((gp, stem, inputs, i + 1, out))
+
+  async def _do(job):
+    gp, stem, inputs, idx, out = job
+    rc, _ = await runner.run_agent(inputs, project, model, out, sem)
+    return job, rc
+
+  done = await asyncio.gather(*[_do(j) for j in jobs])
+
+  per_case: dict[tuple, list] = defaultdict(list)
+  for (gp, stem, inputs, idx, out), rc in done:
+    if rc != 0:
+      print(f"[score] skip {stem} run{idx} (agent exited {rc}).", file=sys.stderr)
+      continue
+    # A run with no trajectory.json didn't really finish (crash/timeout) — don't
+    # score garbage; surface it so the user can fix their case/env.
+    if not os.path.isfile(os.path.join(out, "trajectory.json")):
+      print(f"[score] skip {stem} run{idx}: no trajectory.json — the agent run "
+            f"did not complete (check the agent env: deps + kcmd built). Output: "
+            f"{out}", file=sys.stderr)
+      continue
+    res = run_golden_eval(out, gp, model=model, persona_id=persona,
+                          report_dir=os.path.join(batch_dir, stem),
+                          report_name=f"run{idx}.md")
+    if "error" in res:
+      print(f"[score] {stem} run{idx}: {res['error']}", file=sys.stderr)
+      continue
+    per_case[(gp, stem)].append(res)
+
+  results = []
+  for (gp, stem), rl in per_case.items():
+    if not rl:
+      continue
+    agg = _aggregate_runs(rl, mode=rl[0].get("mode"), model=model)
+    # Persist the AVERAGED result too (full, untruncated rationale + per-run
+    # breakdown + consistency) next to the per-run run<i>.md reports, so nothing
+    # is lost to terminal truncation.
+    write_report(agg, os.path.join(batch_dir, stem), filename="aggregate.md")
+    results.append(agg)
+  return results
 
 
 def main(argv=None) -> int:
   ap = argparse.ArgumentParser(
       prog="python -m eval",
-      description="Dynamic (golden-free) evaluation of an enrichment run.")
-  ap.add_argument("--output-dir", required=True,
-                  help="Enrichment output dir (contains catalog/ and trajectory.json).")
+      description="Evaluate enrichment — score an existing output, or --run golden cases.")
+  ap.add_argument("--output-dir", default=None,
+                  help="SCORE mode: the agent's output dir (catalog/ + trajectory.json). "
+                       "Comma-separated to pair with --goldens. RUN mode: optional report "
+                       "root (defaults to a timestamped folder under $TMPDIR).")
+  ap.add_argument("--golden", default=None, help="A single golden file.")
+  ap.add_argument("--goldens", default=None,
+                  help="Comma-separated golden files → evaluate several at once.")
+  ap.add_argument("--run", action="store_true",
+                  help="RUN each golden as a CASE on the agent (generate mdcode via its "
+                       "`run` block + setup), then score. Requires --project.")
+  ap.add_argument("--project", default=None,
+                  help="GCP project (RUN mode): agent Vertex project + dataset-copy target. "
+                       "Also sets GOOGLE_CLOUD_PROJECT for the judge.")
+  ap.add_argument("--runs", type=int, default=None,
+                  help="Times to run each case for run-level + averaged metrics. "
+                       "Default 3 in --run mode. Only "
+                       "valid with a golden (--run / --golden); rejected for dynamic "
+                       "eval, which scores an output dir once.")
+  ap.add_argument("--concurrency", type=int,
+                  default=max(1, int(os.environ.get("KC_EVAL_MAX_CONCURRENCY", "2"))),
+                  help="RUN mode: max concurrent agent processes (default 2 / "
+                       "KC_EVAL_MAX_CONCURRENCY); the agent caps its own LLM concurrency.")
+  ap.add_argument("--dry-run", action="store_true",
+                  help="RUN mode: print the plan (cases, runs) without running anything.")
+  ap.add_argument("--persona", default=None,
+                  help="Persona id from the golden's `personas` (golden mode only).")
   ap.add_argument("--model", default="gemini-2.5-pro",
-                  help="Judge model: any Vertex AI model id you have access to "
-                       "(default: gemini-2.5-pro).")
+                  help="Model for the agent (RUN) and the judge — any Vertex AI model id "
+                       "you have access to (default gemini-2.5-pro).")
   ap.add_argument("--json", action="store_true",
                   help="Emit raw JSON instead of a formatted scorecard.")
   args = ap.parse_args(argv)
 
-  if not os.path.isdir(args.output_dir):
-    print(f"error: not a directory: {args.output_dir}", file=sys.stderr)
+  if args.runs is not None and args.runs < 1:
+    print("error: --runs must be >= 1.", file=sys.stderr)
+    return 2
+
+  goldens: list[str] = []
+  if args.goldens:
+    goldens = [g.strip() for g in args.goldens.split(",") if g.strip()]
+  elif args.golden:
+    goldens = [args.golden]
+  for g in goldens:
+    if not os.path.isfile(g):
+      print(f"error: golden not found: {g}", file=sys.stderr)
+      return 2
+
+  # ----- RUN mode: generate mdcode via the agent, then score -----
+  if args.run:
+    if not goldens:
+      print("error: --run needs --golden/--goldens (the case to run).", file=sys.stderr)
+      return 2
+    if not args.project:
+      print("error: --run needs --project (agent Vertex project + dataset target).",
+            file=sys.stderr)
+      return 2
+    os.environ.setdefault("GOOGLE_CLOUD_PROJECT", args.project)
+    os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+    if not _has_judge_auth():
+      print("warning: no Vertex auth — run `gcloud auth application-default login`.",
+            file=sys.stderr)
+    run_id = (datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+              + "_" + uuid.uuid4().hex[:6])
+    root = args.output_dir or os.path.join(tempfile.gettempdir(),
+                                           "kc_golden_eval_reports")
+    batch_dir = os.path.join(root, f"golden_run_{run_id}")
+    os.makedirs(batch_dir, exist_ok=True)
+    run_n = args.runs or 3
+    results = asyncio.run(_run_cases(goldens, args.project, args.model, run_n,
+                                     args.concurrency, batch_dir, args.persona,
+                                     args.dry_run))
+    if results is None:
+      return 2
+    if args.dry_run:
+      return 0
+    # manifest for the user: what ran, when, where.
+    with open(os.path.join(batch_dir, "manifest.json"), "w", encoding="utf-8") as f:
+      json.dump({"run_id": run_id, "when": run_id, "project": args.project,
+                 "model": args.model, "runs_per_case": run_n,
+                 "concurrency": args.concurrency,
+                 "cases": [os.path.basename(g) for g in goldens],
+                 "results": [{"golden": _label(r), "average": r.get("average_score")}
+                             for r in results]}, f, indent=2)
+    if args.json:
+      print(json.dumps(results, indent=2))
+    else:
+      for r in results:
+        print(_fmt(r))
+      print(_fmt_summary(results, batch_dir) if len(results) > 1
+            else f"\n  reports: {batch_dir}\n")
+    return 0 if results else 1
+
+  # ----- SCORE mode: score an already-produced output dir -----
+  if not args.output_dir:
+    print("error: --output-dir is required (or use --run to generate it).",
+          file=sys.stderr)
+    return 2
+  # Dynamic eval (no golden) scores ONE output dir once; multiple runs would just
+  # re-score the same output and mean nothing. Reject --runs > 1 there — it only
+  # applies to golden case-runs (`--run`, which generates N independent runs).
+  if not goldens and (args.runs or 0) > 1:
+    print("error: --runs only applies to golden case-runs (--run). Dynamic eval "
+          "scores an output dir once — drop --runs, or pass a golden via --golden "
+          "/ --run.", file=sys.stderr)
+    return 2
+  output_dirs = [d.strip() for d in args.output_dir.split(",") if d.strip()]
+  if goldens:
+    if len(output_dirs) == 1:
+      jobs = [(output_dirs[0], g) for g in goldens]
+    elif len(output_dirs) == len(goldens):
+      jobs = list(zip(output_dirs, goldens))
+    else:
+      print("error: --output-dir must be one dir or match the --goldens count.",
+            file=sys.stderr)
+      return 2
+  else:
+    jobs = [(d, None) for d in output_dirs]
+  for d, g in jobs:
+    if not os.path.isdir(d):
+      print(f"error: not a directory: {d}", file=sys.stderr)
+      return 2
+  if args.persona and not goldens:
+    print("error: --persona requires a golden.", file=sys.stderr)
     return 2
   if not _has_judge_auth():
-    print("warning: GOOGLE_CLOUD_PROJECT not set — judge-based metrics "
-          "(hallucination_free, rubric) need Vertex AI auth (set GOOGLE_CLOUD_PROJECT "
-          "+ run `gcloud auth application-default login`). Deterministic metrics still run.",
-          file=sys.stderr)
+    print("warning: GOOGLE_CLOUD_PROJECT not set — judge metrics need Vertex AI auth; "
+          "deterministic metrics still run.", file=sys.stderr)
 
-  results = run_dynamic_eval(args.output_dir, model=args.model)
-  if "error" in results:
-    print(f"error: {results['error']}", file=sys.stderr)
-    return 1
-  print(json.dumps(results, indent=2) if args.json else _fmt(results))
-  return 0
+  all_results, rc = [], 0
+  for d, g in jobs:
+    run_results = []
+    for _ in range(args.runs or 1):
+      res = (run_golden_eval(d, g, model=args.model, persona_id=args.persona)
+             if g else run_dynamic_eval(d, model=args.model))
+      if "error" in res:
+        print(f"error [{g or d}]: {res['error']}", file=sys.stderr)
+        rc = 1
+        break
+      run_results.append(res)
+    if not run_results:
+      continue
+    agg = _aggregate_runs(run_results, mode=run_results[0].get("mode"),
+                          model=args.model)
+    # For multi-run scoring, persist the averaged report (single runs already
+    # wrote their own full report next to trajectory.json / in the golden tmp dir).
+    if len(run_results) > 1:
+      rep_dir = os.path.join(tempfile.gettempdir(), "kc_golden_eval_reports")
+      os.makedirs(rep_dir, exist_ok=True)
+      stem = (os.path.splitext(os.path.basename(g))[0] if g
+              else os.path.basename(d.rstrip("/")) or "run")
+      p = write_report(agg, rep_dir, filename=f"aggregate_{stem}.md")
+      if p and not args.json:
+        print(f"  averaged report → {p}", file=sys.stderr)
+    all_results.append(agg)
+    if not args.json:
+      print(_fmt(agg))
+  if args.json:
+    print(json.dumps(all_results[0] if len(all_results) == 1 else all_results, indent=2))
+  elif len(all_results) > 1:
+    print(_fmt_summary(all_results, None))
+  return rc
 
 
 if __name__ == "__main__":

--- a/agents/enrichment/eval/aggregate.py
+++ b/agents/enrichment/eval/aggregate.py
@@ -1,0 +1,291 @@
+"""Cross-run aggregation for `--runs > 1`.
+
+Rolls N per-run results into one case result:
+
+  - each aggregated metric carries the mean `score`, a representative *real*
+    `rationale` (preferring a failing run's — NOT the string "mean of N runs"),
+    `run_scores` (per-run), and `runs_passed` ("k/n");
+  - the case also keeps `per_run` (the per-run drill-down: each run's metrics +
+    rationale); and
+  - two informational cross-run STABILITY metrics — `concept_consistency`
+    (does the agent produce the same SET of concepts each run) and
+    `content_consistency` (do recurring concepts state the same FACTS) — which
+    are **n/a (None) unless there are ≥2 runs**. They never gate the case and are
+    excluded from the average.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import re
+
+from . import loaders
+from . import metrics
+
+
+def _run_overviews(run_results: list[dict]) -> list[dict]:
+  """One {concept_name: overview_text} map per *independent* run, loaded from each
+  run's generated mdcode. Concept name = the entry's basename sans `.overview.md`.
+
+  Runs that point at the SAME output dir are deduped: consistency measures
+  agent run-to-run variability, so re-scoring one output N times (dynamic
+  `--runs` on a single dir) is a single independent run, not N — otherwise it
+  would trivially report 100% "consistency" comparing identical output to itself.
+  """
+  entries, seen = [], set()
+  for r in run_results:
+    od = r.get("output_dir")
+    if not od or od in seen:
+      continue
+    seen.add(od)
+    arts = loaders.load_mdcode(os.path.join(od, "catalog"))
+    files = arts.get("overview_md") or {}
+    if files:
+      entries.append({os.path.basename(k).replace(".overview.md", ""): v
+                      for k, v in files.items()})
+  return entries
+
+
+def metric_rollup(run_results: list[dict]) -> list[dict]:
+  """Per-metric roll-up across a case's runs:
+  mean score, a representative rationale (prefer a failing run's), run_scores,
+  and runs_passed."""
+  agg: dict[str, dict] = {}
+  order: list[str] = []
+  for r in run_results:
+    for m in r.get("metrics", []):
+      name = m["name"]
+      if name not in agg:
+        agg[name] = {"name": name, "scores": [], "npass": 0, "n": 0,
+                     "rationale": "", "insights": "",
+                     "description": m.get("description", name)}
+        order.append(name)
+      e = agg[name]
+      sc = m.get("score")
+      if sc is not None:  # skip judge-errored (unscored) runs
+        e["scores"].append(round(float(sc), 4))
+      e["n"] += 1
+      passed = m.get("passed", True)
+      if passed:
+        e["npass"] += 1
+      d = (m.get("rationale") or "").strip()
+      if d and (not e["rationale"] or not passed):
+        e["rationale"] = d
+      ins = (m.get("insights") or "").strip()
+      if ins and (not e["insights"] or not passed):
+        e["insights"] = ins
+  out = []
+  for name in order:
+    e = agg[name]
+    scores = e["scores"]
+    out.append({"name": name,
+                "score": round(sum(scores) / len(scores), 4) if scores else None,
+                "description": e["description"],
+                # Representative detail (a failing run's when any failed). When a
+                # judge is available this is rewritten into a uniform, run-aware
+                # rationale by explain_metrics in aggregate_runs (see below) —
+                # no judge → this fallback stays.
+                "rationale": e["rationale"],
+                "insights": e["insights"],
+                "run_scores": scores,
+                "runs_passed": f"{e['npass']}/{e['n']}"})
+  return out
+
+
+def consistency_metrics(run_results: list[dict], judge) -> list[dict]:
+  """Two cross-run STABILITY metrics,
+  matched SEMANTICALLY via the judge (string/word fallback with no judge):
+
+    - concept_consistency: does the agent produce the same SET of concepts every
+      run (each concept scores the fraction of runs it appears in, so producing
+      more/fewer concepts between runs lowers it);
+    - content_consistency: for concepts that recur, are the FACTS consistent.
+
+  Informational — never gates. **n/a (None) when <2 runs** (surfaced with a note,
+  matching the reference design, since consistency is undefined for a single run)."""
+  run_entries = _run_overviews(run_results)
+  n_runs = len(run_entries)
+  counts = [len(e) for e in run_entries]
+  if n_runs < 2:
+    def _sk(name, desc):
+      return {"name": name, "score": None, "passed": True, "description": desc,
+              "rationale": "Need ≥2 independent runs (distinct agent outputs) to "
+                           "measure cross-run consistency. Use the golden "
+                           "case-runner `--run --runs N`, which generates N fresh "
+                           "runs; dynamic `--runs` on one output dir re-scores the "
+                           "same output and isn't independent.",
+              "insights": "Generate the output 2-3× (different runs) to assess "
+                          "stability.",
+              "run_scores": counts, "runs_passed": ""}
+    return [_sk("concept_consistency",
+                "Cross-run stability of WHICH concepts are produced"),
+            _sk("content_consistency",
+                "Cross-run stability of the FACTS stated")]
+
+  concepts = metrics.consistency_judge(run_entries, judge) if judge else None
+  if concepts:  # semantic alignment from the judge
+    fracs = [len(c.get("runs", [])) / n_runs for c in concepts if c.get("runs")]
+    concept_score = round(sum(fracs) / len(fracs), 3) if fracs else None
+    cvals = [float(c["content_consistency"]) for c in concepts
+             if len(c.get("runs", [])) >= 2
+             and isinstance(c.get("content_consistency"), (int, float))]
+    content_score = round(sum(cvals) / len(cvals), 3) if cvals else None
+    unstable = [c.get("name") for c in concepts if len(c.get("runs", [])) < n_runs]
+    diverging = [c.get("name") for c in concepts if len(c.get("runs", [])) >= 2
+                 and isinstance(c.get("content_consistency"), (int, float))
+                 and float(c["content_consistency"]) < 0.6]
+    n_concepts = len(concepts)
+    match_note = "semantic match"
+  else:  # deterministic fallback (no judge): string/word overlap
+    norm = lambda k: re.sub(r"[-_.\s]", "", k.lower())
+    words = lambda t: set(re.findall(r"[a-z0-9]{4,}", (t or "").lower()))
+    by_concept: dict[str, dict] = {}
+    for i, e in enumerate(run_entries):
+      for name, txt in e.items():
+        c = by_concept.setdefault(norm(name),
+                                  {"name": name, "runs": set(), "texts": []})
+        c["runs"].add(i)
+        c["texts"].append(words(txt))
+    n_concepts = len(by_concept)
+    fracs = [len(c["runs"]) / n_runs for c in by_concept.values()]
+    concept_score = round(sum(fracs) / len(fracs), 3) if fracs else None
+    cvals, diverging = [], []
+    for c in by_concept.values():
+      ws = [w for w in c["texts"] if w]
+      if len(ws) < 2:
+        continue
+      sims = [len(a & b) / len(a | b) if (a | b) else 1.0
+              for a, b in itertools.combinations(ws, 2)]
+      ov = sum(sims) / len(sims)
+      cvals.append(ov)
+      if ov < 0.5:
+        diverging.append(c["name"])
+    content_score = round(sum(cvals) / len(cvals), 3) if cvals else None
+    unstable = [c["name"] for c in by_concept.values() if len(c["runs"]) < n_runs]
+    match_note = "name/word match (enable judge for semantic match)"
+
+  concept_detail = (
+      f"Across {n_runs} runs the agent produced {min(counts)}–{max(counts)} "
+      f"entries covering {n_concepts} distinct concepts ({match_note}); on average "
+      f"each concept appears in {round((concept_score or 0) * 100)}% of runs. "
+      + ("Every concept appears in all runs." if not unstable
+         else f"Concepts NOT in every run (more/fewer between runs): "
+              f"{', '.join(filter(None, unstable))[:220]}."))
+  content_detail = (
+      f"For concepts present in ≥2 runs, their facts are "
+      f"{round((content_score or 0) * 100)}% consistent across runs ({match_note})."
+      + (f" Diverging facts in: {', '.join(filter(None, diverging))[:220]}."
+         if diverging else "")
+      ) if content_score is not None else (
+          "No concept recurred across runs to compare content.")
+  return [
+      {"name": "concept_consistency", "score": concept_score,
+       "passed": (concept_score or 0) >= 0.7,
+       "description": "Cross-run stability of WHICH concepts are produced",
+       "rationale": concept_detail,
+       "insights": ("" if (concept_score or 0) >= 0.85 else
+                    "Stabilize which concepts become entries (consistent "
+                    "splitting/merging) so the same set is produced each run."),
+       "run_scores": counts, "runs_passed": ""},
+      {"name": "content_consistency", "score": content_score,
+       "passed": (content_score if content_score is not None else 1) >= 0.7,
+       "description": "Cross-run stability of the FACTS stated",
+       "rationale": content_detail,
+       "insights": ("" if (content_score or 1) >= 0.85 else
+                    "Reduce fact drift: make recurring entries state the same "
+                    "facts each run."),
+       "run_scores": [], "runs_passed": ""},
+  ]
+
+
+def runs_detail(run_results: list[dict]) -> list[dict]:
+  """Per-run drill-down: each run's metrics +
+  rationale + its average + telemetry, so a human can read what earned each
+  score."""
+  out = []
+  for i, r in enumerate(run_results):
+    mets = [{"name": m["name"],
+             "score": (round(m["score"], 3)
+                       if isinstance(m.get("score"), (int, float)) else None),
+             "passed": m.get("passed"),
+             "rationale": m.get("rationale", ""),
+             "insights": m.get("insights", "")}
+            for m in r.get("metrics", [])]
+    out.append({"index": i + 1,
+                "average_score": r.get("average_score"),
+                "output_dir": r.get("output_dir"),
+                "telemetry": r.get("telemetry", {}),
+                "metrics": mets})
+  return out
+
+
+def _mean(vals):
+  vals = [v for v in vals if isinstance(v, (int, float))]
+  return sum(vals) / len(vals) if vals else None
+
+
+def aggregate_runs(run_results: list[dict], mode: str | None = None,
+                   model: str = "gemini-2.5-pro") -> dict:
+  """Aggregate N per-run result dicts (from run_golden_eval/run_dynamic_eval) into
+  one case result: per-metric mean +
+  representative rationale + run_scores/runs_passed, per-run drill-down, the two
+  consistency metrics, mean telemetry, and per-run averages."""
+  n = len(run_results)
+  base = dict(run_results[0])
+  has_auth = bool(os.environ.get("GOOGLE_CLOUD_PROJECT")
+                  or os.environ.get("GOOGLE_GENAI_USE_VERTEXAI"))
+  judge = metrics.default_judge(model) if has_auth else None
+
+  rollup = metric_rollup(run_results)
+  # Rewrite the per-metric rationale/insights into one uniform, run-aware voice
+  # via a single batched judge call. The
+  # explainer reasons over the evidence + per-run scores and names the specific
+  # lower run(s) itself, so we DON'T tag a single representative run. Falls back to
+  # the deterministic representative detail when there's no judge or the call
+  # fails. explain_metrics reads evidence from `detail`, so pass rationale as that.
+  if judge is not None:
+    try:
+      expl = metrics.explain_metrics(
+          [{**m, "detail": m.get("rationale", "")} for m in rollup],
+          mode or "", judge)
+    except Exception:  # pylint: disable=broad-except
+      expl = {}
+    for m in rollup:
+      e = expl.get(m["name"])
+      if e:
+        if e.get("rationale"):
+          m["rationale"] = e["rationale"]
+        if e.get("insights"):
+          m["insights"] = e["insights"]
+  # Only surface the cross-run consistency metrics when there are ≥2 INDEPENDENT
+  # runs (distinct output dirs). Dynamic `--runs` re-scores one output dir, so it
+  # has a single distinct output and consistency is undefined — omit the rows
+  # entirely there rather than show permanent n/a. Real independent runs come from
+  # the golden case-runner (`--run --runs N`).
+  distinct_outputs = len({r.get("output_dir") for r in run_results
+                          if r.get("output_dir")})
+  if distinct_outputs >= 2:
+    try:
+      rollup += consistency_metrics(run_results, judge)
+    except Exception:  # pylint: disable=broad-except
+      pass  # consistency is informational — never let it break the case score.
+
+  run_avgs = [r.get("average_score") for r in run_results
+              if isinstance(r.get("average_score"), (int, float))]
+  tel = lambda k: [(r.get("telemetry") or {}).get(k) for r in run_results]
+  lat = _mean(tel("latency_s"))
+  base["metrics"] = rollup
+  # Average excludes consistency (informational) — it's the mean of per-run means.
+  base["average_score"] = round(sum(run_avgs) / len(run_avgs), 4) if run_avgs else None
+  base["per_run_averages"] = run_avgs
+  base["runs"] = n
+  base["per_run"] = runs_detail(run_results)
+  base["telemetry"] = {
+      "tokens_in": round(_mean(tel("tokens_in")) or 0),
+      "tokens_out": round(_mean(tel("tokens_out")) or 0),
+      "tokens_total": round(_mean(tel("tokens_total")) or 0),
+      "num_tool_calls": round(_mean(tel("num_tool_calls")) or 0),
+      "latency_s": round(lat, 1) if lat is not None else None,
+  }
+  return base

--- a/agents/enrichment/eval/corpora/README.md
+++ b/agents/enrichment/eval/corpora/README.md
@@ -1,0 +1,22 @@
+# Enrichment eval corpora
+
+Synthetic, publishable Markdown source documents for **doc-mode golden evaluation**.
+Three self-contained domains, ~11 docs each:
+
+- `financial_services/`
+- `phone_services/`
+- `supply_chain/`
+
+These let customers run doc-mode (and table/overlay grounding) golden evals from
+**local files** — no need to convert anything into Google Docs. Point the agent's
+`--docs` / `--folder` at a domain folder, e.g.:
+
+```bash
+python3 agents/enrichment/src/agent_runner.py --mode=doc \
+  --folder=agents/enrichment/eval/corpora/supply_chain \
+  --entry_group=<project>.<location>.<entryGroupId> \
+  --project=<project> --model=gemini-2.5-pro --output_dir=/tmp/out
+```
+
+All content is synthetic (safe to publish); it carries no provenance/eval labels
+in the document bodies so it doesn't bias the agent.

--- a/agents/enrichment/eval/corpora/financial_services/aml_investigations_playbook.md
+++ b/agents/enrichment/eval/corpora/financial_services/aml_investigations_playbook.md
@@ -1,0 +1,25 @@
+# AML Investigations Playbook
+
+**Owner:** Financial Crime Investigations **Audience:** AML investigators
+
+This playbook describes how an investigator works an alert from creation to disposition, including when to escalate to a regulatory filing.
+
+## Where alerts come from
+
+**AML** transaction monitoring generates alerts when a customer's activity deviates from expectations — unusual volumes, structuring patterns, or movement inconsistent with the stated profile. The monitoring is risk-based and leans on the customer's **KYC** profile and risk rating: an investigator's first move is always to pull the KYC file, because what counts as "unusual" depends entirely on who the customer is supposed to be.
+
+## Working an alert
+
+1. **Review KYC context.** Confirm identity, expected activity, and risk rating. Weak or stale KYC is itself a finding and may require a refresh.
+2. **Reconstruct the activity.** Trace the flow of funds and compare against the expected profile.
+3. **Decide.** Either close the alert as explained, or escalate it.
+
+## Escalation to a SAR
+
+When the investigation establishes a **reasonable suspicion** of illicit activity, the investigator escalates for a **Suspicious Activity Report (SAR)**. Key rules:
+
+- **No tipping off.** Under no circumstances may the customer be told that a SAR is contemplated or filed. Continue servicing the account normally.
+- **Meet the deadline.** The SAR has a regulatory filing window that begins when suspicion is established — do not let an investigation drift past it.
+- **Document the basis.** The narrative must connect the observed activity to the suspicion; "looked odd" is not sufficient.
+
+The SAR is the formal endpoint of the AML process and the bridge from internal suspicion to the authorities. Filing a SAR does not, by itself, require closing the account — that is a separate risk decision.

--- a/agents/enrichment/eval/corpora/financial_services/basel_iii_filing_summary.md
+++ b/agents/enrichment/eval/corpora/financial_services/basel_iii_filing_summary.md
@@ -1,0 +1,24 @@
+# Basel III Regulatory Filing — Internal Summary
+
+**Owner:** Regulatory Reporting **Status:** Authoritative reference for regulatory minimums **Audience:** Treasury, Risk, Finance
+
+This summary restates the binding Basel III requirements most relevant to our liquidity reporting. Where any internal document quotes a different figure for a regulatory minimum, the number here governs.
+
+## Liquidity Coverage Ratio (LCR)
+
+The **Liquidity Coverage Ratio (LCR)** is the Basel III short-term liquidity standard. It requires a bank to hold enough high-quality liquid assets (HQLA) to cover its total net cash outflows over a 30-calendar-day stress scenario:
+
+**LCR \= HQLA / total net cash outflows over 30 days**
+
+**Regulatory minimum: the LCR must be at least 100%.** This is the binding floor. A ratio of 100% means HQLA exactly cover modeled 30-day stressed outflows; the requirement is that the ratio never falls below this level. Any internal management targets above 100% (for example, an operating buffer) are matters of risk appetite, not regulation — the regulatory obligation is the ≥100% floor.
+
+HQLA are defined in tiers (Level 1 and Level 2 assets) with prescribed haircuts; net cash outflows are computed by applying standardized run-off rates to liabilities and inflow caps to receivables.
+
+## Reporting obligations
+
+- The LCR is reported to the regulator on the prescribed schedule.
+- A breach of the 100% minimum, even intraday at reporting date, is a notifiable event and must be escalated immediately to the Regulatory Reporting and Treasury leads.
+
+## Other standards (for reference)
+
+The Net Stable Funding Ratio (NSFR) addresses longer-term funding stability and is covered in a separate summary. This document is limited to the LCR.

--- a/agents/enrichment/eval/corpora/financial_services/compliance_policy_handbook.md
+++ b/agents/enrichment/eval/corpora/financial_services/compliance_policy_handbook.md
@@ -1,0 +1,17 @@
+# Compliance Policy Handbook
+
+**Owner:** Financial Crime Compliance **Audience:** All customer-facing and operations staff
+
+This handbook is the central reference for our financial-crime controls. It introduces the three pillars that newcomers most often confuse: KYC, AML, and the SAR.
+
+## Know Your Customer (KYC)
+
+**KYC** is the process of verifying who a customer is and assessing the risk they pose, performed at onboarding and refreshed periodically thereafter. At minimum it requires verifying identity documents and establishing beneficial ownership for non-individual customers before an account is activated. KYC also assigns each customer a risk rating — standard or enhanced — which determines how much scrutiny and documentation is required. KYC is sometimes called customer due diligence (CDD); treat the terms as equivalent in our policies. Importantly, KYC is not a one-time gate: the customer risk rating it produces is the foundation that ongoing monitoring relies on.
+
+## Anti-Money Laundering (AML)
+
+**AML** refers to the broader set of controls and monitoring designed to detect and prevent money laundering. Where KYC establishes who the customer is, AML watches what they do — principally through ongoing transaction monitoring that looks for patterns inconsistent with the customer's expected behavior. AML monitoring is risk-based: it leans on the KYC risk rating to decide how closely to watch a given customer.
+
+## Suspicious Activity Report (SAR)
+
+When AML monitoring or an investigator surfaces activity that gives rise to a reasonable suspicion of illicit conduct, the firm files a **Suspicious Activity Report (SAR)** with the relevant authority. Two rules are absolute: the SAR is **confidential** — we must never "tip off" the customer that a report has been or may be filed — and it is **time-bound**, with a regulatory deadline running from the point suspicion is established. The SAR is the formal output at the end of the chain that begins with KYC and runs through AML.

--- a/agents/enrichment/eval/corpora/financial_services/customer_onboarding_sop.md
+++ b/agents/enrichment/eval/corpora/financial_services/customer_onboarding_sop.md
@@ -1,0 +1,26 @@
+# Customer Onboarding SOP
+
+**Owner:** Retail Banking Operations **Audience:** Onboarding agents, branch staff
+
+This SOP walks through opening a new customer account, from identity checks to the first risk decision.
+
+## Step 1 — Identity verification (KYC)
+
+No account is activated until **KYC** is complete. KYC here means verifying the applicant's identity against acceptable documents and, for business customers, identifying the beneficial owners. The agent records the verification result and the customer's KYC risk rating (standard or enhanced due diligence). If documents cannot be verified, the application is paused, not approved. Remember that KYC is the basis for later monitoring, so accuracy at this step matters beyond onboarding.
+
+## Step 2 — Screening
+
+Run the applicant against sanctions and watchlists. A hit routes the case to Financial Crime Compliance before proceeding.
+
+## Step 3 — Product and credit decision
+
+If the customer is applying for a credit product, onboarding requests a **credit risk score** for the applicant. The credit risk score is a quantified estimate of the borrower's likelihood of default; it drives both the approve/decline decision and the pricing (interest rate, limit) offered. Inputs include the applicant's repayment history, existing exposure, and income or leverage. A low score does not automatically decline an application, but it tightens the terms; a very low score routes to manual underwriting.
+
+## Step 4 — Activation
+
+Once KYC has passed, screening is clear, and any credit decision is recorded, the account is activated. The KYC risk rating and credit risk score are both stored on the customer profile so downstream monitoring and servicing can use them.
+
+## Common errors
+
+- Activating before KYC verification completes — never do this.
+- Confusing the KYC *risk rating* (financial-crime risk) with the *credit risk score* (default risk). They are different assessments for different purposes.

--- a/agents/enrichment/eval/corpora/financial_services/finance_business_glossary.md
+++ b/agents/enrichment/eval/corpora/financial_services/finance_business_glossary.md
@@ -1,0 +1,13 @@
+# Finance Business Glossary
+
+**Owner:** Finance Data & Analytics **Purpose:** Shared definitions for metrics used across finance reporting.
+
+A plain-language glossary so that analysts, product, and reporting teams use the same meaning for the same term. Definitions only — no system or field detail.
+
+**Net Interest Margin (NIM).** A profitability metric: net interest income (what we earn on assets minus what we pay on liabilities) divided by average interest-earning assets. NIM expresses how much margin the balance sheet produces per dollar of earning assets. It is reported in earnings and treasury reviews and moves with the interest-rate environment.
+
+**Credit Risk Score.** A quantified estimate of how likely a borrower is to default. It is built from repayment history, current exposure, and income or leverage, and it drives lending decisions and loan pricing. Lower scores indicate higher default risk. Used both at origination and for ongoing portfolio monitoring. (Note: this is distinct from a customer's KYC risk rating, which measures financial-crime risk, not default risk.)
+
+**Customer Lifetime Value (CLV).** The total net profit we expect to earn from a customer over the entire relationship — projected revenue from the customer minus the cost to serve and retain them, across their expected lifetime. CLV is used to decide how much we can justify spending to acquire and keep a customer. A high-CLV segment warrants more acquisition and retention investment than a low-CLV one.
+
+**A note on naming.** Different teams write CLV differently. Marketing decks often say "customer LTV" or just "LTV"; finance reporting says "CLV." These are the same metric — the lifetime value of a customer — and should not be treated as two different measures.

--- a/agents/enrichment/eval/corpora/financial_services/marketing_analytics_deck_notes.md
+++ b/agents/enrichment/eval/corpora/financial_services/marketing_analytics_deck_notes.md
@@ -1,0 +1,24 @@
+# Marketing Analytics — Deck Notes
+
+**Owner:** Growth Marketing Analytics **Format:** Speaker notes accompanying the quarterly growth deck
+
+Working notes behind the growth review slides. Informal; numbers are illustrative.
+
+## Slide 3 — Why we measure customer LTV
+
+The headline metric for this deck is **customer LTV** — the total net profit we expect a customer to generate over their whole relationship with us, revenue minus cost-to-serve and retention spend, summed across their expected lifetime. It is the single number that tells us how much we can afford to spend to win and keep a customer. If acquisition cost exceeds customer LTV for a segment, we are buying unprofitable customers.
+
+## Slide 4 — LTV by segment
+
+We split customer LTV by acquisition channel and product mix. The premium-account segment shows the highest customer LTV by a wide margin, which is why we argue for shifting acquisition budget toward it. Note the finance team reports this same quantity as "CLV" in the official metrics — it is the same lifetime-value measure, just labeled differently across teams, so the deck and the finance dashboards should reconcile.
+
+## Slide 5 — Levers
+
+Two ways to raise customer LTV:
+
+- **Retention** — reducing attrition lengthens the lifetime over which value accrues. Small retention gains compound into large LTV gains.
+- **Cross-sell** — increasing products per customer raises revenue per period.
+
+## Slide 6 — Ask
+
+Reallocate 15% of acquisition spend from the lowest-LTV channel to the premium-account channel next quarter. Expected effect: higher blended customer LTV without raising total acquisition budget.

--- a/agents/enrichment/eval/corpora/financial_services/risk_management_framework.md
+++ b/agents/enrichment/eval/corpora/financial_services/risk_management_framework.md
@@ -1,0 +1,21 @@
+# Risk Management Framework
+
+**Owner:** Enterprise Risk **Audience:** Risk, treasury, and finance leadership
+
+This framework describes the principal risks we manage and the metrics we use to keep them in bounds. Two are central to this document: credit risk and liquidity risk.
+
+## Credit risk
+
+Credit risk is the risk that a borrower fails to repay. We quantify it at the borrower level with a **credit risk score** — an estimate of default likelihood derived from repayment history, current exposure, and income/leverage. The score is used at origination to decide and price lending, and on an ongoing basis to monitor the health of the portfolio. Aggregated across the book, credit risk scores feed our expected-loss provisioning. A deteriorating average score is an early warning that the portfolio is taking on more default risk.
+
+## Liquidity risk
+
+Liquidity risk is the risk that we cannot meet obligations as they fall due. Our primary control metric is the **Liquidity Coverage Ratio (LCR)** — the ratio of high-quality liquid assets (HQLA) to projected net cash outflows over a 30-day stress period. Conceptually:
+
+**LCR \= HQLA / net cash outflows over 30 days**
+
+The LCR is a regulatory liquidity requirement. As a matter of internal risk appetite we aim to operate with comfortable headroom — our internal management target is to hold the LCR **around 110%** so that normal fluctuations never bring us close to the regulatory floor. The precise regulatory minimum itself is set out in the Basel III rules and summarized in our regulatory filing materials; this framework defers to those for the binding number.
+
+## Governance
+
+Risk appetite statements for both metrics are reviewed by the Risk Committee quarterly. Breaches of internal targets trigger escalation before any regulatory threshold is approached.

--- a/agents/enrichment/eval/corpora/financial_services/settlement_delay_postmortem.md
+++ b/agents/enrichment/eval/corpora/financial_services/settlement_delay_postmortem.md
@@ -1,0 +1,30 @@
+# Postmortem: Settlement Cutoff Migration Delay
+
+**Status:** Final **Owner:** Trade Operations / Settlements **Date:** Most recent record on settlement timing — supersedes prior cutoff guidance where they conflict.
+
+## Summary
+
+Following migration to the new settlement platform, a batch of trades missed their intended settlement day. Investigation found the cause was an outdated cutoff time in our operating procedure: the new platform enforces an earlier cutoff than the one analysts were working to.
+
+## Background
+
+We settle on **T+1** (one business day after trade date). Same-day inclusion in a settlement run depends on the daily **cutoff time**. The legacy runbook documented a **16:00 ET** cutoff, and analysts continued to work to that time after the migration.
+
+## What happened
+
+The migrated platform was configured to a **15:30 ET** cutoff to align with the upstream market infrastructure's new schedule. On the affected day, several trades matched between 15:30 and 16:00 ET. Analysts believed these were inside the window; the platform rolled them to the next business day, creating an unexpected extra day of settlement exposure and a set of client queries.
+
+## Root cause
+
+Stale procedure. The **cutoff moved to 15:30 ET** with the migration, but the runbook and analyst habits still reflected the old 16:00 ET time.
+
+## Corrective action
+
+- **Effective immediately, the settlement cutoff is 15:30 ET.** All settlement instructions must be matched and released by 15:30 ET to make the same-day run. This is the current cutoff and replaces the 16:00 ET figure in the Trade Operations Runbook.
+- Update the Trade Operations Runbook to 15:30 ET.
+- Add a platform alert at 15:15 ET warning of approaching cutoff.
+
+## Follow-ups
+
+1. Settlements lead to confirm the runbook is updated this week.
+2. Communicate the 15:30 ET cutoff to all settlements analysts.

--- a/agents/enrichment/eval/corpora/financial_services/trade_ops_runbook.md
+++ b/agents/enrichment/eval/corpora/financial_services/trade_ops_runbook.md
@@ -1,0 +1,28 @@
+# Trade Operations Runbook
+
+**Owner:** Trade Operations / Settlements **Audience:** Settlements analysts
+
+This runbook is the operational reference for clearing and settling trades. It is the standing source for our settlement timing.
+
+## What settlement is
+
+**Settlement** is the process that finalizes a trade: the buyer's cash and the seller's securities actually change hands, discharging both parties' obligations. A trade is only economically complete once it has settled — until then it is a pending obligation carrying counterparty risk.
+
+## Settlement cycle
+
+Our equities and most fixed-income instruments settle on a **T+1** basis: settlement takes place **one business day after the trade date**. So a trade executed Monday settles Tuesday, assuming both are business days. Holidays and weekends extend the calendar accordingly.
+
+## Daily cutoff
+
+Each settlement day has a **cutoff time** that determines which batch a trade makes. **The standing cutoff is 16:00 ET.** Settlement instructions received and matched before 16:00 ET are processed in that day's settlement run; instructions arriving after the cutoff roll into the next business day's cycle. Operations must ensure all matched trades are instructed ahead of the cutoff to avoid an unintended extra day of settlement risk.
+
+## Daily checklist
+
+1. Confirm trades captured overnight are matched with counterparties.
+2. Resolve any unmatched/affirmed exceptions well before the cutoff.
+3. Release the settlement batch ahead of 16:00 ET.
+4. Reconcile settled positions end of day; investigate any fails.
+
+## Fails
+
+A settlement fail (one side cannot deliver cash or securities) is logged, counterparty notified, and the trade re-attempted the next cycle. Persistent fails are escalated to the Settlements lead.

--- a/agents/enrichment/eval/corpora/financial_services/travel_expense_policy.md
+++ b/agents/enrichment/eval/corpora/financial_services/travel_expense_policy.md
@@ -1,0 +1,33 @@
+# Corporate Travel & Expense Policy
+
+**Owner:** Finance Shared Services **Applies to:** All employees incurring business travel or expenses
+
+This policy governs booking travel and claiming reimbursable expenses. It has no bearing on customer, risk, or treasury operations.
+
+## Booking travel
+
+- Book flights and hotels through the approved corporate travel tool. Out-of-tool bookings are reimbursed only with prior manager approval.
+- Economy class is standard for flights under six hours. Premium economy may be approved for longer flights with director sign-off.
+- Choose hotels within the published per-city nightly cap.
+
+## Expense claims
+
+- Submit expenses within 30 days of the spend date. Claims older than 60 days require an exception approval.
+- Itemized receipts are required for any expense over the receipt threshold.
+- Personal expenses must never be charged to the corporate card; if mixed, flag and reimburse the company portion immediately.
+
+## Meals and entertainment
+
+- Daily meal allowances follow the published per-diem by city.
+- Client entertainment requires a documented business purpose and attendee list.
+
+## Mileage and ground transport
+
+- Personal-vehicle mileage is reimbursed at the standard published rate.
+- Use standard ride-share or taxi for ground transport; luxury tiers are not reimbursable.
+
+## Approvals
+
+- Each expense report routes to the claimant's manager for approval before payment. Reports with policy exceptions route additionally to Finance Shared Services.
+
+Questions about eligibility go to the Finance Shared Services help desk.

--- a/agents/enrichment/eval/corpora/financial_services/treasury_operations_guide.md
+++ b/agents/enrichment/eval/corpora/financial_services/treasury_operations_guide.md
@@ -1,0 +1,27 @@
+# Treasury Operations Guide
+
+**Owner:** Group Treasury **Audience:** Treasury analysts and ALM team
+
+This guide covers the day-to-day metrics Treasury manages: balance-sheet profitability, liquidity, and the mechanics of trade settlement.
+
+## Net Interest Margin (NIM)
+
+**Net Interest Margin (NIM)** is our core measure of balance-sheet profitability. It is the difference between the interest we earn on assets and the interest we pay on liabilities, expressed relative to our interest-earning assets:
+
+**NIM \= (interest income − interest expense) / average earning assets**
+
+NIM tells us how efficiently we are turning the balance sheet into net interest income. Treasury watches NIM against the rate environment: when funding costs rise faster than asset yields, NIM compresses, and vice versa.
+
+## Liquidity Coverage Ratio (LCR)
+
+Treasury owns the day-to-day management of the **Liquidity Coverage Ratio (LCR)** — high-quality liquid assets over 30-day net cash outflows. In normal operations we steer the LCR to the internal management target of **about 110%**, keeping headroom above the regulatory minimum defined under Basel III. Treasury forecasts the LCR daily and adjusts the HQLA portfolio to stay within appetite.
+
+## Settlement
+
+Treasury also oversees **settlement** — the finalization of trades by exchanging cash and securities. Our equities and most fixed-income trades settle on a **T+1** basis: settlement occurs one business day after the trade date. Each settlement day has a processing **cutoff** after which trades roll to the next cycle; per the Trade Operations Runbook the standing cutoff is **16:00 ET**. Trades instructed before the cutoff settle in that day's batch; later instructions settle the following business day.
+
+## Daily routine
+
+1. Refresh NIM and LCR forecasts from overnight balances.
+2. Confirm the settlement pipeline is clear ahead of the cutoff.
+3. Escalate any projected LCR move toward appetite limits.

--- a/agents/enrichment/eval/corpora/phone_services/billing_charging_system_overview.md
+++ b/agents/enrichment/eval/corpora/phone_services/billing_charging_system_overview.md
@@ -1,0 +1,29 @@
+# Billing & Charging System Overview
+
+**Owner:** Billing Platform Engineering **Audience:** Engineers and analysts working with charging and invoicing
+
+This overview explains how usage becomes a bill, in concept. No schema detail.
+
+## Rating and the billing cycle
+
+The system turns raw usage events into money in two conceptual stages: **rating** and **billing**.
+
+- **Rating** applies the customer's price plan to each usage event to compute a charge.
+- **Billing** accumulates rated charges over the customer's **billing cycle** — the recurring period over which usage is aggregated — and produces an invoice at the cycle close.
+
+Each subscriber belongs to a billing cycle; cycle boundaries are staggered across the customer base so invoicing load is spread through the month rather than spiking on a single day.
+
+## Prepaid vs postpaid
+
+The billing cycle behaves differently by plan type:
+
+- **Postpaid:** usage is rated and accumulated across the cycle, then invoiced at the end. The customer pays in arrears.
+- **Prepaid:** charges are decremented from a balance in real time as usage occurs; the "cycle" is mainly a window for plan allowances rather than an invoice period.
+
+## Where QoS comes in
+
+Charging and **QoS (Quality of Service)** intersect for data plans. Some plans tie a data allowance to a QoS treatment — for example, full-speed data up to a threshold, after which the subscriber's traffic is moved to a lower-priority QoS class (commonly experienced as "throttling") rather than being cut off. The charging system signals the policy function when a threshold is crossed so the appropriate QoS class is applied for the remainder of the cycle.
+
+## Reconciliation
+
+At cycle close, rated charges are reconciled against the invoice total before issuance; discrepancies are held for review rather than billed.

--- a/agents/enrichment/eval/corpora/phone_services/churn_analysis_quarterly_report.md
+++ b/agents/enrichment/eval/corpora/phone_services/churn_analysis_quarterly_report.md
@@ -1,0 +1,28 @@
+# Churn Analysis — Quarterly Report
+
+**Owner:** Subscriber Analytics **Audience:** Commercial and care leadership
+
+This report summarizes subscriber loss for the quarter and the drivers behind it.
+
+## Headline
+
+**Customer churn** — the rate at which subscribers leave our service over a period — was the focus this quarter. (Some teams call this "customer attrition"; it is the same measure of subscribers lost, and we use the terms interchangeably in this report.) Churn is reported as the share of the subscriber base that deactivated during the quarter.
+
+## What drove churn
+
+Three drivers accounted for most voluntary departures:
+
+1. **Price.** Subscribers leaving for cheaper competitor plans were the largest group, concentrated among out-of-contract subscribers.
+2. **Network quality.** A meaningful share of departures correlated with areas of poor coverage or call quality — including regions flagged in the recent dropped-calls investigation. Network experience and churn are linked: poor VoLTE quality shows up later as cancellations.
+3. **Competitor offers.** Aggressive port-in incentives from a rival drove a spike mid-quarter.
+
+## Where churn concentrated
+
+- Out-of-contract subscribers churned at several times the rate of those in contract.
+- Single-product subscribers churned more than those with multiple services, consistent with the view that deeper relationships are stickier.
+
+## Recommendations
+
+- Target retention offers at out-of-contract, single-product subscribers before competitor windows.
+- Feed network-quality hotspots to engineering; reducing dropped calls should reduce quality-driven churn.
+- Track churn against customer lifetime value so retention spend goes where it protects the most value.

--- a/agents/enrichment/eval/corpora/phone_services/customer_care_handbook.md
+++ b/agents/enrichment/eval/corpora/phone_services/customer_care_handbook.md
@@ -1,0 +1,27 @@
+# Customer Care Handbook
+
+**Owner:** Customer Care Enablement **Audience:** Frontline care agents
+
+Reference for handling the most common subscriber requests. Plain language for agents, not engineers.
+
+## Switching to us — keeping your number
+
+Customers very often want to bring their existing phone number when they join. This is **number portability** — the customer keeps their number when moving between carriers. Agents will also hear it called "porting," "LNP," or "MNP"; these all mean the same thing. To start a port-in, collect the customer's current account details and submit a port request; there is a defined process and a validation window during which the losing carrier confirms the details. Set expectations that the number transfers once validation completes — it is not always instant.
+
+## Billing questions
+
+Most billing questions come down to the **billing cycle** — the recurring period over which we accumulate a customer's usage and then issue an invoice. Each customer is assigned to a billing cycle, and their charges for that period are totaled and billed at the cycle close. Two points to convey:
+
+- Usage is tallied within the cycle and billed at its end (for postpaid plans).
+- A customer's cycle dates may differ from another customer's; "my friend was billed on a different day" is normal.
+
+If a customer disputes a charge, check where in the billing cycle the usage fell before escalating.
+
+## Cancellations and retention
+
+When a customer asks to leave, treat it as a retention moment. Customer departures are what the business calls **churn** (you may also see "attrition") — the rate at which subscribers leave. Care plays a direct role in reducing churn: identify the reason (price, coverage, a competitor offer), and apply the approved retention options before processing a cancellation.
+
+## Escalation
+
+- Port stuck past the validation window → Provisioning.
+- Repeated billing disputes for one account → Billing Operations.

--- a/agents/enrichment/eval/corpora/phone_services/dropped_calls_postmortem.md
+++ b/agents/enrichment/eval/corpora/phone_services/dropped_calls_postmortem.md
@@ -1,0 +1,30 @@
+# Postmortem: Metro Region Dropped-Calls Incident
+
+**Status:** Final **Owner:** Network Operations **Date:** Most recent record on VoLTE QoS targets — supersedes the standing QoS Policy figure where they conflict.
+
+## Summary
+
+Over a two-week window, subscribers in the metro region experienced elevated VoLTE call drops and audible clipping. Investigation found that the standing latency target for the conversational-voice class was too loose for our actual network conditions, allowing calls to degrade before any alarm fired.
+
+## Background
+
+**VoLTE (Voice over LTE)** carries voice as packets and depends on the conversational-voice **QoS** class. The standing **QoS Policy** sets a one-way packet **latency budget of 100 ms** for that class. Monitoring alarmed only when latency exceeded that budget.
+
+## What happened
+
+In the affected cells, one-way latency frequently sat in the 80–100 ms band — *within* the 100 ms policy budget, so no alarm — yet call quality was already degrading and drops were climbing. The 100 ms target, inherited from an older network generation, did not reflect the tighter budget our current VoLTE codec and jitter profile actually need.
+
+## Root cause
+
+The VoLTE latency target was too high. At 100 ms the policy tolerated latency that in practice produced clipping and drops, and the alarm threshold tied to it fired too late to act.
+
+## Corrective action
+
+- **Effective immediately, the VoLTE one-way latency target is tightened to 80 ms.** This is the current target for the conversational-voice class carrying VoLTE and replaces the 100 ms figure in the QoS Policy. Calls must be kept under 80 ms one-way latency.
+- Re-tune monitoring to alarm at 80 ms, with a warning at 70 ms.
+- Architecture to fold the 80 ms target into the next QoS Policy revision.
+
+## Follow-ups
+
+1. Update the QoS Policy to 80 ms.
+2. Review other real-time class budgets for the same legacy-inheritance issue.

--- a/agents/enrichment/eval/corpora/phone_services/network_engineering_glossary.md
+++ b/agents/enrichment/eval/corpora/phone_services/network_engineering_glossary.md
@@ -1,0 +1,17 @@
+# Network Engineering Glossary
+
+**Owner:** Mobile Core Engineering **Audience:** New network and platform engineers
+
+A shared reference for the mobile-network terms that come up daily. Brief definitions; deeper treatment lives in the dedicated design docs.
+
+**APN (Access Point Name).** The APN is the identifier a device presents to the network to say *which packet data network it wants to reach*. It tells the core which gateway to route a data session through — for example, a public-internet APN versus an internal IMS APN for voice signaling. The APN is part of the device's data profile and is applied when a data session is established. Different APNs can map to different services and policies.
+
+**IMSI (International Mobile Subscriber Identity).** The IMSI is the globally unique identity of a subscriber, provisioned onto the SIM. It is what the network uses to recognize and authenticate a subscriber. Because it uniquely identifies the subscriber, the IMSI is the key reference used when subscribers connect — at home or, via roaming, on another operator's network.
+
+**QoS (Quality of Service).** QoS is the set of mechanisms that prioritize traffic and hold it to performance targets — latency, packet loss, and throughput. Traffic is sorted into classes, and each class is given a treatment appropriate to its needs. Real-time services need stricter QoS than best-effort data.
+
+**VoLTE (Voice over LTE).** VoLTE carries voice calls as packets over the LTE data network (via IMS) rather than over the legacy circuit-switched voice path. Because voice is delay-sensitive, VoLTE depends on a high-priority QoS class to keep calls clear; the specific QoS targets are defined in the QoS Policy.
+
+## Usage note
+
+"SIM identity" is sometimes used loosely to mean the IMSI; prefer "IMSI" in engineering docs. Voice-over-LTE, VoLTE, and "IMS voice" all refer to the same service.

--- a/agents/enrichment/eval/corpora/phone_services/number_portability_process_sop.md
+++ b/agents/enrichment/eval/corpora/phone_services/number_portability_process_sop.md
@@ -1,0 +1,29 @@
+# Number Portability Process SOP
+
+**Owner:** Provisioning & Interconnect **Audience:** Porting desk and provisioning engineers
+
+This SOP defines how we execute number portability, both port-in (a subscriber joining us and keeping their number) and port-out (leaving us).
+
+## What number portability is
+
+**Number portability** is the subscriber's ability to keep their telephone number when changing carriers. Across the industry and our own tooling it appears under several names — **Local Number Portability (LNP)**, **Mobile Number Portability (MNP)**, or simply "porting." They refer to the same capability; this SOP uses "number portability" throughout. The capability is mandated by the regulator, who also sets the maximum timelines we must meet.
+
+## Roles
+
+- **Recipient (gaining) carrier** — the carrier the number is moving to.
+- **Donor (losing) carrier** — the carrier the number is moving from.
+
+## Port-in procedure
+
+1. **Collect** the customer's number, current account identifier, and any account PIN required by the donor.
+2. **Submit** the port request to the central porting clearinghouse.
+3. **Validation window** — the donor validates the request against its records. Mismatched details are the most common rejection reason; correct and resubmit.
+4. **Activation** — on successful validation, the number is cut over to our network and the donor releases it. Brief loss of service during cutover is expected.
+
+## Port-out procedure
+
+When we are the donor, we must validate incoming requests promptly and release numbers within the regulatory timeline. We may not unduly delay or block a valid port-out, though we may surface a retention offer before release.
+
+## Timelines and escalation
+
+Regulatory rules cap how long a port may take. A port stalled beyond the validation window is escalated to the interconnect team; do not leave a customer mid-port.

--- a/agents/enrichment/eval/corpora/phone_services/qos_policy_doc.md
+++ b/agents/enrichment/eval/corpora/phone_services/qos_policy_doc.md
@@ -1,0 +1,31 @@
+# Quality of Service (QoS) Policy
+
+**Owner:** Network Policy & Architecture **Status:** Standing policy (see Dropped-Calls Postmortem for any later revisions)
+
+This policy defines how traffic classes are treated on our network and the targets each must meet.
+
+## Purpose of QoS
+
+**Quality of Service (QoS)** is how the network gives different kinds of traffic different treatment so that each meets its needs. Without QoS, a large file download could starve a live voice call of the timely delivery it requires. QoS sorts traffic into classes and assigns each class a priority and a set of performance targets — primarily latency, packet loss, and jitter.
+
+## Traffic classes
+
+We use standardized QoS class identifiers. The key ones:
+
+- **Conversational voice** — highest priority, reserved for real-time voice.
+- **Real-time streaming** — high priority, tolerant of slightly more delay.
+- **Interactive / best-effort data** — default classes for general traffic.
+
+## VoLTE requirements
+
+**VoLTE (Voice over LTE)** carries voice as packets over LTE and is therefore entirely dependent on QoS to sound acceptable. VoLTE traffic must be carried on the **conversational voice** class. The policy targets for that class are:
+
+- **One-way packet latency budget: 100 ms.**
+- Packet loss: under 1%.
+- Guaranteed bit rate appropriate to the voice codec.
+
+If VoLTE traffic is not placed on the conversational-voice class, or the latency budget is exceeded, callers experience clipping, delay, and dropped calls.
+
+## Enforcement
+
+QoS is enforced end-to-end — on the radio scheduler and across the core transport. Policy is applied per bearer when a session is established. Changes to class targets require Architecture review.

--- a/agents/enrichment/eval/corpora/phone_services/retail_store_opening_checklist.md
+++ b/agents/enrichment/eval/corpora/phone_services/retail_store_opening_checklist.md
@@ -1,0 +1,40 @@
+# Retail Store Opening Checklist
+
+**Owner:** Retail Operations **Applies to:** Store managers and shift leads
+
+A daily checklist for opening one of our retail stores. This is store-floor operations and is unrelated to network, billing, or subscriber systems.
+
+## Before doors open
+
+- [ ] Disable the alarm and confirm the security panel shows "disarmed."
+- [ ] Unlock the storeroom; verify overnight stock deliveries against the manifest.
+- [ ] Count the cash float and confirm it matches the logged amount.
+- [ ] Power on point-of-sale terminals and confirm they connect.
+- [ ] Power on demo handsets and confirm they are charged and locked to display mode.
+
+## Merchandising
+
+- [ ] Straighten window displays and remove any expired promotional signage.
+- [ ] Restock accessory walls to planogram.
+- [ ] Confirm pricing labels match the current price list.
+
+## Staffing
+
+- [ ] Confirm the shift roster is fully covered; call in cover for any no-shows.
+- [ ] Brief the team on the day's promotions and any service advisories.
+- [ ] Assign zones (sales floor, service desk, greeter).
+
+## Health & safety
+
+- [ ] Walk the floor for trip hazards and spills.
+- [ ] Confirm fire exits are clear and emergency lighting is functional.
+- [ ] Check that the first-aid kit is stocked.
+
+## Open
+
+- [ ] At opening time, unlock the front doors and switch the sign to "Open."
+- [ ] Greeter takes position.
+
+## End-of-day note
+
+Closing uses a separate checklist; ensure the float is reconciled and the alarm is re-armed on exit.

--- a/agents/enrichment/eval/corpora/phone_services/roaming_partner_agreement_summary.md
+++ b/agents/enrichment/eval/corpora/phone_services/roaming_partner_agreement_summary.md
@@ -1,0 +1,23 @@
+# Roaming Partner Agreement — Summary
+
+**Owner:** Roaming & Interconnect Business **Audience:** Roaming managers, settlement analysts
+
+A plain-language summary of what a roaming agreement is and the obligations it creates. The legal text governs; this is orientation.
+
+## What a roaming agreement is
+
+A **roaming agreement** is a bilateral arrangement with another operator that lets each party's subscribers use the other's network when outside home coverage. When one of our subscribers travels into a partner's footprint, the partner's network serves them as a "visited network," and we do the same for the partner's subscribers here. Without such an agreement, a subscriber abroad would simply have no service.
+
+## How subscribers are recognized
+
+Roaming relies on the **IMSI (International Mobile Subscriber Identity)** to tell home subscribers apart from the visited network's own. When a device attaches to a visited network, that network reads the IMSI, identifies the home operator from it, and signals home to authenticate the subscriber and authorize service. Every clause about which subscribers are covered ultimately keys off the IMSI ranges assigned to each party.
+
+## Commercial terms
+
+- **Settlement rates.** The agreement fixes the wholesale rates each operator charges the other for voice, data, and messaging consumed by visiting subscribers. These inter-operator charges are reconciled and settled periodically.
+- **Coverage and service scope.** Specifies which services (e.g., data, VoLTE) are supported for roamers and any technical preconditions.
+- **Fraud and usage controls.** Near-real-time usage exchange to catch abnormal roaming usage early.
+
+## Operations
+
+Roaming managers monitor partner reachability and the quality roamers receive; settlement analysts reconcile the wholesale charges against the agreed rates each billing period.

--- a/agents/enrichment/eval/corpora/phone_services/sim_provisioning_runbook.md
+++ b/agents/enrichment/eval/corpora/phone_services/sim_provisioning_runbook.md
@@ -1,0 +1,29 @@
+# SIM Provisioning Runbook
+
+**Owner:** Subscriber Provisioning **Audience:** Provisioning engineers and OSS operators
+
+This runbook covers preparing a SIM and subscriber so a device can attach to the network and use data.
+
+## What we provision
+
+Two things make a subscriber usable: their identity on the SIM, and the data profile that lets their device reach services.
+
+### IMSI
+
+Every SIM is provisioned with an **IMSI (International Mobile Subscriber Identity)** — the globally unique subscriber identifier the network authenticates against. The IMSI is written to the SIM during personalization and registered in the subscriber database (HSS/HLR). Without a valid, registered IMSI, the device cannot authenticate or attach. The IMSI is the anchor that everything else about the subscriber hangs off.
+
+### APN
+
+The subscriber's data profile includes one or more **APNs (Access Point Names)**. The APN determines which packet data gateway — and therefore which network and policy set — a data session uses. A typical profile contains an internet APN for general data and may include a separate IMS APN used for VoLTE signaling. Provisioning the wrong APN is a common cause of "attached but no data" tickets: the subscriber authenticates fine (IMSI is good) but their sessions route to the wrong or a non-existent gateway.
+
+## Procedure
+
+1. Personalize the SIM with the IMSI and security keys.
+2. Register the IMSI in the subscriber database with the correct service plan.
+3. Apply the data profile, including the correct APN(s) for the plan.
+4. Test: confirm attach (validates IMSI) and a data session on each APN.
+
+## Common faults
+
+- **Attach fails** → IMSI not registered or key mismatch.
+- **Attaches, no data** → APN missing or misconfigured.

--- a/agents/enrichment/eval/corpora/phone_services/telecom_systems_terminology_overview.md
+++ b/agents/enrichment/eval/corpora/phone_services/telecom_systems_terminology_overview.md
@@ -1,0 +1,21 @@
+# Telecom Systems & Terminology Overview
+
+**Audience:** New analysts and partners integrating with our subscriber systems **Owner:** Mobile Core Engineering
+
+A meaning-first overview of how subscriber identity and data access fit together. Deliberately conceptual — no field or schema detail.
+
+## Identity: the IMSI
+
+At the center of a mobile subscriber sits the **IMSI (International Mobile Subscriber Identity)**. It is the globally unique identifier of the subscriber, held on the SIM, and it is what the network authenticates when a device tries to connect. Think of the IMSI as the subscriber's passport: it proves who they are to the home network and, when they travel, lets a visited network find and check with their home network. Almost everything the network does for a subscriber begins by resolving their IMSI.
+
+## Data access: the APN
+
+Identity gets you onto the network; the **APN (Access Point Name)** decides what you can reach. The APN names the packet data network a session should connect to, and so selects the gateway and the policies that apply. One subscriber may have several APNs — for instance a general internet APN and a separate IMS APN that carries voice signaling for VoLTE. Choosing the right APN is what makes a data session land on the right service with the right treatment.
+
+## How they relate
+
+The two are complementary: the IMSI answers *who is this subscriber?* and the APN answers *what network/service is this session for?* A subscriber must be authenticated by IMSI before any session is established, and each session then uses an APN to reach its destination. Misconfigure the IMSI and the device cannot attach at all; misconfigure the APN and the device attaches but cannot reach the intended service.
+
+## Why this matters for data
+
+When you see subscriber records or session logs, expect the IMSI to be the join key for "which subscriber," and the APN to indicate "which service/network" a session used. Keeping the distinction clear avoids conflating *identity* with *access*.

--- a/agents/enrichment/eval/corpora/supply_chain/bom_spec.md
+++ b/agents/enrichment/eval/corpora/supply_chain/bom_spec.md
@@ -1,0 +1,23 @@
+# Bill of Materials — Engineering Specification
+
+**Owner:** Product Engineering **Audience:** Design engineers, manufacturing planners
+
+This specification defines how a **Bill of Materials (BOM)** is authored and maintained for products we manufacture or assemble.
+
+## What the BOM is
+
+The BOM is the authoritative, structured definition of what goes into a product. For a given finished-good **SKU**, the BOM lists every component and sub-assembly and the exact quantity of each required to build one unit. It is the bridge between engineering intent and what procurement actually buys: change the BOM and you change the shopping list.
+
+## Structure
+
+BOMs are **hierarchical (multi-level)**. A finished good is composed of sub-assemblies; each sub-assembly is itself a parent with its own BOM of lower components, and so on down to purchased raw components. This tree lets us reuse a sub-assembly across many products — its BOM is defined once and referenced wherever it is used.
+
+Each line in a BOM carries, at minimum, the component identity and the per-parent quantity. A finished-good SKU has exactly one released BOM at a time; revisions are versioned so that production always builds against a known recipe.
+
+## Relationship to SKUs
+
+Every manufactured finished-good SKU maps to a BOM. The reverse is not one-to-one: a single component can appear in the BOMs of many different finished SKUs. When demand is planned at the finished-SKU level, the planning system "explodes" each SKU through its BOM to derive how many of each component must be procured — multiplying parent demand by the per-unit quantities at every level of the tree.
+
+## Change control
+
+BOM changes are engineering-controlled. Because a BOM edit directly alters component demand and procurement, no buyer or planner may alter component quantities outside the BOM. Engineering releases a new BOM revision; downstream systems pick it up automatically.

--- a/agents/enrichment/eval/corpora/supply_chain/demand_planning_meeting_notes.md
+++ b/agents/enrichment/eval/corpora/supply_chain/demand_planning_meeting_notes.md
@@ -1,0 +1,20 @@
+# Demand Planning — Weekly Sync Notes
+
+**Date:** Q3, Week 6 **Attendees:** Demand Planning, Supply Chain Analytics, DC Ops (partial)
+
+Informal notes from the weekly demand/supply review. Not a policy document — decisions of record go into the Inventory Policy Memo.
+
+## Discussion
+
+- **Service levels holding except apparel.** Most categories are meeting target fill rate. Apparel Class-A SKUs have seen three near-misses this quarter where on-hand dipped close to zero before replenishment landed.
+
+- **Safety stock under pressure.** The team agreed the near-misses trace back to safety stock being sized for last year's demand variability. Safety stock is the cushion we hold above forecast to absorb demand spikes and late inbound; when variability rises and the cushion doesn't, you get exactly these near-misses. Action: Analytics to re-evaluate Class-A safety stock days.
+
+- **Reorder point follows safety stock.** Several people noted that bumping safety stock will automatically raise the **reorder point**, since the reorder point is the level that triggers replenishment and is built on top of safety stock plus demand-over-lead-time. No one wants to touch the reorder point directly — the agreement is to fix safety stock and let the reorder point move with it.
+
+- **Lead time stable.** No material change in supplier lead times this quarter, so the near-misses are demand-side, not supply-side.
+
+## Open actions
+
+1. Analytics: model Class-A safety stock against current-year variability; bring a recommendation to next week.
+2. DC Ops: confirm count accuracy in apparel zones isn't masking the issue.

--- a/agents/enrichment/eval/corpora/supply_chain/inventory_management_glossary.md
+++ b/agents/enrichment/eval/corpora/supply_chain/inventory_management_glossary.md
@@ -1,0 +1,17 @@
+# Inventory Management Glossary
+
+This glossary is maintained by the Supply Chain Analytics team as a shared reference for terminology used across our planning, procurement, and warehouse processes. It is intended as an onboarding aid for new analysts and a tie-breaker when teams use terms inconsistently.
+
+## Core terms
+
+**SKU (Stock Keeping Unit).** A SKU is our internal identifier for a distinct, sellable product variant. "Variant" matters here: a single product line such as a t-shirt becomes many SKUs once you account for size and color, because each size/color/pack combination is tracked separately. The SKU is the unit at which we hold and count inventory in every distribution center. People sometimes casually call it the "item number," which is fine, but do not confuse the SKU with the **UPC** or **GTIN**. The UPC/GTIN is an *external* barcode standard assigned for retail scanning and is shared across the industry; the SKU is internal to us and never leaves our systems. A product can have one UPC but several of our SKUs over its life, so the two are not interchangeable.
+
+**Lead time.** The elapsed time from the moment we place a purchase order with a supplier to the moment the goods are received, inspected, and available to pick. It is not just shipping time — it includes the supplier's own order processing and our inbound putaway. Lead time is rarely a constant; its variability is one of the main reasons we carry buffer inventory.
+
+**Safety stock.** Extra inventory we deliberately hold on top of expected demand to absorb surprises — a demand spike, or a supplier shipment that runs late. Without safety stock, any variability in demand or lead time would translate directly into stockouts. We size safety stock either as a number of days of supply or against a target service level.
+
+**Reorder point.** The inventory level at which the system automatically triggers a replenishment order. When on-hand stock for a SKU falls to its reorder point, a purchase order is generated. The reorder point is derived from demand, lead time, and safety stock — see the Inventory Policy Memo for the exact formula.
+
+## A note on usage
+
+When writing planning documents, prefer "reorder point" over the informal "reorder level"; both refer to the same thing but the former is what our ERP fields are labeled. Likewise, "buffer stock" and "safety stock" are synonyms.

--- a/agents/enrichment/eval/corpora/supply_chain/inventory_policy_memo.md
+++ b/agents/enrichment/eval/corpora/supply_chain/inventory_policy_memo.md
@@ -1,0 +1,27 @@
+# Inventory Policy Memo
+
+**Classification:** Decision of record **Owner:** Supply Chain Analytics **Supersedes:** prior year's policy memo
+
+This memo defines the inventory parameters our planning system uses. Values here are authoritative until a subsequent memo or postmortem revises them.
+
+## Reorder point
+
+The **reorder point (ROP)** is the on-hand level that triggers a replenishment order for a SKU. We compute it as:
+
+**ROP \= (average daily demand × lead time in days) \+ safety stock**
+
+The first term covers expected consumption during the time it takes to replenish; the second term is the cushion against variability. Because the ROP is built directly on lead time and safety stock, any change to either flows through to the ROP automatically. We do not set the ROP by hand.
+
+## Safety stock
+
+**Safety stock** is the buffer held above expected demand to protect service against demand spikes and lead-time variability. Our current policy sizes safety stock in **days of supply**, differentiated by velocity class:
+
+- **Class A (fast movers): 14 days of supply.**
+- Class B: 10 days of supply.
+- Class C: 7 days of supply.
+
+These figures were set against last year's observed demand variability. They are the values planning should use unless a later decision of record changes them.
+
+## Review cadence
+
+Safety stock days are reviewed at minimum annually, or sooner if a stockout postmortem recommends a change. Lead time is monitored continuously by procurement; a sustained lead-time shift is grounds for an off-cycle review.

--- a/agents/enrichment/eval/corpora/supply_chain/inventory_systems_overview.md
+++ b/agents/enrichment/eval/corpora/supply_chain/inventory_systems_overview.md
@@ -1,0 +1,19 @@
+# Inventory Systems Overview
+
+**Audience:** New analysts and engineers integrating with our planning stack **Owner:** Supply Chain Analytics
+
+This overview explains, in plain language, how the core inventory concepts relate to one another in our systems. It deliberately avoids field-level detail; it is about meaning, not schemas.
+
+## Products and their identifiers
+
+Everything in inventory hangs off the **SKU (Stock Keeping Unit)**. A SKU represents one sellable variant of a product — a specific size, color, and pack configuration. When merchandising launches a "product," engineering and planning see it as a set of SKUs, one per variant. The SKU is the level at which we forecast, hold stock, and replenish.
+
+It is worth repeating a common point of confusion: the SKU is *internal*. The barcode a cashier scans is a **UPC/GTIN**, an external standard. We store the UPC/GTIN as an attribute so we can map scans back to a SKU, but the two are different identifiers with different owners — the UPC/GTIN comes from a global registry, the SKU is assigned by us. Treating them as the same thing causes double-counting, so keep them distinct.
+
+## Finished goods and their recipes
+
+For anything we manufacture or assemble, each finished-good SKU is associated with a **Bill of Materials (BOM)**. The BOM is the recipe: the list of components and sub-assemblies, and how many of each, required to build one unit of that SKU. BOMs can be multi-level — a sub-assembly named in one BOM may itself have its own BOM — which is how complex products are represented as a tree of simpler parts. The BOM is what links a finished SKU to the component materials procurement must buy.
+
+## How it fits together
+
+In short: demand is forecast per SKU; finished SKUs explode through their BOMs into component demand; that component demand drives procurement. The SKU is the hub that the rest of the system revolves around.

--- a/agents/enrichment/eval/corpora/supply_chain/logistics_network_overview.md
+++ b/agents/enrichment/eval/corpora/supply_chain/logistics_network_overview.md
@@ -1,0 +1,27 @@
+# Logistics Network Overview
+
+**Owner:** Network Strategy **Audience:** Planning, transportation, and operations leadership
+
+This document describes the shape of our physical distribution network and the role each tier plays.
+
+## Network tiers
+
+Our network moves goods from suppliers to demand through a tiered set of **distribution centers (DCs)**. A DC is a facility that stores inventory and fulfills downstream demand. We operate two tiers:
+
+- **Regional DCs** hold broad assortment and replenish the next tier.
+- **Forward DCs** (also called fulfillment nodes) sit closer to demand and ship directly to stores or customers.
+
+Each DC, regardless of tier, maintains its own on-hand inventory per SKU and makes its own replenishment decisions. The network is therefore a graph of inventory-holding nodes, not a single pool of stock.
+
+## Lead time across the network
+
+When we talk about **lead time** at the network level, we mean the end-to-end time to get a SKU from its source to the node that needs it. There are two flavors:
+
+- **Inbound lead time** — supplier PO to receipt at a regional DC. This is the lead time procurement plans against.
+- **Inter-node lead time** — the transit time to move stock from a regional DC to a forward DC.
+
+Both contribute to how much buffer a forward node must carry: the longer and more variable the combined lead time to a node, the more safety stock that node needs to maintain service. Network design is largely the exercise of trading off the number of DCs against the lead time (and therefore inventory) required to serve demand.
+
+## Order routing
+
+When demand arrives, the order router selects a DC that holds the needed SKU, preferring the node with the shortest fulfillment lead time to the destination. If the nearest node is out of stock, the router falls back to another node that holds the SKU.

--- a/agents/enrichment/eval/corpora/supply_chain/office_badge_facilities_policy.md
+++ b/agents/enrichment/eval/corpora/supply_chain/office_badge_facilities_policy.md
@@ -1,0 +1,31 @@
+# Office Badge & Facilities Policy
+
+**Owner:** Workplace Services **Applies to:** All corporate office employees and visitors
+
+This policy covers building access, badging, and shared facility etiquette at our corporate offices. It is unrelated to warehouse or distribution operations.
+
+## Badge access
+
+- All employees must wear their photo access badge above the waist while on premises. Badges are issued by Workplace Services on the first day.
+- Tailgating is prohibited. Each person must badge in individually at secured doors, even when traveling in a group.
+- Lost badges must be reported to the reception desk within 24 hours so the badge can be deactivated. A temporary day-pass can be issued against a government ID.
+
+## Visitors
+
+- Visitors must be pre-registered in the lobby system by their host and sign in on arrival. Visitors are escorted at all times and receive a visitor badge that expires at end of day.
+
+## Shared spaces
+
+- Conference rooms are bookable through the room calendar; please release rooms you are not using.
+- Kitchens are cleaned nightly; staff are asked to wash personal dishes and not leave food in shared refrigerators over the weekend.
+- Quiet zones are designated on each floor; phone calls should be taken in phone booths or meeting rooms.
+
+## Parking and bikes
+
+- Parking permits are assigned per site; bicycles must be stored in the secured bike room, not in stairwells.
+
+## Emergencies
+
+- In the event of a fire alarm, use the nearest stairwell and proceed to the designated assembly point. Do not use elevators.
+
+For any facilities request — temperature, lighting, repairs — file a ticket with Workplace Services.

--- a/agents/enrichment/eval/corpora/supply_chain/procurement_sop.md
+++ b/agents/enrichment/eval/corpora/supply_chain/procurement_sop.md
@@ -1,0 +1,21 @@
+# Procurement Standard Operating Procedure
+
+**Owner:** Procurement Operations **Audience:** Buyers, sourcing managers
+
+This SOP describes how the procurement team converts a replenishment need into a received shipment, and how supplier choices are made along the way.
+
+## 1\. Triggering a purchase
+
+Replenishment is demand-driven. When a SKU's on-hand position drops to its reorder point, our planning system raises a purchase requisition. For manufactured goods, the requisition is exploded against the product's **Bill of Materials (BOM)** so that we order the right component materials in the right quantities. The BOM is the structured list of every component and sub-assembly, with the quantity of each, needed to build one finished unit. A buyer should never hand-edit component quantities on a PO without checking the BOM, because the BOM is the single source of truth for what goes into a product.
+
+## 2\. Choosing a supplier
+
+Where a component can be bought from more than one supplier, the buyer consults the **supplier scorecard**. The scorecard is a rolling performance rating that combines on-time delivery percentage, quality (defect/return rate), and price competitiveness into a single view. Higher-rated suppliers receive a larger share of order volume. New suppliers cannot receive production orders until they have been onboarded and have an initial scorecard established.
+
+## 3\. Lead time and order timing
+
+Every supplier-part combination has an expected **lead time** — the total time from PO placement to goods being available to pick, including the supplier's processing time, transit, and our inbound handling. Buyers must use the current quoted lead time, not historical averages, when promising replenishment dates, because lead times drift as supplier capacity changes. If a supplier's lead time increases materially, flag it to planning so safety stock can be revisited.
+
+## 4\. Receiving
+
+On receipt, goods are inspected and only "good" quantity is posted as available. Lead time is considered complete at this posting, not at dock arrival.

--- a/agents/enrichment/eval/corpora/supply_chain/q3_stockout_postmortem.md
+++ b/agents/enrichment/eval/corpora/supply_chain/q3_stockout_postmortem.md
@@ -1,0 +1,28 @@
+# Postmortem: Q3 Apparel Class-A Stockouts
+
+**Status:** Final **Owner:** Supply Chain Analytics **Date:** End of Q3 (most recent decision of record on this topic)
+
+## Summary
+
+During Q3, several Class-A apparel SKUs stocked out at forward DCs despite the planning system operating as designed. No system fault was found. The root cause was that our safety stock parameters were undersized for current demand variability.
+
+## Timeline
+
+- Weeks 4–6: three near-miss events flagged in Demand Planning syncs.
+- Week 7: two Class-A SKUs hit zero on-hand at a forward DC for \~2 days.
+- Week 8: investigation opened.
+
+## Root cause
+
+The reorder point fired correctly each time — on-hand fell to the reorder point and a PO was generated on schedule. The problem was upstream of the trigger: the **safety stock** cushion was too thin. Class-A safety stock had been set at **14 days of supply** against last year's variability. Demand variability for apparel has risen materially since then, so 14 days no longer covered the gap between reorder firing and replenishment landing. Because the reorder point is computed on top of safety stock, an undersized safety stock also meant the reorder point was firing later than it should have.
+
+## Corrective action
+
+Effective immediately, **Class-A safety stock is raised to 21 days of supply.** This is the new value planning should apply for Class-A items; it reflects current-year demand variability and supersedes the figure in the standing Inventory Policy Memo for Class A. Class B and C remain under review and are unchanged for now.
+
+The reorder point was not adjusted directly; raising safety stock to 21 days will lift the Class-A reorder point automatically through the standard formula.
+
+## Follow-ups
+
+1. Analytics to fold the 21-day Class-A figure into the next Inventory Policy Memo revision.
+2. Re-evaluate Class B/C safety stock against current variability next quarter.

--- a/agents/enrichment/eval/corpora/supply_chain/supplier_onboarding_guide.md
+++ b/agents/enrichment/eval/corpora/supply_chain/supplier_onboarding_guide.md
@@ -1,0 +1,27 @@
+# Supplier Onboarding Guide
+
+**Owner:** Strategic Sourcing **Purpose:** Bring a new supplier from first contact to production-ready.
+
+Onboarding a supplier is about establishing two things before we depend on them: a reliable **lead time** and an initial **supplier scorecard**.
+
+## Step 1 — Qualification
+
+Collect business and compliance documentation, run financial and quality checks, and agree commercial terms. No production orders are placed during qualification.
+
+## Step 2 — Establishing lead time
+
+We ask each new supplier to commit to a quoted lead time for each part — the full duration from PO placement to goods available for pick, including their order processing and transit. We validate the quote with one or two trial orders. Trial-order actuals, not the quote alone, become the lead time we plan against, because suppliers often quote optimistically. Lead time variability observed during trials is recorded; high variability means planning will need more safety stock to protect service.
+
+## Step 3 — The supplier scorecard
+
+Every active supplier carries a **supplier scorecard** (also called a vendor rating). It is a structured, periodically refreshed rating of the supplier's performance, combining:
+
+- **On-time delivery %** — share of POs received by the promised date.
+- **Quality** — defect, return, and rejection rates.
+- **Price competitiveness** — relative to alternate suppliers for the same part.
+
+The scorecard is the basis for how much volume a supplier earns. A new supplier starts with a provisional score from the trial orders; it matures as real PO history accumulates. Buyers consult the scorecard whenever a part has more than one qualified source.
+
+## Step 4 — Go live
+
+Once lead time is validated and a scorecard exists, the supplier is flagged production-ready and becomes eligible for demand-driven replenishment orders.

--- a/agents/enrichment/eval/corpora/supply_chain/warehouse_ops_runbook.md
+++ b/agents/enrichment/eval/corpora/supply_chain/warehouse_ops_runbook.md
@@ -1,0 +1,26 @@
+# Warehouse Operations Runbook
+
+**Scope:** Day-to-day operations inside a distribution center (DC) **Owner:** DC Operations
+
+## What a distribution center is
+
+A **distribution center (DC)** is a facility that receives inventory in bulk, stores it, and fulfills downstream orders to stores or customers. Each DC is a node in our logistics network sitting between suppliers upstream and demand downstream. Critically, every DC holds and counts its own inventory independently: the same SKU can have very different on-hand quantities across DCs, and replenishment decisions are made per DC. People sometimes call these facilities "fulfillment centers" or "fulfillment nodes"; in our network the terms are used interchangeably.
+
+## Inbound
+
+1. Receive against the purchase order. Verify carton counts.
+2. Inspect and post good quantity as available. Damaged units are quarantined.
+3. Putaway: assign each **SKU** to a storage location. Because we track inventory at the SKU level, every putaway must be scanned to the exact SKU — not the product family — or downstream picks will fail.
+
+## Storage and counts
+
+Cycle counts run continuously by zone. Any count discrepancy is reconciled at the SKU \+ location level. The DC's on-hand position per SKU is what feeds the planning system's reorder calculations, so count accuracy directly affects when replenishment fires.
+
+## Outbound
+
+Picks are generated from downstream orders, batched by zone, packed, and manifested to the carrier. A DC only ships SKUs it physically holds; if a SKU is out of stock at one DC, the order router may source it from another DC in the network.
+
+## Escalations
+
+- Receiving mismatch vs PO → notify Procurement.
+- Persistent stockouts of a fast-moving SKU → notify Demand Planning to review safety stock and reorder point.

--- a/agents/enrichment/eval/corpora/thelook_ecommerce/business_glossary.md
+++ b/agents/enrichment/eval/corpora/thelook_ecommerce/business_glossary.md
@@ -1,0 +1,79 @@
+# theLook eCommerce — Business Glossary
+
+**Owner:** Commerce Data & Analytics
+**Audience:** Analysts, data scientists, and engineers querying the eCommerce warehouse
+
+Shared definitions for the core business concepts in the theLook eCommerce
+dataset. theLook is a multi-brand online apparel and accessories retailer. Use
+these definitions so metrics and reports mean the same thing across teams.
+
+## Order vs. Order Item
+
+These are two different grains and must not be confused.
+
+- An **Order** is a single purchase event placed by a customer. One order can
+  contain many items; `num_of_item` records how many. An order carries an overall
+  fulfillment `status` and the customer who placed it (`user_id`).
+- An **Order Item** is a single unit of a single product within an order. It is
+  the **revenue grain** — every line that a customer actually paid for is one
+  order item. Revenue, margin, and units-sold are all computed at this grain, not
+  at the order grain.
+
+A customer who buys two shirts and one hat in one checkout creates **one order**
+and **three order items**.
+
+## Sale Price, Retail Price, and Cost
+
+These three money fields are easy to mix up; they are distinct and live on
+different tables.
+
+- **Cost** — what theLook paid its supplier for the unit (wholesale / landed
+  cost). Found as `products.cost` and `inventory_items.cost`. Never shown to the
+  customer.
+- **Retail Price** — the list price theLook advertises for a product
+  (`products.retail_price`). This is the catalog price, *before* any discount.
+- **Sale Price** — the price the customer **actually paid** for a unit, recorded
+  on the transaction line as `order_items.sale_price`. This is the authoritative
+  figure for revenue. Sale price may differ from retail price because of
+  promotions or markdowns.
+
+**Rule of thumb:** revenue uses `order_items.sale_price`; margin compares it to
+`cost`; `retail_price` is the reference list price, not realized revenue.
+
+## Gross Margin
+
+**Gross Margin** is the profit on a unit before operating costs:
+`sale_price - cost` per order item (or `retail_price - cost` at list price for
+catalog analysis). **Gross Margin %** is `gross_margin / sale_price`.
+
+## SKU and Product Taxonomy
+
+- **SKU (Stock Keeping Unit)** — the identifier theLook uses to track a sellable
+  product variant in inventory (`products.sku`). One SKU corresponds to one row
+  in `products`.
+- Products are organized in a three-level taxonomy:
+  - **Department** — the broadest grouping (e.g. Men, Women).
+  - **Category** — the product type within a department (e.g. Jeans, Outerwear).
+  - **Brand** — the manufacturer or label.
+
+## Distribution Center
+
+A **Distribution Center** is a physical warehouse that stocks and ships
+products. Every product is assigned to exactly one distribution center via
+`products.distribution_center_id`. Distribution centers carry a name and a
+geographic location (latitude/longitude) used for fulfillment and shipping-time
+analysis.
+
+## Inventory Item
+
+An **Inventory Item** is one physical unit of a product held in stock. It is
+created when stock is received (`created_at`) and is marked `sold_at` when it is
+purchased. The difference between those two timestamps is how long the unit sat
+in inventory before selling.
+
+## Traffic Source
+
+**Traffic Source** is the marketing channel that brought a customer to theLook,
+stored on `users.traffic_source`. Typical values are Search, Organic, Email,
+Display, and Facebook. It is the basis for customer-acquisition and
+channel-attribution analysis.

--- a/agents/enrichment/eval/corpora/thelook_ecommerce/data_model.md
+++ b/agents/enrichment/eval/corpora/thelook_ecommerce/data_model.md
@@ -1,0 +1,53 @@
+# theLook eCommerce — Data Model and Relationships
+
+**Owner:** Commerce Data & Analytics
+**Audience:** Engineers and analysts joining across the eCommerce tables
+
+The grain of each table and how the tables relate. Use this to write correct
+joins and to understand lineage.
+
+## Tables and their grain
+
+- **`users`** — one row per customer. Grain: customer. Holds demographics
+  (age, gender), location (city/state/country, lat/long), acquisition channel
+  (`traffic_source`), and signup time (`created_at`).
+- **`orders`** — one row per order (a checkout event). Grain: order. Links to the
+  customer via `user_id`.
+- **`order_items`** — one row per unit of a product in an order. Grain: order
+  line / sold unit. This is the central fact table for revenue.
+- **`products`** — one row per sellable product (SKU). Grain: product.
+- **`inventory_items`** — one row per physical unit of stock. Grain: stock unit.
+- **`distribution_centers`** — one row per fulfillment warehouse. Grain:
+  warehouse.
+
+## Relationships (foreign keys)
+
+- `orders.user_id` → `users.id`
+- `order_items.order_id` → `orders.order_id`
+- `order_items.user_id` → `users.id`
+- `order_items.product_id` → `products.id`
+- `order_items.inventory_item_id` → `inventory_items.id`
+- `products.distribution_center_id` → `distribution_centers.id`
+- `inventory_items.product_id` → `products.id`
+
+`order_items` is the hub: it ties together the customer, the order, the product,
+and the specific inventory unit that was shipped. Most analytical queries start
+from `order_items` and join outward.
+
+## Denormalization note (important)
+
+`inventory_items` **denormalizes** the product attributes. The `product_*`
+columns on `inventory_items` (`product_category`, `product_name`,
+`product_brand`, `product_retail_price`, `product_department`, `product_sku`,
+`product_distribution_center_id`) are copies of the corresponding fields in
+`products`, carried for convenience so inventory queries don't need a join. The
+**authoritative source for product attributes is the `products` table** — if the
+two ever disagree, trust `products`. Do not treat the `inventory_items.product_*`
+columns as independent facts.
+
+## Lineage summary
+
+Customer (`users`) places an Order (`orders`), which is composed of Order Items
+(`order_items`). Each order item references a Product (`products`) and the
+physical Inventory Item (`inventory_items`) that fulfilled it. Products are
+stocked and shipped from a Distribution Center (`distribution_centers`).

--- a/agents/enrichment/eval/corpora/thelook_ecommerce/metrics.md
+++ b/agents/enrichment/eval/corpora/thelook_ecommerce/metrics.md
@@ -1,0 +1,56 @@
+# theLook eCommerce — Metric Definitions
+
+**Owner:** Commerce Data & Analytics
+**Purpose:** Canonical formulas for the core commerce metrics, expressed against
+the warehouse columns. Use these so every team computes the same number.
+
+All revenue and unit metrics are computed at the **order-item grain**
+(`order_items`), which is the sold-unit grain. See the Business Glossary for the
+Order vs. Order Item distinction and the price definitions.
+
+## Revenue
+
+**Gross Revenue** = `SUM(order_items.sale_price)` over items whose status is not
+Cancelled.
+
+**Net Revenue** = `SUM(order_items.sale_price)` over items that are neither
+Cancelled nor Returned. Net revenue is gross revenue with returns removed.
+
+> Always exclude Cancelled items from any revenue figure; exclude Returned items
+> additionally for *net* revenue.
+
+## Average Order Value (AOV)
+
+**AOV** = Gross Revenue / number of distinct orders
+= `SUM(order_items.sale_price) / COUNT(DISTINCT order_items.order_id)`.
+AOV is an order-grain metric derived from item-grain revenue.
+
+## Units Sold
+
+**Units Sold** = `COUNT(order_items.id)` for non-cancelled items. Each order item
+is one unit.
+
+## Return Rate
+
+**Return Rate** = returned units / sold units
+= `COUNT(order_items WHERE returned_at IS NOT NULL) / COUNT(order_items WHERE status <> 'Cancelled')`.
+
+## Gross Margin and Margin %
+
+**Gross Margin** = `SUM(order_items.sale_price - products.cost)` (join
+`order_items.product_id` → `products.id`), over non-returned, non-cancelled items.
+
+**Gross Margin %** = Gross Margin / Net Revenue.
+
+## Inventory Sell-Through and Days-in-Inventory
+
+**Sell-Through Rate** = sold inventory units / total inventory units
+= `COUNT(inventory_items WHERE sold_at IS NOT NULL) / COUNT(inventory_items)`.
+
+**Average Days in Inventory** = mean of `(sold_at - created_at)` over sold
+inventory items — how long a unit sits in stock before it sells.
+
+## Customer Acquisition by Channel
+
+Group `users` by `traffic_source` to attribute customers (and, by joining through
+orders, revenue) to acquisition channels.

--- a/agents/enrichment/eval/corpora/thelook_ecommerce/order_lifecycle.md
+++ b/agents/enrichment/eval/corpora/thelook_ecommerce/order_lifecycle.md
@@ -1,0 +1,60 @@
+# theLook eCommerce — Order Lifecycle and Status
+
+**Owner:** Fulfillment Operations
+**Audience:** Analysts working with orders, fulfillment, and returns
+
+How an order moves from placement to completion (or return), and what each
+status and timestamp means. Applies to both the `orders` table and the
+`order_items` table.
+
+## Order status
+
+`orders.status` describes the overall state of the order. The lifecycle is:
+
+1. **Processing** — the order has been placed and is being prepared; payment
+   captured, not yet shipped.
+2. **Shipped** — the order has left a distribution center.
+3. **Complete** — the order was delivered and the return window has effectively
+   closed.
+4. **Returned** — one or more items came back; the order is in a returned state.
+5. **Cancelled** — the order was cancelled before fulfillment and generated no
+   revenue.
+
+## Order Item status
+
+`order_items.status` tracks the **same lifecycle at the line-item grain**. Because
+an order can be partially fulfilled or partially returned, item status can differ
+from the parent order's status — e.g. an order may be **Complete** while one of
+its order items is **Returned**. Always compute fulfillment and return metrics
+from `order_items.status`, not from `orders.status`, when item-level accuracy
+matters.
+
+## The timestamp funnel
+
+Both `orders` and `order_items` carry a sequence of event timestamps that record
+when the item moved through each stage:
+
+- **`created_at`** — when the order/line was placed.
+- **`shipped_at`** — when it shipped from the distribution center.
+- **`delivered_at`** — when it reached the customer.
+- **`returned_at`** — when it was returned, if applicable.
+
+These enable funnel and cycle-time analysis: processing time
+(`shipped_at - created_at`), transit time (`delivered_at - shipped_at`), and
+return latency (`returned_at - delivered_at`). A NULL timestamp means that stage
+has not happened.
+
+## Returns
+
+An order item is a **return** when `returned_at` is set (or its `status` is
+Returned). Returns reverse the revenue and margin of that line and should be
+excluded from net revenue. **Return Rate** is the share of sold units that were
+later returned.
+
+## Revenue-bearing vs. non-revenue states
+
+Only **Complete**, **Shipped**, and **Processing** items represent realized or
+in-flight revenue. **Cancelled** items never generated revenue and must be
+excluded from all revenue metrics. **Returned** items generated revenue that was
+subsequently reversed; exclude them from *net* revenue but keep them for
+gross-vs-net and return analysis.

--- a/agents/enrichment/eval/dynamic_eval.py
+++ b/agents/enrichment/eval/dynamic_eval.py
@@ -50,6 +50,47 @@ def fmt_score(score) -> str:
   return "n/a" if score is None else f"{float(score) * 100:.1f}"
 
 
+def build_results(output_dir, agent_type, mode, metric_results, traj, tokens,
+                  latency, **extra):
+  """Shared result-dict builder for both the dynamic and golden eval paths.
+
+  Normalizes a list of MetricResult into the on-disk/JSON shape (scores kept
+  0..1; fmt_score scales to 0-100 for display) + the average + telemetry. `extra`
+  merges extra top-level keys (e.g. golden=<path> for the golden path).
+  """
+  label = getattr(metrics, "_METRIC_LABEL", {})
+  out_metrics, numeric = [], []
+  for r in metric_results:
+    sc = None if r.score is None else round(float(r.score), 4)
+    if sc is not None:
+      numeric.append(sc)
+    out_metrics.append({
+        "name": r.name,
+        "score": sc,
+        # `passed` is needed by the cross-run roll-up (runs_passed = k/n); kept on
+        # every per-run metric so aggregate.py can mirror the reference design.
+        "passed": bool(getattr(r, "passed", True)),
+        "description": label.get(r.name, r.name),
+        "rationale": r.detail,
+        "insights": getattr(r, "insights", "") or "",
+    })
+  return {
+      "output_dir": output_dir,
+      "agent_type": agent_type,
+      "mode": mode,
+      "metrics": out_metrics,
+      "average_score": round(sum(numeric) / len(numeric), 4) if numeric else None,
+      "telemetry": {
+          "tokens_in": tokens.get("input", 0),
+          "tokens_out": tokens.get("output", 0),
+          "tokens_total": tokens.get("total", 0),
+          "num_tool_calls": len(traj.get("tool_uses") or []),
+          "latency_s": latency or None,
+      },
+      **extra,
+  }
+
+
 def write_report(results: dict, output_dir: str,
                  filename: str = "eval_report.md") -> str:
   """Write a full, untruncated eval report (Markdown) next to trajectory.json.
@@ -79,6 +120,14 @@ def write_report(results: dict, output_dir: str,
     lines.append(f"## {m['name']} — {fmt_score(sc)}/100")
     if m.get("description"):
       lines.append(f"_{m['description']}_")
+    # Per-run signal (mean across runs): runs k/n + each run's score. Consistency
+    # metrics hold entry COUNTS (not 0..1) and explain them in their rationale.
+    rs = m.get("run_scores")
+    if rs and not m["name"].endswith("_consistency"):
+      rp = m.get("runs_passed")
+      lines.append("")
+      lines.append(f"- per run: {', '.join(fmt_score(s) for s in rs)}"
+                   + (f"  ·  passed {rp}" if rp else ""))
     lines.append("")
     lines.append("**Rationale:**")
     lines.append("")
@@ -89,6 +138,26 @@ def write_report(results: dict, output_dir: str,
       lines.append("")
       lines.append(_wrap_para(m.get("insights")))
     lines.append("")
+
+  # Per-run breakdown (multi-run cases): each run's metrics + rationale, so a
+  # reader can drill into what earned each score.
+  per_run = results.get("per_run")
+  if per_run and len(per_run) > 1:
+    lines.append("---")
+    lines.append("")
+    lines.append("# Per-run breakdown")
+    lines.append("")
+    for run in per_run:
+      avg = run.get("average_score")
+      lines.append(f"## Run {run.get('index')} — average {fmt_score(avg)}/100")
+      lines.append("")
+      for m in run.get("metrics", []):
+        lines.append(f"- **{m['name']}** — {fmt_score(m.get('score'))}/100"
+                     + ("" if m.get("passed", True) else " (below gate)"))
+        rat = " ".join((m.get("rationale") or "").split())
+        if rat:
+          lines.append(f"  - {rat}")
+      lines.append("")
   path = os.path.join(output_dir, filename)
   try:
     with open(path, "w", encoding="utf-8") as f:
@@ -112,7 +181,13 @@ def run_dynamic_eval(output_dir: str, model: str = "gemini-2.5-pro",
   """
   traj = loaders.load_trajectory(output_dir)
   agent_type = traj.get("agent_type", "doc")
-  mode = "table" if agent_type == "table" else "doc"
+  # Pass the real mode through (doc / table / context_overlay), respecting the
+  # agent's per-mode contract. context_overlay keeps its own mode so
+  # check_structural skips the entry-type check (overlay entries are `generic`,
+  # mixed with `.ref` bigquery types — metrics._ENTRY_TYPE has no overlay key) and
+  # the table-only metrics (reference grounding here; entry_grounding/per-table
+  # fact_recall in golden eval) don't apply to it.
+  mode = agent_type if agent_type in ("table", "context_overlay") else "doc"
 
   _log(f"scoring {output_dir}  (mode={mode})")
   arts = loaders.load_mdcode(os.path.join(output_dir, "catalog"))
@@ -191,33 +266,6 @@ def run_dynamic_eval(output_dir: str, model: str = "gemini-2.5-pro",
     _log("  (rubric skipped)")
   _log("done — scorecard below")
 
-  label = getattr(metrics, "_METRIC_LABEL", {})
-  out_metrics, numeric = [], []
-  for r in mres:
-    sc = None if r.score is None else round(float(r.score), 4)
-    if sc is not None:
-      numeric.append(sc)
-    out_metrics.append({
-        "name": r.name,
-        "score": sc,
-        "description": label.get(r.name, r.name),
-        "rationale": r.detail,
-        "insights": getattr(r, "insights", "") or "",
-    })
-
-  results = {
-      "output_dir": output_dir,
-      "agent_type": agent_type,
-      "mode": mode,
-      "metrics": out_metrics,
-      "average_score": round(sum(numeric) / len(numeric), 4) if numeric else None,
-      "telemetry": {
-          "tokens_in": tokens.get("input", 0),
-          "tokens_out": tokens.get("output", 0),
-          "tokens_total": tokens.get("total", 0),
-          "num_tool_calls": len(traj.get("tool_uses") or []),
-          "latency_s": latency or None,
-      },
-  }
+  results = build_results(output_dir, agent_type, mode, mres, traj, tokens, latency)
   write_report(results, output_dir)
   return results

--- a/agents/enrichment/eval/golden_eval.py
+++ b/agents/enrichment/eval/golden_eval.py
@@ -1,0 +1,241 @@
+"""Golden-based evaluation of an enrichment run.
+
+Where the dynamic (golden-free) evaluator grounds only in what the agent
+retrieved, this scores the output against a hand-authored / harvested GOLDEN that
+declares the concepts, facts, sections, and terms the enrichment SHOULD contain.
+See goldens/README.md for the golden schema and how to build one.
+
+Adds, on top of the dynamic metrics (structural_validity, perf, hallucination_free):
+  - concept_recall / concept_precision : did we capture the expected concepts as
+    entries, without spurious/duplicate ones? (doc mode; needs expected_topics)
+  - fact_recall                        : are each concept's / table's golden facts
+    conveyed? (doc + table)
+  - enrichment_diversity               : are the expected sections present?
+                                         (needs expected_headings)
+  - business_terms_presence            : are the expected business terms covered?
+  - persona_alignment                  : (optional) does the output emphasize a
+                                         persona's focus areas? (needs personas)
+
+Scores are 0..1 (None = self-skipped). CLI: `python -m eval --output-dir DIR --golden G.json`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+from . import loaders
+from . import metrics
+from . import dynamic_eval
+
+# Default pass thresholds (report-oriented; tune per your bar).
+_THRESHOLDS = {"concept_recall": 0.7, "concept_precision": 0.7, "fact_recall": 0.7}
+
+
+def _classify_extras(extras, allowlist):
+  """Split produced 'extra' entries into acceptable (match the golden's
+  acceptable_extra_concepts allowlist) vs truly spurious. Allowlist items may be a
+  string or {name, aliases:[...]}; matching is hyphen/underscore/space-insensitive."""
+  import re
+  def norm(s):
+    return re.sub(r"[-_\s]", "",
+                  str(s).replace(".overview.md", "").replace(".md", "").lower())
+  pats = []
+  for c in (allowlist or []):
+    if isinstance(c, dict):
+      names = [c.get("name", "")] + list(c.get("aliases") or [])
+      label = c.get("name", "")
+    else:
+      label, names = c, [c]
+    pats.append((label, [norm(n) for n in names if n]))
+  acceptable, spurious = [], []
+  for e in extras:
+    ne = norm(e)
+    hit = next((label for label, normed in pats
+                if any(p and (p in ne or ne in p) for p in normed)), None)
+    (acceptable if hit else spurious).append((e, hit))
+  return acceptable, spurious
+
+
+def _trajectory_source(traj: dict) -> str:
+  parts = []
+  for t in (traj.get("tool_responses") or []):
+    r = t.get("response") if isinstance(t, dict) else t
+    if isinstance(r, dict):
+      texts = [str(r[k]) for k in ("content", "text", "overview", "description")
+               if r.get(k)]
+      parts.extend(texts or [json.dumps(r)[:50000]])
+    elif isinstance(r, str):
+      parts.append(r)
+  return "\n\n".join(parts)
+
+
+# Map each recorded tool_use (trajectory.json) to the marker phrase that
+# metrics.fired_tools() recognizes, so check_trajectory (unchanged, stdout-based) can read github's structured tool calls. This lets the
+# trajectory metric (must_call / must_not_call) work off trajectory.json instead
+# of needing the agent's stdout.
+_TRAJ_TOOL_PHRASE = {
+    "fetch_gdoc": "Fetching",          # -> drive_fetch
+    "read_local_md": "Fetching",       # -> drive_fetch (local markdown source)
+    "get_table_entry": "bigquery-dataset",   # -> dataset_pull
+    "reference_table": "bigquery-dataset",   # -> dataset_pull
+    "explore_repo": "github",          # -> github_fetch
+}
+
+
+def _traj_markers(traj: dict) -> str:
+  """Synthesize a marker string from trajectory.json tool_uses so the (unchanged)
+  stdout-based check_trajectory can derive which tool categories fired."""
+  names = [t.get("name") for t in (traj.get("tool_uses") or [])
+           if isinstance(t, dict)]
+  return " ".join(_TRAJ_TOOL_PHRASE.get(n, "") for n in names if n)
+
+
+def run_golden_eval(output_dir: str, golden_path: str,
+                    model: str = "gemini-2.5-pro", persona_id: str | None = None,
+                    perf_budget: dict | None = None,
+                    report_dir: str | None = None,
+                    report_name: str | None = None) -> dict:
+  """Evaluate one run against a golden file. Returns a results dict.
+
+  `report_dir` / `report_name` let a batch caller collect the per-golden reports
+  in one folder (one .md per golden); by default the report is named by the
+  golden + run so several goldens scoring the same output dir don't clobber each
+  other.
+  """
+  with open(golden_path, encoding="utf-8") as f:
+    golden = json.load(f)
+
+  traj = loaders.load_trajectory(output_dir)
+  agent_type = traj.get("agent_type", "doc")
+  # Pass the real mode through (doc / table / context_overlay), respecting the
+  # agent's per-mode contract. context_overlay keeps its own mode so
+  # check_structural skips the entry-type check (overlay entries are `generic`,
+  # mixed with `.ref` bigquery types — metrics._ENTRY_TYPE has no overlay key) and
+  # the table-only metrics (entry_grounding, reference grounding, per-table
+  # fact_recall) don't apply to it.
+  mode = agent_type if agent_type in ("table", "context_overlay") else "doc"
+  arts = loaders.load_mdcode(os.path.join(output_dir, "catalog"))
+  if not arts.get("overview_md") and not arts.get("yaml"):
+    return {"error": f"No generated mdcode found under {output_dir}/catalog."}
+
+  tokens = dict(traj.get("token_usage") or {})
+  tokens["total"] = (tokens.get("input", 0) or 0) + (tokens.get("output", 0) or 0)
+  latency = float(traj.get("latency") or 0.0)
+  # No-op judge when auth is absent → judge metrics self-skip (deterministic
+  # metrics still run) instead of hanging on retries / erroring.
+  judge = (metrics.default_judge(model)
+           if (os.environ.get("GOOGLE_CLOUD_PROJECT")
+               or os.environ.get("GOOGLE_GENAI_USE_VERTEXAI"))
+           else (lambda _p: ""))
+  res: list = []
+
+  # Deterministic
+  res.append(metrics.check_structural(arts, mode))
+  # Input-conditioned tool use (must_call / must_not_call) . github records the actual tool calls in trajectory.json, so we derive the
+  # fired tools from there (no agent stdout needed). check_trajectory/metrics.py are unchanged.
+  res.append(metrics.check_trajectory(_traj_markers(traj),
+                                      golden.get("trajectory", {})))
+  res.append(metrics.check_perf(latency, arts, perf_budget or {}, tokens))
+  if mode == "table":
+    res.append(metrics.check_entry_grounding(arts))
+  if golden.get("expected_headings"):
+    res.append(metrics.check_expected_headings(arts, golden["expected_headings"]))
+
+  # Judge: business terms — presence + (dedicated per-term MaC) validity. business_terms_validity is typically low today (the agent
+  # doesn't emit per-term files) but is included for parity so scores are comparable.
+  if golden.get("business_terms"):
+    res.append(metrics.check_business_terms(arts, golden["business_terms"], judge))
+    res.append(metrics.check_business_terms_validity(
+        arts, golden["business_terms"], judge))
+
+  # Merge/update path: if the golden declares pre-baked context, verify it was
+  # PRESERVED through enrichment only when prebaked_facts is set.
+  if golden.get("prebaked_facts"):
+    res.append(metrics.check_context_preservation(
+        arts, golden["prebaked_facts"], judge))
+
+  thr = _THRESHOLDS
+  # Judge: concept recall/precision + fact recall
+  if mode == "doc" and golden.get("expected_topics"):
+    tm = metrics.match_topics(arts, golden["expected_topics"], judge, 0.7)
+    per_topic = tm.get("per_topic", [])
+    matched = [t["topic"] for t in per_topic if t.get("matched")]
+    missed = [t["topic"] for t in per_topic if not t.get("matched")]
+    extra = tm.get("extra_entries", [])
+    res.append(metrics.MetricResult(
+        "concept_recall", tm["concept_recall"],
+        tm["concept_recall"] >= thr["concept_recall"],
+        f"Captured {len(matched)} of {len(per_topic)} expected concepts as entries"
+        + (f"; missing: {', '.join(missed)}." if missed else ".")))
+    n_prod = len(tm.get("produced_entries", []))
+    acc, spu = _classify_extras(extra, golden.get("acceptable_extra_concepts"))
+    precision = (n_prod - len(spu)) / n_prod if n_prod else 1.0
+    detail = (f"{n_prod - len(extra)} of {n_prod} produced entries map to a core "
+              "expected concept")
+    if spu:
+      detail += "; spurious: " + ", ".join(e for e, _ in spu)
+    res.append(metrics.MetricResult(
+        "concept_precision", round(precision, 3),
+        precision >= thr["concept_precision"], detail + "."))
+    res.append(metrics.MetricResult(
+        "fact_recall", tm["fact_coverage"],
+        tm["fact_coverage"] >= thr["fact_recall"], _fact_detail(per_topic)))
+  elif mode == "table" and golden.get("tables"):
+    topics = [{"canonical": t["table"], "flavor_hints": [t["table"]],
+               "golden_facts": t.get("golden_facts", [])} for t in golden["tables"]]
+    tm = metrics.match_topics(arts, topics, judge, 0.7)
+    res.append(metrics.MetricResult(
+        "fact_recall", tm["fact_coverage"],
+        tm["fact_coverage"] >= thr["fact_recall"],
+        _fact_detail(tm.get("per_topic", []))))
+
+  # Judge: persona alignment (optional)
+  if persona_id and golden.get("personas", {}).get(persona_id):
+    res.append(metrics.check_persona_alignment(
+        arts, golden["personas"][persona_id], judge))
+
+  # Judge: rubric dims (redundancy_index / disambiguation_efficacy /
+  # absence_of_contradictions) — same set dynamic eval scores. Degrades gracefully without a judge.
+  try:
+    res.extend(metrics.score_rubric(arts, judge, golden.get("business_terms")))
+  except Exception:  # pylint: disable=broad-except
+    pass
+
+  # Judge: hallucination grounded on trajectory (+ table reference)
+  src = _trajectory_source(traj)
+  extra_g = ""
+  if mode == "table":
+    refs = loaders.load_references(output_dir)
+    extra_g = "\n\n".join(
+        list((refs.get("yaml") or {}).values())
+        + list((arts.get("reference_yaml") or {}).values())
+        + list((arts.get("reference_overview_md") or {}).values())
+        + list((arts.get("yaml") or {}).values()))
+  res.append(metrics.check_hallucination(arts, src, judge, extra_grounding=extra_g))
+
+  # Shared result builder (same shape + 0-100 scaling as the dynamic path).
+  results = dynamic_eval.build_results(output_dir, agent_type, mode, res, traj,
+                                       tokens, latency, golden=golden_path)
+  # Golden reports go to a dedicated tmp folder (not next to trajectory.json).
+  # Named by golden + run so several goldens scoring the same output dir (or
+  # parallel runs) don't clobber each other; a batch caller can override both.
+  report_dir = report_dir or os.path.join(
+      tempfile.gettempdir(), "kc_golden_eval_reports")
+  os.makedirs(report_dir, exist_ok=True)
+  gstem = os.path.splitext(os.path.basename(golden_path))[0]
+  run = os.path.basename(output_dir.rstrip("/")) or "run"
+  fname = report_name or f"golden_report_{gstem}__{run}.md"
+  dynamic_eval.write_report(results, report_dir, filename=fname)
+  results["report_path"] = os.path.join(report_dir, fname)
+  return results
+
+
+def _fact_detail(per_topic: list) -> str:
+  missing = [f"[{t['topic']}] {f}"
+             for t in per_topic for f in (t.get("missing_facts") or [])]
+  if not missing:
+    return "All golden facts are conveyed by the matched entries."
+  return f"Missing/partial facts: " + "; ".join(missing[:6]) + (
+      f" (+{len(missing)-6} more)" if len(missing) > 6 else "")

--- a/agents/enrichment/eval/goldens/README.md
+++ b/agents/enrichment/eval/goldens/README.md
@@ -1,0 +1,174 @@
+# Golden files
+
+A **golden** declares what an enrichment run *should* contain for a given input,
+so the eval can score the output against it. Dynamic (golden-free) eval grounds
+only in what the agent retrieved; a golden adds **concept recall/precision**,
+**fact recall**, **section coverage**, **term coverage**, and (optionally)
+**persona alignment**.
+
+Run it (every bundled golden has a `run` block, so `--run` does the agent run +
+scoring for you):
+
+```bash
+cd agents/enrichment
+python -m eval --run --goldens eval/goldens/supply_chain.json --project <your_gcp_project>
+# or score an output you already produced:
+python -m eval --output-dir <run output> --golden eval/goldens/supply_chain.json
+```
+
+(Same judge auth as dynamic eval — `GOOGLE_CLOUD_PROJECT` + ADC.)
+
+## Schema
+
+Keep the fields that fit your mode (see `TEMPLATE.json`):
+
+| Field | Mode | Drives | Meaning |
+|-------|------|--------|---------|
+| `expected_topics` | doc | concept_recall, concept_precision, fact_recall | List of `{canonical, flavor_hints[], golden_facts[]}` — the concepts you expect as entries. `flavor_hints` are synonyms the judge treats as the same concept; `golden_facts` are statements the entry should convey. |
+| `acceptable_extra_concepts` | doc | concept_precision | Optional concepts that are fine to produce and **won't** count against precision (string or `{name, aliases[]}`). |
+| `tables` | table | fact_recall | List of `{table, golden_facts[]}` — each table's expected facts. |
+| `expected_headings` | both | enrichment_diversity | Sections the overview should contain (e.g. `Lineage`, `Sample Queries`). |
+| `business_terms` | both | business_terms_presence, business_terms_validity | Terms the output should cover (presence) + whether each gets a dedicated per-term definition file (validity). |
+| `personas` | doc | persona_alignment | `{id: {instruction, focus_areas[], shared_concepts[]}}` — run with `--persona <id>`. |
+| `prebaked_facts` | both | context_preservation | Facts that existed before enrichment and must be PRESERVED (not clobbered) through the run. |
+| `trajectory` | both | trajectory | `{must_call: [...], must_not_call: [...]}` — tool categories the agent must / must not use (`drive_fetch`, `dataset_pull`, `github_fetch`). Checked against the actual `trajectory.json` tool calls. |
+
+Every golden run also gets the **dynamic** metrics automatically:
+`structural_validity`, `perf`, `hallucination_free`, and the rubric dims
+`redundancy_index` / `disambiguation_efficacy` / `absence_of_contradictions` — so
+a golden only needs to declare the golden-specific fields above.
+
+The eval auto-detects mode from the run's `trajectory.json` (`agent_type`), so use
+`expected_topics` for doc runs and `tables` for table runs. **`context_overlay`**
+runs keep their own mode (matching the reference design): structural validity
+skips the entry-type check (overlay entries are `generic`, mixed with read-only
+`.ref` bigquery entries), and the table-only metrics — `entry_grounding`,
+reference grounding, per-table `fact_recall` — don't apply. Score an overlay
+golden with `business_terms` / `expected_headings` (and rely on the trajectory
+for `hallucination_free`).
+
+## How to build goldens — three sources
+
+1. **Author them deliberately.** Hand-write `golden_facts`/`expected_topics` for the
+   scenarios and failure modes you care about (synonyms, contradictions, ambiguous
+   entities). Start small; `TEMPLATE.json` shows every field.
+
+2. **Work backward from already-documented data.** Take a dataset that already has
+   good human-written descriptions, **keep the source the agent reads** (schema,
+   sample data, source docs) but **hold out the human descriptions**, run the agent,
+   and use those held-out descriptions as `golden_facts`. The existing documentation
+   becomes a large, real golden set "for free." Filter to facts the source actually
+   supports (don't include tribal knowledge the agent could never recover).
+
+3. **Harvest from human review (HITL).** When a person approves or edits a generated
+   entry, capture the approved/corrected output as a golden. The set then grows
+   continuously from real usage instead of being authored once.
+
+## theLook eCommerce — runnable table-mode golden (out-of-the-box)
+
+`thelook_ecommerce.json` is a ready-to-run **table-mode** golden built on the
+public BigQuery dataset `bigquery-public-data.thelook_ecommerce` (a synthetic
+multi-brand online retailer) and grounded by the local markdown corpus under
+`eval/corpora/thelook_ecommerce/` (4 docs: business glossary, order lifecycle,
+data model, metrics) — no Google Drive needed.
+
+Run it end-to-end with **one command** (from `agents/enrichment/`). The eval does
+everything from the golden's `run` block — copies the public dataset into your
+project (idempotent), enriches it in table mode grounded by the local corpus, and
+scores it. You only pass your project:
+
+```bash
+python -m eval --run --goldens eval/goldens/thelook_ecommerce.json \
+    --project <your_gcp_project> --model gemini-2.5-pro --runs 3
+```
+
+That gives run-level + averaged metrics across 3 runs and writes the reports to a
+timestamped folder under `$TMPDIR/kc_golden_eval_reports/`. Prereqs: ADC
+(`gcloud auth application-default login`) and a built `kcmd`
+(`cd agents/mdcode && npm run build`).
+
+The golden scores per-table `golden_facts` (fact recall), `business_terms`
+coverage, and `expected_headings` — all stated in / derivable from the grounding
+corpus. (You don't run `bq` or the agent yourself — `--run` handles the
+copy-public-dataset setup and the agent run; see "Run a golden as a CASE" below
+for the `run`-block schema and how to author your own cases.)
+
+## Run a golden as a CASE (`--run`) — including your own
+
+Add a `run` block to any golden to make it a runnable **case**: `python -m eval
+--run` then generates the Metadata-as-Code itself (you don't pre-run the agent),
+repeats it `--runs` times, scores each, and reports run-level + averaged metrics.
+This mirrors a single-agent eval (single agent).
+
+```jsonc
+"run": {
+  "mode": "table",                 // "table" | "doc" | "context_overlay"
+  "topic": "Metadata enrichment",
+  "folders": "eval/corpora/my_corpus",   // local dirs and/or Drive folders (comma-sep); relative to agents/enrichment
+  "docs": "https://docs.google.com/...,./notes/x.md",  // optional, mixed
+  "entry_group": "proj.location.my-eg",  // required for doc / context_overlay
+  "dataset": "proj.my_dataset",          // table / context_overlay (omit if using setup below)
+  "setup": {                              // optional: copy a public dataset into your project first
+    "copy_public_dataset": {"source": "bigquery-public-data.thelook_ecommerce", "dataset": "thelook_ecommerce"}
+  }
+}
+```
+
+Run it (works for any golden with a `run` block — your own cases included):
+
+```bash
+python -m eval --run --goldens eval/goldens/thelook_ecommerce.json \
+    --project <your_gcp_project> --runs 3 --concurrency 2
+# several at once:
+python -m eval --run --goldens eval/goldens/a.json,eval/goldens/b.json --project <p>
+```
+
+- `--runs N` (default 3 in `--run` mode): per-run + averaged metrics, plus the
+  cross-run **concept_consistency** / **content_consistency** stability metrics
+  (informational; shown only when there are ≥2 independent runs — omitted
+  otherwise, since consistency is undefined for a single run).
+- `--concurrency` (default 2, env `KC_EVAL_MAX_CONCURRENCY`): max concurrent agent
+  processes; the agent also caps its own per-mode LLM concurrency, so keep this low.
+- Reports land in a timestamped run folder
+  (`$TMPDIR/kc_golden_eval_reports/golden_run_<time>_<id>/`) with one report per
+  `<golden>/run<i>.md`, an **averaged `<golden>/aggregate.md`** (the mean metrics
+  with full untruncated rationale, per-metric run scores, and a per-run
+  breakdown — what the terminal scorecard truncates), plus a `manifest.json`.
+- Prereqs for `--run`: ADC (`gcloud auth application-default login`) and a built
+  `kcmd` (`cd agents/mdcode && npm run build`) — every mode (doc included) shells
+  out to it (`kcmd init`/`pull`).
+
+## Bundled runnable goldens
+
+All four shipped goldens have a `run` block, so each is one-command:
+
+| Golden | Mode | Setup |
+|--------|------|-------|
+| `thelook_ecommerce.json` | table | copies `bigquery-public-data.thelook_ecommerce` into your project |
+| `financial_services.json` | doc | grounds on `eval/corpora/financial_services` |
+| `phone_services.json` | doc | grounds on `eval/corpora/phone_services` |
+| `supply_chain.json` | doc | grounds on `eval/corpora/supply_chain` |
+
+The doc goldens declare a generalizable `entry_group` of the form
+`{project}.global.kc-eval-<name>` — the `{project}` placeholder is replaced with
+your `--project` at run time, so nothing in the golden is hardwired to one
+project. Run them like any other case:
+
+```bash
+# one doc case
+python -m eval --run --goldens eval/goldens/financial_services.json --project <p>
+# all four at once
+python -m eval --run --project <p> --goldens \
+  eval/goldens/thelook_ecommerce.json,eval/goldens/financial_services.json,eval/goldens/phone_services.json,eval/goldens/supply_chain.json
+```
+
+(All cases need a built `kcmd` — every mode runs `kcmd init`/`pull`. The table
+case additionally needs BigQuery access for the dataset copy.)
+
+## Notes
+
+- A golden is a strong but imperfect oracle: a good agent can sometimes write
+  something correct that your golden didn't list (a false "miss") — spot-check
+  low scores.
+- Keep facts atomic and checkable; the judge matches them semantically (paraphrase
+  is fine), it does not require exact wording.

--- a/agents/enrichment/eval/goldens/TEMPLATE.json
+++ b/agents/enrichment/eval/goldens/TEMPLATE.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "Golden template. Keep the fields that fit your enrichment mode; delete the rest. The eval compares the agent's output to these expectations. See README.md.",
+
+  "_doc_mode": "DOC MODE (knowledge base from documents): declare the concepts you expect as entries.",
+  "expected_topics": [
+    {
+      "canonical": "Reorder Point",
+      "flavor_hints": ["reorder level", "ROP", "replenishment trigger"],
+      "golden_facts": [
+        "The reorder point is the inventory level at which a new order is placed.",
+        "ROP = average daily demand x lead time, plus safety stock."
+      ]
+    }
+  ],
+  "_acceptable_extra_concepts_doc": "Optional concepts that are fine to produce and must NOT count against precision.",
+  "acceptable_extra_concepts": [{"name": "SKU", "aliases": ["stock keeping unit"]}],
+
+  "_table_mode": "TABLE MODE (BigQuery dataset): one entry per table; declare each table's golden facts.",
+  "tables": [
+    {
+      "table": "my_table",
+      "golden_facts": [
+        "What the table contains and its grain (one row per ...).",
+        "A key column's meaning, or a lineage/relationship fact."
+      ]
+    }
+  ],
+
+  "_sections": "Sections the overview should contain (scored by enrichment_diversity).",
+  "expected_headings": ["Lineage", "Sample Queries"],
+
+  "_terms": "Business terms the output should cover. Scores business_terms_presence (covered?) and business_terms_validity (a dedicated per-term definition file? — typically low today).",
+  "business_terms": ["session", "event"],
+
+  "_prebaked_facts": "OPTIONAL. Facts that already existed before enrichment and must be PRESERVED (not clobbered) through the run. Scores context_preservation.",
+  "prebaked_facts": ["The orders table is the system of record for fulfilled orders."],
+
+  "_trajectory": "OPTIONAL input-conditioned tool use, checked against the actual trajectory.json tool calls. Categories: drive_fetch, dataset_pull, github_fetch. Scores trajectory.",
+  "trajectory": {
+    "must_call": [],
+    "must_not_call": ["dataset_pull"]
+  },
+
+  "_personas": "OPTIONAL persona-conditioned eval. Run with --persona <id>. Scores persona_alignment.",
+  "personas": {
+    "analyst": {
+      "instruction": "the --topic string this persona would pass to the agent",
+      "focus_areas": ["areas this persona should see emphasized"],
+      "shared_concepts": ["concepts every persona must still cover"]
+    }
+  }
+}

--- a/agents/enrichment/eval/goldens/financial_services.json
+++ b/agents/enrichment/eval/goldens/financial_services.json
@@ -1,0 +1,86 @@
+{
+  "_comment": "Doc-mode golden for the financial_services corpus (eval/corpora/financial_services). Runnable with `python -m eval --run --goldens eval/goldens/financial_services.json --project <p>` (uses the `run` block below), or score an existing run with `--output-dir <out> --golden eval/goldens/financial_services.json`. Concepts are matched semantically by the judge; facts must trace to the corpus.",
+  "corpus": "financial_services",
+  "grounding": "eval/corpora/financial_services (run doc mode: --folders=eval/corpora/financial_services --entry_group=<your eg>)",
+  "run": {
+    "mode": "doc",
+    "topic": "Financial services compliance and risk metrics",
+    "folders": "eval/corpora/financial_services",
+    "entry_group": "{project}.global.kc-eval-financial-services",
+    "location": "global",
+    "_doc": "Makes this a runnable CASE: `python -m eval --run --goldens eval/goldens/financial_services.json --project <p>` generates the doc-mode mdcode itself (grounded by the local corpus) and scores it. {project} is replaced with --project. --folders is relative to agents/enrichment."
+  },
+  "business_terms": [
+    "Net Interest Margin",
+    "Credit Risk Score",
+    "Customer Lifetime Value",
+    "KYC Risk Rating"
+  ],
+  "acceptable_extra_concepts": [
+    {
+      "name": "KYC Risk Rating",
+      "aliases": [
+        "kyc",
+        "know your customer",
+        "financial-crime risk"
+      ]
+    },
+    {
+      "name": "AML",
+      "aliases": [
+        "anti-money-laundering",
+        "aml investigations"
+      ]
+    },
+    {
+      "name": "Basel III",
+      "aliases": [
+        "basel",
+        "regulatory capital filing"
+      ]
+    }
+  ],
+  "expected_topics": [
+    {
+      "canonical": "Net Interest Margin",
+      "flavor_hints": [
+        "NIM",
+        "net interest margin"
+      ],
+      "golden_facts": [
+        "net interest income (earned on assets minus paid on liabilities) divided by average interest-earning assets",
+        "expresses how much margin the balance sheet produces per dollar of earning assets",
+        "moves with the interest-rate environment; reported in earnings and treasury reviews"
+      ]
+    },
+    {
+      "canonical": "Credit Risk Score",
+      "flavor_hints": [
+        "credit risk",
+        "default risk score"
+      ],
+      "golden_facts": [
+        "a quantified estimate of how likely a borrower is to default",
+        "built from repayment history, current exposure, and income or leverage",
+        "drives lending decisions and loan pricing; lower scores mean higher default risk",
+        "distinct from a customer's KYC risk rating, which measures financial-crime risk, not default risk"
+      ]
+    },
+    {
+      "canonical": "Customer Lifetime Value",
+      "flavor_hints": [
+        "CLV",
+        "customer LTV",
+        "LTV"
+      ],
+      "golden_facts": [
+        "total net profit expected from a customer over the entire relationship (projected revenue minus cost to serve and retain)",
+        "used to decide how much to justify spending to acquire and keep a customer",
+        "marketing's 'customer LTV'/'LTV' and finance's 'CLV' are the same metric and should not be treated as two measures"
+      ]
+    }
+  ],
+  "non_entries": [
+    "KYC risk rating (mentioned for contrast with Credit Risk Score; should not be merged into it)"
+  ]
+}

--- a/agents/enrichment/eval/goldens/phone_services.json
+++ b/agents/enrichment/eval/goldens/phone_services.json
@@ -1,0 +1,95 @@
+{
+  "_comment": "Doc-mode golden for the phone_services corpus (eval/corpora/phone_services). Runnable with `python -m eval --run --goldens eval/goldens/phone_services.json --project <p>` (uses the `run` block below), or score an existing run with `--output-dir <out> --golden eval/goldens/phone_services.json`. Concepts are matched semantically by the judge; facts must trace to the corpus.",
+  "corpus": "phone_services",
+  "grounding": "eval/corpora/phone_services (run doc mode: --folders=eval/corpora/phone_services --entry_group=<your eg>)",
+  "run": {
+    "mode": "doc",
+    "topic": "Telecom / mobile network services and quality metrics",
+    "folders": "eval/corpora/phone_services",
+    "entry_group": "{project}.global.kc-eval-phone-services",
+    "location": "global",
+    "_doc": "Makes this a runnable CASE: `python -m eval --run --goldens eval/goldens/phone_services.json --project <p>` generates the doc-mode mdcode itself (grounded by the local corpus) and scores it. {project} is replaced with --project. --folders is relative to agents/enrichment."
+  },
+  "business_terms": [
+    "APN",
+    "IMSI",
+    "QoS",
+    "VoLTE",
+    "SIM"
+  ],
+  "acceptable_extra_concepts": [
+    {
+      "name": "Number Portability",
+      "aliases": [
+        "portability",
+        "number porting",
+        "port-in"
+      ]
+    },
+    {
+      "name": "Roaming",
+      "aliases": [
+        "roaming",
+        "roaming partner"
+      ]
+    },
+    {
+      "name": "Churn",
+      "aliases": [
+        "customer churn",
+        "churn rate"
+      ]
+    }
+  ],
+  "expected_topics": [
+    {
+      "canonical": "APN",
+      "flavor_hints": [
+        "Access Point Name"
+      ],
+      "golden_facts": [
+        "the identifier a device presents to say which packet data network it wants to reach",
+        "tells the core which gateway to route a data session through (e.g. public-internet vs internal IMS APN)",
+        "part of the device's data profile, applied when a data session is established; different APNs map to different services/policies"
+      ]
+    },
+    {
+      "canonical": "IMSI",
+      "flavor_hints": [
+        "International Mobile Subscriber Identity",
+        "SIM identity"
+      ],
+      "golden_facts": [
+        "the globally unique identity of a subscriber, provisioned onto the SIM",
+        "what the network uses to recognize and authenticate a subscriber",
+        "the key reference used when subscribers connect at home or via roaming"
+      ]
+    },
+    {
+      "canonical": "QoS",
+      "flavor_hints": [
+        "Quality of Service"
+      ],
+      "golden_facts": [
+        "mechanisms that prioritize traffic and hold it to latency, packet-loss, and throughput targets",
+        "traffic is sorted into classes, each given a treatment appropriate to its needs",
+        "real-time services need stricter QoS than best-effort data"
+      ]
+    },
+    {
+      "canonical": "VoLTE",
+      "flavor_hints": [
+        "Voice over LTE",
+        "IMS voice"
+      ],
+      "golden_facts": [
+        "carries voice calls as packets over the LTE data network via IMS, not the legacy circuit-switched path",
+        "delay-sensitive, so it depends on a high-priority QoS class to keep calls clear",
+        "VoLTE, Voice-over-LTE, and 'IMS voice' all refer to the same service"
+      ]
+    }
+  ],
+  "non_entries": [
+    "'SIM identity' used loosely for IMSI (prefer IMSI; should not be a separate entry)"
+  ]
+}

--- a/agents/enrichment/eval/goldens/supply_chain.json
+++ b/agents/enrichment/eval/goldens/supply_chain.json
@@ -1,0 +1,144 @@
+{
+  "_comment": "Doc-mode golden for the supply_chain corpus (eval/corpora/supply_chain). Runnable with `python -m eval --run --goldens eval/goldens/supply_chain.json --project <p>` (uses the `run` block below), or score an existing run with `--output-dir <out> --golden eval/goldens/supply_chain.json`. Concepts are matched semantically by the judge; facts must trace to the corpus.",
+  "corpus": "supply_chain",
+  "grounding": "eval/corpora/supply_chain (run doc mode: --folders=eval/corpora/supply_chain --entry_group=<your eg>)",
+  "run": {
+    "mode": "doc",
+    "topic": "Supply chain planning, inventory and procurement",
+    "folders": "eval/corpora/supply_chain",
+    "entry_group": "{project}.global.kc-eval-supply-chain",
+    "location": "global",
+    "_doc": "Makes this a runnable CASE: `python -m eval --run --goldens eval/goldens/supply_chain.json --project <p>` generates the doc-mode mdcode itself (grounded by the local corpus) and scores it. {project} is replaced with --project. --folders is relative to agents/enrichment."
+  },
+  "business_terms": [
+    "SKU",
+    "Bill of Materials",
+    "Lead Time",
+    "Safety Stock",
+    "Reorder Point",
+    "Supplier Scorecard",
+    "Distribution Center"
+  ],
+  "_acceptable_extra_concepts_doc": "Grounded but less central than the core expected_topics: producing one is NOT counted spurious by concept_precision (and not required by recall). Document-shaped entries (e.g. 'inventory-policy-memo', 'procurement-sop', 'warehouse-ops-runbook') are still penalized.",
+  "acceptable_extra_concepts": [
+    {
+      "name": "Order Routing",
+      "aliases": [
+        "order routing",
+        "order router",
+        "order routing logic",
+        "demand to procurement flow"
+      ]
+    },
+    {
+      "name": "Supplier Onboarding",
+      "aliases": [
+        "supplier onboarding",
+        "onboarding",
+        "supplier onboarding process",
+        "supplier selection"
+      ]
+    },
+    {
+      "name": "Inbound Receiving",
+      "aliases": [
+        "inbound receiving",
+        "receiving",
+        "receiving and inspection",
+        "inbound",
+        "putaway"
+      ]
+    }
+  ],
+  "expected_topics": [
+    {
+      "canonical": "SKU",
+      "flavor_hints": [
+        "Stock Keeping Unit",
+        "item number"
+      ],
+      "golden_facts": [
+        "identifies a product at variant level (size/color/pack), not the product family",
+        "internal identifier, distinct from external UPC/GTIN barcodes",
+        "a finished-good SKU maps to a Bill of Materials",
+        "is the unit of inventory tracking across distribution centers"
+      ]
+    },
+    {
+      "canonical": "Bill of Materials",
+      "flavor_hints": [
+        "BOM",
+        "product structure"
+      ],
+      "golden_facts": [
+        "lists components and the quantity of each required to build one finished unit",
+        "can be multi-level (sub-assemblies have their own BOMs)",
+        "drives procurement of component materials"
+      ]
+    },
+    {
+      "canonical": "Lead Time",
+      "flavor_hints": [
+        "procurement lead time",
+        "supplier lead time"
+      ],
+      "golden_facts": [
+        "elapsed time from placing a purchase order to goods being available to pick",
+        "includes supplier processing, transit, and inbound putaway",
+        "variability drives the need for safety stock; an input to the reorder point"
+      ]
+    },
+    {
+      "canonical": "Safety Stock",
+      "flavor_hints": [
+        "buffer stock"
+      ],
+      "golden_facts": [
+        "extra inventory held to absorb demand and lead-time variability",
+        "sized as days of supply or against a service-level target",
+        "Class-A safety stock was raised from 14 to 21 days of supply after the Q3 stockout postmortem (most recent value governs)"
+      ]
+    },
+    {
+      "canonical": "Reorder Point",
+      "flavor_hints": [
+        "ROP",
+        "reorder level"
+      ],
+      "golden_facts": [
+        "the inventory level that triggers a replenishment order",
+        "ROP = (average daily demand x lead time) + safety stock",
+        "depends on both lead time and safety stock"
+      ]
+    },
+    {
+      "canonical": "Supplier Scorecard",
+      "flavor_hints": [
+        "vendor rating",
+        "supplier rating"
+      ],
+      "golden_facts": [
+        "structured rating of supplier performance used in sourcing",
+        "combines on-time delivery %, quality/defect rate, and price competitiveness",
+        "influences order allocation among suppliers"
+      ]
+    },
+    {
+      "canonical": "Distribution Center",
+      "flavor_hints": [
+        "DC",
+        "fulfillment center",
+        "fulfillment node"
+      ],
+      "golden_facts": [
+        "facility that stores inventory and fulfills downstream orders",
+        "holds inventory at the SKU level; a node between suppliers and demand",
+        "each DC has its own on-hand inventory and replenishment"
+      ]
+    }
+  ],
+  "non_entries": [
+    "UPC/GTIN (external barcode mentioned for contrast; must NOT be its own entry nor merged into SKU)",
+    "Office Badge & Facilities Policy (off-domain distractor doc; should yield no entries)"
+  ]
+}

--- a/agents/enrichment/eval/goldens/thelook_ecommerce.json
+++ b/agents/enrichment/eval/goldens/thelook_ecommerce.json
@@ -1,0 +1,113 @@
+{
+  "_comment": "Table-mode golden for enriching theLook eCommerce, a synthetic multi-brand online retailer published as the public BigQuery dataset bigquery-public-data.thelook_ecommerce. Out-of-the-box flow (see README.md 'theLook eCommerce'): copy the public dataset into your own project (it is read-only), run the agent in table mode against your copy grounded by the local markdown corpus eval/corpora/thelook_ecommerce/, then score that run with `python -m eval --output-dir <out> --golden goldens/thelook_ecommerce.json`. Scoring matches each table by NAME, so the project prefix in your catalog path does not need to match. The golden_facts below are stated in the grounding corpus.",
+  "corpus": "thelook_ecommerce",
+  "dataset": "bigquery-public-data.thelook_ecommerce",
+  "_dataset_doc": "Public SOURCE dataset (read-only). Copy it into your project (e.g. <project>.thelook_ecommerce) and enrich the copy — see README.md for the one-line `bq` copy.",
+  "grounding": "eval/corpora/thelook_ecommerce (4 local markdown docs: business_glossary, order_lifecycle, data_model, metrics) — pass as --folders to the agent.",
+  "run": {
+    "_doc": "Makes this golden a runnable CASE for `python -m eval --run --project <p>`: copy the public dataset into <project>.thelook_ecommerce (idempotent), then enrich it in table mode grounded by the local markdown corpus. --folders is relative to agents/enrichment.",
+    "mode": "table",
+    "topic": "Metadata enrichment",
+    "folders": "eval/corpora/thelook_ecommerce",
+    "setup": {
+      "copy_public_dataset": {
+        "source": "bigquery-public-data.thelook_ecommerce",
+        "dataset": "thelook_ecommerce"
+      }
+    }
+  },
+  "business_terms": [
+    "Gross Margin",
+    "Sale Price",
+    "Retail Price",
+    "Cost",
+    "SKU",
+    "Order Item",
+    "Order",
+    "Inventory Item",
+    "Distribution Center",
+    "Traffic Source"
+  ],
+  "tables": [
+    {
+      "table": "order_items",
+      "golden_facts": [
+        "grain is one unit of one product within an order — the revenue grain for the dataset",
+        "sale_price is the price the customer actually paid, distinct from products.retail_price (list price) and cost (wholesale)",
+        "links a sold unit to its order, product, and the physical inventory_item that fulfilled it",
+        "status and returned_at track per-line fulfillment and returns; returns reverse revenue and are excluded from net revenue"
+      ],
+      "business_terms": [
+        "Sale Price",
+        "Order Item",
+        "Gross Margin"
+      ]
+    },
+    {
+      "table": "products",
+      "golden_facts": [
+        "catalog of sellable products at the SKU grain",
+        "gross margin is retail_price minus cost; the actually-paid price (sale_price) lives on order_items",
+        "organized by a department > category > brand taxonomy, with sku as the stock-keeping identifier",
+        "distribution_center_id assigns each product to the fulfillment warehouse that stocks it"
+      ],
+      "business_terms": [
+        "SKU",
+        "Gross Margin",
+        "Retail Price",
+        "Cost"
+      ]
+    },
+    {
+      "table": "orders",
+      "golden_facts": [
+        "one row per order (a checkout event), linked to the customer via user_id",
+        "num_of_item counts the items in the order; the revenue grain is order_items, not orders",
+        "status follows the lifecycle Processing, Shipped, Complete, plus Returned and Cancelled",
+        "created_at, shipped_at, delivered_at, and returned_at track the fulfillment funnel"
+      ],
+      "business_terms": [
+        "Order",
+        "Order Item"
+      ]
+    },
+    {
+      "table": "inventory_items",
+      "golden_facts": [
+        "one row per physical unit of stock; created_at is when stock was received and sold_at is when the unit sold",
+        "denormalizes product attributes via product_* columns copied from products, which remains the authoritative source",
+        "sell-through rate and average days-in-inventory are derived from sold_at versus created_at"
+      ],
+      "business_terms": [
+        "Inventory Item",
+        "SKU"
+      ]
+    },
+    {
+      "table": "distribution_centers",
+      "golden_facts": [
+        "one row per fulfillment warehouse that stocks and ships products",
+        "products are assigned to a center via products.distribution_center_id",
+        "carries a name and geographic location (latitude/longitude) used for shipping-time analysis"
+      ],
+      "business_terms": [
+        "Distribution Center"
+      ]
+    },
+    {
+      "table": "users",
+      "golden_facts": [
+        "one row per customer, with demographics, location, and signup time (created_at)",
+        "traffic_source records the acquisition channel (e.g. Search, Organic, Email, Display, Facebook)",
+        "linked to orders via user_id for customer-level revenue and acquisition analysis"
+      ],
+      "business_terms": [
+        "Traffic Source"
+      ]
+    }
+  ],
+  "expected_headings": [
+    "Lineage",
+    "Sample Queries"
+  ]
+}

--- a/agents/enrichment/eval/runner.py
+++ b/agents/enrichment/eval/runner.py
@@ -1,0 +1,125 @@
+"""Run a golden as a CASE: optional dataset-copy setup + N agent runs.
+
+`python -m eval --run` uses this to match a single-agent eval: a golden
+file can carry a `run` block (the agent inputs + optional `setup`), and the eval
+copies any public dataset into the user's project, runs the agent `--runs` times
+(under a concurrency cap so parallel runs don't blow Vertex quota), and hands the
+output dirs back to the scorer.
+
+The agent itself caps its own internal LLM concurrency per mode
+(`CONCURRENCY_LIMIT` in modes/table_mode.py = 12, doc_mode.py = 6, per-doc = 20);
+this module caps how many agent *processes* run at once on top of that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+
+# The published agent lives next to the eval package: agents/enrichment/src.
+_AGENT_DIR = os.environ.get("KC_AGENT_DIR") or os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+
+
+def _bq(*args: str) -> subprocess.CompletedProcess:
+  return subprocess.run(["bq", *args], capture_output=True, text=True, check=False)
+
+
+def ensure_dataset_copy(source: str, target_project: str, target_dataset: str,
+                        location: str = "US") -> str:
+  """Make `target_project.target_dataset` exist by copying it from `source`.
+
+  Idempotent: if the target dataset already exists it is left untouched. `source`
+  is `project.dataset` (e.g. `bigquery-public-data.thelook_ecommerce`); the source
+  is read via its public/shared access and per-table copy failures are non-fatal.
+  Returns the `project.dataset` of the copy.
+  """
+  target_ref = f"{target_project}:{target_dataset}"
+  if _bq("--project_id", target_project, "show", "--dataset",
+         target_ref).returncode == 0:
+    print(f"[setup] dataset {target_project}.{target_dataset} already exists "
+          "— reusing (no copy).", flush=True)
+    return f"{target_project}.{target_dataset}"
+  print(f"[setup] copying {source} -> {target_project}.{target_dataset} ...",
+        flush=True)
+  _bq("--project_id", target_project, "mk", "--dataset",
+      f"--location={location}", target_ref)
+  src_project, src_dataset = source.split(".", 1)
+  ls = _bq("--format=json", "--project_id", target_project, "ls",
+           "--max_results=10000", f"{src_project}:{src_dataset}")
+  try:
+    tables = [it["tableReference"]["tableId"]
+              for it in (json.loads(ls.stdout) or [])]
+  except (json.JSONDecodeError, KeyError, TypeError):
+    tables = []
+  for tbl in tables:
+    cp = _bq("--project_id", target_project, "cp", "-f", "--no_clobber",
+             f"{src_project}:{src_dataset}.{tbl}",
+             f"{target_project}:{target_dataset}.{tbl}")
+    if cp.returncode != 0:
+      print(f"[setup] warning: copy {tbl} failed (non-fatal): "
+            f"{(cp.stderr or '').strip()[:160]}", flush=True)
+  print(f"[setup] copied {len(tables)} table(s).", flush=True)
+  return f"{target_project}.{target_dataset}"
+
+
+def resolve_inputs(golden: dict, project: str) -> dict:
+  """Build the agent CLI inputs for a golden's `run` block.
+
+  Runs any `setup.copy_public_dataset` and, for it, sets `dataset` to the copy in
+  the user's project. Returns a dict of agent flags (mode/topic/dataset/folders/
+  docs/entry_group/glossaries).
+
+  Any `{project}` placeholder in a run-block string value is replaced with the
+  user's `--project`, so a doc-mode golden can declare a generalizable
+  `entry_group` like `{project}.global.kc-eval-foo` and still target whoever runs
+  it.
+  """
+  run = dict(golden.get("run") or {})
+  setup = run.pop("setup", None) or {}
+  cp = setup.get("copy_public_dataset")
+  if cp:
+    ds = ensure_dataset_copy(cp["source"], project, cp["dataset"],
+                             location=cp.get("location", "US"))
+    run.setdefault("dataset", ds)
+  return {k: (v.replace("{project}", project) if isinstance(v, str) else v)
+          for k, v in run.items()}
+
+
+def _argv(inputs: dict, project: str, model: str, output_dir: str) -> list[str]:
+  argv = [sys.executable, os.path.join(_AGENT_DIR, "agent_runner.py"),
+          f"--project={project}", f"--model={model}",
+          f"--output_dir={output_dir}"]
+  for key in ("mode", "topic", "dataset", "entry_group", "folders", "docs",
+              "glossaries", "location"):
+    val = inputs.get(key)
+    if val:
+      argv.append(f"--{key}={val}")
+  return argv
+
+
+async def run_agent(inputs: dict, project: str, model: str, output_dir: str,
+                    sem: asyncio.Semaphore) -> tuple[int, str]:
+  """Run one agent process for `inputs` into `output_dir`, gated by `sem`."""
+  os.makedirs(output_dir, exist_ok=True)
+  argv = _argv(inputs, project, model, output_dir)
+  env = dict(os.environ)
+  env["PYTHONPATH"] = _AGENT_DIR + os.pathsep + env.get("PYTHONPATH", "")
+  env["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+  env["GOOGLE_CLOUD_PROJECT"] = project
+  env.setdefault("GOOGLE_CLOUD_LOCATION", inputs.get("location") or "global")
+  # Run from the eval-invocation dir (agents/enrichment) so relative inputs like
+  # `--folders=eval/corpora/...` resolve; PYTHONPATH (absolute) keeps imports OK.
+  async with sem:
+    print(f"[run] agent ({inputs.get('mode', 'doc')}) -> {output_dir}", flush=True)
+    proc = await asyncio.create_subprocess_exec(
+        *argv, cwd=os.getcwd(), env=env,
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
+    out, _ = await proc.communicate()
+    log = out.decode(errors="replace") if out else ""
+    if proc.returncode != 0:
+      print(f"[run] FAILED ({output_dir}): {log.strip()[-400:]}", flush=True)
+    return proc.returncode, log

--- a/agents/enrichment/eval/tools/import_to_drive.py
+++ b/agents/enrichment/eval/tools/import_to_drive.py
@@ -1,0 +1,82 @@
+"""Import a folder of local Markdown files into Google Drive as Google Docs.
+
+Doc-mode enrichment reads from Google Drive, so to run a doc-mode eval case you
+first need the source documents in *your* Drive. This uploads each `*.md` file in
+a local folder as a Google Doc into a new (or given) Drive folder and prints the
+folder id — feed that to the agent with `--mode=doc --folder=<id>`, then evaluate
+against the matching golden.
+
+Auth: Application Default Credentials with a Drive WRITE scope. Run once:
+
+    gcloud auth application-default login \\
+      --scopes='openid,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive'
+
+Usage:
+
+    python eval/tools/import_to_drive.py --src eval/corpora/supply_chain \\
+        --folder-name "kc-eval supply_chain"
+    # (optional) --parent <existing_drive_folder_id> to nest the new folder
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def _service():
+  from google.auth import default as adc  # pytype: disable=import-error
+  from googleapiclient.discovery import build  # pytype: disable=import-error
+  creds, _ = adc(scopes=["https://www.googleapis.com/auth/drive"])
+  return build("drive", "v3", credentials=creds, cache_discovery=False)
+
+
+def import_folder(src: str, folder_name: str, parent: str | None = None) -> str:
+  """Create a Drive folder and upload every *.md in `src` as a Google Doc.
+  Returns the new folder id."""
+  from googleapiclient.http import MediaFileUpload  # pytype: disable=import-error
+  svc = _service()
+  meta = {"name": folder_name, "mimeType": "application/vnd.google-apps.folder"}
+  if parent:
+    meta["parents"] = [parent]
+  folder_id = svc.files().create(body=meta, fields="id").execute()["id"]
+
+  md_files = sorted(f for f in os.listdir(src) if f.endswith(".md"))
+  if not md_files:
+    print(f"warning: no .md files found in {src}", file=sys.stderr)
+  for fn in md_files:
+    path = os.path.join(src, fn)
+    body = {"name": os.path.splitext(fn)[0],
+            "mimeType": "application/vnd.google-apps.document",  # convert MD -> Doc
+            "parents": [folder_id]}
+    media = MediaFileUpload(path, mimetype="text/markdown", resumable=False)
+    doc_id = svc.files().create(body=body, media_body=media,
+                                fields="id").execute()["id"]
+    print(f"  + {fn}  ->  https://docs.google.com/document/d/{doc_id}")
+  return folder_id
+
+
+def main(argv=None) -> int:
+  ap = argparse.ArgumentParser(
+      prog="python eval/tools/import_to_drive.py",
+      description="Upload a local folder of Markdown files into Drive as Google Docs.")
+  ap.add_argument("--src", required=True, help="Local folder containing *.md files.")
+  ap.add_argument("--folder-name", default="kc-eval-corpus",
+                  help="Name for the new Drive folder.")
+  ap.add_argument("--parent", default=None,
+                  help="Optional existing Drive folder id to create inside.")
+  args = ap.parse_args(argv)
+  if not os.path.isdir(args.src):
+    print(f"error: not a directory: {args.src}", file=sys.stderr)
+    return 2
+  folder_id = import_folder(args.src, args.folder_name, args.parent)
+  print()
+  print(f"Drive folder id: {folder_id}")
+  print(f"Now run:  python -m eval ... (enrich with --mode=doc --folder={folder_id}), "
+        f"then  python -m eval --output-dir <out> --golden <corpus>.json")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/agents/enrichment/src/agent_runner.py
+++ b/agents/enrichment/src/agent_runner.py
@@ -40,10 +40,20 @@ _TOPIC = flags.DEFINE_string(
     "Free-text use case / instruction guiding enrichment (anything).",
 )
 _DOCS = flags.DEFINE_list(
-    "docs", [], "Comma-separated list of Google Doc URLs or IDs (doc mode)."
+    "docs", [],
+    "Comma-separated mixed list, routed per entry: Google Doc URLs/IDs and/or "
+    "local .md files. A local .md file is a doc-mode depth-0 spine; for "
+    "table/context_overlay it grounds table overviews."
 )
-_FOLDER = flags.DEFINE_string(
-    "folder", None, "Optional Google Drive folder ID/URL to seed from."
+_FOLDERS = flags.DEFINE_list(
+    "folders", [],
+    "Comma-separated mixed list, routed per entry: Google Drive folder "
+    "URLs/IDs and/or local directories of .md files. Drive/local dirs seed "
+    "depth-1 children (doc mode) or grounding docs (table/context_overlay)."
+)
+# Backward-compatible alias for the former singular flag; merged with --folders.
+_FOLDER = flags.DEFINE_list(
+    "folder", [], "Deprecated alias for --folders (merged with it)."
 )
 
 # --- Source code input (all modes): agentic GitHub repo understanding -------
@@ -213,6 +223,10 @@ def main(argv):
 
   mode = _MODE.value or ("table" if _DATASET.value else "doc")
 
+  # --folders is canonical; --folder is a deprecated alias. Merge both so old
+  # invocations keep working.
+  folder_inputs = list(_FOLDERS.value or []) + list(_FOLDER.value or [])
+
   if mode == "context_overlay":
     if not _DATASET.value:
       raise app.UsageError(
@@ -226,7 +240,7 @@ def main(argv):
     session = asyncio.run(
         context_overlay_mode.run(
             _DATASET.value,
-            _FOLDER.value,
+            folder_inputs,
             _TOPIC.value,
             _OUTPUT_DIR.value,
             _MODEL.value,
@@ -249,7 +263,7 @@ def main(argv):
     session = asyncio.run(
         table_mode.run(
             _DATASET.value,
-            _FOLDER.value,
+            folder_inputs,
             _TOPIC.value,
             _OUTPUT_DIR.value,
             _MODEL.value,
@@ -276,7 +290,7 @@ def main(argv):
         doc_mode.run(
             _TOPIC.value,
             _DOCS.value,
-            _FOLDER.value,
+            folder_inputs,
             _OUTPUT_DIR.value,
             _MODEL.value,
             _ENTRY_GROUP.value,

--- a/agents/enrichment/src/common.py
+++ b/agents/enrichment/src/common.py
@@ -3,12 +3,54 @@
 import asyncio
 import json
 import os
+import random
 import re
 import threading
 import uuid
 
 from engine import EnumerationResult, create_enumeration_runner
 from google.genai import Client, types
+
+# Transient Vertex/model-serving errors that are safe to retry. These otherwise
+# abort a whole run: one call's exception propagates out of asyncio.gather and
+# cancels the concurrent siblings. Matched case-insensitively on the error text
+# (the SDK surfaces these as ClientError/ServerError/ApiError with the status in
+# the message, so substring matching is more robust than exception types).
+_RETRYABLE_MARKERS = (
+    "429", "resource_exhausted", "rate limit", "quota exceeded",
+    "503", "unavailable", "500", "internal error",
+    "decode_preempted", "preempted", "unable_to_retry",
+    "deadline", "timed out", "timeout", "connection reset",
+)
+
+
+def _is_retryable(exc: Exception) -> bool:
+  msg = str(exc).lower()
+  return any(m in msg for m in _RETRYABLE_MARKERS)
+
+
+async def _with_retry(fn, *, what="LLM call", attempts=6,
+                      base_delay=2.0, max_delay=60.0):
+  """Run async `fn()` with exponential backoff on transient model errors.
+
+  Retries 429 RESOURCE_EXHAUSTED / 503 / 500 / DECODE_PREEMPTED / timeouts a few
+  times (exp backoff + jitter) so a single transient Vertex blip doesn't abort
+  the whole enrichment run. Non-retryable errors raise immediately; if all
+  attempts are exhausted the last error propagates.
+  """
+  for i in range(attempts):
+    try:
+      return await fn()
+    except Exception as e:  # pylint: disable=broad-except
+      if i == attempts - 1 or not _is_retryable(e):
+        raise
+      delay = min(max_delay, base_delay * (2 ** i)) + random.uniform(0, 1.5)
+      print(
+          f"[retry] {what}: {type(e).__name__}: {str(e)[:140]} — "
+          f"attempt {i + 1}/{attempts}, backing off {delay:.1f}s",
+          flush=True,
+      )
+      await asyncio.sleep(delay)
 
 # v2.5 #4 + v2.6 #5: bypass ADK's LlmAgent/InMemoryRunner.
 # Per-thread client cache — the genai SDK's pyOpenSSL transport mutates an SSL
@@ -66,12 +108,15 @@ async def generate_text_direct(
         model=model, contents=user_prompt, config=config
     )
 
-  response = await asyncio.to_thread(_call)
-  usage = getattr(response, "usage_metadata", None)
-  if usage is not None and usage_acc is not None:
-    usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
-    usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
-  return response.text or ""
+  async def _once():
+    response = await asyncio.to_thread(_call)
+    usage = getattr(response, "usage_metadata", None)
+    if usage is not None and usage_acc is not None:
+      usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+      usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+    return response.text or ""
+
+  return await _with_retry(_once, what=f"generate_content({model})")
 
 
 # Back-compat alias for the v2.5 writer callers (semantically the same function).
@@ -104,10 +149,6 @@ async def run_enumeration(
     source context still mentions them.
   """
   runner = create_enumeration_runner(model)
-  user_id = str(uuid.uuid4())
-  session = await runner.session_service.create_session(
-      app_name=runner.app_name, user_id=user_id
-  )
 
   seed_block = ""
   if seed_entries:
@@ -139,28 +180,39 @@ async def run_enumeration(
       f"COMPILED CONTEXT:\n{compiled_context}\n\n"
       "Produce the canonical categorized entry list per the schema."
   )
-  raw_text = ""
-  async for event in runner.run_async(
-      user_id=user_id,
-      session_id=session.id,
-      new_message=types.Content(
-          role="user", parts=[types.Part.from_text(text=prompt)]
-      ),
-  ):
-    usage = getattr(event, "usage_metadata", None)
-    if usage:
-      usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
-      usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
-    if event.content and event.content.parts:
-      for part in event.content.parts:
-        if part.text:
-          raw_text += part.text
-  cleaned = raw_text.strip()
-  if cleaned.startswith("```"):
-    m = re.match(r"^```(?:json)?\s*\n(.*)\n```$", cleaned, re.S)
-    if m:
-      cleaned = m.group(1).strip()
-  return EnumerationResult.model_validate_json(cleaned)
+  async def _once():
+    user_id = str(uuid.uuid4())
+    session = await runner.session_service.create_session(
+        app_name=runner.app_name, user_id=user_id
+    )
+    raw_text = ""
+    local_in = local_out = 0
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=types.Content(
+            role="user", parts=[types.Part.from_text(text=prompt)]
+        ),
+    ):
+      usage = getattr(event, "usage_metadata", None)
+      if usage:
+        local_in += getattr(usage, "prompt_token_count", 0) or 0
+        local_out += getattr(usage, "candidates_token_count", 0) or 0
+      if event.content and event.content.parts:
+        for part in event.content.parts:
+          if part.text:
+            raw_text += part.text
+    if usage_acc is not None:
+      usage_acc["input"] += local_in
+      usage_acc["output"] += local_out
+    cleaned = raw_text.strip()
+    if cleaned.startswith("```"):
+      m = re.match(r"^```(?:json)?\s*\n(.*)\n```$", cleaned, re.S)
+      if m:
+        cleaned = m.group(1).strip()
+    return EnumerationResult.model_validate_json(cleaned)
+
+  return await _with_retry(_once, what="enumeration")
 
 
 async def run_schema_agent(runner, prompt: str, model_cls, usage_acc: dict):
@@ -170,32 +222,39 @@ async def run_schema_agent(runner, prompt: str, model_cls, usage_acc: dict):
   by run_enumeration, for any LlmAgent created with an `output_schema`. Returns
   an instance of `model_cls` (a pydantic BaseModel subclass).
   """
-  user_id = str(uuid.uuid4())
-  session = await runner.session_service.create_session(
-      app_name=runner.app_name, user_id=user_id
-  )
-  raw_text = ""
-  async for event in runner.run_async(
-      user_id=user_id,
-      session_id=session.id,
-      new_message=types.Content(
-          role="user", parts=[types.Part.from_text(text=prompt)]
-      ),
-  ):
-    usage = getattr(event, "usage_metadata", None)
-    if usage and usage_acc is not None:
-      usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
-      usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
-    if event.content and event.content.parts:
-      for part in event.content.parts:
-        if part.text:
-          raw_text += part.text
-  cleaned = raw_text.strip()
-  if cleaned.startswith("```"):
-    m = re.match(r"^```(?:json)?\s*\n(.*)\n```$", cleaned, re.S)
-    if m:
-      cleaned = m.group(1).strip()
-  return model_cls.model_validate_json(cleaned)
+  async def _once():
+    user_id = str(uuid.uuid4())
+    session = await runner.session_service.create_session(
+        app_name=runner.app_name, user_id=user_id
+    )
+    raw_text = ""
+    local_in = local_out = 0
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=types.Content(
+            role="user", parts=[types.Part.from_text(text=prompt)]
+        ),
+    ):
+      usage = getattr(event, "usage_metadata", None)
+      if usage:
+        local_in += getattr(usage, "prompt_token_count", 0) or 0
+        local_out += getattr(usage, "candidates_token_count", 0) or 0
+      if event.content and event.content.parts:
+        for part in event.content.parts:
+          if part.text:
+            raw_text += part.text
+    if usage_acc is not None:
+      usage_acc["input"] += local_in
+      usage_acc["output"] += local_out
+    cleaned = raw_text.strip()
+    if cleaned.startswith("```"):
+      m = re.match(r"^```(?:json)?\s*\n(.*)\n```$", cleaned, re.S)
+      if m:
+        cleaned = m.group(1).strip()
+    return model_cls.model_validate_json(cleaned)
+
+  return await _with_retry(_once, what="schema_agent")
 
 
 async def run_text(runner, prompt: str, usage_acc: dict | None = None) -> str:
@@ -203,27 +262,34 @@ async def run_text(runner, prompt: str, usage_acc: dict | None = None) -> str:
 
   Accumulates token usage into usage_acc when provided.
   """
-  user_id = str(uuid.uuid4())
-  session = await runner.session_service.create_session(
-      app_name=runner.app_name, user_id=user_id
-  )
-  out = ""
-  async for event in runner.run_async(
-      user_id=user_id,
-      session_id=session.id,
-      new_message=types.Content(
-          role="user", parts=[types.Part.from_text(text=prompt)]
-      ),
-  ):
-    usage = getattr(event, "usage_metadata", None)
-    if usage and usage_acc is not None:
-      usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
-      usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
-    if event.content and event.content.parts:
-      for part in event.content.parts:
-        if part.text:
-          out += part.text
-  return out
+  async def _once():
+    user_id = str(uuid.uuid4())
+    session = await runner.session_service.create_session(
+        app_name=runner.app_name, user_id=user_id
+    )
+    out = ""
+    local_in = local_out = 0
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=types.Content(
+            role="user", parts=[types.Part.from_text(text=prompt)]
+        ),
+    ):
+      usage = getattr(event, "usage_metadata", None)
+      if usage:
+        local_in += getattr(usage, "prompt_token_count", 0) or 0
+        local_out += getattr(usage, "candidates_token_count", 0) or 0
+      if event.content and event.content.parts:
+        for part in event.content.parts:
+          if part.text:
+            out += part.text
+    if usage_acc is not None:
+      usage_acc["input"] += local_in
+      usage_acc["output"] += local_out
+    return out
+
+  return await _with_retry(_once, what="adk_generate")
 
 
 async def run_structured(
@@ -241,6 +307,29 @@ async def run_structured(
   except Exception as e:
     print(f"[!] Error parsing structured output: {e}\nRaw output: {raw_text}")
     return None
+
+
+def _delink_local_sources(text: str) -> str:
+  """Render local-file source citations as plain text instead of links.
+
+  The writer cites sources as `[Title](URL)`. For a local markdown input the
+  "URL" is a filesystem path (e.g. `/tmp/corpus/orders.md`), which is a broken
+  link when the overview is viewed in a browser and meaningless once the entry
+  is published to the catalog. Keep the title text but drop the local target;
+  real web links (http/https/mailto, incl. Google Docs/Drive) are left intact.
+  """
+  def _repl(m):
+    label, target = m.group(1), m.group(2).strip()
+    low = target.lower()
+    if low.startswith(("http://", "https://", "mailto:")):
+      return m.group(0)  # keep real web links
+    if target.startswith(("/", "./", "../", "~")) or low.endswith(
+        (".md", ".markdown")
+    ):
+      return label  # local path: keep the text, drop the broken link
+    return m.group(0)
+
+  return re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _repl, text)
 
 
 def clean_overview_body(text: str) -> str:
@@ -261,6 +350,8 @@ def clean_overview_body(text: str) -> str:
     m = re.match(r"^---\s*\n(?:.*?\n)?---\s*\n(.*)$", t, re.S)
     if m:
       t = m.group(1).strip()
+  # Local-file source citations -> plain text (broken/meaningless as links).
+  t = _delink_local_sources(t)
   return t
 
 
@@ -293,6 +384,34 @@ def parse_mdcode_blocks(text: str, output_dir: str) -> list[str]:
     written.append(filename)
     print(f"[+] Saved {filename} to {full_path}")
   return written
+
+
+def doc_tool_calls(docs: list) -> tuple[list, list]:
+  """Build per-document trajectory tool calls from a prepared-docs list.
+
+  Gives table/context_overlay modes the same per-source tool-call recording doc
+  mode already has, so eval counts tool calls consistently and grounds
+  hallucination checks on clean per-doc `content` (not a truncated json blob of
+  the routing response). Each doc dict carries a `_kind` set by the mode's
+  prepare step: `local_md` -> read_local_md, `code` -> explore_repo, anything
+  else -> fetch_gdoc. Returns (tool_uses, tool_responses).
+  """
+  uses, responses = [], []
+  for d in (docs or []):
+    kind = d.get("_kind", "gdoc")
+    url = d.get("url", "")
+    content = (d.get("content") or "")[:50000]
+    if kind == "code":
+      uses.append({"name": "explore_repo", "args": {"component": d.get("name", "")}})
+      responses.append(
+          {"name": "explore_repo", "response": {"url": url, "content": content}})
+    else:
+      tn = "read_local_md" if kind == "local_md" else "fetch_gdoc"
+      uses.append({"name": tn, "args": {"url": url}})
+      responses.append(
+          {"name": tn,
+           "response": {"url": url, "name": d.get("name", ""), "content": content}})
+  return uses, responses
 
 
 def write_trajectory(

--- a/agents/enrichment/src/engine.py
+++ b/agents/enrichment/src/engine.py
@@ -64,19 +64,18 @@ class VertexGemini(Gemini):
     return self._cached_client
 
 
-# Pinned for structured-extraction steps with SMALL inputs (per-doc descriptors,
-# JSON routing). Flash is ~3-4x faster. The caller's --model is used for: (a)
-# the heavy write steps where quality matters, and (b) the doc-mode batch
-# summarizer — see comment on create_summarizer_runner below.
-_LIGHT_MODEL = "gemini-3.5-flash"
+# High-volume / small-input steps (per-doc descriptors, JSON routing, per-doc
+# summaries). These default to the caller's --model so nothing is pinned to a
+# model the user may not have access to; set KC_LIGHT_MODEL to point them at a
+# cheaper/faster model (e.g. a Flash variant) without changing --model.
+def _light_model(main_model: str) -> str:
+  """Model for high-volume calls: KC_LIGHT_MODEL if set, else the main --model."""
+  return os.environ.get("KC_LIGHT_MODEL") or main_model
 
-# Per-doc summarizer model. Each call is ONE doc in (≤60K chars), one neutral
-# card out (~2K chars) — small enough to stay well under Flash's per-call
-# context limits regardless of routing, and lighter on latency / cost than
-# Pro. Result is cached at ~/.kc_enrich_cache/summaries/ keyed on
-# (doc_id, modifiedTime), so any drift introduced by using a smaller model
-# only shows up on the FIRST run against a doc.
-PER_DOC_SUMMARIZER_MODEL = _LIGHT_MODEL
+# Per-doc summarizer: doc_mode resolves the model via _light_model(model) at run
+# time (KC_LIGHT_MODEL override, else --model). Each call is ONE doc in
+# (≤60K chars) -> one neutral card out (~2K chars), cached at
+# ~/.kc_enrich_cache/summaries/ keyed on (doc_id, modifiedTime).
 
 
 # ============================ Doc mode ============================
@@ -203,13 +202,12 @@ def create_doc_query_extractor_runner(model: str) -> InMemoryRunner:
   Returns:
     An InMemoryRunner for the extractor agent.
   """
-  del model  # unused
   agent = llm_agent.LlmAgent(
       name="DocQueryExtractorAgent",
       description=(
           "Extracts SQL examples for ONE table from its routed documentation."
       ),
-      model=VertexGemini(model=_LIGHT_MODEL),
+      model=VertexGemini(model=_light_model(model)),
       instruction=DOC_QUERY_EXTRACTOR_INSTRUCTION,
   )
   return InMemoryRunner(agent=agent)
@@ -311,7 +309,7 @@ def create_doc_summarizer_runner(model: str) -> InMemoryRunner:
       description=(
           "Summarizes a single Drive document into a compact descriptor."
       ),
-      model=VertexGemini(model=_LIGHT_MODEL),
+      model=VertexGemini(model=_light_model(model)),
       instruction="""You are summarizing ONE document so a router can decide which BigQuery tables it is relevant to.
 
 Output EXACTLY this Markdown shape and nothing else:
@@ -330,7 +328,7 @@ def create_router_runner(model: str) -> InMemoryRunner:
   agent = llm_agent.LlmAgent(
       name="RelevanceRouterAgent",
       description="Scores folder-document relevance to one BigQuery table.",
-      model=VertexGemini(model=_LIGHT_MODEL),
+      model=VertexGemini(model=_light_model(model)),
       instruction="""You are a precise relevance router. You are given ONE BigQuery table (its name and columns) and a numbered list of candidate documents (each with a title, summary, and key entities).
 
 Decide which documents genuinely provide domain knowledge that would help DOCUMENT THIS SPECIFIC TABLE — e.g. they define this table, its columns/metrics, its source system, or the business process it records. A document that merely shares a broad theme but does not concern this table's data is NOT relevant.

--- a/agents/enrichment/src/modes/context_overlay_mode.py
+++ b/agents/enrichment/src/modes/context_overlay_mode.py
@@ -32,6 +32,7 @@ import time
 import common
 from engine import (
     OVERLAY_WRITER_INSTRUCTION,
+    _light_model,
     create_doc_summarizer_runner,
 )
 from modes import table_mode
@@ -40,15 +41,13 @@ from tools import bq_usage_tools
 from tools import feedback_tools
 from tools import github_tools
 from tools import kcmd_tools
-from tools.drive_tools import extract_folder_id, extract_gdoc_id, fetch_doc_text
-from tools.drive_tools import get_cache_stats
+from tools.drive_tools import extract_gdoc_id, fetch_doc_text
+from tools.drive_tools import get_cache_stats, is_local_path, list_local_md, read_local_md
 import yaml
 
 # Overlay entries are generic-typed in the editable entry group; the enriched
 # content lands in the `overview` aspect (same convention as doc mode).
 _OVERLAY_ENTRY_TYPE = "dataplex-types.global.generic"
-# Flash for the per-table writers (small inputs) — matches table mode.
-_WRITER_MODEL = "gemini-3.5-flash"
 CONCURRENCY_LIMIT = 12
 MAX_DOC_CHARS = 30000
 
@@ -75,15 +74,35 @@ async def _prepare_explicit_docs(
   """
   if not doc_urls:
     return []
+  # Expand each entry: a local .md file -> itself; a local directory -> its .md
+  # files; anything else -> a Google Doc URL/ID fetched from Drive. So the
+  # combined "doc URLs OR folder" field accepts local markdown too.
+  sources = []  # (is_local, identifier)
+  for u in doc_urls:
+    u = (u or "").strip()
+    if not u:
+      continue
+    if is_local_path(u):
+      paths = list_local_md(u)
+      sources.extend((True, p) for p in paths)
+      print(f"[Route] --docs {u!r} -> local markdown ({len(paths)} file(s)).",
+            flush=True)
+    else:
+      sources.append((False, u))
+      print(f"[Route] --docs {u!r} -> Drive doc.", flush=True)
   sem = asyncio.Semaphore(CONCURRENCY_LIMIT)
 
-  async def _prep(idx, url):
-    content = await asyncio.to_thread(
-        fetch_doc_text, extract_gdoc_id(url) or url, ""
-    )
+  async def _prep(idx, is_local, ident):
+    if is_local:
+      content = await asyncio.to_thread(read_local_md, ident)
+    else:
+      content = await asyncio.to_thread(
+          fetch_doc_text, extract_gdoc_id(ident) or ident, ""
+      )
+    name = os.path.basename(ident) if is_local else ident
     async with sem:
       prompt = (
-          f"DOCUMENT TITLE: {url}\nSOURCE URL: {url}\n\nDOCUMENT"
+          f"DOCUMENT TITLE: {name}\nSOURCE URL: {ident}\n\nDOCUMENT"
           f" CONTENT:\n{content[:50000]}"
       )
       descriptor = await common.run_text(
@@ -91,20 +110,23 @@ async def _prepare_explicit_docs(
       )
     return {
         "id": idx,
-        "name": url,
-        "url": url,
+        "name": name,
+        "url": ident,
         "content": content,
         "descriptor": descriptor.strip(),
+        "_kind": "local_md" if is_local else "gdoc",
     }
 
   return list(
-      await asyncio.gather(*[_prep(i, u) for i, u in enumerate(doc_urls)])
+      await asyncio.gather(
+          *[_prep(i, isl, idt) for i, (isl, idt) in enumerate(sources)]
+      )
   )
 
 
 async def _prepare_all_docs(
     topic: str,
-    folder: str | None,
+    folders: list[str] | None,
     doc_urls: list[str] | None,
     usage_acc: dict,
     model: str,
@@ -113,32 +135,35 @@ async def _prepare_all_docs(
     repo_subdir: str = "",
     mcp_config: str = "",
 ) -> list[dict]:
-  """Build the router-descriptor doc list from a folder, explicit URLs, and/or a
+  """Build the router-descriptor doc list from folders, explicit docs, and/or a
 
   GitHub repo.
 
-  The router indexes docs by their `id` == list position, so ids are reassigned
-  sequentially after merging the sources. Code component cards (when --repo is
-  set) join the pool in the same shape and are routed to tables like any other
-  candidate document.
+  `folders` and `doc_urls` are mixed lists routed per entry (Drive vs local
+  markdown). The router indexes docs by their `id` == list position, so ids are
+  reassigned sequentially after merging the sources. Code component cards (when
+  --repo is set) join the pool in the same shape and are routed to tables like
+  any other candidate document.
   """
   docs = []
-  if folder:
-    docs.extend(await table_mode._prepare_docs(topic, folder, usage_acc, model))
+  if folders:
+    docs.extend(
+        await table_mode._prepare_docs(topic, folders, usage_acc, model))
   if doc_urls:
     docs.extend(await _prepare_explicit_docs(doc_urls, usage_acc, model))
   if repo:
-    docs.extend(
-        await github_tools.gather_repo_context(
-            repo,
-            repo_ref,
-            repo_subdir,
-            topic,
-            model,
-            usage_acc,
-            mcp_config_path=mcp_config or None,
-        )
+    code_docs = await github_tools.gather_repo_context(
+        repo,
+        repo_ref,
+        repo_subdir,
+        topic,
+        model,
+        usage_acc,
+        mcp_config_path=mcp_config or None,
     )
+    for d in code_docs:
+      d["_kind"] = "code"
+    docs.extend(code_docs)
   for i, d in enumerate(docs):
     d["id"] = i
   return docs
@@ -213,7 +238,7 @@ def _write_overlay_files(
 
 async def run(
     dataset: str,
-    folder: str | None,
+    folders: list[str] | None,
     topic: str,
     output_dir: str | None,
     model: str,
@@ -234,7 +259,9 @@ async def run(
   _t0 = time.monotonic()
   project, dataset_id = table_mode._parse_dataset(dataset)
   eg_project, eg_location, eg_id = _parse_eg(entry_group)
-  folder = extract_folder_id(folder) if folder else folder
+  # --folder is a mixed list (Drive folders and/or local md dirs); each entry is
+  # routed and id-extracted per entry inside _prepare_all_docs.
+  folders = list(folders or [])
   # Same up-front feedback load as table_mode — proposals route per-table
   # to the overlay's own _write_one below.
   all_feedback = feedback_tools.load_feedback(feedback_dir, feedback_files)
@@ -243,7 +270,7 @@ async def run(
   print("=== CONTEXT-OVERLAY AGENT: tables + documents ===")
   print(f"Topic: {topic}")
   print(
-      f"Dataset: {project}.{dataset_id}  |  Folder: {folder or '(none)'}  | "
+      f"Dataset: {project}.{dataset_id}  |  Folders: {folders or '(none)'}  | "
       f" Entry group: {entry_group}"
   )
   if all_feedback:
@@ -348,7 +375,7 @@ async def run(
   doc_descriptors, usage_by_table = await asyncio.gather(
       _prepare_all_docs(
           topic,
-          folder,
+          folders,
           docs,
           usage_acc,
           model,
@@ -500,7 +527,7 @@ async def run(
           + feedback_block
       )
       overlay_overview = await common.generate_text_direct(
-          OVERLAY_WRITER_INSTRUCTION, overlay_prompt, _WRITER_MODEL, usage_acc
+          OVERLAY_WRITER_INSTRUCTION, overlay_prompt, _light_model(model), usage_acc
       )
 
       # The read-only `<table>.ref.*` mirror is written by `kcmd reference`
@@ -574,7 +601,7 @@ async def run(
           description=meta.get("description", "") or "",
           category_id=cat_id,
           grounding_prompt=overlay_prompt,
-          writer_model=_WRITER_MODEL,
+          writer_model=_light_model(model),
           overview_body=overlay_overview,
           overview_path=os.path.join(
               output_dir,
@@ -590,11 +617,15 @@ async def run(
 
   results = await asyncio.gather(*[_write_one(m) for m in tables])
 
-  # 6. Persist trajectory (mirrors table mode): tables, routed docs, enumeration.
-  tool_uses = [
+  # 6. Persist trajectory (mirrors table mode): per-source fetches first
+  # (fetch_gdoc/read_local_md/explore_repo) so eval counts tool calls
+  # consistently and grounds hallucination on clean per-doc content; route_docs
+  # keeps only the routing (name/url), not content, to avoid duplicating it.
+  tool_uses, tool_responses = common.doc_tool_calls(doc_descriptors)
+  tool_uses.extend(
       {"name": "reference_table", "args": {"table": m["table"]}} for m in tables
-  ]
-  tool_responses = [
+  )
+  tool_responses.extend(
       {
           "name": "reference_table",
           "response": {
@@ -603,7 +634,7 @@ async def run(
           },
       }
       for m in tables
-  ]
+  )
   for meta, sel_docs, _text, _es in results:
     tool_uses.append({"name": "route_docs", "args": {"table": meta["table"]}})
     tool_responses.append({
@@ -611,12 +642,7 @@ async def run(
         "response": {
             "table": meta["table"],
             "relevant_docs": [
-                {
-                    "name": d["name"],
-                    "url": d["url"],
-                    "content": d["content"][:50000],
-                }
-                for d in sel_docs
+                {"name": d["name"], "url": d["url"]} for d in sel_docs
             ],
         },
     })

--- a/agents/enrichment/src/modes/doc_mode.py
+++ b/agents/enrichment/src/modes/doc_mode.py
@@ -15,8 +15,8 @@ from engine import (
     ENTRY_WRITER_INSTRUCTION,  # legacy ADK path, kept for compat
     EnumerationResult,
     PER_DOC_SUMMARIZER_INSTRUCTION,
-    PER_DOC_SUMMARIZER_MODEL,
     TOPIC_REDUCER_INSTRUCTION,
+    _light_model,
     create_entry_writer_runner,  # legacy fallback, no longer wired in
     create_enumeration_runner,
     create_mdcode_runner,
@@ -32,7 +32,10 @@ from tools.drive_tools import (
     extract_gdoc_id,
     fetch_doc_text,
     get_cache_mode,
+    is_local_path,
     list_folder_files,
+    list_local_md,
+    read_local_md,
     read_summary_cache,
     write_summary_cache,
 )
@@ -41,7 +44,7 @@ import yaml
 MAX_BATCH_SIZE = 10  # Reverted from v2.6's 3 (back to v2.5). v2.6 tried Flash via direct API to allow bigger throughput but Vertex routes Flash to a 32K-capped backend variant regardless of API path for this project, forcing batch=3, which then over-saturated Flash quota on back-to-back runs and bloated the EnumerationAgent's input.
 MAX_DEPTH = 2  # Was 3 — depth-3 mostly surfaced tangential links; dropping it cuts crawl + summarize ~30% (v2.5 optimization #1).
 CONCURRENCY_LIMIT = 6  # Reverted from v2.6's 12 (back to v2.5). Summarizer is on Pro again; 12 trips Vertex 429s on big-input Pro calls.
-# Stage 1 (per-doc summary) runs on PER_DOC_SUMMARIZER_MODEL (Flash) — small
+# Stage 1 (per-doc summary) runs on _light_model(model) (Flash) — small
 # per-call payloads, well within Flash routing limits, tolerates 20-way
 # concurrency without 429s. Stage 1 is the cold-run hot path; cache hits
 # bypass it entirely so warm-cache runs ignore this limit.
@@ -271,10 +274,56 @@ def _normalize_entries(output_dir: str) -> list[str]:
   return fixed
 
 
+def _partition_doc_inputs(docs: list[str], folders: list[str] | None):
+  """Route each --docs/--folder entry to Drive vs local markdown by format.
+
+  Both flags are mixed, comma-separated lists routed per entry (see
+  drive_tools.is_local_path, which is format-first):
+    --docs:   a Drive Doc URL/ID -> drive_docs; a local .md file -> depth-0
+              spine; a local directory -> depth-1 children.
+    --folder: a Drive folder URL/ID -> drive_folders; a local directory (or
+              file) -> depth-1 children.
+  Returns (drive_docs, drive_folders, local_spine_md, local_child_md).
+  """
+  local_spine_md, local_child_md = [], []
+  drive_docs, drive_folders = [], []
+  for d in (docs or []):
+    d = (d or "").strip()
+    if not d:
+      continue
+    if is_local_path(d):
+      files = list_local_md(d)
+      if os.path.isdir(os.path.expanduser(d)):
+        local_child_md.extend(files)
+        kind = f"local md folder ({len(files)} file(s))"
+      else:
+        local_spine_md.extend(files)
+        kind = "local md spine file" if files else "local md file (MISSING)"
+    else:
+      drive_docs.append(d)
+      kind = "Drive doc"
+    print(f"[Route] --docs {d!r} -> {kind}", flush=True)
+  for f in (folders or []):
+    f = (f or "").strip()
+    if not f:
+      continue
+    if is_local_path(f):
+      files = list_local_md(f)
+      local_child_md.extend(files)
+      kind = (f"local md folder ({len(files)} file(s))" if files
+              else "local md folder (EMPTY/MISSING)")
+    else:
+      drive_folders.append(f)
+      kind = "Drive folder"
+    print(f"[Route] --folder {f!r} -> {kind}", flush=True)
+  return (drive_docs, drive_folders,
+          sorted(set(local_spine_md)), sorted(set(local_child_md)))
+
+
 async def run(
     topic: str,
     docs: list[str],
-    folder: str | None,
+    folders: list[str] | None,
     output_dir: str | None,
     model: str,
     entry_group: str,
@@ -373,16 +422,25 @@ async def run(
   folder_seed_urls = []  # folder files: injected as depth-1 children
   folder_files = []
 
-  folder = extract_folder_id(folder) if folder else folder
+  # Route --docs/--folder per entry: Drive inputs vs local markdown (a local .md
+  # via --docs is a depth-0 spine; a local dir via --docs/--folder is depth-1
+  # children). Local files are injected after the crawl so they never hit Drive.
+  start_docs, drive_folders, local_spine_md, local_child_md = (
+      _partition_doc_inputs(start_docs, folders))
+  if local_spine_md or local_child_md:
+    print(f"[Local] 📂 Markdown inputs: {len(local_spine_md)} spine file(s), "
+          f"{len(local_child_md)} folder child(ren). Relative paths resolve "
+          f"from CWD: {os.getcwd()}", flush=True)
 
-  # Seed additional inputs by listing a Drive folder (Docs, Sheets, Slides, PDFs).
-  if folder:
+  drive_folders = [extract_folder_id(f) for f in drive_folders if f]
+
+  # Seed additional inputs by listing each Drive folder (Docs/Sheets/Slides/PDF).
+  for folder in drive_folders:
     print(f"[Crawler] 📁 Listing Drive folder: {folder}", flush=True)
-    folder_files = list_folder_files(folder)
-    print(
-        f"[Crawler] 📁 Found {len(folder_files)} file(s) in folder.", flush=True
-    )
-    for f in folder_files:
+    one = list_folder_files(folder)
+    print(f"[Crawler] 📁 Found {len(one)} file(s) in folder.", flush=True)
+    folder_files.extend(one)
+    for f in one:
       fid = f.get("id")
       if not fid:
         continue
@@ -395,8 +453,12 @@ async def run(
   # the Master Scope, so synthesize one and treat the folder files as its
   # depth-1 children. If explicit --docs were given, those remain the spine.
   synthetic_scope_text = ""
-  if folder_seed_urls and not start_docs:
-    synthetic_scope_text = _build_synthetic_scope(topic, folder_files)
+  scope_files = list(folder_files) + [
+      {"name": os.path.basename(p), "mimeType": "text/markdown"}
+      for p in local_child_md
+  ]
+  if scope_files and not start_docs and not local_spine_md:
+    synthetic_scope_text = _build_synthetic_scope(topic, scope_files)
 
   print("=" * 60)
   print(
@@ -465,6 +527,18 @@ async def run(
       " total.\n"
   )
 
+  # Inject local markdown as already-fetched docs (read from disk, no Drive
+  # round-trip). Spine files at depth 0 (become Master Scope), folder/dir files
+  # at depth 1 — exactly mirroring --docs / --folder for Google Docs.
+  for p in local_spine_md:
+    all_fetched_docs.append((p, 0, read_local_md(p)))
+  for p in local_child_md:
+    all_fetched_docs.append((p, 1, read_local_md(p)))
+  if local_spine_md or local_child_md:
+    print(f"[Local] 📄 Injected {len(local_spine_md) + len(local_child_md)} "
+          f"local markdown file(s): {len(local_spine_md)} spine, "
+          f"{len(local_child_md)} folder child(ren).", flush=True)
+
   # Extract Depth 0 documents as Master Scope. When seeding from a folder
   # there are no depth-0 docs, so the synthetic scope stands in as the spine.
   master_scope_docs = [doc for doc in all_fetched_docs if doc[1] == 0]
@@ -477,7 +551,7 @@ async def run(
     )
 
   # 2a. Stage-1 Map (cache-aware): topic-NEUTRAL per-doc summary card.
-  # Runs on PER_DOC_SUMMARIZER_MODEL (Flash) at higher concurrency since each
+  # Runs on _light_model(model) (Flash) at higher concurrency since each
   # call is one small doc in / one short card out — no batch context, well
   # under Flash routing limits. Cache key = (doc_id, modified_time) under
   # ~/.kc_enrich_cache/summaries/ when KC_ENRICH_CACHE_MODE=summary (default);
@@ -485,7 +559,7 @@ async def run(
   cache_mode = get_cache_mode()
   print(
       "[Agent] 🧠 Stage 1: per-doc summary (cache mode:"
-      f" {cache_mode}, model: {PER_DOC_SUMMARIZER_MODEL}, concurrency:"
+      f" {cache_mode}, model: {_light_model(model)}, concurrency:"
       f" {PER_DOC_CONCURRENCY})...",
       flush=True,
   )
@@ -506,7 +580,7 @@ async def run(
             content,
             mtime_by_id.get(doc_id, mtime_by_id.get(url)),
             per_doc_sem,
-            PER_DOC_SUMMARIZER_MODEL,
+            _light_model(model),
             usage_acc,
         )
     )
@@ -673,15 +747,17 @@ async def run(
   # Trajectory persists: per-doc fetches (the "tools" of doc mode) plus the
   # enumerated entry list so eval can ground scoring in BOTH what was read and
   # what was emitted.
+  # Local markdown inputs are read off disk (read_local_md), not fetched from
+  # Drive (fetch_gdoc); label each tool use by its actual source so eval counts
+  # them correctly instead of attributing local files to fetch_gdoc.
   tool_uses = [
-      {"name": "fetch_gdoc", "args": {"url": url, "depth": depth}}
+      {"name": "read_local_md" if is_local_path(url) else "fetch_gdoc",
+       "args": {"url": url, "depth": depth}}
       for (url, depth, _content) in all_fetched_docs
   ]
   tool_responses = [
-      {
-          "name": "fetch_gdoc",
-          "response": {"url": url, "depth": depth, "content": content[:50000]},
-      }
+      {"name": "read_local_md" if is_local_path(url) else "fetch_gdoc",
+       "response": {"url": url, "depth": depth, "content": content[:50000]}}
       for (url, depth, content) in all_fetched_docs
   ]
   for c in code_cards:
@@ -813,7 +889,7 @@ async def _write_one_kb_entry(
     body = await common.generate_text_direct(
         ENTRY_WRITER_INSTRUCTION,
         user_prompt,
-        _LIGHT_MODEL_FOR_WRITER,
+        _light_model(model),
         usage_acc,
     )
 
@@ -861,7 +937,7 @@ async def _write_one_kb_entry(
       description=entry.description,
       category_id=category.id,
       grounding_prompt=user_prompt,
-      writer_model=_LIGHT_MODEL_FOR_WRITER,
+      writer_model=_light_model(model),
       overview_body=body,
       overview_path=overview_path,
       kind="kb",
@@ -998,8 +1074,3 @@ async def apply_reenumeration(session, new_enum, removed_ids) -> None:
             f"[refine] ➕ added entry: {es.category_id}/{es.entry_id}",
             flush=True,
         )
-
-
-# Flash for the writer step: per-entry inputs are small (one entry's slice of
-# context, typically <20K tokens) so the ADK 32K Flash routing trap doesn't bite.
-_LIGHT_MODEL_FOR_WRITER = "gemini-3.5-flash"

--- a/agents/enrichment/src/modes/table_mode.py
+++ b/agents/enrichment/src/modes/table_mode.py
@@ -21,6 +21,7 @@ import time
 import typing as t
 import common
 from engine import (
+    _light_model,
     create_doc_query_extractor_runner,
     create_doc_summarizer_runner,
     create_router_runner,
@@ -31,7 +32,14 @@ from tools import bq_usage_tools
 from tools import feedback_tools
 from tools import github_tools
 from tools import kcmd_tools
-from tools.drive_tools import extract_folder_id, fetch_doc_text, list_folder_files
+from tools.drive_tools import (
+    extract_folder_id,
+    fetch_doc_text,
+    is_local_path,
+    list_folder_files,
+    list_local_md,
+    read_local_md,
+)
 import yaml
 
 # kcmd's canonical entry type for BigQuery tables under a bq-dataset scope.
@@ -136,29 +144,61 @@ def _write_table_files(
 
 
 async def _prepare_docs(
-    topic: str, folder_id: str | None, usage_acc: t.Dict[str, int], model: str
+    topic: str,
+    folders: list[str] | None,
+    usage_acc: t.Dict[str, int],
+    model: str,
 ) -> t.List[t.Dict[str, t.Any]]:
-  """Fetch folder docs and summarize each into a compact router descriptor.
+  """Fetch grounding docs from each folder and summarize into router descriptors.
+
+  `folders` is a mixed, comma-separated list routed per entry (see
+  drive_tools.is_local_path): a Drive folder URL/ID is listed via the Drive
+  API; a local directory (or .md file) grounds overviews from disk.
 
   Args:
     topic: Focus topic.
-    folder_id: Folder ID.
+    folders: Mixed list of Drive folder URLs/IDs and/or local md dirs/files.
     usage_acc: Usage accumulator.
     model: Model name.
 
   Returns:
-    A list of {id, name, url, content, descriptor}.
+    A list of {id, name, url, content, descriptor, _kind}.
   """
   del topic  # unused
-  if not folder_id:
-    return []
+  files = []
+  for entry in (folders or []):
+    entry = (entry or "").strip()
+    if not entry:
+      continue
+    if is_local_path(entry):
+      md_paths = list_local_md(entry)
+      files.extend(
+          {
+              "id": p,
+              "name": os.path.basename(p),
+              "webViewLink": p,
+              "mimeType": "text/markdown",
+              "modifiedTime": str(os.path.getmtime(p)),
+              "_local": True,
+          }
+          for p in md_paths
+      )
+      print(
+          f"[Route] --folder {entry!r} -> local markdown ({len(md_paths)}"
+          f" file(s), resolved {os.path.abspath(os.path.expanduser(entry))}).",
+          flush=True,
+      )
+    else:
+      folder_id = extract_folder_id(entry)
+      found = list_folder_files(folder_id)
+      files.extend(found)
+      print(
+          f"[Route] --folder {entry!r} -> Drive folder ({len(found)} file(s)).",
+          flush=True,
+      )
 
-  print(f"[Folder] 📁 Listing Drive folder: {folder_id}", flush=True)
-  files = list_folder_files(folder_id)
-  print(
-      f"[Folder] 📁 Found {len(files)} file(s). Fetching + summarizing...",
-      flush=True,
-  )
+  if not files:
+    return []
 
   sem = asyncio.Semaphore(CONCURRENCY_LIMIT)
 
@@ -166,14 +206,17 @@ async def _prepare_docs(
     fid = f.get("id")
     url = f.get("webViewLink") or fid
     name = f.get("name", "")
-    # v5 #2: pass modifiedTime so the per-doc cache invalidates when Drive
-    # reports the file changed since the last run.
-    content = await asyncio.to_thread(
-        fetch_doc_text,
-        fid,
-        f.get("mimeType", ""),
-        modified_time=f.get("modifiedTime"),
-    )
+    if f.get("_local"):
+      content = await asyncio.to_thread(read_local_md, fid)
+    else:
+      # v5 #2: pass modifiedTime so the per-doc cache invalidates when Drive
+      # reports the file changed since the last run.
+      content = await asyncio.to_thread(
+          fetch_doc_text,
+          fid,
+          f.get("mimeType", ""),
+          modified_time=f.get("modifiedTime"),
+      )
     async with sem:
       prompt = (
           f"DOCUMENT TITLE: {name}\nSOURCE URL: {url}\n\nDOCUMENT"
@@ -188,6 +231,7 @@ async def _prepare_docs(
         "url": url,
         "content": content,
         "descriptor": descriptor.strip(),
+        "_kind": "local_md" if f.get("_local") else "gdoc",
     }
 
   docs = await asyncio.gather(
@@ -375,7 +419,7 @@ async def _route_docs_for_table(
 
 async def run(
     dataset: str,
-    folder: str | None,
+    folders: list[str] | None,
     topic: str,
     output_dir: str | None,
     model: str,
@@ -394,8 +438,9 @@ async def run(
 ):
   _t0 = time.monotonic()
   project, dataset_id = _parse_dataset(dataset)
-  # Accept either a bare folder id or a full Drive folder URL.
-  folder = extract_folder_id(folder) if folder else folder
+  # --folder is a mixed list (Drive folders and/or local md dirs); each entry is
+  # routed and id-extracted per entry inside _prepare_docs.
+  folders = list(folders or [])
   # Load user-feedback proposals up front so per-table routing is cheap.
   # Empty list = no feedback path provided (or no proposals found); the
   # rest of the pipeline degrades to "no feedback" semantics naturally.
@@ -404,7 +449,7 @@ async def run(
   print("=" * 60)
   print("=== ADK TABLE AGENT: Dataplex-Sourced, Folder-Grounded Enrichment ===")
   print(f"Topic: {topic}")
-  print(f"Dataset: {project}.{dataset_id}  |  Folder: {folder or '(none)'}")
+  print(f"Dataset: {project}.{dataset_id}  |  Folders: {folders or '(none)'}")
   if all_feedback:
     print(
         f"[Feedback] 📝 Loaded {len(all_feedback)} user-feedback"
@@ -506,7 +551,7 @@ async def run(
         flush=True,
     )
     docs, usage_by_table = await asyncio.gather(
-        _prepare_docs(topic, folder, usage_acc, model),
+        _prepare_docs(topic, folders, usage_acc, model),
         asyncio.to_thread(
             bq_usage_tools.fetch_dataset_usage,
             project,
@@ -526,7 +571,7 @@ async def run(
         flush=True,
     )
   else:
-    docs = await _prepare_docs(topic, folder, usage_acc, model)
+    docs = await _prepare_docs(topic, folders, usage_acc, model)
     usage_by_table = {}
   # Source-code source (optional): explore a GitHub repo agentically and add its
   # component cards to the candidate-document pool. They are scored by the same
@@ -544,6 +589,8 @@ async def run(
         usage_acc,
         mcp_config_path=mcp_config or None,
     )
+    for d in code_docs:
+      d["_kind"] = "code"
     docs.extend(code_docs)
     for i, d in enumerate(docs):
       d["id"] = i
@@ -688,7 +735,7 @@ async def run(
           + feedback_block
       )
       body = await common.generate_text_direct(
-          ENTRY_WRITER_INSTRUCTION, prompt, _WRITER_MODEL, usage_acc
+          ENTRY_WRITER_INSTRUCTION, prompt, _light_model(model), usage_acc
       )
       written = _write_table_files(output_dir, project, dataset_id, meta, body)
       # Merge INFORMATION_SCHEMA-derived patterns + SQL examples extracted
@@ -743,7 +790,7 @@ async def run(
           description=meta.get("description", "") or "",
           category_id=cat_id,
           grounding_prompt=prompt,
-          writer_model=_WRITER_MODEL,
+          writer_model=_light_model(model),
           overview_body=body,
           overview_path=os.path.join(
               kcmd_tools._dataset_dir(output_dir, project, dataset_id),
@@ -772,11 +819,16 @@ async def run(
   # 6. Persist trajectory for dynamic eval (mirrors doc mode). Records the
   # tables, their routed docs, AND the enumeration so eval can ground scoring.
   if output_dir:
-    tool_uses = [
+    # Per-source fetches first (fetch_gdoc/read_local_md/explore_repo) — same
+    # recording doc mode does — so eval counts tool calls consistently and
+    # grounds hallucination on clean per-doc content. route_docs below keeps only
+    # the routing (name/url), not content, to avoid duplicating it.
+    tool_uses, tool_responses = common.doc_tool_calls(docs)
+    tool_uses.extend(
         {"name": "get_table_entry", "args": {"table": m["table"]}}
         for m in tables
-    ]
-    tool_responses = [
+    )
+    tool_responses.extend(
         {
             "name": "get_table_entry",
             "response": {
@@ -785,7 +837,7 @@ async def run(
             },
         }
         for m in tables
-    ]
+    )
     for meta, sel_docs, _text, _es in results:
       tool_uses.append({"name": "route_docs", "args": {"table": meta["table"]}})
       tool_responses.append({
@@ -793,12 +845,7 @@ async def run(
           "response": {
               "table": meta["table"],
               "relevant_docs": [
-                  {
-                      "name": d["name"],
-                      "url": d["url"],
-                      "content": d["content"][:50000],
-                  }
-                  for d in sel_docs
+                  {"name": d["name"], "url": d["url"]} for d in sel_docs
               ],
           },
       })
@@ -893,8 +940,3 @@ def _inject_category(
   except (OSError, yaml.YAMLError):
     pass
 
-
-# Flash for the per-table writer: small inputs (one table + a few docs) stay
-# well under the ADK 32K Flash routing cap. Pro is still the user-supplied
-# --model and is used by the enumerator (which needs reasoning across all tables).
-_WRITER_MODEL = "gemini-3.5-flash"

--- a/agents/enrichment/src/tools/drive_tools.py
+++ b/agents/enrichment/src/tools/drive_tools.py
@@ -11,6 +11,7 @@ re-run:
     https://www.googleapis.com/auth/drive.readonly'
 """
 
+import glob
 import io
 import os
 import re
@@ -78,6 +79,72 @@ def extract_folder_id(url_or_id: str) -> str:
   return s.split("?", 1)[0].rstrip("/")
 
 
+_MD_EXTS = (".md", ".markdown")
+
+
+def is_local_path(s: str) -> bool:
+  """Route a single --docs/--folder entry to local markdown vs Google Drive.
+
+  Format-first so the decision never depends on what happens to exist in the
+  process CWD (which, via the webapp, is the agent subprocess's dir): an
+  http(s) URL or a bare Drive-id token is Drive; a `.md`/`.markdown` suffix or
+  a path-shaped string (absolute, `./`, `../`, `~`, or containing a separator)
+  is local. Only a bare relative name with no path markers falls back to an
+  existence check before defaulting to Drive. See `extract_gdoc_id` /
+  `extract_folder_id` for the Drive side.
+  """
+  s = (s or "").strip()
+  if not s:
+    return False
+  low = s.lower()
+  if low.startswith(("http://", "https://")):  # Google Doc / Drive folder URL
+    return False
+  if "docs.google.com" in low or "drive.google.com" in low:  # scheme-less URL
+    return False
+  if low.endswith(_MD_EXTS):  # explicit markdown file
+    return True
+  if s.startswith(("/", "./", "../", "~")) or os.sep in s:  # path-shaped
+    return True
+  return os.path.exists(os.path.expanduser(s))  # bare name: tiebreak, else Drive
+
+
+def list_local_md(path: str) -> list[str]:
+  """Expand a local path into a sorted list of ABSOLUTE markdown file paths.
+
+  A local .md/.markdown file -> [that file]; a local directory -> every
+  .md/.markdown under it (recursive). Anything else -> []. Relative paths are
+  resolved against the process CWD (absolute paths are recommended for
+  customers). Local analogue of list_folder_files() for a Drive folder.
+
+  Args:
+    path: A local file or directory path (relative paths resolve from CWD).
+
+  Returns:
+    A sorted list of absolute .md/.markdown file paths, or [] if none.
+  """
+  p = os.path.abspath(os.path.expanduser(path or ""))
+  if os.path.isfile(p):
+    return [p] if p.lower().endswith(_MD_EXTS) else []
+  if os.path.isdir(p):
+    out = []
+    for ext in _MD_EXTS:
+      out.extend(glob.glob(os.path.join(p, "**", "*" + ext), recursive=True))
+    return sorted(set(out))
+  return []
+
+
+def read_local_md(path: str, max_chars: int = _DEFAULT_MAX_CHARS) -> str:
+  """Read a local markdown file's text (local analogue of fetch_doc_text)."""
+  try:
+    with open(
+        os.path.expanduser(path), encoding="utf-8", errors="replace"
+    ) as f:
+      return f.read()[:max_chars]
+  except OSError as e:
+    print(f"[Local] could not read {path}: {e}", flush=True)
+    return ""
+
+
 def list_folder_files(folder_id: str, page_size: int = 100) -> list[dict]:
   """List supported files in a Drive folder as structured dicts.
 
@@ -116,7 +183,18 @@ def list_folder_files(folder_id: str, page_size: int = 100) -> list[dict]:
       page_token = resp.get("nextPageToken")
       if not page_token:
         break
-  except HttpError:
+  except HttpError as e:
+    # Don't fail silently: a 403 here (missing drive.readonly scope) otherwise
+    # looks like an empty folder and the Drive source is quietly skipped.
+    print(
+        f"[Folder] ⚠️  Drive list failed for folder {folder_id!r}: {e}\n"
+        "          If this is 403 insufficientPermissions, your ADC token is\n"
+        "          missing the drive.readonly scope — re-run: gcloud auth\n"
+        "          application-default login --scopes='openid,https://www."
+        "googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/"
+        "drive.readonly'",
+        flush=True,
+    )
     return out
   return out
 


### PR DESCRIPTION
## Summary
Brings `agents/enrichment` up to date with the latest enrichment agent and adds the
full **evaluation harness**, all on the `agents/` layout. Single commit.

### Evaluation (`agents/enrichment/eval/`)
- Dynamic (golden-free) + golden-based eval; `--run` case-runner; multi-run
  averaged metrics + cross-run concept/content consistency; aggregate report.
- Bundled runnable goldens (theLook eCommerce + financial_services /
  phone_services / supply_chain) + local markdown corpora; `TEMPLATE.json` +
  `agents/enrichment/eval/goldens/README.md` document the schema.

### Agent (`agents/enrichment/src/`)
- Local Markdown inputs for `--docs` / `--folders` (routed per entry; `--folder`
  kept as a deprecated alias).
- Retry on transient Vertex errors (429 / 503 / DECODE_PREEMPTED);
  `KC_LIGHT_MODEL` override; per-source trajectory tool calls in
  table / context_overlay.

All paths use the `agents/` layout; `agents/enrichment/README.md` refreshed. Scope
is limited to `agents/enrichment/`.
