### PR TITLE
fix: viewer absolute links + spec alignment across codebase (fixes #48)

### DIFF
--- a/okf/src/reference_agent/web/fetcher.py
+++ b/okf/src/reference_agent/web/fetcher.py
@@ -7,7 +7,7 @@ from urllib.request import Request, urlopen
 
 from markdownify import markdownify
 
-_USER_AGENT = "okf-reference-agent/0.1 (+https://github.com/amirhormati/open-knowledge-format)"
+_USER_AGENT = "okf-reference-agent/0.1 (+https://github.com/GoogleCloudPlatform/knowledge-catalog)"
 _MAX_MARKDOWN_BYTES = 40 * 1024
 
 _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)


### PR DESCRIPTION
Three categories of fixes from a second-pass audit of the `reference_agent` codebase (`okf/src/reference_agent/`):

## 1. Viewer: handle spec-recommended bundle-relative absolute links (fixes #48)

`generator.py` `_extract_links()` was skipping all links starting with `/` — which is the **recommended** link form per [OKF §5.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md#51-absolute-bundle-relative-links). This meant the reference viewer generated 0 edges for the spec's own recommended link style, rendering bundles as disconnected node clouds.

**Before:**
```python
if "://" in target or target.startswith("/"):
    continue
```

**After:** `/`-prefixed targets are resolved against `bundle_root`:
```python
if target.startswith("/"):
    resolved = (bundle_root_resolved / target.lstrip("/")).resolve()
else:
    resolved = (doc_dir / target).resolve()
```

Also widened the link regex to accept CommonMark link titles (`](path.md "title")`), which were silently dropped despite being valid standard markdown.

## 2. Prompt drift: align agent instructions with OKF spec

Both `reference_instruction.md` and `web_ingestion_instruction.md` had two issues:

- **Frontmatter requirements:** Listed `type`, `title`, `description`, `timestamp` all as "required" — but [OKF §4.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md#41-frontmatter) says only `type` is REQUIRED. The rest are recommended. Updated both prompts.

- **Cross-linking guidance:** Told agents "Use file-relative paths only. Never start a link with `/`" — directly contradicting OKF §5.1 which **recommends** bundle-relative absolute links. Updated both prompts to recommend absolute links as the primary form, with relative as a fallback.

## 3. Docstring drift: `bundle_tools.py` aligned with spec §4.1

`write_concept_doc()` docstring claimed `type`, `title`, `description`, `timestamp` are "minimum required" — now says only `type` is required, matching the spec and PR #64.

---

**Test results:** All 21 non-BigQuery tests pass (4 BigQuery tests fail with `ModuleNotFoundError: google.cloud.bigquery` — pre-existing dependency issue, not caused by these changes).

Related: #48 (viewer absolute links), #64 (REQUIRED_FRONTMATTER_KEYS fix)