### PR TITLE
chore: harden root .gitignore with Python and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 .DS_Store
+*.pyc
+*.pyo
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+*.egg-info/
+build/
+dist/
 node_modules/
 .venv/
+.env


### PR DESCRIPTION
Adds commonly needed entries missing from the root .gitignore:

- `*.pyc`, `*.pyo`, `__pycache__/` — Python bytecode
- `.pytest_cache/`, `.mypy_cache/` — test/type caches
- `*.egg-info/` — Python package metadata
- `build/`, `dist/` — build outputs
- `.env` — secrets

These were already present in subdirectory .gitignore files (okf/, agents/mdcode/, etc.) but missing at root level, causing untracked files for anyone working in new directories.