### PR TITLE
Add agent requirements.txt and improve onboarding docs

### DIFF
--- a/agents/enrichment/README.md
+++ b/agents/enrichment/README.md
@@ -91,6 +91,16 @@ agents/
 
 ## Prerequisites
 
+You'll need a few CLIs on your PATH before installing anything Python-side:
+
+- **Node.js + npm** (any recent LTS — `node --version`, `npm --version`) to
+  build `kcmd`.
+- **`gcloud` CLI** (`gcloud --version`) for Application Default Credentials.
+  Install: <https://cloud.google.com/sdk/docs/install>.
+- **Python 3.11+** (`python3 --version`).
+
+Then:
+
 1. **Build `kcmd`** (the agent shells out to it). From the repo root:
    ```bash
    cd agents/mdcode
@@ -109,16 +119,16 @@ agents/
    (override with `$KCMD_BIN`), so adding it to `PATH` is only needed for running
    `kcmd` yourself (e.g. `kcmd push`). Verify with `which kcmd`.
 
-2. **Python 3.11+** and the agent dependencies (a venv is recommended):
+2. **Python deps** (a venv is recommended):
    ```bash
    python3 -m venv ~/.venv/kc-enrich
    source ~/.venv/kc-enrich/bin/activate
-   pip install google-adk google-genai google-api-python-client google-auth \
-               google-cloud-bigquery mcp pypdf pyyaml requests absl-py
+   pip install -r agents/enrichment/src/requirements.txt
    ```
    (`google-cloud-bigquery` powers the table-mode usage signal; `mcp` is only
    needed for the GitHub source over a local stdio server — the default hosted
-   remote server works without it.)
+   remote server works without it.) The same hand-typed list lives at the top of
+   `agents/enrichment/src/requirements.txt` if you'd rather pin versions yourself.
 
 3. **Application Default Credentials** (the agent uses Vertex AI, `kcmd` uses
    `gcloud` for catalog auth, and Drive access for source docs):
@@ -280,7 +290,24 @@ list). `--project`, `--model`, and `--output_dir` are required in **every** mode
 - **`--repo`** — GitHub repo as `owner/name` or a URL, explored agentically via the GitHub MCP server as an extra code-context source. Needs a token in the server's environment (default env var `GITHUB_PERSONAL_ACCESS_TOKEN`). Empty = no code source.
 - **`--repo_ref`** — Branch/tag/SHA to read (default: the repo's default branch). Example: `--repo_ref=main`.
 - **`--repo_subdir`** — Path prefix to scope the exploration, e.g. `--repo_subdir=src/server`.
-- **`--mcp_config`** — Path to an `mcp.json` describing the GitHub MCP server. Falls back to `KC_ENRICH_MCP_CONFIG`, then the hosted remote server (`https://api.githubcopilot.com/mcp/`). Pick a server entry with `KC_ENRICH_GITHUB_MCP_SERVER` (default `github_remote`; use `github` for the local stdio binary).
+- **`--mcp_config`** — Path to an `mcp.json` describing the GitHub MCP server. Falls back to `KC_ENRICH_MCP_CONFIG`, then the hosted remote server (`https://api.githubcopilot.com/mcp/`). Pick a server entry with `KC_ENRICH_GITHUB_MCP_SERVER` (default `github_remote`; use `github` for the local stdio binary). A minimal `mcp.json` with both entries:
+  ```json
+  {
+    "mcpServers": {
+      "github_remote": {
+        "type": "http",
+        "url": "https://api.githubcopilot.com/mcp/",
+        "headers": {"Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"}
+      },
+      "github": {
+        "type": "stdio",
+        "command": "github-mcp-server",
+        "args": ["stdio"],
+        "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"}
+      }
+    }
+  }
+  ```
 
 #### Refinement *(all modes, after a run)*
 
@@ -362,8 +389,13 @@ reference answers — it grounds its checks in the agent's own `trajectory.json`
 (what it actually retrieved), so it works on your own data out of the box.
 
 ```bash
+# Run from agents/enrichment/ — `python -m eval` resolves the `eval` package
+# relative to this directory.
 cd agents/enrichment
 pip install -r eval/requirements.txt
+# If you plan to use --run (which spawns the agent itself), also install the
+# agent's deps:
+#   pip install -r src/requirements.txt
 
 # Judge auth — Vertex AI, the same auth the agent uses:
 export GOOGLE_CLOUD_PROJECT=<project>

--- a/agents/enrichment/eval/requirements.txt
+++ b/agents/enrichment/eval/requirements.txt
@@ -1,4 +1,12 @@
 # Enrichment eval (dynamic, golden-free) — judge + parsing deps.
+#
+# This file only covers the SCORING dependencies. The `--run` flag in
+# `python -m eval` additionally spawns the enrichment agent, which has
+# its own dependencies in `agents/enrichment/src/requirements.txt`.
+# Install both when using `--run`:
+#   pip install -r agents/enrichment/src/requirements.txt \
+#               -r agents/enrichment/eval/requirements.txt
+
 google-genai>=1.0.0
 google-auth>=2.0.0
 pyyaml>=6.0

--- a/agents/enrichment/src/requirements.txt
+++ b/agents/enrichment/src/requirements.txt
@@ -1,0 +1,18 @@
+# Knowledge Catalog Enrichment Agent — Python dependencies.
+#
+# Install with:
+#   pip install -r agents/enrichment/src/requirements.txt
+#
+# Mirrors the hand-typed list in agents/enrichment/README.md (Prerequisites).
+# Pin versions in your own deployment as appropriate.
+
+google-adk
+google-genai
+google-api-python-client
+google-auth
+google-cloud-bigquery
+mcp                # only needed if --repo uses the local stdio GitHub MCP server (the default hosted remote works without it)
+pypdf
+pyyaml
+requests
+absl-py


### PR DESCRIPTION
Three small changes that smooth the path for a new user trying to run the
enrichment agent end-to-end from the README alone:

(1) Add agents/enrichment/src/requirements.txt — mirrors the hand-typed
    pip install list from the README so users can `pip install -r ...`
    instead of copy-pasting a long single-line command. Lists every package
    used by the three modes (agent core + drive/bigquery/mcp/pypdf/etc.).
    The README is updated to use this file in the install step.

(2) Update agents/enrichment/eval/requirements.txt with a comment noting
    that `--run` mode also requires the agent's runtime deps from
    src/requirements.txt. Previously the eval reqs only listed the three
    judge/parsing deps, which is enough to score a pre-generated run but
    leads to ImportErrors when first-time users try `python -m eval --run`.

(3) README polish:
    - Add explicit Prerequisites bullets for Node.js+npm (needed to build
      kcmd), gcloud CLI (needed for ADC), and Python 3.11+. Previously only
      Python was mentioned; npm and gcloud were used in the build/auth
      steps but never called out as system prerequisites.
    - Note that `python -m eval` must be run from agents/enrichment/ (the
      `eval` package is resolved relative to the CWD).
    - Add a minimal mcp.json example showing both the github_remote (HTTP)
      and github (stdio) server entries that --mcp_config consumes. The
      file format wasn't documented anywhere, so first-time --repo users
      had to guess or read source.

No code changes. Existing flows are unaffected.

