### PR TITLE
Add OpenAPI-to-OKF producer to toolbox

### DIFF
--- a/toolbox/README.md
+++ b/toolbox/README.md
@@ -10,3 +10,8 @@ Contains tools to work with Knowledge Catalog metadata.
   Provides an ready-to-use agent and customizable harness to produce, evolve/improve
   and maintain metadata within Knowledge Catalog and make it ready for consumption by
   agents.
+
+* [OpenAPI to OKF](./openapi-to-okf/README.md)
+  Converts any OpenAPI 3.x description into a conformant OKF v0.1 bundle, so any
+  service that already publishes an OpenAPI document can expose its API catalog as
+  agent-readable OKF with no hand-authoring.

--- a/toolbox/openapi-to-okf/README.md
+++ b/toolbox/openapi-to-okf/README.md
@@ -1,0 +1,49 @@
+# openapi-to-okf
+
+Turn any OpenAPI 3.x description into a conformant Open Knowledge Format
+(OKF v0.1) bundle. Dependency-free Node, no build step.
+
+## Why
+
+OpenAPI is the most widely published API description format. This producer lets
+any service expose its existing API catalog as agent-readable OKF knowledge with
+no hand-authoring, which grows the producer side of the ecosystem (see the OKF
+README: "export pipelines from existing catalogs ... or scripts walking a
+database").
+
+## Usage
+
+```
+node openapi-to-okf.mjs <openapi.json> <output-dir> [--base <api-base-url>]
+```
+
+Example:
+
+```
+node openapi-to-okf.mjs openapi.json out/ --base https://api.example.com
+```
+
+## What it emits
+
+- one concept doc per operation (`type: "API Operation"`) with method, path,
+  parameters, and relative-markdown links to the schemas it references
+- one concept doc per `components.schemas` entry (`type: "Schema"`)
+- frontmatter-free `index.md` directory listings and `log.md`, per the spec
+- a bundle-root `index.md` that declares `okf_version` only
+
+## Conformance
+
+- every concept file has a non-empty `type`
+- `okf_version` appears only in the bundle-root `index.md`
+- all internal links are standard relative markdown (no `[[wiki]]` syntax)
+- reserved files (`index.md`, `log.md`) carry no frontmatter, except the root
+  `index.md` which carries `okf_version` only
+
+## Example bundle
+
+`example/` is a real bundle produced from a public production API (TempGuru's
+event-staffing API: 7 operations, 13 schemas, 24 files). Regenerate with:
+
+```
+node openapi-to-okf.mjs path/to/openapi.json example/ --base https://mcp.tempguru.co
+```

--- a/toolbox/openapi-to-okf/example/index.md
+++ b/toolbox/openapi-to-okf/example/index.md
@@ -1,0 +1,13 @@
+---
+okf_version: "0.1"
+---
+
+# TempGuru Public Data API
+
+Public event-staffing data for the US and Canada, served by TempGuru (Temporary Assistance Guru, Inc.).
+
+API base: `https://mcp.tempguru.co`. Generated from an OpenAPI 3.1.0 spec.
+
+- [Operations](operations/index.md) (7)
+- [Schemas](schemas/index.md) (13)
+- [Change log](log.md)

--- a/toolbox/openapi-to-okf/example/log.md
+++ b/toolbox/openapi-to-okf/example/log.md
@@ -1,0 +1,6 @@
+# Change Log
+
+## 1.2.0
+
+- Generated from OpenAPI 3.1.0 (`TempGuru Public Data API` v1.2.0) by openapi-to-okf.
+- 7 operations, 13 schemas.

--- a/toolbox/openapi-to-okf/example/operations/checkavailability.md
+++ b/toolbox/openapi-to-okf/example/operations/checkavailability.md
@@ -1,0 +1,28 @@
+---
+type: "API Operation"
+title: "Lead-time guidance for an event"
+description: "Use this when an agent wants to know whether TempGuru can typically staff an event at a given city and date, for example, 'is two weeks enough notice for Dallas?' Returns a recommendation in the se..."
+method: "GET"
+path: "/api/v1/availability"
+resource: "https://mcp.tempguru.co/api/v1/availability"
+operation_id: "checkAvailability"
+tags:
+  - "Planning"
+---
+# Lead-time guidance for an event
+Use this when an agent wants to know whether TempGuru can typically staff an event at a given city and date, for example, 'is two weeks enough notice for Dallas?' Returns a recommendation in the set {yes, tight, rush, very-rush} based on the city's market tier and how far out the event is. **This is planning guidance, not a real-time reservation.** A confirmed booking requires a quote request at https://tempguru.co/get-staffing.
+- **Operation:** `GET https://mcp.tempguru.co/api/v1/availability`
+- **Tags:** Planning
+## Parameters
+
+- `city` (query, required): City name (e.g., 'Boston') or slug from /api/v1/cities (e.g., 'boston-event-staffing').
+- `date` (query, required): Event date in ISO format (YYYY-MM-DD).
+- `role` (query): Optional role slug or name. When provided, the response also includes the rate range for that role in the resolved city.
+- `headcount` (query): Optional headcount for the event. Echoed in the response so agents can include it in downstream quote requests.
+
+## Related schemas
+
+- [AvailabilityResponse](../schemas/availabilityresponse.md)
+- [Error](../schemas/error.md)
+
+[All operations](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/operations/getcompliancebystate.md
+++ b/toolbox/openapi-to-okf/example/operations/getcompliancebystate.md
@@ -1,0 +1,25 @@
+---
+type: "API Operation"
+title: "State-level employment compliance summary"
+description: "Use this when an agent needs an at-a-glance summary of event staffing compliance for a specific state, minimum wage, weekly and daily overtime thresholds, and state-specific quirks (California meal..."
+method: "GET"
+path: "/api/v1/compliance"
+resource: "https://mcp.tempguru.co/api/v1/compliance"
+operation_id: "getComplianceByState"
+tags:
+  - "Compliance"
+---
+# State-level employment compliance summary
+Use this when an agent needs an at-a-glance summary of event staffing compliance for a specific state, minimum wage, weekly and daily overtime thresholds, and state-specific quirks (California meal-break rules, NY spread-of-hours, etc.). Useful for planning multi-state events and for explaining why W-2 staffing matters in jurisdictions with strict labor enforcement. **Informational only, not legal advice.** Consult employment counsel for binding interpretation.
+- **Operation:** `GET https://mcp.tempguru.co/api/v1/compliance`
+- **Tags:** Compliance
+## Parameters
+
+- `state` (query, required): Two-letter US state code (e.g., 'CA') or full name (e.g., 'California'). All 50 states plus DC supported.
+
+## Related schemas
+
+- [ComplianceResponse](../schemas/complianceresponse.md)
+- [Error](../schemas/error.md)
+
+[All operations](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/operations/gethealth.md
+++ b/toolbox/openapi-to-okf/example/operations/gethealth.md
@@ -1,0 +1,21 @@
+---
+type: "API Operation"
+title: "Service health probe"
+description: "Use this when an agent or monitoring system wants to verify the API is alive and check which version is running."
+method: "GET"
+path: "/api/v1/health"
+resource: "https://mcp.tempguru.co/api/v1/health"
+operation_id: "getHealth"
+tags:
+  - "Operational"
+---
+# Service health probe
+Use this when an agent or monitoring system wants to verify the API is alive and check which version is running. Returns immediately with no caching. Suitable as the target of an api-catalog `status` link (RFC 9727).
+- **Operation:** `GET https://mcp.tempguru.co/api/v1/health`
+- **Tags:** Operational
+
+## Related schemas
+
+- [HealthResponse](../schemas/healthresponse.md)
+
+[All operations](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/operations/getrolepricing.md
+++ b/toolbox/openapi-to-okf/example/operations/getrolepricing.md
@@ -1,0 +1,26 @@
+---
+type: "API Operation"
+title: "All-inclusive hourly rate range for a role in a city"
+description: "Use this when an agent needs to quote a price range for a specific role in a specific city, for example, 'what do brand ambassadors cost in Boston?' Returns a hourly_range_low / hourly_range_high r..."
+method: "GET"
+path: "/api/v1/pricing"
+resource: "https://mcp.tempguru.co/api/v1/pricing"
+operation_id: "getRolePricing"
+tags:
+  - "Planning"
+---
+# All-inclusive hourly rate range for a role in a city
+Use this when an agent needs to quote a price range for a specific role in a specific city, for example, 'what do brand ambassadors cost in Boston?' Returns a `hourly_range_low` / `hourly_range_high` range reflecting event-type and shift variability within that market tier. **All rates are all-inclusive W-2 bill rates** covering worker pay, payroll taxes, workers' comp, liability, and coordinator support. Rate ranges are planning estimates, a real quote requires event specifics.
+- **Operation:** `GET https://mcp.tempguru.co/api/v1/pricing`
+- **Tags:** Planning
+## Parameters
+
+- `role` (query, required): Role slug or display name (e.g., 'brand-ambassadors' or 'Brand Ambassadors'). See /api/v1/roles for the canonical list.
+- `city` (query, required): City name or slug (e.g., 'Boston' or 'boston-event-staffing'). See /api/v1/cities for the canonical list.
+
+## Related schemas
+
+- [PricingResponse](../schemas/pricingresponse.md)
+- [Error](../schemas/error.md)
+
+[All operations](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/operations/index.md
+++ b/toolbox/openapi-to-okf/example/operations/index.md
@@ -1,0 +1,9 @@
+# Operations
+
+- [List cities TempGuru serves](listcities.md), `GET /api/v1/cities`
+- [List event staffing roles](listroles.md), `GET /api/v1/roles`
+- [Lead-time guidance for an event](checkavailability.md), `GET /api/v1/availability`
+- [All-inclusive hourly rate range for a role in a city](getrolepricing.md), `GET /api/v1/pricing`
+- [State-level employment compliance summary](getcompliancebystate.md), `GET /api/v1/compliance`
+- [Submit a staffing quote request (the API's only write operation)](submitquoterequest.md), `POST /api/v1/quote-requests`
+- [Service health probe](gethealth.md), `GET /api/v1/health`

--- a/toolbox/openapi-to-okf/example/operations/listcities.md
+++ b/toolbox/openapi-to-okf/example/operations/listcities.md
@@ -1,0 +1,26 @@
+---
+type: "API Operation"
+title: "List cities TempGuru serves"
+description: "Use this when an agent needs the canonical list of cities where TempGuru has a dedicated market presence, or wants to filter by state or by tier (hub / mid / small)."
+method: "GET"
+path: "/api/v1/cities"
+resource: "https://mcp.tempguru.co/api/v1/cities"
+operation_id: "listCities"
+tags:
+  - "Discovery"
+---
+# List cities TempGuru serves
+Use this when an agent needs the canonical list of cities where TempGuru has a dedicated market presence, or wants to filter by state or by tier (hub / mid / small). Tier classification is used everywhere else in the API to determine lead times and rate bands.
+- **Operation:** `GET https://mcp.tempguru.co/api/v1/cities`
+- **Tags:** Discovery
+## Parameters
+
+- `state` (query): Filter by state. Accepts either a 2-letter postal code (e.g., 'CA') or a full state name (e.g., 'California'). US states and Canadian provinces both supported.
+- `tier` (query): Filter by market tier. 'hub' = 25 major metros (NYC, LA, Boston, etc.); 'mid' = 129 secondary markets; 'small' = 191 tertiary markets.
+
+## Related schemas
+
+- [CitiesResponse](../schemas/citiesresponse.md)
+- [Error](../schemas/error.md)
+
+[All operations](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/operations/listroles.md
+++ b/toolbox/openapi-to-okf/example/operations/listroles.md
@@ -1,0 +1,21 @@
+---
+type: "API Operation"
+title: "List event staffing roles"
+description: "Use this when an agent needs the canonical list of roles TempGuru staffs (brand ambassadors, registration, hospitality, setup, ushers, gate, crowd control, guest services, booth monitors, team leads)."
+method: "GET"
+path: "/api/v1/roles"
+resource: "https://mcp.tempguru.co/api/v1/roles"
+operation_id: "listRoles"
+tags:
+  - "Discovery"
+---
+# List event staffing roles
+Use this when an agent needs the canonical list of roles TempGuru staffs (brand ambassadors, registration, hospitality, setup, ushers, gate, crowd control, guest services, booth monitors, team leads). The returned `slug` values are the keys to use in the pricing and availability endpoints.
+- **Operation:** `GET https://mcp.tempguru.co/api/v1/roles`
+- **Tags:** Discovery
+
+## Related schemas
+
+- [RolesResponse](../schemas/rolesresponse.md)
+
+[All operations](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/operations/submitquoterequest.md
+++ b/toolbox/openapi-to-okf/example/operations/submitquoterequest.md
@@ -1,0 +1,24 @@
+---
+type: "API Operation"
+title: "Submit a staffing quote request (the API's only write operation)"
+description: "Use this when, and only when, the user has explicitly confirmed they want to submit a staffing request to TempGuru."
+method: "POST"
+path: "/api/v1/quote-requests"
+resource: "https://mcp.tempguru.co/api/v1/quote-requests"
+operation_id: "submitQuoteRequest"
+tags:
+  - "Quote Submission"
+---
+# Submit a staffing quote request (the API's only write operation)
+Use this when, and only when, the user has explicitly confirmed they want to submit a staffing request to TempGuru. This is the single write operation in this API; everything else is a read-only lookup. It creates a structured lead in TempGuru's CRM, and a human coordinator replies with a quote within one business day (orders confirm within 48 hours of approval). **Opt-in by design:** collect the contact details and the event plan, show the user exactly what will be submitted, and call this once after explicit confirmation, never speculatively. **Not a reservation:** it does not hold staff, guarantee pricing or availability, or create a contract, and **no payment** is required until the user approves the quote. Contact and event details go only to TempGuru's CRM so a coordinator can reply, they are never written to telemetry or analytics. Build the plan first with the read operations (cities, roles, pricing, availability, compliance). Lightly rate limited per source IP, on HTTP 429, respect `Retry-After` and fall back to the form at https://tempguru.co/get-staffing.
+- **Operation:** `POST https://mcp.tempguru.co/api/v1/quote-requests`
+- **Tags:** Quote Submission
+
+## Related schemas
+
+- [QuoteRequestInput](../schemas/quoterequestinput.md)
+- [QuoteRequestConfirmation](../schemas/quoterequestconfirmation.md)
+- [Error](../schemas/error.md)
+- [QuoteRequestFailure](../schemas/quoterequestfailure.md)
+
+[All operations](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/availabilityresponse.md
+++ b/toolbox/openapi-to-okf/example/schemas/availabilityresponse.md
@@ -1,0 +1,22 @@
+---
+type: "Schema"
+title: "AvailabilityResponse"
+---
+# AvailabilityResponse
+Schema `AvailabilityResponse`.
+## Properties
+
+- `input` (object, required)
+- `city_found` (boolean, required)
+- `city` (string, required)
+- `state` (string, required)
+- `city_tier` (string, required)
+- `event_date` (string, required)
+- `days_until_event` (integer, required)
+- `typical_lead_time_hours` (integer, required)
+- `recommendation` (string, required): yes = comfortable window; tight = at or near typical lead time; rush = inside lead time; very-rush = <24h.
+- `role` (object)
+- `count` (integer)
+- `notes` (array, required)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/citiesresponse.md
+++ b/toolbox/openapi-to-okf/example/schemas/citiesresponse.md
@@ -1,0 +1,14 @@
+---
+type: "Schema"
+title: "CitiesResponse"
+---
+# CitiesResponse
+Schema `CitiesResponse`.
+## Properties
+
+- `input` (object, required): Echo of the query parameters used.
+- `total` (integer, required)
+- `tier_breakdown` (object, required)
+- `cities` (array, required)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/city.md
+++ b/toolbox/openapi-to-okf/example/schemas/city.md
@@ -1,0 +1,17 @@
+---
+type: "Schema"
+title: "City"
+---
+# City
+Schema `City`.
+## Properties
+
+- `slug` (string, required)
+- `name` (string, required)
+- `state` (string, required)
+- `state_abbr` (string, required)
+- `country` (string, required)
+- `tier` (string, required)
+- `url` (string, required)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/complianceresponse.md
+++ b/toolbox/openapi-to-okf/example/schemas/complianceresponse.md
@@ -1,0 +1,22 @@
+---
+type: "Schema"
+title: "ComplianceResponse"
+---
+# ComplianceResponse
+Schema `ComplianceResponse`.
+## Properties
+
+- `input` (object, required)
+- `state` (string, required)
+- `state_abbr` (string, required)
+- `min_wage_usd` (number, required)
+- `w2_required` (boolean, required)
+- `w2_note` (string)
+- `overtime_threshold_weekly_hours` (integer, required)
+- `overtime_threshold_daily_hours` (integer)
+- `unique_rules` (array, required)
+- `liability_coverage_included` (boolean)
+- `workers_comp_included` (boolean)
+- `citation_note` (string)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/error.md
+++ b/toolbox/openapi-to-okf/example/schemas/error.md
@@ -1,0 +1,11 @@
+---
+type: "Schema"
+title: "Error"
+---
+# Error
+Schema `Error`.
+## Properties
+
+- `error` (object, required)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/healthresponse.md
+++ b/toolbox/openapi-to-okf/example/schemas/healthresponse.md
@@ -1,0 +1,12 @@
+---
+type: "Schema"
+title: "HealthResponse"
+---
+# HealthResponse
+Schema `HealthResponse`.
+## Properties
+
+- `status` (string, required)
+- `version` (string, required)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/index.md
+++ b/toolbox/openapi-to-okf/example/schemas/index.md
@@ -1,0 +1,15 @@
+# Schemas
+
+- [Error](error.md)
+- [City](city.md)
+- [Role](role.md)
+- [PriceBand](priceband.md)
+- [CitiesResponse](citiesresponse.md)
+- [RolesResponse](rolesresponse.md)
+- [AvailabilityResponse](availabilityresponse.md)
+- [PricingResponse](pricingresponse.md)
+- [ComplianceResponse](complianceresponse.md)
+- [QuoteRequestInput](quoterequestinput.md)
+- [QuoteRequestConfirmation](quoterequestconfirmation.md)
+- [QuoteRequestFailure](quoterequestfailure.md)
+- [HealthResponse](healthresponse.md)

--- a/toolbox/openapi-to-okf/example/schemas/priceband.md
+++ b/toolbox/openapi-to-okf/example/schemas/priceband.md
@@ -1,0 +1,12 @@
+---
+type: "Schema"
+title: "PriceBand"
+---
+# PriceBand
+Schema `PriceBand`.
+## Properties
+
+- `low` (number, required): Lower end of the hourly rate range (USD).
+- `high` (number, required): Upper end of the hourly rate range (USD).
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/pricingresponse.md
+++ b/toolbox/openapi-to-okf/example/schemas/pricingresponse.md
@@ -1,0 +1,23 @@
+---
+type: "Schema"
+title: "PricingResponse"
+---
+# PricingResponse
+Schema `PricingResponse`.
+## Properties
+
+- `input` (object, required)
+- `role` (string, required)
+- `role_slug` (string, required)
+- `city` (string, required)
+- `state` (string, required)
+- `city_tier` (string, required)
+- `hourly_range_low` (number, required)
+- `hourly_range_high` (number, required)
+- `currency` (string, required)
+- `all_inclusive` (string, required)
+- `tier_definition` (string)
+- `all_tiers_for_context` (object)
+- `pricing_notes` (string)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/quoterequestconfirmation.md
+++ b/toolbox/openapi-to-okf/example/schemas/quoterequestconfirmation.md
@@ -1,0 +1,14 @@
+---
+type: "Schema"
+title: "QuoteRequestConfirmation"
+---
+# QuoteRequestConfirmation
+Schema `QuoteRequestConfirmation`.
+## Properties
+
+- `submitted` (boolean, required)
+- `deal_name` (string, required): Internal name assigned to the lead in TempGuru's CRM.
+- `message` (string, required): Human-readable confirmation to relay to the user.
+- `next_steps` (array, required): What happens next, relay to the user.
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/quoterequestfailure.md
+++ b/toolbox/openapi-to-okf/example/schemas/quoterequestfailure.md
@@ -1,0 +1,13 @@
+---
+type: "Schema"
+title: "QuoteRequestFailure"
+---
+# QuoteRequestFailure
+Schema `QuoteRequestFailure`.
+## Properties
+
+- `submitted` (boolean, required)
+- `error` (string, required): What failed upstream.
+- `message` (string, required): Fallback instructions with direct TempGuru contact details, relay to the user.
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/quoterequestinput.md
+++ b/toolbox/openapi-to-okf/example/schemas/quoterequestinput.md
@@ -1,0 +1,23 @@
+---
+type: "Schema"
+title: "QuoteRequestInput"
+description: "A confirmed staffing plan plus the contact details a coordinator needs to reply."
+---
+# QuoteRequestInput
+A confirmed staffing plan plus the contact details a coordinator needs to reply. Mirrors the MCP `request_quote` tool's input schema exactly.
+## Properties
+
+- `contact_name` (string, required): Full name of the contact person.
+- `contact_email` (string, required): Contact email address for the quote response.
+- `company` (string, required): Company or organization name.
+- `event_name` (string, required): Name of the event.
+- `event_type` (string, required): Event type: trade-show, conference, festival, concert, sporting-event, corporate, brand-activation, or other.
+- `city` (string, required): City where the event is held.
+- `event_dates` (string, required): Event dates as a human-readable string.
+- `roles` (array, required): Roles and headcount needed for the event.
+- `budget_range` (string): Estimated total budget range if calculated.
+- `attire` (string): Staff attire requirements.
+- `special_requirements` (string): Any special requirements: language skills, certifications, overnight shifts, etc.
+- `compliance_notes` (string): Any compliance flags surfaced by the compliance endpoint.
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/role.md
+++ b/toolbox/openapi-to-okf/example/schemas/role.md
@@ -1,0 +1,16 @@
+---
+type: "Schema"
+title: "Role"
+---
+# Role
+Schema `Role`.
+## Properties
+
+- `slug` (string, required)
+- `name` (string, required)
+- `description` (string, required)
+- `skill_tier` (integer, required)
+- `typical_shift_length_hours` (integer, required)
+- `url` (string, required)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/example/schemas/rolesresponse.md
+++ b/toolbox/openapi-to-okf/example/schemas/rolesresponse.md
@@ -1,0 +1,13 @@
+---
+type: "Schema"
+title: "RolesResponse"
+---
+# RolesResponse
+Schema `RolesResponse`.
+## Properties
+
+- `input` (object, required)
+- `total` (integer, required)
+- `roles` (array, required)
+
+[All schemas](index.md) · [bundle root](../index.md)

--- a/toolbox/openapi-to-okf/openapi-to-okf.mjs
+++ b/toolbox/openapi-to-okf/openapi-to-okf.mjs
@@ -1,0 +1,193 @@
+// openapi-to-okf, turn any OpenAPI 3.x spec into an Open Knowledge Format (OKF
+// v0.1) bundle: a directory of plain Markdown files with YAML frontmatter that
+// link to one another. One concept per file. The only required frontmatter
+// field is `type`. Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog
+//
+// This is a GENERIC producer (no TempGuru specifics). It is the artifact behind
+// the proposed contribution to Google's OKF repo: a reusable bridge that lets any
+// API publisher expose its OpenAPI catalog as agent-readable knowledge. Validated
+// against a real production spec (TempGuru's public event-staffing API).
+//
+// Usage:
+//   node openapi-to-okf.mjs <path-to-openapi.json> <output-dir> [--base <api-base-url>]
+//
+// Output:
+//   <output-dir>/index.md            bundle root, declares okf_version (the only
+//                                    index.md allowed to carry frontmatter, per spec)
+//   <output-dir>/log.md              change log (no frontmatter, per spec)
+//   <output-dir>/operations/*.md     one concept per path+method operation
+//   <output-dir>/schemas/*.md        one concept per components.schemas entry
+
+import { readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+// ── args ─────────────────────────────────────────────────────────────────────
+const [specPath, outDir, ...rest] = process.argv.slice(2);
+if (!specPath || !outDir) {
+  console.error("usage: node openapi-to-okf.mjs <openapi.json> <output-dir> [--base <url>]");
+  process.exit(1);
+}
+const baseFlag = rest.indexOf("--base");
+const apiBase = baseFlag >= 0 ? rest[baseFlag + 1] : undefined;
+
+const spec = JSON.parse(readFileSync(resolve(specPath), "utf8"));
+const out = resolve(outDir);
+
+// ── helpers ────────────────────────────────────────────────────────────────
+const OKF_VERSION = "0.1";
+// Always double-quote string scalars so colons, commas, URLs never break YAML.
+const scalar = (v) =>
+  typeof v === "number" || typeof v === "boolean" ? String(v) : JSON.stringify(String(v));
+const fm = (obj) => {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null || v === "") continue;
+    if (Array.isArray(v)) {
+      if (!v.length) continue;
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - ${scalar(item)}`);
+    } else lines.push(`${k}: ${scalar(v)}`);
+  }
+  lines.push("---");
+  return lines.join("\n");
+};
+const slug = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+const oneLine = (s) => (s || "").replace(/\s+/g, " ").trim();
+// Clean one-sentence summary for frontmatter: strip markdown, stop at first period.
+const summarize = (s) => {
+  const clean = oneLine(s).replace(/\*\*/g, "").replace(/`/g, "");
+  const firstSentence = clean.split(/(?<=\.)\s/)[0];
+  return (firstSentence.length > 200 ? firstSentence.slice(0, 197) + "..." : firstSentence) || undefined;
+};
+// Join a server origin and an OpenAPI path without doubling a shared prefix.
+const joinUrl = (origin, path) => {
+  if (!origin) return path;
+  const o = origin.replace(/\/+$/, "");
+  try {
+    const oPath = new URL(o).pathname.replace(/\/+$/, "");
+    if (oPath && path.startsWith(oPath + "/")) return new URL(o).origin + path;
+  } catch { /* origin not a full URL, fall through */ }
+  return o + path;
+};
+let fileCount = 0;
+const write = (rel, content) => {
+  const full = join(out, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content.endsWith("\n") ? content : content + "\n");
+  fileCount += 1;
+};
+// A $ref like "#/components/schemas/City" -> { name: "City", file: "../schemas/city.md" }
+const refTo = (ref, fromDir) => {
+  const name = ref.split("/").pop();
+  const prefix = fromDir === "operations" ? ".." : ".";
+  return { name, link: `[${name}](${prefix}/schemas/${slug(name)}.md)` };
+};
+const collectRefs = (node, acc = new Set()) => {
+  if (!node || typeof node !== "object") return acc;
+  if (typeof node.$ref === "string" && node.$ref.includes("/components/schemas/")) acc.add(node.$ref);
+  for (const v of Object.values(node)) collectRefs(v, acc);
+  return acc;
+};
+
+rmSync(out, { recursive: true, force: true });
+
+const info = spec.info || {};
+const servers = (spec.servers || []).map((s) => s.url).filter(Boolean);
+const base = apiBase || servers[0] || "";
+
+// ── operations ───────────────────────────────────────────────────────────────
+const METHODS = ["get", "post", "put", "patch", "delete"];
+const operations = [];
+for (const [path, item] of Object.entries(spec.paths || {})) {
+  for (const method of METHODS) {
+    const op = item[method];
+    if (!op) continue;
+    const id = op.operationId || `${method}-${slug(path)}`;
+    operations.push({ id, method: method.toUpperCase(), path, op });
+  }
+}
+
+for (const { id, method, path, op } of operations) {
+  const refs = [...collectRefs(op)].map((r) => refTo(r, "operations"));
+  const params = (op.parameters || []).map(
+    (p) => `- \`${p.name}\` (${p.in}${p.required ? ", required" : ""})${p.description ? `: ${oneLine(p.description)}` : ""}`,
+  );
+  const body = [
+    `# ${op.summary || id}`,
+    "",
+    oneLine(op.description) || `\`${method} ${path}\``,
+    "",
+    `- **Operation:** \`${method} ${joinUrl(base, path)}\``,
+    op.tags?.length ? `- **Tags:** ${op.tags.join(", ")}` : "",
+    "",
+    params.length ? `## Parameters\n\n${params.join("\n")}` : "",
+    refs.length ? `\n## Related schemas\n\n${refs.map((r) => `- ${r.link}`).join("\n")}` : "",
+    `\n[All operations](index.md) · [bundle root](../index.md)`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  write(
+    `operations/${slug(id)}.md`,
+    `${fm({
+      type: "API Operation",
+      title: op.summary || id,
+      description: summarize(op.description),
+      method,
+      path,
+      resource: base ? joinUrl(base, path) : undefined,
+      operation_id: op.operationId,
+      tags: op.tags,
+    })}\n${body}\n`,
+  );
+}
+
+// ── schemas ──────────────────────────────────────────────────────────────────
+const schemas = Object.entries(spec.components?.schemas || {});
+for (const [name, schema] of schemas) {
+  const props = Object.entries(schema.properties || {}).map(([k, v]) => {
+    const req = (schema.required || []).includes(k) ? ", required" : "";
+    return `- \`${k}\` (${v.type || v.$ref?.split("/").pop() || "any"}${req})${v.description ? `: ${oneLine(v.description)}` : ""}`;
+  });
+  const body = [
+    `# ${name}`,
+    "",
+    oneLine(schema.description) || `Schema \`${name}\`.`,
+    "",
+    props.length ? `## Properties\n\n${props.join("\n")}` : "",
+    `\n[All schemas](index.md) · [bundle root](../index.md)`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  write(
+    `schemas/${slug(name)}.md`,
+    `${fm({ type: "Schema", title: name, description: summarize(schema.description) })}\n${body}\n`,
+  );
+}
+
+// ── directory index files (no frontmatter, per spec §6) ───────────────────────
+write(
+  "operations/index.md",
+  `# Operations\n\n${operations
+    .map((o) => `- [${o.op.summary || o.id}](${slug(o.id)}.md), \`${o.method} ${o.path}\``)
+    .join("\n")}\n`,
+);
+if (schemas.length) {
+  write(
+    "schemas/index.md",
+    `# Schemas\n\n${schemas.map(([n]) => `- [${n}](${slug(n)}.md)`).join("\n")}\n`,
+  );
+}
+
+// ── bundle root (the only index.md allowed frontmatter: okf_version only) ──────
+write(
+  "index.md",
+  `---\nokf_version: ${scalar(OKF_VERSION)}\n---\n\n# ${info.title || "API Knowledge"}\n\n${oneLine(info.description)?.split(". ")[0] || ""}.\n\n${base ? `API base: \`${base}\`. ` : ""}Generated from an OpenAPI ${spec.openapi || "3.x"} spec.\n\n- [Operations](operations/index.md) (${operations.length})\n${schemas.length ? `- [Schemas](schemas/index.md) (${schemas.length})\n` : ""}- [Change log](log.md)\n`,
+);
+
+// ── log (no frontmatter, per spec §7) ──────────────────────────────────────────
+write(
+  "log.md",
+  `# Change Log\n\n## ${info.version || "initial"}\n\n- Generated from OpenAPI ${spec.openapi || "3.x"} (\`${info.title || ""}\` v${info.version || "?"}) by openapi-to-okf.\n- ${operations.length} operations, ${schemas.length} schemas.\n`,
+);
+
+console.log(`Wrote ${fileCount} OKF files to ${out} (${operations.length} operations, ${schemas.length} schemas).`);

--- a/toolbox/openapi-to-okf/package.json
+++ b/toolbox/openapi-to-okf/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "okf-openapi-to-okf",
+  "version": "0.1.0",
+  "description": "Convert any OpenAPI 3.x description into a conformant OKF v0.1 bundle. Dependency-free Node, no build step.",
+  "type": "module",
+  "bin": {
+    "openapi-to-okf": "./openapi-to-okf.mjs"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "okf",
+    "open-knowledge-format",
+    "openapi",
+    "knowledge-catalog",
+    "producer"
+  ]
+}

--- a/toolbox/openapi-to-okf/test/fixture-openapi.json
+++ b/toolbox/openapi-to-okf/test/fixture-openapi.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Widget API",
+    "version": "1.0.0",
+    "description": "Tiny fixture API used by the openapi-to-okf conformance test."
+  },
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "listWidgets",
+        "summary": "List widgets",
+        "description": "Return every widget in the catalog.",
+        "responses": {
+          "200": {
+            "description": "A list of widgets.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Widget" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Widget": {
+        "type": "object",
+        "description": "A single widget.",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/toolbox/openapi-to-okf/test/openapi-to-okf.test.mjs
+++ b/toolbox/openapi-to-okf/test/openapi-to-okf.test.mjs
@@ -1,0 +1,51 @@
+// Conformance test for the openapi-to-okf producer: run it against a fixture
+// OpenAPI 3.x document and assert the emitted bundle obeys OKF v0.1 — every
+// concept has a non-empty `type`, links are plain relative markdown (no
+// [[wiki]] syntax), and `okf_version` appears only in the bundle-root index.md.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const producer = join(here, "..", "openapi-to-okf.mjs");
+const fixture = join(here, "fixture-openapi.json");
+
+function walkMd(dir) {
+  const out = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkMd(p));
+    else if (e.name.endsWith(".md")) out.push(p);
+  }
+  return out;
+}
+
+test("produces a conformant OKF v0.1 bundle from an OpenAPI 3.x spec", () => {
+  const out = mkdtempSync(join(tmpdir(), "okf-openapi-"));
+  execFileSync("node", [producer, fixture, out, "--base", "https://api.example.com"]);
+
+  const files = walkMd(out);
+  assert.ok(files.length >= 2, "emits multiple markdown files");
+
+  const root = join(out, "index.md");
+  assert.match(readFileSync(root, "utf8"), /okf_version:\s*["']?0\.1/, "root index.md declares okf_version");
+
+  let okfVersionCount = 0;
+  for (const f of files) {
+    const base = basename(f);
+    const body = readFileSync(f, "utf8");
+    assert.ok(!body.includes("[["), `${base}: must not use [[wiki]] links`);
+    if (/^okf_version:/m.test(body)) okfVersionCount++;
+
+    if (base === "index.md" || base === "log.md") continue; // reserved files
+    const fm = body.match(/^---\n([\s\S]*?)\n---/);
+    assert.ok(fm, `${base}: concept must have YAML frontmatter`);
+    assert.match(fm[1], /^type:\s*\S/m, `${base}: concept must declare a non-empty type`);
+  }
+  assert.equal(okfVersionCount, 1, "okf_version appears only once (bundle-root index.md)");
+});


### PR DESCRIPTION
Implements the producer proposed in #56.

A dependency-free Node producer (`toolbox/openapi-to-okf/`) that converts any OpenAPI 3.x description into a conformant OKF v0.1 bundle:

- one concept per operation (`type: API Operation`) and per `components.schemas` entry (`type: Schema`), cross-linked with relative markdown links
- reserved `index.md` / `log.md` carry no frontmatter; `okf_version` appears only in the bundle-root `index.md`
- no build step, no dependencies

OpenAPI is the most widely published API description format, so this is a low-friction on-ramp for the producer side of the ecosystem: any service that already serves an OpenAPI document can expose its API catalog as agent-readable OKF with no hand-authoring.

Included:

- `example/` — a real bundle produced from a public production API (7 operations, 13 schemas)
- `test/` — a `node:test` conformance test (`npm test`): asserts every concept declares a non-empty `type`, links are plain relative markdown (no `[[wiki]]`), and `okf_version` appears exactly once

Registered in `toolbox/README.md`. Happy to adjust naming or placement to match maintainer preferences.

Closes #56.
