### PR TITLE
Add OKF summary policy receipt fixtures

### DIFF
--- a/okf/samples/summary-policy-consumer-receipts/README.md
+++ b/okf/samples/summary-policy-consumer-receipts/README.md
@@ -1,0 +1,18 @@
+# Summary policy consumer receipt fixtures
+
+These fixtures are tiny, deterministic examples for testing whether an OKF
+consumer preserved the load-bearing meaning declared by a concept's
+`summary_policy` frontmatter.
+
+Each case contains:
+
+- `concept.md` — an OKF concept with stable `required_assertions` and
+  `forbidden_compressions` IDs.
+- `good-summary.md` — a transformed summary that should pass.
+- `bad-summary.md` — a transformed summary that should fail.
+- `expected.yaml` — the expected consumer receipt for both summaries.
+
+The receipt does not try to decide truth in the world. It only checks whether a
+consumer preserved the source concept's declared policy during summarization.
+This keeps OKF source-side and consumer-agnostic while making summary policy
+conformance testable.

--- a/okf/samples/summary-policy-consumer-receipts/entity-substitution/bad-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/entity-substitution/bad-summary.md
@@ -1,0 +1,1 @@
+WAU is the monthly active user metric for a seven-day reporting period.

--- a/okf/samples/summary-policy-consumer-receipts/entity-substitution/concept.md
+++ b/okf/samples/summary-policy-consumer-receipts/entity-substitution/concept.md
@@ -1,0 +1,20 @@
+---
+type: Reference
+title: WAU and MAU metric boundary
+description: A small example where two related metric entities must remain distinct.
+timestamp: '2026-06-18T00:00:00+00:00'
+tags: [summary-policy, conformance]
+summary_policy:
+  required_assertions:
+    - id: wau_mau_distinct
+      text: "Weekly active users (WAU) and monthly active users (MAU) are distinct metrics."
+  forbidden_compressions:
+    - id: merge_wau_into_mau
+      text: "Do not summarize WAU as MAU or collapse the two metrics into one."
+---
+
+# Metric boundary
+
+Weekly active users (WAU) counts unique users active within a seven-day window.
+Monthly active users (MAU) counts unique users active within a calendar-month or
+rolling-month window. WAU and MAU are related but distinct metrics.

--- a/okf/samples/summary-policy-consumer-receipts/entity-substitution/expected.yaml
+++ b/okf/samples/summary-policy-consumer-receipts/entity-substitution/expected.yaml
@@ -1,0 +1,14 @@
+case_id: entity-substitution
+source: concept.md
+operation: summarize
+expect:
+  good-summary.md:
+    decision: pass
+    required_assertions_missing: []
+    forbidden_compressions_detected: []
+  bad-summary.md:
+    decision: fail
+    required_assertions_missing:
+      - assertion_id: wau_mau_distinct
+    forbidden_compressions_detected:
+      - compression_id: merge_wau_into_mau

--- a/okf/samples/summary-policy-consumer-receipts/entity-substitution/good-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/entity-substitution/good-summary.md
@@ -1,0 +1,2 @@
+WAU counts unique users in a seven-day window, while MAU counts unique users in
+a month-scale window. They are related but distinct metrics.

--- a/okf/samples/summary-policy-consumer-receipts/provenance-erasure/bad-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/provenance-erasure/bad-summary.md
@@ -1,0 +1,2 @@
+Customer setup fees are recognized over the expected service period unless a
+separate performance obligation is documented.

--- a/okf/samples/summary-policy-consumer-receipts/provenance-erasure/concept.md
+++ b/okf/samples/summary-policy-consumer-receipts/provenance-erasure/concept.md
@@ -1,0 +1,20 @@
+---
+type: Reference
+title: Revenue recognition policy source
+description: A small example where attribution to the governing source must survive.
+timestamp: '2026-06-18T00:00:00+00:00'
+tags: [summary-policy, conformance]
+summary_policy:
+  required_assertions:
+    - id: source_is_finance_policy
+      text: "The revenue recognition rule is sourced from the Finance Policy Manual."
+  forbidden_compressions:
+    - id: unattributed_rule
+      text: "Do not present the revenue recognition rule without its governing source."
+---
+
+# Policy note
+
+The revenue recognition rule comes from the **Finance Policy Manual**, section
+4.2. Customer setup fees are recognized over the expected service period unless
+a separate performance obligation is documented.

--- a/okf/samples/summary-policy-consumer-receipts/provenance-erasure/expected.yaml
+++ b/okf/samples/summary-policy-consumer-receipts/provenance-erasure/expected.yaml
@@ -1,0 +1,14 @@
+case_id: provenance-erasure
+source: concept.md
+operation: summarize
+expect:
+  good-summary.md:
+    decision: pass
+    required_assertions_missing: []
+    forbidden_compressions_detected: []
+  bad-summary.md:
+    decision: fail
+    required_assertions_missing:
+      - assertion_id: source_is_finance_policy
+    forbidden_compressions_detected:
+      - compression_id: unattributed_rule

--- a/okf/samples/summary-policy-consumer-receipts/provenance-erasure/good-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/provenance-erasure/good-summary.md
@@ -1,0 +1,3 @@
+According to the Finance Policy Manual section 4.2, customer setup fees are
+recognized over the expected service period unless a separate performance
+obligation is documented.

--- a/okf/samples/summary-policy-consumer-receipts/semantic-inversion/bad-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/semantic-inversion/bad-summary.md
@@ -1,0 +1,1 @@
+The review found that the treatment increased serious adverse events.

--- a/okf/samples/summary-policy-consumer-receipts/semantic-inversion/concept.md
+++ b/okf/samples/summary-policy-consumer-receipts/semantic-inversion/concept.md
@@ -1,0 +1,20 @@
+---
+type: Reference
+title: Trial exclusion result
+description: A small example where a negated result must survive summarization.
+timestamp: '2026-06-18T00:00:00+00:00'
+tags: [summary-policy, conformance]
+summary_policy:
+  required_assertions:
+    - id: no_evidence_of_harm
+      text: "The review found no evidence that the treatment increased serious adverse events."
+  forbidden_compressions:
+    - id: harm_inversion
+      text: "Do not summarize the finding as evidence that the treatment increased serious adverse events."
+---
+
+# Finding
+
+The review found **no evidence** that the treatment increased serious adverse
+events in the observed population. This is not the same as proving the treatment
+reduces serious adverse events.

--- a/okf/samples/summary-policy-consumer-receipts/semantic-inversion/expected.yaml
+++ b/okf/samples/summary-policy-consumer-receipts/semantic-inversion/expected.yaml
@@ -1,0 +1,14 @@
+case_id: semantic-inversion
+source: concept.md
+operation: summarize
+expect:
+  good-summary.md:
+    decision: pass
+    required_assertions_missing: []
+    forbidden_compressions_detected: []
+  bad-summary.md:
+    decision: fail
+    required_assertions_missing:
+      - assertion_id: no_evidence_of_harm
+    forbidden_compressions_detected:
+      - compression_id: harm_inversion

--- a/okf/samples/summary-policy-consumer-receipts/semantic-inversion/good-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/semantic-inversion/good-summary.md
@@ -1,0 +1,2 @@
+The review found no evidence that the treatment increased serious adverse
+events, while also avoiding the stronger claim that it reduces those events.


### PR DESCRIPTION
## Summary
- add tiny OKF summary-policy consumer-receipt fixtures for semantic inversion, entity substitution, and provenance erasure
- each case has `concept.md`, `good-summary.md`, `bad-summary.md`, and `expected.yaml`
- keep the fixture contract consumer-agnostic: it checks preservation against declared `summary_policy`, not truth in the world

## Context
This follows the discussion in #53 about pairing source-side `summary_policy` with consumer-side receipts/conformance fixtures.

## Validation
- parsed all `expected.yaml` files with Python/YAML
- checked each `concept.md` has OKF frontmatter and `summary_policy`
- `git diff --check`

Note: I could not run the full OKF pytest suite in this environment because `pytest` is not installed.