### PR TITLE
Add optional structured sources metadata

### DIFF
--- a/okf/SPEC.md
+++ b/okf/SPEC.md
@@ -129,6 +129,15 @@ description: <Optional one-line summary>
 resource: <Optional canonical URI for the underlying asset>
 tags: [<tag>, <tag>, …]            # Optional
 timestamp: <ISO 8601 datetime>     # Optional last-modified time
+sources:                           # Optional machine-readable provenance
+  - id: <Optional stable source identifier>
+    type: <Optional source kind>
+    resource: <Optional URI or bundle-relative path>
+    locator: <Optional source-specific pointer>
+    captured_at: <Optional ISO 8601 datetime>
+    digest:
+      algorithm: <Optional digest algorithm>
+      value: <Optional digest value>
 # … other producer-defined key/value pairs
 ---
 ```
@@ -156,6 +165,8 @@ timestamp: <ISO 8601 datetime>     # Optional last-modified time
   rather than physical resources.
 - `tags` — A YAML list of short strings for cross-cutting categorization.
 - `timestamp` — ISO 8601 datetime of last meaningful change.
+- `sources` — A YAML list of source records for machine-readable
+  provenance. See §8.
 
 **Extensions:** Producers MAY include any additional keys. Consumers
 SHOULD preserve unknown keys when round-tripping and SHOULD NOT reject
@@ -335,6 +346,28 @@ bottom of the document, numbered:
 Citation links MAY be absolute URLs, bundle-relative paths, or paths
 into a `references/` subdirectory that mirrors external material as
 first-class OKF concepts.
+
+Concepts MAY also include a `sources` frontmatter field containing a
+YAML list of source records. `sources` is intended for machine-readable
+provenance. It complements, but does not replace, the human-readable
+`# Citations` section.
+
+A source record MAY contain:
+
+- `id` — Producer-defined stable identifier for the source.
+- `type` — Producer-defined source kind, such as `web_page`, `runbook`,
+  `dataset`, `conversation_turn`, `ticket`, or `paper`.
+- `resource` — Absolute URI or bundle-relative path for the source.
+- `locator` — Producer-defined pointer within the source, such as a
+  line, section, byte range, page, row, turn id, or fragment.
+- `captured_at` — ISO 8601 datetime when the producer captured or
+  snapshotted this source material, if known.
+- `digest` — Optional object containing `algorithm` and `value`,
+  representing a content digest of the source material when the
+  producer has one.
+
+Consumers SHOULD tolerate additional source record fields and SHOULD
+NOT require every source record to contain every field.
 
 ---
 


### PR DESCRIPTION
### Summary

Add an optional `sources` frontmatter field for machine-readable provenance.

This complements the existing human-readable `# Citations` section. It gives producers a shared way to identify supporting source material without requiring a source schema or changing OKF conformance.

### Motivation

OKF already defines citations as links in the body. That is good for humans and LLMs reading the document, but less convenient for tools that need to answer:

- Which source systems produced this concept?
- Which external or bundle-local resources support this claim?
- Can this concept be refreshed, audited, or traced back to origin material?
- Was the cited source captured or snapshotted at a known time?
- Does a producer have a stable content digest for the source artifact?

Different OKF producers will need this whether they are exporting data catalog metadata, documentation, incident notes, generated enrichment output, or memory records. A shared optional field avoids every producer inventing incompatible names such as `source_refs`, `evidence`, `citations_meta`, or `provenance`.

### Compatibility

- Existing citation sections remain valid.
- Existing consumers can ignore `sources`.
- `sources` can be adopted independently of any future provenance or trust extension.
- `digest` is optional because many useful sources are dynamic, partial, or identified by URI rather than preserved bytes.
- This is related to issue #47 because it names the source metadata that a future trust extension could refer to.

### Test plan

- `git diff --check -- okf/SPEC.md`