### PR TITLE
Add ConversationLearner agent under agents/

### DIFF
--- a/agents/conversation_learner/.gitignore
+++ b/agents/conversation_learner/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+.adk/
+__pycache__/
+*.pyc
+.env
+proposal.json

--- a/agents/conversation_learner/README.md
+++ b/agents/conversation_learner/README.md
@@ -1,0 +1,125 @@
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+# ConversationLearner
+
+**ConversationLearner** is an enterprise Agentic AI assistant built on the Google Agent Development Kit (ADK). It acts as an LLM-as-a-judge over conversational trajectories to detect friction and hallucination, generating metadata enrichment proposals.
+
+## Architecture & Integration
+- **Trajectory Analysis**: Uses Cloud Logging to fetch recent conversational trajectories.
+- **LLM-as-a-judge**: Evaluates conversational turns to extract detection signals, gaps, and generate `ContextEnrichmentProposal` records.
+
+## Running Locally
+
+```bash
+export GOOGLE_CLOUD_PROJECT="your-project-id"
+export GOOGLE_CLOUD_LOCATION="us-central1"
+export GOOGLE_GENAI_USE_VERTEXAI=True
+
+# From the conversation_learner directory
+adk run .
+```
+
+Example prompt:
+```
+generate learnings for projects/<project-number>/locations/us-central1/reasoningEngines/<engine-id> in the past 7 days
+```
+
+The agent will print the number of log entries retrieved, the unique conversation IDs found, and save enrichment proposals to `proposal.json`.
+
+> **Note on Observability**: The agent retrieves conversations from Cloud Logging using OpenTelemetry trace logs (`gen_ai.client.inference.operation.details`). These logs are only emitted for sessions that ran while **Observability was enabled** on the Reasoning Engine. Sessions started before Observability was activated will not appear.
+
+## Running Tests
+
+```bash
+export GOOGLE_CLOUD_PROJECT=test-project
+
+# From the agents/ directory
+/path/to/venv/bin/python3 -m pytest conversation_learner/tests/ -v
+```
+
+## Deployment Instructions
+
+The agent can be managed and deployed on Vertex AI Agent Engine (Reasoning Engines) using the `deploy.py` script. The script uses environment variables for configuration.
+
+### Service Account & IAM Permissions
+
+When deployed on Vertex AI Reasoning Engines, the runtime container executes under a designated service account. You can specify this account by exporting the `SERVICE_ACCOUNT` environment variable before deploying.
+
+#### Required IAM Roles
+
+To successfully fetch logs and execute agent logic, the target service account must be granted the following roles:
+*   **Logging Viewer** (`roles/logging.viewer`): To read Cloud Logging entries for agent trajectories.
+*   **Service Usage Consumer** (`roles/serviceusage.serviceUsageConsumer`): On the billing project.
+*   **Storage Object Admin** (`roles/storage.objectAdmin`): On the Cloud Storage staging bucket.
+
+### Observability & Telemetry
+
+The runtime container is automatically instrumented with OpenTelemetry tracing and Cloud Logging correlation.
+
+### Prerequisites
+
+Create and activate a Python virtual environment, then install required dependencies:
+
+```bash
+# Create virtual environment
+python3 -m venv .venv
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+### 1. Creating a New Deployment
+
+To deploy a new instance of ConversationLearner:
+
+```bash
+export GOOGLE_CLOUD_PROJECT="your-project-id"
+export GOOGLE_CLOUD_LOCATION="us-central1"
+export STAGING_BUCKET="gs://your-staging-bucket"  # Optional; defaults to gs://{project_id}-adk-staging
+export DEPLOY_ACTION="create"
+
+python3 deploy.py
+```
+
+### 2. Updating an Existing Deployment
+
+To update an existing agent engine runtime (e.g. after updating instructions or authentication logic):
+
+```bash
+export GOOGLE_CLOUD_PROJECT="your-project-id"
+export GOOGLE_CLOUD_LOCATION="us-central1"
+export DEPLOY_ACTION="update"
+export RESOURCE_ID="projects/your-project-id/locations/us-central1/reasoningEngines/your-engine-id"
+
+python3 deploy.py
+```
+
+### 3. Deleting a Deployment
+
+To remove an agent engine resource:
+
+```bash
+export GOOGLE_CLOUD_PROJECT="your-project-id"
+export GOOGLE_CLOUD_LOCATION="us-central1"
+export DEPLOY_ACTION="delete"
+export RESOURCE_ID="projects/your-project-id/locations/us-central1/reasoningEngines/your-engine-id"
+
+python3 deploy.py
+```

--- a/agents/conversation_learner/SKILL.md
+++ b/agents/conversation_learner/SKILL.md
@@ -1,0 +1,65 @@
+<!--
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+---
+name: ConversationLearner
+description: Acts as an LLM-as-a-judge over conversational trajectories to detect friction and hallucination.
+---
+
+# ConversationLearner Instructions
+
+[SYSTEM INSTRUCTION]
+You are ConversationLearner for an Enterprise Semantic Layer. Your objective is to act as an LLM-as-a-judge over conversational trajectories (User Prompts, Agent Reasoning, Tool Uses, BigQuery Executions, Retrieved Metadata Context, and User Feedback).
+
+When given a conversation ID or a Cloud Logging URL, you MUST first call the `get_agent_trajectories` tool to retrieve the trajectory. If given a URL, extract the `gen_ai.conversation.id` parameter value (e.g. `1912219564456804352`) and use it as the `conversation_id`.
+When given a Reasoning Engine ID and a time filter (e.g. past 2 days, or a specific arbitrary time window), call the `get_agent_trajectories` tool with `reasoning_engine_id` and either `days_ago` or `start_time` and `end_time` (using ISO 8601 strings).
+
+Analyze the provided trajectory (or multiple trajectories if grouped by conversation) to identify metadata gaps in the Knowledge Catalog. If a gap or validation is found in a conversation, you must classify BOTH the `detection_signal` (how you know based on behavior) AND the `gap_type` (what metadata actually needs fixing). Generate a proposal for each gap found across all conversations.
+
+### 1. CLASSIFY THE DETECTION_SIGNAL (The Evidence)
+Scan the trajectory for one of the following behavioral patterns:
+* DIRECT_USER_CORRECTION: User directly rejects the agent, provides a correction, or gives explicit negative feedback.
+* IMPLICIT_USER_FRICTION: User abruptly rephrases, narrows scope, or alters their wording. Includes the user manually bypassing the agent's chosen table.
+* AGENT_SELF_REFLECTION: Agent hits a SQL/Tool execution error and successfully self-corrects in its internal monologue.
+* USER_SATISFACTION: Successful execution with no negative user follow-ups or explicit positive feedback.
+
+### 2. CLASSIFY THE GAP_TYPE (The Root Cause)
+Based on the signal, classify what is missing in the Knowledge Catalog context:
+* LEXICAL_SYNONYM_GAP: Misunderstood jargon, synonym, or internal terminology. Action -> UPDATE_OVERVIEW_ASPECT (add the disambiguating description to the corresponding overview aspect).
+* BUSINESS_LOGIC_GAP: Missing metric formula, calculation, or declarative business rule. Action -> UPDATE_OVERVIEW_ASPECT (add the disambiguating description to the corresponding overview aspect).
+* STRUCTURAL_ROUTING_GAP: Agent chose the wrong table/join due to ambiguous descriptions or missing relationships. Action -> UPDATE_OVERVIEW_ASPECT (add the disambiguating description to the corresponding overview aspect).
+* UNCATALOGED_ASSET_DISCOVERY: Successful query utilized an uncataloged table/view. Action -> FLAG_FOR_CATALOGING.
+* VALIDATED_CONTEXT: Execution was flawless on the first try. Context is completely correct. Action -> BOOST_CONFIDENCE.
+
+### 3. REDACTION RULES
+Before writing any field in a proposal, redact sensitive data:
+* Replace SSNs (`XXX-XX-XXXX`), credit card numbers, phone numbers, and email addresses with `[REDACTED]`.
+* Replace passwords, API keys, tokens, or any credential values with `[REDACTED]`.
+* Keep enough context so the enrichment instruction remains actionable, but never include the raw sensitive value.
+
+### 4. EXTRACTION RULES
+* Map the required Enrichment Action precisely based on the Gap Type.
+* Extract the exact `trajectory_quote` to serve as auditable evidence for human Data Stewards.
+* Populate `enrichment_agent_instruction` with a direct, imperative natural language prompt containing ONLY what the Enrichment Agent needs to execute the fix (target asset path, proposed fix action, and the exact value to apply). DO NOT include the backstory, reasoning, or evidence of why the change is needed.
+* Always attempt to extract the `user_query_intent` and `golden_sql` to serve as a future Regression Eval Candidate.
+* If NO learning signal or gap is found in the trajectory, return an empty array for `proposals`.
+
+CRITICAL: 
+1. Only process the EXACT conversation ID provided by the user. Do NOT hallucinate, guess, or retry with other conversation IDs if the first one fails or returns no messages.
+2. Put ALL of your proposals into a SINGLE list and make EXACTLY ONE call to the save_trajectory_analysis_result tool.
+3. After calling save_trajectory_analysis_result, immediately stop and return your final response to the user. Do not call any more tools.
+4. Your final response MUST begin by stating the total number of log entries retrieved, the number of unique conversations, and listing all conversation IDs found.
+5. NEVER include raw sensitive data (SSNs, card numbers, emails, phone numbers, credentials) in any proposal field. Redact them as described in section 3.

--- a/agents/conversation_learner/__init__.py
+++ b/agents/conversation_learner/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ConversationLearner agent package."""

--- a/agents/conversation_learner/agent.py
+++ b/agents/conversation_learner/agent.py
@@ -1,0 +1,393 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ConversationLearner agent for analyzing conversational trajectories."""
+
+import json
+import os
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timedelta, timezone
+
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.models import google_llm
+from google.api_core.exceptions import GoogleAPICallError, RetryError
+from google.cloud import logging as cloud_logging
+from pydantic import BaseModel, Field
+
+# Add current directory to sys.path to ensure utils can be imported regardless of execution context
+import sys
+if os.path.dirname(os.path.abspath(__file__)) not in sys.path:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from utils import get_consumer_project
+
+consumer_project = get_consumer_project()
+
+
+def _parse_reasoning_engine_labels(labels: Dict[str, str], output: List[str]) -> bool:
+    """Parses Reasoning Engine labels into the output list."""
+    if "gen_ai.input.messages" not in labels and "gen_ai.output.messages" not in labels:
+        return False
+
+    inp_str = labels.get("gen_ai.input.messages", "[]")
+    out_str = labels.get("gen_ai.output.messages", "[]")
+
+    messages = []
+    try:
+        messages.extend(json.loads(inp_str))
+        messages.extend(json.loads(out_str))
+
+        chunks = []
+        for msg in messages:
+            role = msg.get("role", "UNKNOWN")
+            content_parts = []
+            for part in msg.get("parts", []):
+                if "content" in part:
+                    content_parts.append(part["content"] + "\n")
+                elif "arguments" in part:
+                    content_parts.append(f"Tool Call: {part.get('name', '')} {json.dumps(part['arguments'])}\n")
+                elif "text" in part:
+                    content_parts.append(part["text"] + "\n")
+            content = "".join(content_parts)
+            chunks.append(f"[{role.upper()}]: {content.strip()}")
+
+        for chunk in chunks:
+            output.append(chunk)
+            output.append("-" * 20)
+    except json.JSONDecodeError as e:
+        output.append(f"Error parsing JSON in ReasoningEngine message labels: {e}")
+    except Exception as e:
+        import traceback
+        output.append(f"Error parsing ReasoningEngine message labels: {e}\n{traceback.format_exc()}")
+
+    return True
+
+
+def _parse_generic_payload(payload: Any, output: List[str]) -> None:
+    """Fallback payload parser if Reasoning Engine labels are absent."""
+    role = "UNKNOWN"
+    content_text = ""
+
+    if isinstance(payload, dict):
+        role = payload.get("role", role)
+        if "message" in payload and isinstance(payload["message"], dict):
+            msg_obj = payload["message"]
+            if "user_message" in msg_obj:
+                role = "USER"
+                content_text = msg_obj["user_message"].get("text", "")
+            elif "system_message" in msg_obj:
+                role = "SYSTEM"
+                content_text = msg_obj["system_message"].get("text", "")
+        else:
+            content_text = payload.get("text") or payload.get("message") or str(payload)
+    elif isinstance(payload, str):
+        content_text = payload
+    else:
+        content_text = str(payload)
+
+    output.append(f"[{role}]: {content_text}")
+    output.append("-" * 20)
+
+
+def get_agent_trajectories(
+    conversation_id: Optional[str] = None,
+    reasoning_engine_id: Optional[str] = None,
+    days_ago: Optional[int] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    project_id: str = consumer_project
+) -> str:
+    """
+    Retrieves the conversation trajectories from Google Cloud Logging.
+
+    Args:
+        conversation_id: The ID of the conversation to retrieve.
+        reasoning_engine_id: The ID of the Reasoning Engine to retrieve logs for.
+        days_ago: Number of days to look back when filtering by reasoning_engine_id.
+        start_time: Start time of the time window to filter logs (ISO 8601 string).
+        end_time: End time of the time window to filter logs (ISO 8601 string).
+        project_id: Google Cloud Project ID.
+
+    Returns:
+        A string representation of the agent's conversational trajectories.
+    """
+    output = []
+
+    try:
+        client = cloud_logging.Client(project=project_id)
+        
+        if conversation_id:
+            output.append(f"--- Fetching Conversation: {conversation_id} ---")
+            filter_str = (
+                f'resource.type="aiplatform.googleapis.com/ReasoningEngine" '
+                f'AND labels."gen_ai.conversation.id"="{conversation_id}" '
+                f'AND timestamp>="2023-01-01T00:00:00Z"'
+            )
+            entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING, max_results=10))
+
+            output.append("--- Chat History ---")
+
+            if not entries:
+                output.append("No messages found in this conversation via Cloud Logging.")
+                return "\n".join(output)
+
+            last_entry = entries[0]
+            repr_dict = last_entry.to_api_repr()
+            labels = repr_dict.get("labels", {})
+
+            if not _parse_reasoning_engine_labels(labels, output):
+                _parse_generic_payload(last_entry.payload, output)
+
+        elif reasoning_engine_id and (days_ago is not None or start_time is not None):
+            if start_time:
+                start_time_str = start_time
+                time_range_msg = f"from {start_time_str}"
+                if end_time:
+                    time_range_msg += f" to {end_time}"
+            else:
+                start_time_dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+                start_time_str = start_time_dt.isoformat()
+                time_range_msg = f"for past {days_ago} days"
+
+            output.append(f"--- Fetching Reasoning Engine: {reasoning_engine_id} {time_range_msg} ---")
+            
+            re_id = reasoning_engine_id.split("/")[-1]
+            filter_str = (
+                f'resource.type="aiplatform.googleapis.com/ReasoningEngine" '
+                f'AND resource.labels.reasoning_engine_id="{re_id}" '
+                f'AND timestamp>="{start_time_str}"'
+            )
+            if end_time:
+                filter_str += f' AND timestamp<="{end_time}"'
+            
+            entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING))
+            
+            if not entries:
+                output.append("No messages found for this Reasoning Engine in the specified time range.")
+                return "\n".join(output)
+                
+            conv_entries = {}
+            for entry in entries:
+                repr_dict = entry.to_api_repr()
+                labels = repr_dict.get("labels", {})
+                c_id = labels.get("gen_ai.conversation.id")
+                if c_id and c_id not in conv_entries:
+                    conv_entries[c_id] = entry
+
+            output.append(f"Total log entries retrieved: {len(entries)}. Unique conversations: {len(conv_entries)}.")
+            output.append(f"Conversation IDs: {', '.join(conv_entries.keys())}")
+
+            for c_id, entry in conv_entries.items():
+                output.append(f"\n--- Conversation: {c_id} ---")
+                repr_dict = entry.to_api_repr()
+                labels = repr_dict.get("labels", {})
+                if not _parse_reasoning_engine_labels(labels, output):
+                    _parse_generic_payload(entry.payload, output)
+                    
+        else:
+            output.append("Either conversation_id or (reasoning_engine_id and (days_ago or start_time)) must be provided.")
+
+    except (GoogleAPICallError, RetryError) as e:
+        output.append(f"API Error: {e}")
+    except Exception as e:
+        import traceback
+        output.append(f"An unexpected error occurred: {e}\n{traceback.format_exc()}")
+
+    return "\n".join(output)
+
+
+# ==============================================================================
+# DATA MODELS FOR CONVERSATIONLEARNER
+# ==============================================================================
+
+class DetectionSignal(str, Enum):
+    DIRECT_USER_CORRECTION = "DIRECT_USER_CORRECTION"
+    IMPLICIT_USER_FRICTION = "IMPLICIT_USER_FRICTION"
+    AGENT_SELF_REFLECTION = "AGENT_SELF_REFLECTION"
+    USER_SATISFACTION = "USER_SATISFACTION"
+
+
+class GapType(str, Enum):
+    LEXICAL_SYNONYM_GAP = "LEXICAL_SYNONYM_GAP"
+    BUSINESS_LOGIC_GAP = "BUSINESS_LOGIC_GAP"
+    STRUCTURAL_ROUTING_GAP = "STRUCTURAL_ROUTING_GAP"
+    UNCATALOGED_ASSET_DISCOVERY = "UNCATALOGED_ASSET_DISCOVERY"
+    VALIDATED_CONTEXT = "VALIDATED_CONTEXT"
+
+
+class EnrichmentAction(str, Enum):
+    UPDATE_OVERVIEW_ASPECT = "UPDATE_OVERVIEW_ASPECT"
+    FLAG_FOR_CATALOGING = "FLAG_FOR_CATALOGING"
+    BOOST_CONFIDENCE = "BOOST_CONFIDENCE"
+
+
+class AssetType(str, Enum):
+    TABLE = "TABLE"
+    COLUMN = "COLUMN"
+    GLOSSARY_TERM = "GLOSSARY_TERM"
+    UNCATALOGED_ASSET = "UNCATALOGED_ASSET"
+
+
+class Classification(BaseModel):
+    detection_signal: DetectionSignal = Field(description="The behavioral evidence found in the trajectory.")
+    gap_type: GapType = Field(description="The actual metadata missing from the Knowledge Catalog.")
+
+
+class TargetAsset(BaseModel):
+    type: AssetType
+    name: str = Field(description="The specific Knowledge Catalog asset name, e.g., 'dataset.table_a.gross_margin'")
+
+
+class ProposedEnrichment(BaseModel):
+    action: EnrichmentAction = Field(description="The API action the Metadata Enrichment Agent should take.")
+    value: str = Field(description="The precise synonym string, SQL formula, or text description to apply.")
+
+
+class Evidence(BaseModel):
+    reasoning: str = Field(description="Explain exactly how the detection_signal proves the gap_type.")
+    trajectory_quote: str = Field(description="Quote the exact user phrase, SQL diff, or tool error that validates this learning.")
+
+
+class EvalCandidate(BaseModel):
+    is_valid_candidate: bool = Field(description="True if the trajectory ended with a successful query execution.")
+    user_query_intent: Optional[str] = Field(None, description="The final, clean natural language user question.")
+    golden_sql: Optional[str] = Field(None, description="The correct, successful SQL that satisfied the intent.")
+
+
+class ContextEnrichmentProposal(BaseModel):
+    classification: Classification
+    target_asset: TargetAsset
+    current_context_flaw: Optional[str] = Field(None, description="What the agent incorrectly assumed or what is missing. Null if perfectly valid.")
+    proposed_enrichment: ProposedEnrichment
+    evidence: Evidence
+    confidence_grade: float = Field(ge=0.0, le=1.0, description="Float between 0.0 and 1.0 based on the clarity of the signal.")
+    eval_candidate: EvalCandidate
+    enrichment_agent_instruction: str = Field(description="A clear, actionable natural language instruction for the Metadata Enrichment Agent containing all details needed to perform the enrichment (e.g. target asset, action, and new value). DO NOT include the background reasoning, user story, or evidence.")
+
+
+class TrajectoryAnalysisResult(BaseModel):
+    proposals: List[ContextEnrichmentProposal] = Field(
+        description="A list of proposed enrichments found in the trajectory. Return an empty list [] if no gap or signal is detected."
+    )
+
+def _redact_sensitive(text: str) -> str:
+    """Redacts common PII/sensitive patterns from a string."""
+    import re
+    patterns = [
+        (r'\b\d{3}-\d{2}-\d{4}\b', '[SSN REDACTED]'),
+        (r'\b(?:\d[ -]?){13,16}\b', '[CARD REDACTED]'),
+        (r'[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}', '[EMAIL REDACTED]'),
+        (r'\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b', '[PHONE REDACTED]'),
+        (r'\b(?:password|passwd|secret|api[_-]?key|token|bearer|credential)[\s:=]+\S+', '[CREDENTIAL REDACTED]', re.IGNORECASE),
+    ]
+    for pattern, replacement, *flags in patterns:
+        flag = flags[0] if flags else 0
+        text = re.sub(pattern, replacement, text, flags=flag)
+    return text
+
+
+def _redact_obj(obj):
+    """Recursively redacts sensitive values in a parsed JSON object."""
+    if isinstance(obj, str):
+        return _redact_sensitive(obj)
+    if isinstance(obj, dict):
+        return {k: _redact_obj(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_redact_obj(v) for v in obj]
+    return obj
+
+
+def save_trajectory_analysis_result(result_json: str) -> str:
+    """
+    Saves the final trajectory analysis result to a local file.
+    Must be called to conclude the analysis.
+
+    Args:
+        result_json: JSON string with the following structure:
+            {
+              "proposals": [
+                {
+                  "classification": {
+                    "detection_signal": "<DIRECT_USER_CORRECTION|IMPLICIT_USER_FRICTION|AGENT_SELF_REFLECTION|USER_SATISFACTION>",
+                    "gap_type": "<LEXICAL_SYNONYM_GAP|BUSINESS_LOGIC_GAP|STRUCTURAL_ROUTING_GAP|UNCATALOGED_ASSET_DISCOVERY|VALIDATED_CONTEXT>"
+                  },
+                  "target_asset": {
+                    "type": "<TABLE|COLUMN|GLOSSARY_TERM|UNCATALOGED_ASSET>",
+                    "name": "<asset path, e.g. dataset.table.column>"
+                  },
+                  "current_context_flaw": "<string or null>",
+                  "proposed_enrichment": {
+                    "action": "<UPDATE_OVERVIEW_ASPECT|FLAG_FOR_CATALOGING|BOOST_CONFIDENCE>",
+                    "value": "<the exact synonym, formula, or description to apply>"
+                  },
+                  "evidence": {
+                    "reasoning": "<how the detection_signal proves the gap_type>",
+                    "trajectory_quote": "<exact quote from the trajectory>"
+                  },
+                  "confidence_grade": <0.0 to 1.0>,
+                  "eval_candidate": {
+                    "is_valid_candidate": <true|false>,
+                    "user_query_intent": "<natural language question or null>",
+                    "golden_sql": "<successful SQL or null>"
+                  },
+                  "enrichment_agent_instruction": "<direct imperative instruction for the Enrichment Agent>"
+                }
+              ]
+            }
+    """
+    import re
+    filename = "proposal.json"
+    try:
+        parsed = json.loads(result_json)
+    except json.JSONDecodeError:
+        # Fix invalid backslash escapes that LLMs sometimes produce inside SQL strings
+        fixed = re.sub(r'\\(?!["\\/bfnrtu])', r'\\\\', result_json)
+        parsed = json.loads(fixed)
+    if isinstance(parsed, list):
+        parsed = {"proposals": parsed}
+    parsed = _redact_obj(parsed)
+    with open(filename, "w") as f:
+        json.dump(parsed, f, indent=2)
+    return f"Successfully saved proposal to {filename}"
+
+# Path to the skill file relative to the agent.py location
+SKILL_FILE_PATH = os.path.join(os.path.dirname(__file__), "SKILL.md")
+
+
+def load_instruction() -> str:
+    """Loads the agent instruction from the SKILL.md file."""
+    try:
+        with open(SKILL_FILE_PATH, "r") as f:
+            content = f.read()
+    except FileNotFoundError:
+        content = (
+            "You are ConversationLearner. Analyze conversational trajectories to identify metadata gaps."
+        )
+    return content
+
+
+GEMINI_MODEL = f"projects/{consumer_project}/locations/global/publishers/google/models/gemini-2.5-pro"
+
+conversation_learner = LlmAgent(
+    model=google_llm.Gemini(model=GEMINI_MODEL),
+    name='conversation_learner',
+    description='Acts as an LLM-as-a-judge over conversational trajectories to detect friction and hallucination.',
+    instruction=load_instruction(),
+    tools=[get_agent_trajectories, save_trajectory_analysis_result]
+)
+
+# ADK requires a variable named `root_agent` to serve as the entry point
+root_agent = conversation_learner
+
+

--- a/agents/conversation_learner/deploy.py
+++ b/agents/conversation_learner/deploy.py
@@ -1,0 +1,310 @@
+"""Deployment script for ConversationLearner using environment variables."""
+
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+from google.api_core import exceptions as google_exceptions
+from google.cloud import storage
+import vertexai
+from vertexai import agent_engines
+from vertexai.preview.reasoning_engines import AdkApp
+
+# Ensure current directory is in sys.path so agent can be imported
+agent_dir = os.path.dirname(os.path.abspath(__file__))
+if agent_dir not in sys.path:
+    sys.path.insert(0, agent_dir)
+
+from agent import root_agent
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def setup_staging_bucket(
+    project_id: str, location: str, bucket_name: str
+) -> str:
+    """Checks if the staging bucket exists and creates it if not."""
+    storage_client = storage.Client(project=project_id)
+    try:
+        bucket = storage_client.lookup_bucket(bucket_name)
+        if bucket:
+            logger.info("Staging bucket gs://%s already exists.", bucket_name)
+        else:
+            logger.info(
+                "Staging bucket gs://%s not found. Creating...", bucket_name
+            )
+            new_bucket = storage_client.create_bucket(
+                bucket_name, project=project_id, location=location
+            )
+            logger.info(
+                "Successfully created staging bucket gs://%s in %s.",
+                new_bucket.name,
+                location,
+            )
+            # Enable uniform bucket-level access
+            new_bucket.iam_configuration.uniform_bucket_level_access_enabled = True
+            new_bucket.patch()
+            logger.info(
+                "Enabled uniform bucket-level access for gs://%s.",
+                new_bucket.name,
+            )
+    except google_exceptions.Forbidden as e:
+        logger.error(
+            "Permission denied error for bucket gs://%s. "
+            "Ensure the service account has 'Storage Admin' role. Error: %s",
+            bucket_name,
+            e,
+        )
+        raise
+    except google_exceptions.Conflict as e:
+        logger.warning(
+            "Bucket gs://%s likely already exists. Error: %s",
+            bucket_name,
+            e,
+        )
+    except google_exceptions.ClientError as e:
+        logger.error(
+            "Failed to create or access bucket gs://%s. Error: %s",
+            bucket_name,
+            e,
+        )
+        raise
+
+    return f"gs://{bucket_name}"
+
+
+def create(service_account: str | None = None) -> None:
+    """Creates and deploys ConversationLearner via AdkApp configuration."""
+    agent_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(agent_dir)
+    logger.info(
+        "Deploying ConversationLearner via AdkApp on Vertex AI Agent Engine..."
+    )
+
+    # Read requirements from requirements.txt
+    req_path = os.path.join(agent_dir, "requirements.txt")
+    requirements = []
+    if os.path.exists(req_path):
+        with open(req_path, "r") as f:
+            requirements = [
+                line.strip()
+                for line in f
+                if line.strip() and not line.startswith("#")
+            ]
+    if not requirements:
+        requirements = [
+            "google-adk",
+            "google-cloud-logging",
+            "google-cloud-bigquery",
+            "pydantic",
+            "pydantic-settings",
+            "google-api-core",
+            "google-cloud-aiplatform",
+            "python-dotenv",
+        ]
+
+    logger.info("Initializing AdkApp with root_agent...")
+    app = AdkApp(agent=root_agent, enable_tracing=True)
+
+    observability_env = {
+        "OTEL_TRACES_EXPORTER": os.getenv("OTEL_TRACES_EXPORTER", "gcp_cloud_trace"),
+        "OTEL_LOGS_EXPORTER": os.getenv("OTEL_LOGS_EXPORTER", "gcp_cloud_logging"),
+        "OTEL_PYTHON_LOG_CORRELATION": os.getenv("OTEL_PYTHON_LOG_CORRELATION", "true"),
+    }
+
+    logger.info("Creating remote agent engine with service account %s...", service_account)
+    remote_agent = agent_engines.create(
+        app,
+        display_name="ConversationLearner",
+        description=(
+            "Acts as an LLM-as-a-judge over conversational trajectories to detect friction "
+            "and hallucination, generating metadata enrichment proposals."
+        ),
+        requirements=requirements,
+        extra_packages=["."],
+        env_vars=observability_env,
+        service_account=service_account,
+    )
+
+    agent_name = (
+        remote_agent.resource_name
+        if hasattr(remote_agent, "resource_name")
+        else (
+            remote_agent.api_resource.name
+            if hasattr(remote_agent, "api_resource")
+            and hasattr(remote_agent.api_resource, "name")
+            else str(remote_agent)
+        )
+    )
+    logger.info("Successfully deployed agent: %s", agent_name)
+    print(f"\nSuccessfully deployed agent: {agent_name}")
+
+
+def update(resource_id: str, service_account: str | None = None) -> None:
+    """Updates the specified agent via AdkApp configuration."""
+    agent_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(agent_dir)
+    logger.info(
+        "Updating ConversationLearner %s via AdkApp on Vertex AI Agent"
+        " Engine...",
+        resource_id,
+    )
+
+    # Read requirements from requirements.txt
+    req_path = os.path.join(agent_dir, "requirements.txt")
+    requirements = []
+    if os.path.exists(req_path):
+        with open(req_path, "r") as f:
+            requirements = [
+                line.strip()
+                for line in f
+                if line.strip() and not line.startswith("#")
+            ]
+    if not requirements:
+        requirements = [
+            "google-adk",
+            "google-cloud-logging",
+            "google-cloud-bigquery",
+            "pydantic",
+            "pydantic-settings",
+            "google-api-core",
+            "google-cloud-aiplatform",
+            "python-dotenv",
+        ]
+
+    logger.info("Initializing AdkApp with root_agent...")
+    app = AdkApp(agent=root_agent, enable_tracing=True)
+
+    observability_env = {
+        "OTEL_TRACES_EXPORTER": os.getenv("OTEL_TRACES_EXPORTER", "gcp_cloud_trace"),
+        "OTEL_LOGS_EXPORTER": os.getenv("OTEL_LOGS_EXPORTER", "gcp_cloud_logging"),
+        "OTEL_PYTHON_LOG_CORRELATION": os.getenv("OTEL_PYTHON_LOG_CORRELATION", "true"),
+    }
+
+    logger.info("Updating remote agent engine with service account %s...", service_account)
+    remote_agent = agent_engines.update(
+        resource_id,
+        agent_engine=app,
+        requirements=requirements,
+        extra_packages=["."],
+        env_vars=observability_env,
+        service_account=service_account,
+    )
+
+    agent_name = (
+        remote_agent.resource_name
+        if hasattr(remote_agent, "resource_name")
+        else (
+            remote_agent.api_resource.name
+            if hasattr(remote_agent, "api_resource")
+            and hasattr(remote_agent.api_resource, "name")
+            else str(remote_agent)
+        )
+    )
+    logger.info("Successfully updated agent: %s", agent_name)
+    print(f"\nSuccessfully updated agent: {agent_name}")
+
+
+def delete(resource_id: str) -> None:
+    """Deletes the specified agent."""
+    logger.info("Attempting to delete agent: %s", resource_id)
+    try:
+        remote_agent = agent_engines.get(resource_id)
+        # Handle delete method differences across SDK versions
+        if hasattr(remote_agent, "delete"):
+            try:
+                remote_agent.delete(force=True)
+            except TypeError:
+                remote_agent.delete()
+        logger.info("Successfully deleted remote agent: %s", resource_id)
+        print(f"\nSuccessfully deleted agent: {resource_id}")
+    except google_exceptions.NotFound:
+        logger.error("Agent with resource ID %s not found.", resource_id)
+        print(f"\nAgent not found: {resource_id}")
+    except Exception as e:
+        logger.error(
+            "An error occurred while deleting agent %s: %s", resource_id, e
+        )
+        print(f"\nError deleting agent {resource_id}: {e}")
+
+
+def main() -> None:
+    load_dotenv()
+
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("PROJECT_ID")
+    location = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+    default_bucket_name = f"{project_id}-adk-staging" if project_id else None
+    bucket_name = os.getenv("GOOGLE_CLOUD_STORAGE_BUCKET") or os.getenv(
+        "STAGING_BUCKET", default_bucket_name
+    )
+    service_account = os.getenv("SERVICE_ACCOUNT")
+
+    action = os.getenv("DEPLOY_ACTION", "create").lower()
+    resource_id = os.getenv("RESOURCE_ID")
+
+    logger.info("Using PROJECT: %s", project_id)
+    logger.info("Using LOCATION: %s", location)
+    logger.info("Using BUCKET NAME: %s", bucket_name)
+    logger.info("Using SERVICE ACCOUNT: %s", service_account)
+    logger.info("Using ACTION: %s", action)
+
+    if not project_id:
+        print("\nError: Missing required GCP Project ID.")
+        print("Set GOOGLE_CLOUD_PROJECT or PROJECT_ID environment variable.")
+        return
+    if not location:
+        print("\nError: Missing required GCP Location.")
+        return
+    if not bucket_name and action in ("create", "update"):
+        print(
+            f"\nError: Missing required GCS Bucket Name for staging when"
+            f" DEPLOY_ACTION={action}."
+        )
+        return
+    if action in ("delete", "update") and not resource_id:
+        print(
+            f"\nError: RESOURCE_ID environment variable is required when"
+            f" DEPLOY_ACTION={action}."
+        )
+        return
+
+    try:
+        staging_bucket_uri = None
+        if action in ("create", "update"):
+            staging_bucket_uri = setup_staging_bucket(
+                project_id, location, bucket_name
+            )
+
+        vertexai.init(
+            project=project_id,
+            location=location,
+            staging_bucket=staging_bucket_uri,
+        )
+
+        if action == "create":
+            create(service_account)
+        elif action == "update":
+            update(resource_id, service_account)
+        elif action == "delete":
+            delete(resource_id)
+        else:
+            print(
+                f"\nError: Unknown DEPLOY_ACTION '{action}'. Supported actions:"
+                " create, update, delete."
+            )
+
+
+
+    except google_exceptions.Forbidden as e:
+        print(f"\nPermission Error: {e}")
+    except Exception as e:
+        print(f"\nAn unexpected error occurred: {e}")
+        logger.exception("Unhandled exception in main:")
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/conversation_learner/requirements.txt
+++ b/agents/conversation_learner/requirements.txt
@@ -1,0 +1,24 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+google-adk
+google-cloud-logging
+pydantic
+google-api-core
+google-cloud-aiplatform[agent_engines]
+python-dotenv
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-gcp-trace
+pydantic-settings

--- a/agents/conversation_learner/tests/__init__.py
+++ b/agents/conversation_learner/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/agents/conversation_learner/tests/test_agent.py
+++ b/agents/conversation_learner/tests/test_agent.py
@@ -1,0 +1,504 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ConversationLearner agent."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Required before importing agent — get_consumer_project() reads this at module level.
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")
+
+# Add agents/ to sys.path so `conversation_learner` is importable as a package.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from conversation_learner.agent import (  # noqa: E402
+    _parse_generic_payload,
+    _parse_reasoning_engine_labels,
+    _redact_obj,
+    _redact_sensitive,
+    get_agent_trajectories,
+    save_trajectory_analysis_result,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_log_entry(conversation_id=None, gen_ai_labels=False, payload="log line"):
+    """Build a mock Cloud Logging entry."""
+    entry = MagicMock()
+    labels = {}
+    if conversation_id:
+        labels["gen_ai.conversation.id"] = conversation_id
+    if gen_ai_labels:
+        labels["gen_ai.input.messages"] = json.dumps(
+            [{"role": "user", "parts": [{"text": "what is the total cost?"}]}]
+        )
+        labels["gen_ai.output.messages"] = json.dumps(
+            [{"role": "assistant", "parts": [{"text": "The total cost is $500."}]}]
+        )
+    entry.to_api_repr.return_value = {"labels": labels}
+    entry.payload = payload
+    return entry
+
+
+def _minimal_proposal(**overrides):
+    """Return a minimal valid proposal dict."""
+    base = {
+        "classification": {
+            "detection_signal": "DIRECT_USER_CORRECTION",
+            "gap_type": "BUSINESS_LOGIC_GAP",
+        },
+        "target_asset": {"type": "COLUMN", "name": "proj.dataset.table.cost"},
+        "current_context_flaw": "missing unit",
+        "proposed_enrichment": {"action": "UPDATE_OVERVIEW_ASPECT", "value": "unit is USD"},
+        "evidence": {
+            "reasoning": "user corrected the agent",
+            "trajectory_quote": "the cost unit is dollars",
+        },
+        "confidence_grade": 0.9,
+        "eval_candidate": {
+            "is_valid_candidate": True,
+            "user_query_intent": "get total cost",
+            "golden_sql": "SELECT sum(cost) FROM t",
+        },
+        "enrichment_agent_instruction": "Update cost column description to say unit is USD.",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _redact_sensitive
+# ---------------------------------------------------------------------------
+
+class TestRedactSensitive(unittest.TestCase):
+
+    def test_ssn_redacted(self):
+        self.assertIn("[SSN REDACTED]", _redact_sensitive("SSN: 123-45-6789"))
+        self.assertNotIn("123-45-6789", _redact_sensitive("SSN: 123-45-6789"))
+
+    def test_email_redacted(self):
+        result = _redact_sensitive("contact user@example.com for help")
+        self.assertIn("[EMAIL REDACTED]", result)
+        self.assertNotIn("user@example.com", result)
+
+    def test_phone_us_format_redacted(self):
+        result = _redact_sensitive("call 555-123-4567 now")
+        self.assertIn("[PHONE REDACTED]", result)
+        self.assertNotIn("555-123-4567", result)
+
+    def test_credential_password_redacted(self):
+        result = _redact_sensitive("password=supersecret")
+        self.assertIn("[CREDENTIAL REDACTED]", result)
+        self.assertNotIn("supersecret", result)
+
+    def test_credential_api_key_redacted(self):
+        result = _redact_sensitive("api_key=abc123xyz")
+        self.assertIn("[CREDENTIAL REDACTED]", result)
+
+    def test_credential_token_redacted(self):
+        result = _redact_sensitive("token: eyJhbGciOiJIUzI1NiJ9")
+        self.assertIn("[CREDENTIAL REDACTED]", result)
+
+    def test_clean_text_unchanged(self):
+        text = "The cost column represents billing in thousands of dollars."
+        self.assertEqual(_redact_sensitive(text), text)
+
+    def test_multiple_patterns_in_one_string(self):
+        text = "user@test.com has SSN 123-45-6789"
+        result = _redact_sensitive(text)
+        self.assertIn("[EMAIL REDACTED]", result)
+        self.assertIn("[SSN REDACTED]", result)
+        self.assertNotIn("user@test.com", result)
+        self.assertNotIn("123-45-6789", result)
+
+    def test_empty_string_unchanged(self):
+        self.assertEqual(_redact_sensitive(""), "")
+
+
+# ---------------------------------------------------------------------------
+# _redact_obj
+# ---------------------------------------------------------------------------
+
+class TestRedactObj(unittest.TestCase):
+
+    def test_string_redacted(self):
+        self.assertIn("[SSN REDACTED]", _redact_obj("SSN: 123-45-6789"))
+
+    def test_dict_values_redacted(self):
+        obj = {"trajectory_quote": "email: user@test.com", "label": "clean text"}
+        result = _redact_obj(obj)
+        self.assertIn("[EMAIL REDACTED]", result["trajectory_quote"])
+        self.assertEqual(result["label"], "clean text")
+
+    def test_dict_keys_preserved(self):
+        obj = {"email_field": "user@test.com"}
+        result = _redact_obj(obj)
+        self.assertIn("email_field", result)
+
+    def test_list_items_redacted(self):
+        result = _redact_obj(["123-45-6789", "clean text"])
+        self.assertEqual(result[0], "[SSN REDACTED]")
+        self.assertEqual(result[1], "clean text")
+
+    def test_nested_structure_fully_redacted(self):
+        obj = {
+            "proposals": [
+                {"evidence": {"trajectory_quote": "SSN: 123-45-6789"}}
+            ]
+        }
+        result = _redact_obj(obj)
+        quote = result["proposals"][0]["evidence"]["trajectory_quote"]
+        self.assertIn("[SSN REDACTED]", quote)
+        self.assertNotIn("123-45-6789", quote)
+
+    def test_non_string_scalars_passed_through(self):
+        obj = {"confidence_grade": 0.95, "is_valid": True, "count": 3}
+        self.assertEqual(_redact_obj(obj), obj)
+
+    def test_none_passed_through(self):
+        self.assertIsNone(_redact_obj(None))
+
+
+# ---------------------------------------------------------------------------
+# save_trajectory_analysis_result
+# ---------------------------------------------------------------------------
+
+class TestSaveTrajectoryAnalysisResult(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.orig_dir = os.getcwd()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+
+    def _read_saved(self):
+        with open("proposal.json") as f:
+            return json.load(f)
+
+    def test_valid_json_object_saved(self):
+        data = {"proposals": [_minimal_proposal()]}
+        msg = save_trajectory_analysis_result(json.dumps(data))
+        self.assertIn("Successfully saved", msg)
+        saved = self._read_saved()
+        self.assertEqual(saved["proposals"][0]["target_asset"]["name"], "proj.dataset.table.cost")
+
+    def test_raw_list_wrapped_in_proposals_key(self):
+        proposals = [_minimal_proposal()]
+        save_trajectory_analysis_result(json.dumps(proposals))
+        saved = self._read_saved()
+        self.assertIn("proposals", saved)
+        self.assertEqual(len(saved["proposals"]), 1)
+
+    def test_empty_proposals_list_saved(self):
+        save_trajectory_analysis_result(json.dumps({"proposals": []}))
+        saved = self._read_saved()
+        self.assertEqual(saved["proposals"], [])
+
+    def test_pii_redacted_before_saving(self):
+        proposal = _minimal_proposal()
+        proposal["evidence"]["trajectory_quote"] = "user SSN is 123-45-6789"
+        save_trajectory_analysis_result(json.dumps({"proposals": [proposal]}))
+        saved = self._read_saved()
+        quote = saved["proposals"][0]["evidence"]["trajectory_quote"]
+        self.assertNotIn("123-45-6789", quote)
+        self.assertIn("[SSN REDACTED]", quote)
+
+    def test_invalid_backslash_escape_in_sql_repaired(self):
+        # \s is not a valid JSON escape sequence — simulates LLM output with raw SQL
+        raw = r'{"proposals": [{"golden_sql": "SELECT * FROM t WHERE x = \s"}]}'
+        msg = save_trajectory_analysis_result(raw)
+        self.assertIn("Successfully saved", msg)
+
+    def test_returns_filename_in_message(self):
+        msg = save_trajectory_analysis_result(json.dumps({"proposals": []}))
+        self.assertIn("proposal.json", msg)
+
+
+# ---------------------------------------------------------------------------
+# _parse_reasoning_engine_labels
+# ---------------------------------------------------------------------------
+
+class TestParseReasoningEngineLabels(unittest.TestCase):
+
+    def _labels(self, input_msgs=None, output_msgs=None):
+        labels = {}
+        if input_msgs is not None:
+            labels["gen_ai.input.messages"] = json.dumps(input_msgs)
+        if output_msgs is not None:
+            labels["gen_ai.output.messages"] = json.dumps(output_msgs)
+        return labels
+
+    def test_returns_false_for_empty_labels(self):
+        output = []
+        self.assertFalse(_parse_reasoning_engine_labels({}, output))
+        self.assertEqual(output, [])
+
+    def test_returns_true_with_input_messages_label(self):
+        labels = self._labels(input_msgs=[{"role": "user", "parts": [{"text": "hello"}]}])
+        output = []
+        self.assertTrue(_parse_reasoning_engine_labels(labels, output))
+
+    def test_message_text_appears_in_output(self):
+        labels = self._labels(input_msgs=[{"role": "user", "parts": [{"text": "what is cost?"}]}])
+        output = []
+        _parse_reasoning_engine_labels(labels, output)
+        self.assertTrue(any("what is cost?" in line for line in output))
+
+    def test_role_uppercased_in_output(self):
+        labels = self._labels(input_msgs=[{"role": "user", "parts": [{"text": "hi"}]}])
+        output = []
+        _parse_reasoning_engine_labels(labels, output)
+        self.assertTrue(any("[USER]:" in line for line in output))
+
+    def test_tool_call_part_formatted(self):
+        msg = {"role": "assistant", "parts": [{"name": "run_sql", "arguments": {"query": "SELECT 1"}}]}
+        labels = self._labels(input_msgs=[msg])
+        output = []
+        _parse_reasoning_engine_labels(labels, output)
+        self.assertTrue(any("Tool Call: run_sql" in line for line in output))
+
+    def test_content_part_included(self):
+        msg = {"role": "assistant", "parts": [{"content": "here is the answer"}]}
+        labels = self._labels(input_msgs=[msg])
+        output = []
+        _parse_reasoning_engine_labels(labels, output)
+        self.assertTrue(any("here is the answer" in line for line in output))
+
+    def test_separator_added_after_each_message(self):
+        labels = self._labels(input_msgs=[
+            {"role": "user", "parts": [{"text": "q1"}]},
+            {"role": "assistant", "parts": [{"text": "a1"}]},
+        ])
+        output = []
+        _parse_reasoning_engine_labels(labels, output)
+        separators = [l for l in output if l == "-" * 20]
+        self.assertEqual(len(separators), 2)
+
+    def test_malformed_json_in_labels_handled_gracefully(self):
+        labels = {"gen_ai.input.messages": "not-valid-json"}
+        output = []
+        result = _parse_reasoning_engine_labels(labels, output)
+        self.assertTrue(result)
+        self.assertTrue(any("Error" in line for line in output))
+
+    def test_both_input_and_output_messages_combined(self):
+        labels = self._labels(
+            input_msgs=[{"role": "user", "parts": [{"text": "query"}]}],
+            output_msgs=[{"role": "assistant", "parts": [{"text": "answer"}]}],
+        )
+        output = []
+        _parse_reasoning_engine_labels(labels, output)
+        full = "\n".join(output)
+        self.assertIn("query", full)
+        self.assertIn("answer", full)
+
+
+# ---------------------------------------------------------------------------
+# _parse_generic_payload
+# ---------------------------------------------------------------------------
+
+class TestParseGenericPayload(unittest.TestCase):
+
+    def test_string_payload_included_in_output(self):
+        output = []
+        _parse_generic_payload("hello world", output)
+        self.assertTrue(any("hello world" in line for line in output))
+
+    def test_dict_user_message(self):
+        payload = {"message": {"user_message": {"text": "user asked this"}}}
+        output = []
+        _parse_generic_payload(payload, output)
+        full = "\n".join(output)
+        self.assertIn("[USER]", full)
+        self.assertIn("user asked this", full)
+
+    def test_dict_system_message(self):
+        payload = {"message": {"system_message": {"text": "system instruction"}}}
+        output = []
+        _parse_generic_payload(payload, output)
+        self.assertTrue(any("[SYSTEM]" in line for line in output))
+
+    def test_dict_with_text_field(self):
+        output = []
+        _parse_generic_payload({"text": "direct text content"}, output)
+        self.assertTrue(any("direct text content" in line for line in output))
+
+    def test_dict_with_message_field(self):
+        output = []
+        _parse_generic_payload({"message": "simple message string"}, output)
+        self.assertTrue(any("simple message string" in line for line in output))
+
+    def test_non_string_non_dict_converted_to_string(self):
+        output = []
+        _parse_generic_payload(42, output)
+        self.assertTrue(any("42" in line for line in output))
+
+    def test_separator_always_last_element(self):
+        output = []
+        _parse_generic_payload("anything", output)
+        self.assertEqual(output[-1], "-" * 20)
+
+
+# ---------------------------------------------------------------------------
+# get_agent_trajectories
+# ---------------------------------------------------------------------------
+
+class TestGetAgentTrajectories(unittest.TestCase):
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_no_params_returns_error_message(self, mock_logging):
+        result = get_agent_trajectories(project_id="test-project")
+        self.assertIn("Either conversation_id", result)
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_conversation_id_no_entries_returns_not_found(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_client.list_entries.return_value = []
+
+        result = get_agent_trajectories(conversation_id="abc123", project_id="test-project")
+        self.assertIn("No messages found", result)
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_reasoning_engine_deduplicates_by_conversation_id(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+
+        # 3 entries, 2 unique conversation IDs — first seen (= latest) wins
+        entries = [
+            _make_log_entry("conv-1", gen_ai_labels=True),
+            _make_log_entry("conv-2", gen_ai_labels=True),
+            _make_log_entry("conv-1"),  # duplicate, should be ignored
+        ]
+        mock_client.list_entries.return_value = entries
+
+        result = get_agent_trajectories(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7,
+            project_id="test-project",
+        )
+        self.assertIn("Unique conversations: 2", result)
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_conversation_ids_printed_in_output(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+
+        mock_client.list_entries.return_value = [_make_log_entry("conv-abc", gen_ai_labels=True)]
+
+        result = get_agent_trajectories(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7,
+            project_id="test-project",
+        )
+        self.assertIn("Conversation IDs:", result)
+        self.assertIn("conv-abc", result)
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_entries_without_conversation_id_skipped(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+
+        entries = [
+            _make_log_entry(conversation_id=None),       # no label — skipped
+            _make_log_entry("conv-1", gen_ai_labels=True),
+        ]
+        mock_client.list_entries.return_value = entries
+
+        result = get_agent_trajectories(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7,
+            project_id="test-project",
+        )
+        self.assertIn("Unique conversations: 1", result)
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_reasoning_engine_no_entries_returns_not_found(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+        mock_client.list_entries.return_value = []
+
+        result = get_agent_trajectories(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7,
+            project_id="test-project",
+        )
+        self.assertIn("No messages found", result)
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_full_resource_path_id_extracted(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+        mock_client.list_entries.return_value = []
+
+        get_agent_trajectories(
+            reasoning_engine_id="projects/my-proj/locations/us-central1/reasoningEngines/1234567890123456789",
+            days_ago=7,
+            project_id="test-project",
+        )
+        call_kwargs = mock_client.list_entries.call_args.kwargs
+        self.assertIn("1234567890123456789", call_kwargs["filter_"])
+        self.assertNotIn("projects/my-proj/locations/us-central1/reasoningEngines/", call_kwargs["filter_"])
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_start_and_end_time_included_in_filter(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+        mock_client.list_entries.return_value = []
+
+        get_agent_trajectories(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            start_time="2026-06-01T00:00:00Z",
+            end_time="2026-06-17T00:00:00Z",
+            project_id="test-project",
+        )
+        call_kwargs = mock_client.list_entries.call_args.kwargs
+        self.assertIn("2026-06-01T00:00:00Z", call_kwargs["filter_"])
+        self.assertIn("2026-06-17T00:00:00Z", call_kwargs["filter_"])
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_total_log_entry_count_in_output(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+
+        entries = [_make_log_entry("conv-1", gen_ai_labels=True)] * 5
+        mock_client.list_entries.return_value = entries
+
+        result = get_agent_trajectories(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7,
+            project_id="test-project",
+        )
+        self.assertIn("Total log entries retrieved: 5", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/conversation_learner/utils.py
+++ b/agents/conversation_learner/utils.py
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for the ConversationLearner agent."""
+
+import os
+
+
+def get_consumer_project() -> str:
+  """Extracts the consumer project from the environment variable.
+
+  Returns:
+      The consumer project ID.
+
+  Raises:
+      ValueError: If the GOOGLE_CLOUD_PROJECT environment variable is not set.
+  """
+  consumer_project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+
+  if not consumer_project:
+    raise ValueError("GOOGLE_CLOUD_PROJECT environment variable is required.")
+
+  return consumer_project


### PR DESCRIPTION
ConversationLearner is an enterprise ADK agent that acts as an LLM-as-a-judge over conversational trajectories (from Cloud Logging) to detect friction and hallucination, emitting redacted metadata-enrichment proposals for the Knowledge Catalog.

- Lives at agents/conversation_learner alongside enrichment and mdcode.
- ADK name 'conversation_learner'; brand "ConversationLearner" in docs.
- Includes SKILL.md instruction, deploy.py (Vertex Agent Engine), and unit tests (47 passing).