### PR TITLE
enrichment agent가 Vertex 외 모델도 실행할 수 있도록 LiteLLM provider 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 node_modules/
 .venv/
+.env
+.env.*
+!.env.example

--- a/agents/enrichment/src/.env.example
+++ b/agents/enrichment/src/.env.example
@@ -1,0 +1,23 @@
+# Enrichment agent environment template. Copy to `.env` (gitignored) and edit.
+# Loaded at startup by agent_runner.py when python-dotenv is installed.
+
+# --- LLM serving backend ---------------------------------------------------
+# Leave unset to use Vertex AI (Gemini). Set to `litellm` to serve the model
+# through LiteLLM (Anthropic / OpenAI / self-hosted vLLM, etc.). With a
+# `--model=openai/...` name this is inferred automatically; set it explicitly
+# to be safe.
+KC_MODEL_PROVIDER=litellm
+
+# OpenAI-compatible endpoint (e.g. a self-hosted vLLM server). OPENAI_API_BASE
+# must point at the `/v1` root. vLLM accepts any non-empty key.
+OPENAI_API_BASE=http://HOST:8000/v1
+OPENAI_API_KEY=EMPTY
+
+# Optional JSON forwarded as litellm `extra_body` (provider passthrough). For a
+# Qwen3 reasoning model on vLLM, disable chain-of-thought so it doesn't leak
+# into answers:
+# KC_LITELLM_EXTRA_BODY={"chat_template_kwargs": {"enable_thinking": false}}
+
+# --- GCP (still required: Drive/Docs/BigQuery use Google Cloud) -------------
+# GOOGLE_CLOUD_PROJECT=your-gcp-project
+# GOOGLE_CLOUD_LOCATION=global

--- a/agents/enrichment/src/agent_runner.py
+++ b/agents/enrichment/src/agent_runner.py
@@ -196,7 +196,27 @@ _FEEDBACK_FILES = flags.DEFINE_list(
 )
 
 
+def _load_dotenv():
+  """Best-effort load of a local `.env` (python-dotenv, if installed).
+
+  Lets non-Vertex runs keep KC_MODEL_PROVIDER / OPENAI_API_BASE / OPENAI_API_KEY
+  (and the GCP vars) in a `.env` beside the agent instead of exporting them.
+  No-op if python-dotenv isn't installed or no `.env` is present. Existing
+  environment variables win (`override=False`), so explicit exports still take
+  precedence.
+  """
+  try:
+    from dotenv import load_dotenv  # pylint: disable=g-import-not-at-top
+  except ImportError:
+    return
+  here = os.path.dirname(os.path.abspath(__file__))
+  for path in (os.path.join(here, ".env"), os.path.join(os.getcwd(), ".env")):
+    if os.path.exists(path):
+      load_dotenv(path, override=False)
+
+
 def main(argv):
+  _load_dotenv()
   if len(argv) > 1:
     raise app.UsageError("Too many command-line arguments.")
   if not _PROJECT.value:

--- a/agents/enrichment/src/common.py
+++ b/agents/enrichment/src/common.py
@@ -8,7 +8,12 @@ import re
 import threading
 import uuid
 
-from engine import EnumerationResult, create_enumeration_runner
+from engine import (
+    EnumerationResult,
+    create_enumeration_runner,
+    litellm_call_kwargs,
+    resolve_provider,
+)
 from google.genai import Client, types
 
 # Transient Vertex/model-serving errors that are safe to retry. These otherwise
@@ -91,7 +96,15 @@ async def generate_text_direct(
   `Context has already been used to create a Connection, it cannot be mutated
   again` once a worker thread is reused for a second call. Per-call clients
   are cheap relative to the LLM call latency itself.
+
+  When the model resolves to a non-Vertex provider (resolve_provider == litellm)
+  the call is routed through LiteLLM instead; only the LLM backend changes —
+  Drive/Docs/BigQuery still use GCP.
   """
+  if resolve_provider(model) == "litellm":
+    return await _generate_text_litellm(
+        system_instruction, user_prompt, model, usage_acc
+    )
 
   def _call():
     from google.auth import default
@@ -117,6 +130,41 @@ async def generate_text_direct(
     return response.text or ""
 
   return await _with_retry(_once, what=f"generate_content({model})")
+
+
+async def _generate_text_litellm(
+    system_instruction: str, user_prompt: str, model: str, usage_acc: dict
+) -> str:
+  """Non-Vertex sibling of generate_text_direct, routed through LiteLLM.
+
+  Used for any model resolve_provider() maps to litellm (Anthropic / OpenAI /
+  local). Credentials come from litellm's own env vars (e.g. ANTHROPIC_API_KEY).
+  litellm.acompletion is async-native, so unlike the Vertex path no thread
+  offload is needed. Shares the same retry/usage-accounting contract.
+  """
+  import litellm  # pylint: disable=g-import-not-at-top
+
+  # OpenAI-compatible endpoint + provider passthrough (see litellm_call_kwargs):
+  # api_base/api_key reach a self-hosted vLLM, extra_body can disable a Qwen3
+  # reasoning model's chain-of-thought. Same hook as the ADK make_model path.
+  extra = litellm_call_kwargs()
+
+  async def _once():
+    response = await litellm.acompletion(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_instruction},
+            {"role": "user", "content": user_prompt},
+        ],
+        **extra,
+    )
+    usage = getattr(response, "usage", None)
+    if usage is not None and usage_acc is not None:
+      usage_acc["input"] += getattr(usage, "prompt_tokens", 0) or 0
+      usage_acc["output"] += getattr(usage, "completion_tokens", 0) or 0
+    return (response.choices[0].message.content or "")
+
+  return await _with_retry(_once, what=f"litellm.acompletion({model})")
 
 
 # Back-compat alias for the v2.5 writer callers (semantically the same function).

--- a/agents/enrichment/src/engine.py
+++ b/agents/enrichment/src/engine.py
@@ -30,6 +30,7 @@ Nothing here is project-specific: the model is supplied by the caller (the
 `--project` / `--location`).
 """
 
+import json
 import os
 import typing as t
 
@@ -62,6 +63,62 @@ class VertexGemini(Gemini):
           location=os.environ.get("GOOGLE_CLOUD_LOCATION", "global"),
       )
     return self._cached_client
+
+
+def resolve_provider(model: str) -> str:
+  """Pick the serving backend ('vertex' | 'litellm') for a model name.
+
+  Vertex (Gemini via ADC) stays the default so existing invocations are
+  unchanged. Anything non-Gemini routes through LiteLLM, letting the agent run
+  on Anthropic / OpenAI / local (ollama) models without touching call sites.
+  Set KC_MODEL_PROVIDER=vertex|litellm to override the inference explicitly.
+  Note: only the LLM serving backend changes — Drive/Docs/BigQuery still use GCP.
+  """
+  explicit = os.environ.get("KC_MODEL_PROVIDER", "").strip().lower()
+  if explicit in ("vertex", "litellm"):
+    return explicit
+  name = (model or "").strip().lower()
+  if not name or name.startswith("gemini") or name.startswith("vertex_ai/"):
+    return "vertex"
+  return "litellm"
+
+
+def litellm_call_kwargs() -> dict:
+  """Optional litellm kwargs from the environment (shared by both LLM paths).
+
+  * OPENAI_API_BASE / OPENAI_API_KEY — point at an OpenAI-compatible endpoint
+    (e.g. a self-hosted vLLM server); vLLM accepts any non-empty key.
+  * KC_LITELLM_EXTRA_BODY — JSON forwarded as litellm `extra_body` for provider
+    passthrough, e.g. `{"chat_template_kwargs": {"enable_thinking": false}}` to
+    stop a Qwen3 reasoning model leaking its chain-of-thought into `content`.
+
+  Keeping this model-agnostic (no hardcoded model names) means the same hook
+  serves any OpenAI-compatible backend.
+  """
+  kw = {}
+  if os.environ.get("OPENAI_API_BASE"):
+    kw["api_base"] = os.environ["OPENAI_API_BASE"]
+  if os.environ.get("OPENAI_API_KEY"):
+    kw["api_key"] = os.environ["OPENAI_API_KEY"]
+  raw = os.environ.get("KC_LITELLM_EXTRA_BODY", "").strip()
+  if raw:
+    kw["extra_body"] = json.loads(raw)
+  return kw
+
+
+def make_model(model: str):
+  """Build the ADK model object for `model` per resolve_provider().
+
+  Returns a VertexGemini (Vertex AI via ADC) or an ADK LiteLlm wrapper. LiteLlm
+  is imported lazily so Vertex-only installs need not depend on litellm; its
+  credentials come from litellm's own env vars (e.g. ANTHROPIC_API_KEY) plus the
+  optional OpenAI-compatible overrides in litellm_call_kwargs().
+  """
+  if resolve_provider(model) == "litellm":
+    from google.adk.models.lite_llm import LiteLlm  # pylint: disable=g-import-not-at-top
+
+    return LiteLlm(model=model, **litellm_call_kwargs())
+  return VertexGemini(model=model)
 
 
 # High-volume / small-input steps (per-doc descriptors, JSON routing, per-doc
@@ -101,7 +158,7 @@ def create_summarizer_runner(model: str) -> InMemoryRunner:
   agent = llm_agent.LlmAgent(
       name="SummarizerAgent",
       description="Summarizes Google Drive documents.",
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=SUMMARIZER_INSTRUCTION,
   )
   return InMemoryRunner(agent=agent)
@@ -158,7 +215,7 @@ def create_per_doc_summarizer_runner(model: str) -> InMemoryRunner:
           "Summarizes a single document into a reusable, topic-neutral doc"
           " card. Output is cached across runs."
       ),
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=PER_DOC_SUMMARIZER_INSTRUCTION,
   )
   return InMemoryRunner(agent=agent)
@@ -207,7 +264,7 @@ def create_doc_query_extractor_runner(model: str) -> InMemoryRunner:
       description=(
           "Extracts SQL examples for ONE table from its routed documentation."
       ),
-      model=VertexGemini(model=_light_model(model)),
+      model=make_model(_light_model(model)),
       instruction=DOC_QUERY_EXTRACTOR_INSTRUCTION,
   )
   return InMemoryRunner(agent=agent)
@@ -244,7 +301,7 @@ def create_topic_reducer_runner(model: str) -> InMemoryRunner:
           "Reduces a batch of neutral per-doc summaries through a topic"
           " lens, producing a structured grouped summary."
       ),
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=TOPIC_REDUCER_INSTRUCTION,
   )
   return InMemoryRunner(agent=agent)
@@ -293,7 +350,7 @@ def create_mdcode_runner(
   agent = llm_agent.LlmAgent(
       name="MdcodeAgent",
       description="Generates Dataplex mdcode entries from summaries.",
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=instruction,
   )
   return InMemoryRunner(agent=agent)
@@ -309,7 +366,7 @@ def create_doc_summarizer_runner(model: str) -> InMemoryRunner:
       description=(
           "Summarizes a single Drive document into a compact descriptor."
       ),
-      model=VertexGemini(model=_light_model(model)),
+      model=make_model(_light_model(model)),
       instruction="""You are summarizing ONE document so a router can decide which BigQuery tables it is relevant to.
 
 Output EXACTLY this Markdown shape and nothing else:
@@ -328,7 +385,7 @@ def create_router_runner(model: str) -> InMemoryRunner:
   agent = llm_agent.LlmAgent(
       name="RelevanceRouterAgent",
       description="Scores folder-document relevance to one BigQuery table.",
-      model=VertexGemini(model=_light_model(model)),
+      model=make_model(_light_model(model)),
       instruction="""You are a precise relevance router. You are given ONE BigQuery table (its name and columns) and a numbered list of candidate documents (each with a title, summary, and key entities).
 
 Decide which documents genuinely provide domain knowledge that would help DOCUMENT THIS SPECIFIC TABLE — e.g. they define this table, its columns/metrics, its source system, or the business process it records. A document that merely shares a broad theme but does not concern this table's data is NOT relevant.
@@ -349,7 +406,7 @@ def create_table_overview_runner(model: str) -> InMemoryRunner:
           "Writes the enriched overview for one BigQuery table from its"
           " relevant docs."
       ),
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction="""You are a Knowledge Catalog Enrichment Agent for Google Cloud Dataplex.
 
 You will receive:
@@ -471,7 +528,7 @@ def create_enumeration_runner(model: str) -> InMemoryRunner:
   agent = llm_agent.LlmAgent(
       name="EnumerationAgent",
       description="Produces a canonical, deduplicated, categorized entry list.",
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=_ENUMERATION_INSTRUCTION,
       output_schema=EnumerationResult,
   )
@@ -490,7 +547,7 @@ def create_entry_writer_runner(model: str) -> InMemoryRunner:
       description=(
           "Writes one entry's overview Markdown body from grounded context."
       ),
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=ENTRY_WRITER_INSTRUCTION,
   )
   return InMemoryRunner(agent=agent)
@@ -580,7 +637,7 @@ def create_glossary_runner(model: str) -> InMemoryRunner:
   agent = llm_agent.LlmAgent(
       name="GlossaryAgent",
       description="Extracts business glossary terms from context.",
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=_GLOSSARY_INSTRUCTION,
       output_schema=GlossaryResult,
   )
@@ -712,7 +769,7 @@ def create_refinement_dispatch_runner(model: str) -> InMemoryRunner:
       description=(
           "Classifies a free-text refinement request into a structured plan."
       ),
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=_REFINEMENT_DISPATCH_INSTRUCTION,
       output_schema=RefinementPlan,
   )
@@ -765,7 +822,7 @@ def create_linking_runner(model: str) -> InMemoryRunner:
   agent = llm_agent.LlmAgent(
       name="LinkingAgent",
       description="Maps table columns to glossary terms.",
-      model=VertexGemini(model=model),
+      model=make_model(model),
       instruction=_LINKING_INSTRUCTION,
       output_schema=TableLinkingResult,
   )

--- a/agents/enrichment/src/requirements.txt
+++ b/agents/enrichment/src/requirements.txt
@@ -12,6 +12,8 @@ google-api-python-client
 google-auth
 google-cloud-bigquery
 mcp                # only needed if --repo uses the local stdio GitHub MCP server (the default hosted remote works without it)
+litellm            # only needed for non-Vertex models (--model not gemini-*, or KC_MODEL_PROVIDER=litellm); creds via litellm env vars (e.g. ANTHROPIC_API_KEY)
+python-dotenv      # optional: loads a local .env (KC_MODEL_PROVIDER / OPENAI_API_BASE / OPENAI_API_KEY / GCP vars) at startup
 pypdf
 pyyaml
 requests

--- a/agents/enrichment/src/tools/github_tools.py
+++ b/agents/enrichment/src/tools/github_tools.py
@@ -42,7 +42,7 @@ import re
 import typing as t
 import uuid
 
-from engine import VertexGemini
+from engine import make_model
 from google.adk.agents import llm_agent
 from google.adk.runners import InMemoryRunner
 from google.genai import types
@@ -473,7 +473,7 @@ async def gather_repo_context(
             "Explores a GitHub repository via MCP tools and emits structured"
             " code component cards."
         ),
-        model=VertexGemini(model=model),
+        model=make_model(model),
         instruction=instruction,
         tools=[toolset],
     )


### PR DESCRIPTION

설명:
Vertex AI(ADC 기반 Gemini)를 기본값으로 유지하되, Gemini가 아닌 모델은
LiteLLM을 통해 라우팅하여 호출부 수정 없이 Anthropic / OpenAI / 자체 호스팅
vLLM에서도 에이전트를 실행할 수 있도록 했습니다. 바뀌는 것은 LLM 서빙
백엔드뿐이며, Drive/Docs/BigQuery는 그대로 GCP를 사용합니다.

- engine.py: resolve_provider(), litellm_call_kwargs(), make_model() 추가.
  모든 runner를 VertexGemini(...)에서 make_model(...)로 전환. KC_MODEL_PROVIDER로
  백엔드 추론을 덮어쓸 수 있음.
- common.py: 모델이 litellm provider로 해석될 때 generate_text_direct를
  litellm.acompletion 경유로 라우팅.
- github_tools.py: repo-context 에이전트에 make_model() 사용.
- agent_runner.py: 로컬 .env 파일을 best-effort로 로드(python-dotenv).
- requirements.txt: litellm(선택), python-dotenv(선택) 추가.
- .gitignore / .env.example: .env 파일 무시, 템플릿 추가.