### PR TITLE
Enrichment agent: add Confluence + SharePoint sources and OKF output

### DIFF
--- a/agents/enrichment/README.md
+++ b/agents/enrichment/README.md
@@ -63,6 +63,17 @@ the cards join the relevance router's candidate pool, so code that reads or
 writes a table (or contains SQL referencing it) grounds that table's overview
 and queries aspect.
 
+Beyond Google Drive, any mode can also ingest **Confluence** and **SharePoint**
+as context sources (not extra modes). Pass `--confluence_space` for Confluence
+spaces or `--sharepoint_sites` for SharePoint sites, or simply drop Confluence /
+SharePoint URLs into `--docs` / `--folders` — they are auto-detected and lifted
+into the right source. Their pages/files surface in the same shape as the other
+sources: their own knowledge-base entries in `doc` mode, or relevance-router
+candidates in `table` / `context_overlay`. Confluence is read through the
+Atlassian Rovo MCP server; SharePoint through the Microsoft Graph REST API (text
+files read in full, `.docx`/`.xlsx`/`.pptx`/PDF extracted locally — see
+[docs/sharepoint-setup.md](docs/sharepoint-setup.md) for auth).
+
 After a run, you can iterate on the output with free-text **refinement** —
 either an interactive REPL (`--interactive`) or a single re-invocation
 (`--refine_instruction`). Refinement reuses the already-loaded context and never
@@ -80,6 +91,7 @@ agents/
     │   ├── agent_runner.py      # CLI entrypoint: flags + dispatch to a mode
     │   ├── engine.py            # LLM agents (Vertex Gemini) for all modes
     │   ├── common.py            # shared helpers (run_text, mdcode parsing, trajectory)
+    │   ├── okf_serializer.py    # OKF (Open Knowledge Format) bundle writer (--output_format=okf)
     │   ├── refine.py            # multi-turn refinement (REPL + persist/re-invoke)
     │   ├── linking.py           # glossary column→term linking helper (table mode)
     │   ├── modes/
@@ -91,7 +103,11 @@ agents/
     │       ├── drive_tools.py    # Google Drive/Docs fetch helpers
     │       ├── bq_usage_tools.py # INFORMATION_SCHEMA query history + queries-aspect sidecar
     │       ├── feedback_tools.py # user-feedback proposal loader + per-table router
-    │       └── github_tools.py   # agentic GitHub-repo code source via the GitHub MCP server
+    │       ├── github_tools.py   # agentic GitHub-repo code source via the GitHub MCP server
+    │       ├── confluence_tools.py # Confluence space/page source via the Atlassian Rovo MCP server
+    │       └── sharepoint_tools.py # SharePoint site/file source via the Microsoft Graph REST API
+    ├── scripts/                 # SharePoint auth setup (setup_sharepoint.py, mint_sharepoint_token.py)
+    ├── docs/                    # source-setup guides (sharepoint-setup.md)
     └── eval/                     # evaluation CLI (dynamic golden-free + golden-based)
         ├── __main__.py          # `python -m eval --output-dir ... [--golden ...]` | `--run`
         ├── dynamic_eval.py      # golden-free scoring of a single run
@@ -272,6 +288,9 @@ list). `--project`, `--model`, and `--output_dir` are required in **every** mode
 | `--repo_ref` | ✓ | ✓ | ✓ |
 | `--repo_subdir` | ✓ | ✓ | ✓ |
 | `--mcp_config` | ✓ | ✓ | ✓ |
+| `--confluence_space` | ✓ | ✓ | ✓ |
+| `--sharepoint_sites` | ✓ | ✓ | ✓ |
+| `--output_format` | ✓ | ✓ | ✓ |
 | `--interactive` | ✓ | ✓ | ✓ |
 | `--refine_instruction` | ✓ | ✓ | ✓ |
 
@@ -337,6 +356,18 @@ list). `--project`, `--model`, and `--output_dir` are required in **every** mode
     }
   }
   ```
+
+#### Confluence input *(all modes)*
+
+- **`--confluence_space`** — Comma-separated Confluence space keys to ingest as a context source (e.g. `--confluence_space=DATA,RUNBOOKS`). Top-level pages are listed and the most topic-relevant ones read, through the Atlassian Rovo MCP server. Confluence page/space URLs may also be dropped into `--docs` / `--folders` — they are auto-detected and lifted into this source. Auth via `ATLASSIAN_API_TOKEN` / `ATLASSIAN_OAUTH_TOKEN`; the server can be overridden with `--mcp_config`.
+
+#### SharePoint input *(all modes)*
+
+- **`--sharepoint_sites`** — Comma-separated SharePoint sites — accepts full site URLs from your browser's address bar, e.g. `--sharepoint_sites=https://contoso.sharepoint.com/sites/Marketing`. Walks each site's default document library and reads topic-relevant files via the Microsoft Graph REST API (text read in full; `.docx`/`.xlsx`/`.pptx`/PDF extracted locally). SharePoint URLs may also be dropped into `--docs` / `--folders`. Auth uses an MSAL token cache or `MICROSOFT_ACCESS_TOKEN` — see [docs/sharepoint-setup.md](../docs/sharepoint-setup.md) and `scripts/setup_sharepoint.py`.
+
+#### Output format *(all modes)*
+
+- **`--output_format`** — *(default `kcmd`)* Serialization of the generated tree. `kcmd` writes the native catalog layout (`X.yaml` + `X.overview.md` under `catalog/`). `okf` writes an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle (one `X.md` per concept with YAML frontmatter + `index.md` listings under `bundle/`), publishable via `kcmd push --format okf`.
 
 #### Refinement *(all modes, after a run)*
 
@@ -408,6 +439,12 @@ overview, an `overview` aspect), and — for tables/overlays — a `…​.queri
 sidecar (the `queries` aspect of sample SQL). Every folder also gets an
 auto-generated `index` entry (`index.yaml` + `index.overview.md`) that names the
 folder and carries `contains`/`parent` links, forming a navigable hierarchy.
+
+With **`--output_format=okf`** the same content is instead written as an
+[Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+bundle under `bundle/` — one `X.md` per concept (YAML frontmatter + the overview
+as the Markdown body) plus reserved `index.md` directory listings (the root one
+carries `okf_version`). Publish it with `kcmd push --format okf`.
 
 **Per mode** (entry `type` in parentheses):
 

--- a/agents/enrichment/docs/sharepoint-setup.md
+++ b/agents/enrichment/docs/sharepoint-setup.md
@@ -1,0 +1,215 @@
+# SharePoint integration — setup walkthrough
+
+End-to-end setup for the enrichment agent's SharePoint source: register
+an Entra (Azure AD) application, grant the right Microsoft Graph
+permissions, run the one-time setup script, and ingest SharePoint files
+into your Knowledge Catalog entries.
+
+The agent reads SharePoint files via the Microsoft Graph API.
+
+Total time the first time you do this: ~20–30 minutes (most of it the
+Entra app registration). Subsequent runs are zero-touch — the agent
+silently refreshes access tokens from a local cache.
+
+---
+
+## Prerequisites
+
+- A Microsoft 365 tenant with SharePoint Online and admin rights on
+  the tenant. If you don't have one, a 30-day free
+  [Microsoft 365 Business Basic trial](https://www.microsoft.com/microsoft-365/business/microsoft-365-business-basic)
+  works and includes everything you need.
+- Python 3.11+ with the enrichment agent's deps installed (see the
+  top-level [README](../../../README.md) Setup section).
+- A site in SharePoint with content you want enriched. Any team site
+  with a Documents library works. The Communication site that ships
+  with a fresh tenant works too.
+
+---
+
+## Part 1 — Register an Entra application
+
+The agent uses **delegated OAuth**, so we register an Entra app the
+user will sign in to.
+
+1. Open [entra.microsoft.com](https://entra.microsoft.com) as a tenant
+   administrator.
+2. Left rail → **Identity** → **Applications** → **App registrations**
+   → **+ New registration**.
+3. Fill in:
+   - **Name**: something like `kc-enrichment-agent` (any human-readable
+     name).
+   - **Supported account types**: *Accounts in this organizational
+     directory only (Single tenant)*. Multi-tenant works too but
+     single-tenant is the simplest demo path.
+   - **Redirect URI**: pick **Public client/native (mobile & desktop)**
+     and enter `http://localhost`.
+4. **Register**.
+
+### Capture the IDs
+
+From the app's Overview page, copy these two GUIDs:
+
+- **Application (client) ID** → this becomes `MICROSOFT_CLIENT_ID`.
+- **Directory (tenant) ID** → this becomes `MICROSOFT_TENANT_ID`.
+
+### Enable public-client flows
+
+The agent's setup script uses MSAL's public-client device-code flow,
+which requires this toggle:
+
+1. Left rail of your app → **Authentication**.
+2. Under **Advanced settings**, set **Allow public client flows** to
+   **Yes**.
+3. **Save**.
+
+Without this, you'll get `AADSTS7000218: The request body must contain
+... client_secret` when the setup script tries to sign in.
+
+---
+
+## Part 2 — Grant Microsoft Graph permissions
+
+The agent needs four delegated scopes:
+
+| Scope | Why |
+|---|---|
+| `Sites.Read.All` | Read all SharePoint site collections |
+| `Files.Read.All` | Read all files in SharePoint and OneDrive |
+| `User.Read` | Read the signed-in user's profile |
+| `offline_access` | Issue a refresh token so the agent can silently mint new access tokens |
+
+1. App registration → **API permissions** → **+ Add a permission**.
+2. **Microsoft Graph** → **Delegated permissions**.
+3. Tick all four of the scopes above.
+4. **Add permissions**.
+
+### Grant admin consent
+
+The scopes need a tenant admin to consent on behalf of all users:
+
+1. Back on the **API permissions** page, click **Grant admin consent
+   for `<your tenant>`** at the top.
+2. Confirm. Each scope's status flips to ✅ *Granted for `<tenant>`*.
+
+This is the most common silent-failure step — if you skip it, the
+OAuth flow succeeds but every Graph call returns
+`http_403: Insufficient privileges`.
+
+---
+
+## Part 3 — Run the setup script
+
+The repo ships an interactive walkthrough that detects what's
+configured, prompts for what's missing, runs OAuth, and validates the
+result.
+
+From the repo root:
+
+```bash
+python3 toolbox/enrichment/scripts/setup_sharepoint.py
+```
+
+What it does, in order:
+
+1. Prints current state (env vars, MSAL cache, env file). On first run
+   everything should show ✗.
+2. Prompts for `MICROSOFT_CLIENT_ID` and `MICROSOFT_TENANT_ID` (the two
+   GUIDs from Part 1).
+3. Persists them to `~/.config/kc_agent/microsoft.env`. The agent
+   auto-sources this file on startup — no shell rc edits required.
+4. Asks whether to use **device-code** (works over SSH / headless;
+   default) or **browser** (faster when you're at a desktop).
+5. Prints a short user code + URL. Open the URL on any device, paste
+   the code, sign in with the tenant admin account, consent to the
+   four Graph scopes.
+6. Persists the resulting token cache (containing the refresh token)
+   to `~/.cache/kc_agent/microsoft_token_cache.json` (chmod 600).
+7. Validates by hitting `/me` and `/sites/root` on Graph. Both should
+   come back ✅.
+
+After this succeeds:
+
+- The MSAL cache holds a refresh token good for ~90 days.
+- The agent silently mints fresh access tokens from it on every Graph
+  call — no manual re-mint, no 1-hour cliff.
+- Re-running the setup script or the mint helper isn't needed until
+  the refresh token actually expires or is revoked.
+
+### Other setup-script modes
+
+```bash
+# Read-only state check — no prompts, no OAuth.
+python3 toolbox/enrichment/scripts/setup_sharepoint.py --doctor
+
+# Force a fresh device-code sign-in even if the cache is still valid
+# (e.g. after rotating an Entra secret or changing accounts).
+python3 toolbox/enrichment/scripts/setup_sharepoint.py --re-auth
+```
+
+---
+
+## Part 4 — Run the agent against your SharePoint site
+
+Two flag shapes for pointing the agent at SharePoint content:
+
+```bash
+# (a) Pass full SharePoint URLs in --folders (or --docs). Any URL on a
+#     site that starts with /sites/<NAME>/... gets recognized and the
+#     agent walks that site's default library.
+python3 toolbox/enrichment/src/agent_runner.py \
+  --mode=doc \
+  --topic="Order pipeline metadata" \
+  --folders="https://<tenant>.sharepoint.com/sites/<NAME>/SitePages/Home.aspx" \
+  --entry_group=<project>.<location>.<entryGroupId> \
+  --project=<gcp_project> --model=<vertex_model> --output_dir=<local_out>
+
+# (b) Or pass them explicitly via the typed --sharepoint_* flags.
+python3 toolbox/enrichment/src/agent_runner.py \
+  --mode=doc \
+  --topic="Order pipeline metadata" \
+  --sharepoint_sites="https://<tenant>.sharepoint.com/sites/<NAME>" \
+  --sharepoint_search="orders pipeline runbook" \
+  --entry_group=<project>.<location>.<entryGroupId> \
+  --project=<gcp_project> --model=<vertex_model> --output_dir=<local_out>
+```
+
+If you run the agent **without** completing setup, it prints a friendly
+pointer back to `setup_sharepoint.py` and (when on a tty) offers to
+launch the walkthrough inline.
+
+---
+
+## File-type coverage
+
+Files are extracted based on type:
+
+| File type | Extractor | Notes |
+|---|---|---|
+| `.md`, `.txt`, `.json`, `.xml`, `.yaml` | UTF-8 decode | Read in full |
+| `.docx` | `python-docx` | Paragraph text |
+| `.xlsx` | `openpyxl` (read-only) | Per-sheet CSV-shaped dump of populated cells |
+| `.pptx` | `python-pptx` | Per-slide text from shapes + notes |
+| `.pdf` | `pypdf` | Per-page text extraction |
+| Other binaries (images, archives, legacy `.doc`/`.xls`/`.ppt`) | None | The file is still cited in the catalog entry via its `web_url`, but the content isn't text-extracted |
+
+Files are capped at 5 MB to keep the LLM context bounded; larger files
+are reported with their `web_url` so they're still cited.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `AADSTS7000218: The request body must contain ... client_secret` | "Allow public client flows" not enabled on the Entra app | Re-do Part 1's "Enable public-client flows" step |
+| `AADSTS50011: The redirect URI specified in the request does not match` | Entra app's redirect URI list doesn't include `http://localhost` | Edit Authentication → Web/Public client → add `http://localhost` |
+| `http_403: Insufficient privileges` from the SharePoint integration | Admin consent missing on the API permissions page | Re-do Part 2's "Grant admin consent" step |
+| Agent prints `⚠️ No Microsoft credentials available — skipping SharePoint source` despite running setup | `~/.config/kc_agent/microsoft.env` couldn't be written (permissions) | Setup script will have shown a warning; check the file path is writable |
+| `http_401 / token_expired` from the SharePoint integration | Refresh token has been revoked or aged past ~90 days | Re-run `setup_sharepoint.py --re-auth` |
+| `http_500 SearchPlatformResolutionFailed` from `/search/query` | Tenant's search backend hasn't finished provisioning (can take up to 24h after first SharePoint sign-in) | Use `--sharepoint_sites=<URL>` instead of `--sharepoint_search=<query>` until search comes online |
+| Cards exist but content looks like a placeholder ("Binary content not extracted") | File type doesn't have a local extractor (legacy Office or unsupported binary) | The card still cites the file's `web_url`; for legacy Office, save the file as `.docx`/`.xlsx`/`.pptx` |
+
+`setup_sharepoint.py --doctor` is the fastest way to inspect current
+state without running OAuth — useful when something fails and you want
+to know which piece is missing.

--- a/agents/enrichment/scripts/mint_sharepoint_token.py
+++ b/agents/enrichment/scripts/mint_sharepoint_token.py
@@ -1,0 +1,249 @@
+"""Mint a Microsoft Graph access token for the enrichment agent's SharePoint source.
+
+Two ways the agent gets a Graph bearer token, in order of preference:
+
+  1. **MSAL token cache at `~/.cache/kc_agent/microsoft_token_cache.json`**
+     — written by this script and refreshed silently by the agent's
+     httpx event hook on every Graph call. With `offline_access` in the
+     requested scopes (which it is), MSAL issues a refresh token that's
+     good for ~90 days; the agent can silently mint fresh access tokens
+     from it without any interactive consent. **This is the recommended
+     path** — set it up once and the agent stops complaining about
+     expired tokens.
+  2. **`MICROSOFT_ACCESS_TOKEN` env var** — a raw access token the agent
+     uses as a Bearer header for ~1h, then 401s when it expires. Useful
+     for CI / one-shot runs or when you don't want to write a cache to
+     disk. Same contract as `GITHUB_PERSONAL_ACCESS_TOKEN` /
+     `ATLASSIAN_API_TOKEN`.
+
+This script runs the OAuth flow using MSAL (Microsoft Authentication
+Library) in **device-code** mode: it prints a short code + a verification
+URL to stderr, and you open that URL in a browser on ANY device (your
+laptop, your phone), enter the code, sign in, and consent. The script
+polls Microsoft until you complete the sign-in, then prints the access
+token to stdout AND writes the cache to disk so the agent can silently
+refresh thereafter.
+
+Device-code is the default because it works in every environment (SSH
+session, headless container, CI runner) — no local browser, no
+http://localhost listener, no redirect URI involved at all. Pass
+`--browser` to instead use the local-browser interactive flow (faster
+when you ARE on a desktop machine).
+
+Subsequent runs of this script are cheap: it tries `acquire_token_silent`
+against the cache first, and only falls through to the interactive flow
+if the cache is missing or its refresh token has been revoked / aged out.
+
+Uses the public-client / PKCE flow, so no client secret is needed — just
+the `client_id` (Application ID) and `tenant_id` (Directory ID) of the
+Entra app you registered. See the "SharePoint Setup" tab of the project's
+setup doc for the app-registration walkthrough.
+
+Usage:
+    export MICROSOFT_CLIENT_ID='<Application (client) ID from Entra>'
+    export MICROSOFT_TENANT_ID='<Directory (tenant) ID from Entra>'
+    pip install msal                    # one-time
+    export MICROSOFT_ACCESS_TOKEN=$(python scripts/mint_sharepoint_token.py)
+
+After the first successful run, the cache is populated and the agent
+itself can refresh tokens silently — you only need to re-run this
+script if the refresh token expires (~90 days) or is revoked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+
+
+# These match the scopes the agent's sp_* tools actually need — same set the
+# README documents and that you admin-consented on the Entra app's
+# "API permissions" page.
+_GRAPH_SCOPES = [
+    "https://graph.microsoft.com/Sites.Read.All",
+    "https://graph.microsoft.com/Files.Read.All",
+    "https://graph.microsoft.com/User.Read",
+]
+
+# Where the MSAL token cache (containing the refresh token issued by
+# `offline_access`) lives. Must match the path the agent's
+# sharepoint_tools._MicrosoftAuthRefresher reads from — they are two
+# halves of the same handshake.
+_CACHE_PATH = os.path.expanduser("~/.cache/kc_agent/microsoft_token_cache.json")
+
+
+def _stderr(msg: str) -> None:
+  """Print to stderr (keeps stdout clean for $(...) substitution)."""
+  print(msg, file=sys.stderr, flush=True)
+
+
+def _load_cache():
+  """Load the MSAL serializable token cache from disk, or return an empty
+  one. Returns the cache object (the caller passes it to
+  PublicClientApplication so subsequent acquires consult / mutate it)."""
+  import msal  # noqa: PLC0415
+
+  cache = msal.SerializableTokenCache()
+  if os.path.exists(_CACHE_PATH):
+    try:
+      with open(_CACHE_PATH, "r", encoding="utf-8") as f:
+        cache.deserialize(f.read())
+    except (OSError, ValueError) as e:
+      _stderr(
+          f"WARNING: existing cache at {_CACHE_PATH} could not be loaded"
+          f" ({type(e).__name__}: {e}); will treat as empty and re-mint."
+      )
+  return cache
+
+
+def _save_cache(cache) -> None:
+  """Write the cache back to disk if MSAL mutated it (refresh-token
+  rotation, new account, etc.). chmod 600 so other users can't read the
+  refresh token."""
+  if not cache.has_state_changed:
+    return
+  os.makedirs(os.path.dirname(_CACHE_PATH), exist_ok=True)
+  with open(_CACHE_PATH, "w", encoding="utf-8") as f:
+    f.write(cache.serialize())
+  try:
+    os.chmod(_CACHE_PATH, stat.S_IRUSR | stat.S_IWUSR)
+  except OSError:
+    pass  # non-fatal — Windows / filesystems without POSIX perms
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+      description=(
+          "Mint a Microsoft Graph access token for the SharePoint source."
+      )
+  )
+  parser.add_argument(
+      "--client-id",
+      default=os.environ.get("MICROSOFT_CLIENT_ID", "").strip(),
+      help=(
+          "Application (client) ID from your Entra app registration."
+          " Defaults to $MICROSOFT_CLIENT_ID."
+      ),
+  )
+  parser.add_argument(
+      "--tenant-id",
+      default=os.environ.get("MICROSOFT_TENANT_ID", "").strip(),
+      help=(
+          "Directory (tenant) ID from your Entra app registration."
+          " Defaults to $MICROSOFT_TENANT_ID."
+      ),
+  )
+  parser.add_argument(
+      "--browser",
+      action="store_true",
+      help=(
+          "Use the local-browser interactive flow (requires a desktop"
+          " session with a working browser + http://localhost listener)."
+          " Default is device-code flow, which works over SSH / headless."
+      ),
+  )
+  args = parser.parse_args()
+
+  if not args.client_id:
+    _stderr(
+        "ERROR: missing client_id. Set $MICROSOFT_CLIENT_ID or pass"
+        " --client-id."
+    )
+    return 2
+  if not args.tenant_id:
+    _stderr(
+        "ERROR: missing tenant_id. Set $MICROSOFT_TENANT_ID or pass"
+        " --tenant-id."
+    )
+    return 2
+
+  try:
+    import msal  # noqa: PLC0415  (imported lazily — only needed by this script)
+  except ImportError:
+    _stderr("ERROR: msal not installed. Run: pip install msal")
+    return 2
+
+  authority = f"https://login.microsoftonline.com/{args.tenant_id}"
+  cache = _load_cache()
+  app = msal.PublicClientApplication(
+      args.client_id, authority=authority, token_cache=cache
+  )
+
+  # Step 1: try silent acquire first. If the cache holds a valid refresh
+  # token, this returns a fresh access token without any browser
+  # interaction — the common case on every run after the first.
+  result = None
+  accounts = app.get_accounts()
+  if accounts:
+    silent = app.acquire_token_silent(_GRAPH_SCOPES, account=accounts[0])
+    if silent and "access_token" in silent:
+      _stderr(
+          f"Reusing cached refresh token from {_CACHE_PATH}"
+          f" (account: {accounts[0].get('username', '?')})."
+          " No interactive sign-in needed."
+      )
+      result = silent
+
+  # Step 2: if silent failed (first run, cache empty, or refresh token
+  # expired/revoked), fall through to interactive sign-in.
+  if result is None:
+    if args.browser:
+      _stderr(
+          "Using local-browser interactive flow. A browser should open"
+          " automatically; if not, visit the URL MSAL prints below."
+      )
+      # Transient listener on http://localhost:<port> + auth-code
+      # exchange. Requires that the Entra app has http://localhost in
+      # its allowed redirect URIs.
+      result = app.acquire_token_interactive(scopes=_GRAPH_SCOPES)
+    else:
+      # Device-code flow: print a short user_code + verification URL,
+      # poll Microsoft until the user signs in on any device. Works in
+      # SSH / headless / container / CI — no local browser, no redirect.
+      flow = app.initiate_device_flow(scopes=_GRAPH_SCOPES)
+      if "user_code" not in flow:
+        _stderr(
+            "ERROR: device flow init failed:"
+            f" {flow.get('error')} — {flow.get('error_description')}"
+        )
+        return 1
+      # The `message` field is human-readable text from Microsoft, e.g.
+      # "To sign in, use a web browser to open the page
+      #  https://microsoft.com/devicelogin and enter the code ABC123XY ..."
+      _stderr("")
+      _stderr(flow["message"])
+      _stderr("")
+      _stderr(
+          "Waiting for sign-in... (this script will hang here until you"
+          " complete the consent in your browser; Ctrl+C to abort)"
+      )
+      result = app.acquire_token_by_device_flow(flow)  # blocks
+
+  if "access_token" not in result:
+    _stderr(
+        "ERROR: token acquisition failed:"
+        f" {result.get('error')} — {result.get('error_description')}"
+    )
+    return 1
+
+  # Persist the cache (writes the refresh token on first run, rotates on
+  # subsequent ones). The agent's sharepoint_tools._MicrosoftAuthRefresher
+  # reads from this same path to do silent refreshes mid-agent-run.
+  _save_cache(cache)
+
+  # The token only — no newline-trailing prose — so $(...) captures the
+  # raw JWT cleanly.
+  sys.stdout.write(result["access_token"])
+  sys.stdout.flush()
+  _stderr(
+      "\nToken minted. Access-token lifetime ~1 hour; refresh-token"
+      f" lifetime ~90 days. Cache written to {_CACHE_PATH} — the agent"
+      " will silently refresh from it during long runs."
+  )
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/agents/enrichment/scripts/setup_sharepoint.py
+++ b/agents/enrichment/scripts/setup_sharepoint.py
@@ -1,0 +1,496 @@
+"""Interactive first-time setup walkthrough for the SharePoint source.
+
+The CLI analog of KC App's chat-driven `sharepoint-connect` skill
+(experimental/kc_agent/backend/kc_agent/adk_skills/sharepoint-connect/
+SKILL.md). Detects what's missing, prompts for credentials interactively
+with validation, kicks off the OAuth flow once to populate the MSAL
+token cache, then confirms by hitting two harmless Graph endpoints
+(`/me` and `/sites/root`) to prove the token works against the user's
+tenant.
+
+After this script succeeds:
+  * The cache at ~/.cache/kc_agent/microsoft_token_cache.json holds a
+    refresh token good for ~90 days.
+  * The agent silently refreshes access tokens from the cache on every
+    SharePoint call — no more 1-hour cliff.
+  * Re-running the agent (or running `mint_sharepoint_token.py`) does
+    NOT need interactive sign-in until the refresh token actually
+    expires or is revoked.
+
+Modes:
+  * `python setup_sharepoint.py`               — interactive walkthrough
+                                                  (prompts for missing
+                                                  values, runs device
+                                                  flow, validates).
+  * `python setup_sharepoint.py --doctor`     — checks current state
+                                                  without prompting or
+                                                  running OAuth; prints
+                                                  a status report.
+  * `python setup_sharepoint.py --re-auth`    — force a re-mint even
+                                                  if the cache is still
+                                                  valid (e.g. after
+                                                  rotating an Entra
+                                                  secret).
+
+Run from a tty. Non-interactive (CI) callers should use the env-var
+path: export MICROSOFT_ACCESS_TOKEN with a pre-minted Graph bearer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+# Same scopes the agent + mint_sharepoint_token.py request — must stay
+# in sync across all three.
+_GRAPH_SCOPES = [
+    "https://graph.microsoft.com/Sites.Read.All",
+    "https://graph.microsoft.com/Files.Read.All",
+    "https://graph.microsoft.com/User.Read",
+]
+
+# Same cache path the mint script writes and the agent reads.
+_CACHE_PATH = os.path.expanduser("~/.cache/kc_agent/microsoft_token_cache.json")
+
+# Env file written when the user opts to persist client/tenant ids.
+_ENV_FILE = os.path.expanduser("~/.config/kc_agent/microsoft.env")
+
+# GUID validation — Entra IDs are standard UUIDs.
+_GUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+
+
+# ---------------------------------------------------------------------------
+# Output helpers — interactive script goes to stdout (not stderr like the
+# mint script, since there's no $(…) capture in play).
+# ---------------------------------------------------------------------------
+
+
+def _say(msg: str) -> None:
+  print(msg, flush=True)
+
+
+def _ok(msg: str) -> None:
+  print(f"\033[32m✓\033[0m {msg}", flush=True)
+
+
+def _warn(msg: str) -> None:
+  print(f"\033[33m⚠\033[0m {msg}", flush=True)
+
+
+def _err(msg: str) -> None:
+  print(f"\033[31m✗\033[0m {msg}", flush=True)
+
+
+def _hr() -> None:
+  print("─" * 60, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# State detection
+# ---------------------------------------------------------------------------
+
+
+def _detect_state() -> dict:
+  """Inspect env + filesystem and return a dict describing what's set."""
+  state = {
+      "client_id": os.environ.get("MICROSOFT_CLIENT_ID", "").strip(),
+      "tenant_id": os.environ.get("MICROSOFT_TENANT_ID", "").strip(),
+      "access_token_env": bool(
+          os.environ.get("MICROSOFT_ACCESS_TOKEN", "").strip()
+      ),
+      "cache_exists": os.path.exists(_CACHE_PATH),
+      "cache_has_account": False,
+      "cache_account_username": None,
+      "env_file_exists": os.path.exists(_ENV_FILE),
+  }
+  if state["cache_exists"]:
+    try:
+      import msal  # noqa: PLC0415
+      cache = msal.SerializableTokenCache()
+      with open(_CACHE_PATH, "r", encoding="utf-8") as f:
+        cache.deserialize(f.read())
+      # We can inspect accounts without an authority by constructing a
+      # throwaway app — but only if we know client_id+tenant_id. If we
+      # don't, just report that the cache exists.
+      if state["client_id"] and state["tenant_id"]:
+        authority = f"https://login.microsoftonline.com/{state['tenant_id']}"
+        app = msal.PublicClientApplication(
+            state["client_id"], authority=authority, token_cache=cache
+        )
+        accounts = app.get_accounts()
+        if accounts:
+          state["cache_has_account"] = True
+          state["cache_account_username"] = accounts[0].get("username")
+    except Exception:  # pylint: disable=broad-except
+      pass  # leave the cache-derived fields as defaults
+  return state
+
+
+def _print_state(state: dict) -> None:
+  """Pretty-print the current setup state."""
+  _say("\nCurrent setup state:")
+  _hr()
+
+  if state["client_id"]:
+    _ok(f"MICROSOFT_CLIENT_ID set ({state['client_id'][:8]}...{state['client_id'][-4:]})")
+  else:
+    _err("MICROSOFT_CLIENT_ID not set")
+
+  if state["tenant_id"]:
+    _ok(f"MICROSOFT_TENANT_ID set ({state['tenant_id'][:8]}...{state['tenant_id'][-4:]})")
+  else:
+    _err("MICROSOFT_TENANT_ID not set")
+
+  if state["env_file_exists"]:
+    _ok(f"Env file present at {_ENV_FILE}")
+  else:
+    _warn(f"Env file not present at {_ENV_FILE} (you'll need to re-export the IDs each shell session)")
+
+  if state["cache_exists"] and state["cache_has_account"]:
+    _ok(
+        f"MSAL cache valid at {_CACHE_PATH}"
+        f" (signed in as {state['cache_account_username']})"
+    )
+  elif state["cache_exists"]:
+    _warn(
+        f"MSAL cache file exists at {_CACHE_PATH} but no usable account"
+        " — re-running interactive sign-in will fix it"
+    )
+  else:
+    _err(f"MSAL cache not found at {_CACHE_PATH}")
+
+  if state["access_token_env"]:
+    _ok("MICROSOFT_ACCESS_TOKEN env is set (one-shot fallback path)")
+
+  _hr()
+
+
+# ---------------------------------------------------------------------------
+# Interactive prompts
+# ---------------------------------------------------------------------------
+
+
+def _prompt(label: str, default: Optional[str] = None, validator=None) -> str:
+  """Prompt with optional default + optional validator. Keeps asking
+  until validator returns True (or value is non-empty if no validator)."""
+  while True:
+    prompt = f"{label}"
+    if default:
+      prompt += f" [{default[:8]}...{default[-4:]}]"
+    prompt += ": "
+    val = input(prompt).strip()
+    if not val and default:
+      val = default
+    if not val:
+      _err("Required.")
+      continue
+    if validator:
+      err = validator(val)
+      if err:
+        _err(err)
+        continue
+    return val
+
+
+def _validate_guid(s: str) -> Optional[str]:
+  if not _GUID_RE.match(s):
+    return "Not a valid GUID — expected 8-4-4-4-12 hex digits, e.g. 12345678-1234-1234-1234-123456789abc."
+  return None
+
+
+def _save_env_file(client_id: str, tenant_id: str) -> None:
+  """Persist the IDs so the user doesn't have to re-export every shell.
+  Conservative: chmod 600, even though these are not secrets per se —
+  someone shouldn't be able to swap your client_id without noticing."""
+  os.makedirs(os.path.dirname(_ENV_FILE), exist_ok=True)
+  with open(_ENV_FILE, "w", encoding="utf-8") as f:
+    f.write("# Generated by setup_sharepoint.py — `source` this in your shell\n")
+    f.write("# profile to make the SharePoint integration work without\n")
+    f.write("# re-exporting the IDs every session.\n")
+    f.write(f"export MICROSOFT_CLIENT_ID='{client_id}'\n")
+    f.write(f"export MICROSOFT_TENANT_ID='{tenant_id}'\n")
+  try:
+    os.chmod(_ENV_FILE, stat.S_IRUSR | stat.S_IWUSR)
+  except OSError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# OAuth + cache
+# ---------------------------------------------------------------------------
+
+
+def _run_device_flow(client_id: str, tenant_id: str) -> bool:
+  """Run the device-code flow and persist the cache. Returns True on
+  success."""
+  try:
+    import msal  # noqa: PLC0415
+  except ImportError:
+    _err("msal not installed. Run: pip install msal")
+    return False
+
+  authority = f"https://login.microsoftonline.com/{tenant_id}"
+  cache = msal.SerializableTokenCache()
+  # Preserve any existing cache contents — if the user already has a
+  # session for a different account in the same tenant, we want to keep
+  # it.
+  if os.path.exists(_CACHE_PATH):
+    try:
+      with open(_CACHE_PATH, "r", encoding="utf-8") as f:
+        cache.deserialize(f.read())
+    except (OSError, ValueError):
+      pass
+  app = msal.PublicClientApplication(
+      client_id, authority=authority, token_cache=cache
+  )
+
+  flow = app.initiate_device_flow(scopes=_GRAPH_SCOPES)
+  if "user_code" not in flow:
+    _err(
+        f"Device flow init failed: {flow.get('error')}"
+        f" — {flow.get('error_description')}"
+    )
+    return False
+  _say("")
+  _say(flow["message"])
+  _say("")
+  _say("Waiting for sign-in...")
+  result = app.acquire_token_by_device_flow(flow)
+  if "access_token" not in result:
+    _err(
+        f"Token acquisition failed: {result.get('error')}"
+        f" — {result.get('error_description')}"
+    )
+    return False
+
+  # Persist the cache (refresh token now lives in it).
+  if cache.has_state_changed:
+    os.makedirs(os.path.dirname(_CACHE_PATH), exist_ok=True)
+    with open(_CACHE_PATH, "w", encoding="utf-8") as f:
+      f.write(cache.serialize())
+    try:
+      os.chmod(_CACHE_PATH, stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+      pass
+  _ok(f"Token cache written to {_CACHE_PATH}")
+  return True
+
+
+# ---------------------------------------------------------------------------
+# Validation probes — confirm the token actually works against Graph
+# ---------------------------------------------------------------------------
+
+
+def _validate_token_against_graph(client_id: str, tenant_id: str) -> bool:
+  """Acquire a silent token from the cache and hit /me + /sites/root.
+  Returns True iff both calls succeed."""
+  try:
+    import msal  # noqa: PLC0415
+    import urllib.request as _ur  # noqa: PLC0415
+  except ImportError as e:
+    _err(f"Validation skipped: {e}")
+    return False
+
+  cache = msal.SerializableTokenCache()
+  with open(_CACHE_PATH, "r", encoding="utf-8") as f:
+    cache.deserialize(f.read())
+  authority = f"https://login.microsoftonline.com/{tenant_id}"
+  app = msal.PublicClientApplication(
+      client_id, authority=authority, token_cache=cache
+  )
+  accounts = app.get_accounts()
+  if not accounts:
+    _err("Cache has no account — re-run setup to sign in.")
+    return False
+  result = app.acquire_token_silent(_GRAPH_SCOPES, account=accounts[0])
+  if not result or "access_token" not in result:
+    _err("Silent token acquisition failed.")
+    return False
+  token = result["access_token"]
+
+  def _probe(url: str, label: str) -> bool:
+    try:
+      req = _ur.Request(url, headers={"Authorization": f"Bearer {token}"})
+      with _ur.urlopen(req, timeout=15) as resp:
+        if resp.status == 200:
+          _ok(f"{label} → 200 OK")
+          return True
+        _err(f"{label} → HTTP {resp.status}")
+        return False
+    except Exception as e:  # pylint: disable=broad-except
+      _err(f"{label} → {type(e).__name__}: {e}")
+      return False
+
+  ok1 = _probe("https://graph.microsoft.com/v1.0/me", "/me probe")
+  ok2 = _probe("https://graph.microsoft.com/v1.0/sites/root", "/sites/root probe")
+  return ok1 and ok2
+
+
+# ---------------------------------------------------------------------------
+# Walkthrough
+# ---------------------------------------------------------------------------
+
+
+def _walkthrough() -> int:
+  """The full interactive walkthrough."""
+  state = _detect_state()
+  _print_state(state)
+
+  # Step 1: collect client_id + tenant_id if missing.
+  if not state["client_id"] or not state["tenant_id"]:
+    _say(
+        "\nWe need your Entra app's Application (client) ID and Directory"
+        " (tenant) ID. Get them from"
+        " https://entra.microsoft.com → Identity → Applications → App"
+        " registrations → <your app> → Overview."
+    )
+    _say(
+        "If you haven't registered the app yet, see the 'SharePoint"
+        " Setup' tab of the project doc — it's ~5 minutes."
+    )
+    client_id = _prompt(
+        "Application (client) ID",
+        default=state["client_id"] or None,
+        validator=_validate_guid,
+    )
+    tenant_id = _prompt(
+        "Directory (tenant) ID",
+        default=state["tenant_id"] or None,
+        validator=_validate_guid,
+    )
+  else:
+    client_id = state["client_id"]
+    tenant_id = state["tenant_id"]
+
+  # Step 2: persist the IDs to an env file. The agent_runner.py
+  # auto-sources this file on startup AND immediately after running
+  # this setup script as a subprocess via the trigger gate, so the
+  # gate-spawned flow works even without the user re-sourcing their
+  # shell rc. Writing is unconditional now — if you don't want it,
+  # `rm ~/.config/kc_agent/microsoft.env` after this script finishes.
+  try:
+    _save_env_file(client_id, tenant_id)
+    _ok(
+        f"Wrote {_ENV_FILE}"
+        " (the agent auto-sources this on startup — no shell rc edits"
+        " required)."
+    )
+  except OSError as e:
+    _warn(
+        f"Could not write {_ENV_FILE} ({type(e).__name__}: {e})."
+        " You'll need to re-export MICROSOFT_CLIENT_ID and"
+        " MICROSOFT_TENANT_ID in each shell session, or pass them via"
+        " env on every agent run."
+    )
+
+  # Step 3: device-code flow.
+  _say("\nStarting Microsoft sign-in. Choose 'device code' if SSH/remote,")
+  _say("'browser' if you're at a desktop with a working browser.")
+  mode = input("Use [d]evice-code or [b]rowser? [D/b]: ").strip().lower() or "d"
+  if mode.startswith("b"):
+    _err("Browser mode not implemented in setup_sharepoint.py yet — use")
+    _err("scripts/mint_sharepoint_token.py --browser if you need it.")
+    return 1
+  if not _run_device_flow(client_id, tenant_id):
+    return 1
+
+  # Step 4: validate against Graph.
+  _say("\nValidating the token against Microsoft Graph...")
+  os.environ["MICROSOFT_CLIENT_ID"] = client_id
+  os.environ["MICROSOFT_TENANT_ID"] = tenant_id
+  if _validate_token_against_graph(client_id, tenant_id):
+    _ok("Setup complete. The agent will silently refresh tokens from now on.")
+    _say(
+        "\nIDs persisted to {0} (the agent auto-sources this on every"
+        " run — no shell rc edits required). Refresh-token cache at"
+        " {1} is valid for ~90 days before another sign-in is needed.".format(
+            _ENV_FILE, _CACHE_PATH
+        )
+    )
+    return 0
+  _err(
+      "Validation failed. The token was minted but Graph rejected it."
+      " Most likely cause: admin consent not granted for the four"
+      " delegated scopes (Sites.Read.All, Files.Read.All, User.Read,"
+      " offline_access) on your Entra app. Go to entra.microsoft.com →"
+      " your app → API permissions → Grant admin consent."
+  )
+  return 1
+
+
+def _doctor() -> int:
+  """Read-only state check — no prompts, no OAuth, no writes."""
+  state = _detect_state()
+  _print_state(state)
+  if state["cache_exists"] and state["cache_has_account"]:
+    _say("\nSetup looks healthy. To force a re-mint: --re-auth.")
+    return 0
+  _say(
+      "\nSetup is incomplete. Run without --doctor to walk through it"
+      " interactively."
+  )
+  return 1
+
+
+def _re_auth() -> int:
+  """Force a fresh device-code dance even if the cache is valid."""
+  client_id = os.environ.get("MICROSOFT_CLIENT_ID", "").strip()
+  tenant_id = os.environ.get("MICROSOFT_TENANT_ID", "").strip()
+  if not client_id or not tenant_id:
+    _err(
+        "MICROSOFT_CLIENT_ID and MICROSOFT_TENANT_ID must be set for"
+        " --re-auth. Run setup_sharepoint.py without flags for the full"
+        " walkthrough."
+    )
+    return 2
+  if os.path.exists(_CACHE_PATH):
+    try:
+      Path(_CACHE_PATH).unlink()
+      _ok(f"Removed old cache at {_CACHE_PATH}")
+    except OSError as e:
+      _warn(f"Could not remove old cache: {e}")
+  if not _run_device_flow(client_id, tenant_id):
+    return 1
+  return 0 if _validate_token_against_graph(client_id, tenant_id) else 1
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+      description=(
+          "Interactive first-time setup for the SharePoint source."
+          " Run without flags for the full walkthrough."
+      )
+  )
+  parser.add_argument(
+      "--doctor",
+      action="store_true",
+      help="Read-only state check — print what's set without prompting.",
+  )
+  parser.add_argument(
+      "--re-auth",
+      action="store_true",
+      help="Force a fresh device-code dance even if the cache is valid.",
+  )
+  args = parser.parse_args()
+  if args.doctor:
+    return _doctor()
+  if args.re_auth:
+    return _re_auth()
+  if not sys.stdin.isatty():
+    _err(
+        "setup_sharepoint.py needs an interactive terminal. For CI /"
+        " non-interactive use, set MICROSOFT_ACCESS_TOKEN directly with"
+        " a pre-minted Graph bearer."
+    )
+    return 2
+  return _walkthrough()
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/agents/enrichment/src/agent_runner.py
+++ b/agents/enrichment/src/agent_runner.py
@@ -29,11 +29,43 @@ Nothing is project-specific: pass your own `--project`, `--location`, and
 
 import asyncio
 import os
+import sys
 
 from absl import app
 from absl import flags
 from modes import context_overlay_mode, doc_mode, table_mode
 import refine
+from tools import confluence_tools, sharepoint_tools
+
+
+def _source_microsoft_env() -> None:
+  """Load `~/.config/kc_agent/microsoft.env` (MICROSOFT_CLIENT_ID /
+  MICROSOFT_TENANT_ID, written by setup_sharepoint.py) into os.environ.
+
+  Existing env vars win — the file is a default, not an override. Also
+  re-sourced after the setup subprocess so its newly-written IDs reach
+  this process (subprocess env mutations don't propagate to the parent).
+  """
+  env_file = os.path.expanduser("~/.config/kc_agent/microsoft.env")
+  if not os.path.exists(env_file):
+    return
+  try:
+    with open(env_file, "r", encoding="utf-8") as f:
+      for line in f:
+        line = line.strip()
+        if not line or line.startswith("#"):
+          continue
+        if not line.startswith("export "):
+          continue
+        body = line[len("export "):]
+        if "=" not in body:
+          continue
+        key, val = body.split("=", 1)
+        val = val.strip().strip("'").strip('"')
+        if key and not os.environ.get(key):
+          os.environ[key] = val
+  except OSError:
+    pass
 
 _MODE = flags.DEFINE_enum(
     "mode",
@@ -48,15 +80,20 @@ _TOPIC = flags.DEFINE_string(
 )
 _DOCS = flags.DEFINE_list(
     "docs", [],
-    "Comma-separated mixed list, routed per entry: Google Doc URLs/IDs and/or "
-    "local .md files. A local .md file is a doc-mode depth-0 spine; for "
+    "Comma-separated mixed list, routed per entry: Google Doc URLs/IDs, "
+    "local .md files, Confluence page URLs (auto-lifted into the Confluence "
+    "source), and/or SharePoint URLs (site URLs auto-merged into "
+    "--sharepoint_sites). A local .md file is a doc-mode depth-0 spine; for "
     "table/context_overlay it grounds table overviews."
 )
 _FOLDERS = flags.DEFINE_list(
     "folders", [],
     "Comma-separated mixed list, routed per entry: Google Drive folder "
-    "URLs/IDs and/or local directories of .md files. Drive/local dirs seed "
-    "depth-1 children (doc mode) or grounding docs (table/context_overlay)."
+    "URLs/IDs, local directories of .md files, Confluence URLs (space or "
+    "page links — auto-lifted into the Confluence source), and/or "
+    "SharePoint URLs (site URLs auto-merged into --sharepoint_sites). "
+    "Drive/local dirs seed depth-1 children (doc mode) or grounding docs "
+    "(table/context_overlay)."
 )
 # Backward-compatible alias for the former singular flag; merged with --folders.
 _FOLDER = flags.DEFINE_list(
@@ -94,7 +131,47 @@ _MCP_CONFIG = flags.DEFINE_string(
     "",
     "Path to an mcp.json describing the GitHub MCP server (falls back to"
     " KC_ENRICH_MCP_CONFIG, then a built-in `github-mcp-server stdio`"
-    " default).",
+    " default). The same file may also carry an Atlassian Rovo MCP server"
+    " entry under key `atlassian_remote` for --confluence_* sources.",
+)
+
+# --- Confluence input (all modes) ----------------------------------------
+# A Confluence agent explores Atlassian via the Rovo MCP server and returns
+# page cards in the same router-descriptor shape as the GitHub source (see
+# tools/confluence_tools.py; auth via ATLASSIAN_API_TOKEN / ATLASSIAN_OAUTH_TOKEN,
+# --mcp_config can override the server). Only --confluence_space is on the CLI;
+# the CQL and page-id sources stay internal (page links in --folders / --docs
+# are auto-lifted into them).
+_CONFLUENCE_SPACES = flags.DEFINE_list(
+    "confluence_space",
+    [],
+    "Optional Confluence space keys to ingest as a corpus context source"
+    " (e.g. `DATA,RUNBOOKS`). Top-level pages are listed and the most"
+    " topic-relevant ones are read. Confluence page/space URLs may also be"
+    " dropped into --folders / --docs — they are auto-detected and lifted"
+    " into this source.",
+)
+
+# --- SharePoint input (all modes) ----------------------------------------
+# An inner agent drives Microsoft Graph REST (site → library → folder → file)
+# via sp_* FunctionTools — direct Graph, not MCP, since the first-party
+# SharePoint MCP rejects third-party Entra tokens. Returns file cards in the
+# same shape as the other sources (see tools/sharepoint_tools.py; text files
+# read in full, .docx/.xlsx/.pptx/PDF extracted locally). Auth: MSAL cache or
+# MICROSOFT_ACCESS_TOKEN (see scripts/setup_sharepoint.py). Only
+# --sharepoint_sites is on the CLI; the search and file-id sources stay
+# internal (file links in --folders / --docs are auto-lifted into them).
+_SHAREPOINT_SITES = flags.DEFINE_list(
+    "sharepoint_sites",
+    [],
+    "Optional SharePoint sites — accepts full site URLs from your"
+    " browser's address bar, e.g."
+    " `https://contoso.sharepoint.com/sites/Marketing`. Walks each site's"
+    " default library and reads files that look topic-relevant. You can"
+    " also drop these URLs into --folders / --docs interchangeably. The"
+    " legacy `<host>:<server-relative-path>` form (e.g."
+    " `contoso.sharepoint.com:sites/Marketing`) is still accepted for"
+    " back-compat.",
 )
 _DATASET = flags.DEFINE_string(
     "dataset",
@@ -201,6 +278,16 @@ _FEEDBACK_FILES = flags.DEFINE_list(
     "Optional explicit list of user-feedback file paths (alternative to /"
     " in addition to --feedback_dir).",
 )
+_OUTPUT_FORMAT = flags.DEFINE_enum(
+    "output_format",
+    "kcmd",
+    ["kcmd", "okf"],
+    "Output serialization format. 'kcmd' (default) writes the native catalog"
+    " layout (X.yaml + X.overview.md under catalog/). 'okf' writes an Open"
+    " Knowledge Format bundle (one X.md per concept with YAML frontmatter +"
+    " index.md listings under bundle/), publishable via `kcmd push --format"
+    " okf`.",
+)
 
 
 def main(argv):
@@ -233,6 +320,107 @@ def main(argv):
   # --folders is canonical; --folder is a deprecated alias. Merge both so old
   # invocations keep working.
   folder_inputs = list(_FOLDERS.value or []) + list(_FOLDER.value or [])
+  doc_inputs = list(_DOCS.value or [])
+
+  # Lift Confluence URLs out of --folders / --docs into the typed Confluence
+  # source lists. Drive URLs/IDs and local markdown paths/dirs pass through
+  # untouched, so the existing per-mode routing in is_local_path() stays
+  # correct (it would otherwise route a Confluence URL as a Drive link and
+  # produce a silent dud). Space links merge into --confluence_space; page
+  # links seed the internal page-id list (no longer its own CLI flag).
+  folder_inputs, confluence_spaces, confluence_page_ids = (
+      confluence_tools.partition_sources(
+          folder_inputs,
+          _CONFLUENCE_SPACES.value,
+          [],
+      )
+  )
+  doc_inputs, confluence_spaces, confluence_page_ids = (
+      confluence_tools.partition_sources(
+          doc_inputs, confluence_spaces, confluence_page_ids
+      )
+  )
+
+  # Same lift for SharePoint URLs — site URLs land in --sharepoint_sites and
+  # file links seed the internal file-id list (no longer its own CLI flag).
+  # Viewer/sharing links surface a warning (sourcedoc GUIDs can't be resolved
+  # to a Graph driveItem id without a roundtrip we'd rather not bake into a
+  # parse step).
+  folder_inputs, sharepoint_sites, sharepoint_file_ids = (
+      sharepoint_tools.partition_sources(
+          folder_inputs,
+          _SHAREPOINT_SITES.value,
+          [],
+      )
+  )
+  doc_inputs, sharepoint_sites, sharepoint_file_ids = (
+      sharepoint_tools.partition_sources(
+          doc_inputs, sharepoint_sites, sharepoint_file_ids
+      )
+  )
+
+  # Credentials gate — SharePoint only. Triggers ONLY when the user actually
+  # asked for SharePoint reads AND no creds are configured. Stays silent
+  # otherwise so users who never touch SharePoint aren't prompted. On a tty we
+  # offer to launch setup_sharepoint.py inline; on a non-tty we hard-error.
+  sp_requested = bool(sharepoint_sites or sharepoint_file_ids)
+  if sp_requested:
+    # Load persisted Microsoft IDs lazily — only when SharePoint is used, so a
+    # normal run never reads the env file or mutates os.environ.
+    _source_microsoft_env()
+  if sp_requested and not sharepoint_tools._credentials_configured():
+    msg = (
+        "SharePoint sources were specified but no Microsoft credentials"
+        " are configured. Run:\n"
+        "  python3 toolbox/enrichment/scripts/setup_sharepoint.py\n"
+        "for a one-time interactive walkthrough (registers Entra app +"
+        " populates MSAL cache for silent refresh)."
+    )
+    if sys.stdin.isatty() and sys.stdout.isatty():
+      print(msg)
+      print()
+      try:
+        answer = input(
+            "Launch setup_sharepoint.py now? [Y/n] (Ctrl+C to abort): "
+        ).strip().lower() or "y"
+      except (EOFError, KeyboardInterrupt):
+        print()
+        raise app.UsageError(
+            "Aborted — re-run agent_runner.py after setup is complete."
+        )
+      if answer.startswith("y"):
+        # Spawn setup_sharepoint.py in this same Python; on success
+        # continue the agent run. On failure / non-zero exit, bail.
+        import subprocess  # noqa: PLC0415
+        setup_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..",
+            "scripts",
+            "setup_sharepoint.py",
+        )
+        rc = subprocess.call([sys.executable, setup_path])
+        if rc != 0:
+          raise app.UsageError(
+              "setup_sharepoint.py exited non-zero — re-run agent_runner.py"
+              " once setup is healthy."
+          )
+        # Pick up the env vars setup_sharepoint.py just wrote to the
+        # config file — subprocess env mutations don't propagate to
+        # the parent process, so we re-source here.
+        _source_microsoft_env()
+        if not sharepoint_tools._credentials_configured():
+          raise app.UsageError(
+              "Setup script claimed success but credentials still don't"
+              " look configured — make sure ~/.config/kc_agent/microsoft.env"
+              " got written, then re-run agent_runner.py."
+          )
+      else:
+        raise app.UsageError(
+            "Re-run after completing SharePoint setup (or remove the"
+            " --sharepoint_* flags / SharePoint URLs from --folders/--docs)."
+        )
+    else:
+      raise app.UsageError(msg)
 
   if mode == "context_overlay":
     if not _DATASET.value:
@@ -252,7 +440,7 @@ def main(argv):
             _OUTPUT_DIR.value,
             _MODEL.value,
             _ENTRY_GROUP.value,
-            docs=_DOCS.value,
+            docs=doc_inputs,
             tables_filter=_TABLES.value,
             include_usage=_INCLUDE_USAGE.value,
             usage_window_days=_USAGE_WINDOW_DAYS.value,
@@ -265,6 +453,13 @@ def main(argv):
             repo_subdir=_REPO_SUBDIR.value,
             mcp_config=_MCP_CONFIG.value,
             glossaries=_GLOSSARIES.value or None,
+            output_format=_OUTPUT_FORMAT.value,
+            confluence_spaces=confluence_spaces,
+            confluence_cql=None,
+            confluence_page_ids=confluence_page_ids,
+            sharepoint_sites=sharepoint_sites,
+            sharepoint_search=None,
+            sharepoint_file_ids=sharepoint_file_ids,
         )
     )
   elif mode == "table":
@@ -286,6 +481,13 @@ def main(argv):
             repo_ref=_REPO_REF.value,
             repo_subdir=_REPO_SUBDIR.value,
             mcp_config=_MCP_CONFIG.value,
+            output_format=_OUTPUT_FORMAT.value,
+            confluence_spaces=confluence_spaces,
+            confluence_cql=None,
+            confluence_page_ids=confluence_page_ids,
+            sharepoint_sites=sharepoint_sites,
+            sharepoint_search=None,
+            sharepoint_file_ids=sharepoint_file_ids,
         )
     )
   else:
@@ -297,7 +499,7 @@ def main(argv):
     session = asyncio.run(
         doc_mode.run(
             _TOPIC.value,
-            _DOCS.value,
+            doc_inputs,
             folder_inputs,
             _OUTPUT_DIR.value,
             _MODEL.value,
@@ -318,6 +520,13 @@ def main(argv):
             usage_window_days=_USAGE_WINDOW_DAYS.value,
             anonymize_users=_ANONYMIZE_USERS.value,
             usage_scope=_USAGE_SCOPE.value,
+            output_format=_OUTPUT_FORMAT.value,
+            confluence_spaces=confluence_spaces,
+            confluence_cql=None,
+            confluence_page_ids=confluence_page_ids,
+            sharepoint_sites=sharepoint_sites,
+            sharepoint_search=None,
+            sharepoint_file_ids=sharepoint_file_ids,
         )
     )
 

--- a/agents/enrichment/src/common.py
+++ b/agents/enrichment/src/common.py
@@ -369,6 +369,23 @@ def clean_overview_body(text: str) -> str:
   return t
 
 
+def maybe_convert_to_okf(output_dir: str | None, output_format: str) -> None:
+  """If `output_format == 'okf'`, convert the finished `catalog/` tree into an
+
+  OKF `bundle/` (publishable via `kcmd push --format okf`).
+
+  A no-op for the default 'kcmd' format. Called at the end of each mode's run so
+  every mode emits OKF identically without touching its per-entry write sites.
+  """
+  if output_format != "okf" or not output_dir:
+    return
+  import okf_serializer
+
+  bundle = okf_serializer.convert_tree(output_dir)
+  if bundle:
+    print(f"[OKF] ✅ Converted catalog/ -> OKF bundle at {bundle}", flush=True)
+
+
 def parse_mdcode_blocks(text: str, output_dir: str) -> list[str]:
   """Parse fenced code blocks preceded by a backticked relative path and write
 

--- a/agents/enrichment/src/modes/context_overlay_mode.py
+++ b/agents/enrichment/src/modes/context_overlay_mode.py
@@ -38,7 +38,7 @@ from modes import table_mode
 import refine
 from tools import bq_usage_tools
 from tools import feedback_tools
-from tools import github_tools
+from tools import confluence_tools, github_tools, sharepoint_tools
 from tools import kcmd_tools
 from tools.drive_tools import (
     extract_gdoc_id,
@@ -158,16 +158,31 @@ async def _prepare_all_docs(
     repo_ref: str = "",
     repo_subdir: str = "",
     mcp_config: str = "",
+    confluence_spaces: list[str] | None = None,
+    confluence_cql: list[str] | None = None,
+    confluence_page_ids: list[str] | None = None,
+    sharepoint_sites: list[str] | None = None,
+    sharepoint_search: list[str] | None = None,
+    sharepoint_file_ids: list[str] | None = None,
+    confluence_docs: list[dict] | None = None,
+    sharepoint_docs: list[dict] | None = None,
 ) -> list[dict]:
   """Build the router-descriptor doc list from folders, explicit docs, and/or a
 
-  GitHub repo.
+  GitHub repo, Confluence corpus, and/or SharePoint corpus.
 
   `folders` and `doc_urls` are mixed lists routed per entry (Drive vs local
   markdown). The router indexes docs by their `id` == list position, so ids are
-  reassigned sequentially after merging the sources. Code component cards (when
-  --repo is set) join the pool in the same shape and are routed to tables like
-  any other candidate document.
+  reassigned sequentially after merging the sources. Code component cards
+  (--repo), Confluence page cards (--confluence_*), and SharePoint file cards
+  (--sharepoint_*) join the pool in the same shape and are routed to tables
+  like any other candidate document.
+
+  `confluence_docs` / `sharepoint_docs`, when provided, are pre-gathered cards
+  reused as-is instead of re-fetching (the hybrid doc-mode path passes the
+  cards it already gathered for its KB entries, so the corpus is explored
+  once). When None, the corpus is gathered from the `confluence_*` /
+  `sharepoint_*` query params as usual.
   """
   docs = []
   if folders:
@@ -188,6 +203,38 @@ async def _prepare_all_docs(
     for d in code_docs:
       d["_kind"] = "code"
     docs.extend(code_docs)
+  # Reuse pre-gathered cards (hybrid path) or gather the corpus now.
+  conf_docs = (
+      confluence_docs
+      if confluence_docs is not None
+      else await confluence_tools.gather_confluence_context(
+          confluence_spaces,
+          confluence_cql,
+          confluence_page_ids,
+          topic,
+          model,
+          usage_acc,
+          mcp_config_path=mcp_config or None,
+      )
+  )
+  for d in conf_docs:
+    d["_kind"] = "confluence"
+  docs.extend(conf_docs)
+  sp_docs = (
+      sharepoint_docs
+      if sharepoint_docs is not None
+      else await sharepoint_tools.gather_sharepoint_context(
+          sharepoint_sites,
+          sharepoint_search,
+          sharepoint_file_ids,
+          topic,
+          model,
+          usage_acc,
+      )
+  )
+  for d in sp_docs:
+    d["_kind"] = "sharepoint"
+  docs.extend(sp_docs)
   for i, d in enumerate(docs):
     d["id"] = i
   return docs
@@ -296,7 +343,6 @@ def _move_into_table_folder(
   )
 
 
-
 async def generate_overlays(
     output_dir: str,
     project: str,
@@ -322,6 +368,14 @@ async def generate_overlays(
     repo_ref: str = "",
     repo_subdir: str = "",
     mcp_config: str = "",
+    confluence_spaces: list[str] | None = None,
+    confluence_cql: list[str] | None = None,
+    confluence_page_ids: list[str] | None = None,
+    sharepoint_sites: list[str] | None = None,
+    sharepoint_search: list[str] | None = None,
+    sharepoint_file_ids: list[str] | None = None,
+    confluence_docs: list[dict] | None = None,
+    sharepoint_docs: list[dict] | None = None,
     build_index: bool = True,
 ) -> dict | None:
   """Generate per-table context-overlay entries into an ALREADY-scaffolded EG
@@ -409,6 +463,14 @@ async def generate_overlays(
           repo_ref=repo_ref,
           repo_subdir=repo_subdir,
           mcp_config=mcp_config,
+          confluence_spaces=confluence_spaces,
+          confluence_cql=confluence_cql,
+          confluence_page_ids=confluence_page_ids,
+          sharepoint_sites=sharepoint_sites,
+          sharepoint_search=sharepoint_search,
+          sharepoint_file_ids=sharepoint_file_ids,
+          confluence_docs=confluence_docs,
+          sharepoint_docs=sharepoint_docs,
       ),
       _fetch_usage_or_empty(),
   )
@@ -814,6 +876,13 @@ async def run(
     repo_subdir: str = "",
     mcp_config: str = "",
     glossaries: list[str] | None = None,
+    output_format: str = "kcmd",
+    confluence_spaces: list[str] | None = None,
+    confluence_cql: list[str] | None = None,
+    confluence_page_ids: list[str] | None = None,
+    sharepoint_sites: list[str] | None = None,
+    sharepoint_search: list[str] | None = None,
+    sharepoint_file_ids: list[str] | None = None,
 ):
   project, dataset_id = table_mode._parse_dataset(dataset)
   eg_project, eg_location, eg_id = _parse_eg(entry_group)
@@ -908,7 +977,11 @@ async def run(
       usage_acc, tables_filter=tables_filter, include_usage=include_usage,
       usage_window_days=usage_window_days, anonymize_users=anonymize_users,
       usage_scope=usage_scope, repo=repo, repo_ref=repo_ref,
-      repo_subdir=repo_subdir, mcp_config=mcp_config, build_index=True)
+      repo_subdir=repo_subdir, mcp_config=mcp_config,
+      confluence_spaces=confluence_spaces, confluence_cql=confluence_cql,
+      confluence_page_ids=confluence_page_ids,
+      sharepoint_sites=sharepoint_sites, sharepoint_search=sharepoint_search,
+      sharepoint_file_ids=sharepoint_file_ids, build_index=True)
   if core is None:
     return None
   results = core["results"]
@@ -921,6 +994,10 @@ async def run(
       output_dir, "context_overlay", traj_user_input, tool_uses,
       tool_responses, core["final_text"], usage_acc)
   print(f"[Cache] doc-fetch stats: {get_cache_stats()}", flush=True)
+
+  # OKF output: convert the finished catalog/ tree into an OKF bundle/.
+  common.maybe_convert_to_okf(output_dir, output_format)
+
   return refine.EnrichmentSession(
       mode="context_overlay",
       topic=topic,
@@ -943,8 +1020,6 @@ async def run(
           "tool_responses": tool_responses,
       },
   )
-
-
 
 
 def _set_overlay_category(

--- a/agents/enrichment/src/modes/doc_mode.py
+++ b/agents/enrichment/src/modes/doc_mode.py
@@ -24,7 +24,7 @@ from engine import (
 from google.genai import types
 import refine
 from tools import feedback_tools
-from tools import github_tools
+from tools import confluence_tools, github_tools, sharepoint_tools
 from tools import kcmd_tools
 from tools.drive_tools import (
     extract_folder_id,
@@ -554,6 +554,13 @@ async def run(
     usage_window_days: int = 30,
     anonymize_users: bool = False,
     usage_scope: str = "auto",
+    output_format: str = "kcmd",
+    confluence_spaces: list[str] | None = None,
+    confluence_cql: list[str] | None = None,
+    confluence_page_ids: list[str] | None = None,
+    sharepoint_sites: list[str] | None = None,
+    sharepoint_search: list[str] | None = None,
+    sharepoint_file_ids: list[str] | None = None,
 ):
   # Doc mode generates per-KB-entry overviews. Feedback proposals target
   # tables/columns rather than KB entries, so there's no clean per-entry
@@ -921,6 +928,28 @@ async def run(
         mcp_config_path=mcp_config or None,
     )
 
+  # Confluence corpus (optional): each page becomes its own seed entry (so it
+  # always surfaces as a KB entry) and its card is appended post-reduce.
+  confluence_cards = await confluence_tools.gather_confluence_context(
+      confluence_spaces,
+      confluence_cql,
+      confluence_page_ids,
+      topic,
+      model,
+      usage_acc,
+      mcp_config_path=mcp_config or None,
+  )
+
+  # SharePoint corpus (optional): same treatment as the Confluence cards.
+  sharepoint_cards = await sharepoint_tools.gather_sharepoint_context(
+      sharepoint_sites,
+      sharepoint_search,
+      sharepoint_file_ids,
+      topic,
+      model,
+      usage_acc,
+  )
+
   # 2b. Stage-2 Reduce (uncached): topic-shaped batch reduction over the
   # neutral per-doc cards. Cards are ~5× smaller than raw doc text, so each
   # batch call is cheap relative to the legacy raw-text summarizer.
@@ -977,6 +1006,45 @@ async def run(
         for c in code_cards
     ]
 
+  # Append Confluence page cards verbatim (same post-reduce rationale as
+  # code cards above) and seed each as its own KB entry.
+  confluence_seed_entries = []
+  if confluence_cards:
+    conf_block = "\n\n".join(
+        f"--- CONFLUENCE PAGE: {c['name']} ({c['url']}) ---\n{c['content']}"
+        for c in confluence_cards
+    )
+    compiled_summary += (
+        "\n\n--- CONFLUENCE PAGES ---\n\n" + conf_block
+    )
+    confluence_seed_entries = [
+        {
+            "id": _slugify(c["name"]),
+            "display_name": c["name"],
+            "kind": "kb",
+        }
+        for c in confluence_cards
+    ]
+
+  # Append SharePoint file cards verbatim (same rationale).
+  sharepoint_seed_entries = []
+  if sharepoint_cards:
+    sp_block = "\n\n".join(
+        f"--- SHAREPOINT FILE: {c['name']} ({c['url']}) ---\n{c['content']}"
+        for c in sharepoint_cards
+    )
+    compiled_summary += (
+        "\n\n--- SHAREPOINT FILES ---\n\n" + sp_block
+    )
+    sharepoint_seed_entries = [
+        {
+            "id": _slugify(c["name"]),
+            "display_name": c["name"],
+            "kind": "kb",
+        }
+        for c in sharepoint_cards
+    ]
+
   # HYBRID (reorder + feed): generate the per-table context-overlay entries FIRST,
   # so the KB enumeration below can be scoped to ONLY the cross-cutting knowledge
   # the overlays do NOT already own. The overlays own each table's schema,
@@ -1002,6 +1070,11 @@ async def run(
         usage_window_days=usage_window_days, anonymize_users=anonymize_users,
         usage_scope=usage_scope, repo=repo, repo_ref=repo_ref,
         repo_subdir=repo_subdir, mcp_config=mcp_config,
+        # Reuse the Confluence/SharePoint cards already gathered above for the KB
+        # entries so the overlays are grounded by the same corpus without a second
+        # fetch (passing the cards skips the gather in _prepare_all_docs).
+        confluence_docs=confluence_cards,
+        sharepoint_docs=sharepoint_cards,
         # doc_mode builds ONE combined index over BOTH the KB folders and the
         # overlay folders (merging the overlay dir_meta), so generate_overlays
         # must not build its own -- avoids a double pass that relabels folders.
@@ -1049,7 +1122,7 @@ async def run(
           "kind": "kb",
       }
       for e in existing_kb_entries
-  ] + code_seed_entries
+  ] + code_seed_entries + confluence_seed_entries + sharepoint_seed_entries
   if seed_entries:
     print(
         f"[Agent] 🧭 Enumerating with {len(seed_entries)} seed entries from"
@@ -1241,6 +1314,22 @@ async def run(
         "name": "explore_repo",
         "response": {"url": c["url"], "content": c["content"]},
     })
+  for c in confluence_cards:
+    tool_uses.append(
+        {"name": "read_confluence", "args": {"page": c["name"]}}
+    )
+    tool_responses.append({
+        "name": "read_confluence",
+        "response": {"url": c["url"], "content": c["content"]},
+    })
+  for c in sharepoint_cards:
+    tool_uses.append(
+        {"name": "read_sharepoint", "args": {"file": c["name"]}}
+    )
+    tool_responses.append({
+        "name": "read_sharepoint",
+        "response": {"url": c["url"], "content": c["content"]},
+    })
   tool_uses.append({"name": "enumerate", "args": {"topic": topic}})
   tool_responses.append(
       {"name": "enumerate", "response": enumeration.model_dump()}
@@ -1266,6 +1355,9 @@ async def run(
   from tools.drive_tools import get_cache_stats
 
   print(f"[Cache] doc-fetch stats: {get_cache_stats()}", flush=True)
+
+  # OKF output: convert the finished catalog/ tree into an OKF bundle/.
+  common.maybe_convert_to_okf(output_dir, output_format)
 
   # Build the refinement session (consumed by agent_runner --interactive).
   # HYBRID: include the overlay entries so a later refine turn can target them.

--- a/agents/enrichment/src/modes/table_mode.py
+++ b/agents/enrichment/src/modes/table_mode.py
@@ -28,7 +28,7 @@ from engine import (
 import refine
 from tools import bq_usage_tools
 from tools import feedback_tools
-from tools import github_tools
+from tools import confluence_tools, github_tools, sharepoint_tools
 from tools import kcmd_tools
 from tools.drive_tools import (
     extract_folder_id,
@@ -583,6 +583,13 @@ async def run(
     repo_ref: str = "",
     repo_subdir: str = "",
     mcp_config: str = "",
+    output_format: str = "kcmd",
+    confluence_spaces: list[str] | None = None,
+    confluence_cql: list[str] | None = None,
+    confluence_page_ids: list[str] | None = None,
+    sharepoint_sites: list[str] | None = None,
+    sharepoint_search: list[str] | None = None,
+    sharepoint_file_ids: list[str] | None = None,
 ):
   project, dataset_id = _parse_dataset(dataset)
   # --folder is a mixed list (Drive folders and/or local md dirs); each entry is
@@ -738,8 +745,37 @@ async def run(
     for d in code_docs:
       d["_kind"] = "code"
     docs.extend(code_docs)
-    for i, d in enumerate(docs):
-      d["id"] = i
+
+  # Confluence corpus (optional): page cards join the relevance router's
+  # candidate pool alongside Drive docs and code cards.
+  conf_docs = await confluence_tools.gather_confluence_context(
+      confluence_spaces,
+      confluence_cql,
+      confluence_page_ids,
+      topic,
+      model,
+      usage_acc,
+      mcp_config_path=mcp_config or None,
+  )
+  for d in conf_docs:
+    d["_kind"] = "confluence"
+  docs.extend(conf_docs)
+
+  # SharePoint corpus (optional). Same router-descriptor doc shape.
+  sp_docs = await sharepoint_tools.gather_sharepoint_context(
+      sharepoint_sites,
+      sharepoint_search,
+      sharepoint_file_ids,
+      topic,
+      model,
+      usage_acc,
+  )
+  for d in sp_docs:
+    d["_kind"] = "sharepoint"
+  docs.extend(sp_docs)
+
+  for i, d in enumerate(docs):
+    d["id"] = i
 
   if not docs:
     print(
@@ -1029,6 +1065,9 @@ async def run(
   from tools.drive_tools import get_cache_stats
 
   print(f"[Cache] doc-fetch stats: {get_cache_stats()}", flush=True)
+
+  # OKF output: convert the finished catalog/ tree into an OKF bundle/.
+  common.maybe_convert_to_okf(output_dir, output_format)
 
   # Build the refinement session (consumed by agent_runner --interactive).
   return refine.EnrichmentSession(

--- a/agents/enrichment/src/okf_serializer.py
+++ b/agents/enrichment/src/okf_serializer.py
@@ -1,0 +1,251 @@
+"""OKF (Open Knowledge Format) serializer — the Python twin of kcmd's
+
+`layouts/okf.ts`.
+
+Emits ONE markdown file per concept (YAML frontmatter + body) plus reserved
+`index.md` directory listings, byte-compatible with the kcmd `OkfLayout` so
+`kcmd push --format okf` can publish exactly what the agent writes. The full
+Dataplex entry is preserved under a hidden `x-kcmd` frontmatter key for faithful
+round-trip (consumers ignore unknown keys per SPEC.md); the markdown body is the
+`overview` aspect content.
+
+See SPEC.md: github.com/GoogleCloudPlatform/knowledge-catalog okf/SPEC.md
+"""
+
+import os
+import re
+
+import yaml
+
+OKF_VERSION = "0.1"
+STASH_KEY = "x-kcmd"
+_QUERIES_ASPECT_KEY = "dataplex-types.global.queries"
+
+
+def _frontmatter(entry: dict) -> dict:
+  """Build the OKF frontmatter for a concept from its kcmd entry dict.
+
+  Top-level keys are the SPEC-recommended fields (type/title/description/tags/
+  timestamp/resource); the full entry is stashed under `x-kcmd` so kcmd can
+  reconstruct it losslessly. None-valued keys are dropped.
+  """
+  resource = entry.get("resource") or {}
+  labels = resource.get("labels") or {}
+  tags = [k for k, v in labels.items() if v == "true"] or None
+  fm = {
+      "type": entry.get("type"),
+      "title": resource.get("displayName") or resource.get("name"),
+      "description": resource.get("description"),
+      "tags": tags,
+      "timestamp": resource.get("updateTime") or resource.get("createTime"),
+      "resource": resource.get("name"),
+      # Faithful round-trip stash. The overview lives in the body, not here.
+      STASH_KEY: entry,
+  }
+  return {k: v for k, v in fm.items() if v is not None}
+
+
+def dump_concept(entry: dict, body: str) -> str:
+  """Return the full OKF concept file content (frontmatter + body)."""
+  fm = yaml.safe_dump(
+      _frontmatter(entry), sort_keys=False, allow_unicode=True
+  ).strip()
+  body = body if body.endswith("\n") else body + "\n"
+  return f"---\n{fm}\n---\n{body}"
+
+
+def write_concept(md_path: str, entry: dict, body: str) -> None:
+  """Write one OKF concept file at `md_path` (a `<name>.md` path).
+
+  `body` should already be cleaned (e.g. via common.clean_overview_body).
+  """
+  os.makedirs(os.path.dirname(md_path), exist_ok=True)
+  with open(md_path, "w") as f:
+    f.write(dump_concept(entry, body))
+
+
+def _split_frontmatter(text: str) -> tuple[dict, str]:
+  """Split a `---\\n…\\n---\\n` leading block. Returns (frontmatter, body)."""
+  if not text.startswith("---"):
+    return {}, text
+  m = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", text, re.S)
+  if not m:
+    return {}, text
+  data = yaml.safe_load(m.group(1)) or {}
+  return (data if isinstance(data, dict) else {}), m.group(2)
+
+
+def _okf_citations_heading(body: str) -> str:
+  """Rename the overview's `Source References` heading to OKF's `Citations`.
+
+  Our writer prompts emit a `## Source References` section; OKF's body
+  convention calls this `# Citations` (SPEC §Citations). Only the heading line
+  is renamed (the `#` level is preserved); inline mentions are untouched.
+  """
+  return re.sub(
+      r"(?m)^(#{1,6}[ \t]+)Source References[ \t]*$",
+      r"\1Citations",
+      body,
+  )
+
+
+def convert_tree(output_dir: str) -> str | None:
+  """Convert a finished kcmd-native `catalog/` tree into an OKF `bundle/`.
+
+  Reads every entry (`X.yaml` + sibling `X.overview.md` body + optional
+  `X.queries.md` aspect sidecar) and emits a single `bundle/X.md` OKF concept
+  (frontmatter + body, full entry stashed under `x-kcmd`). Read-only reference
+  mirrors (`X.ref.yaml` / `X.ref.overview.md`) become `X.ref.md`. Reserved
+  `catalog.yaml` and `index.*` are skipped; `index.md` listings are regenerated.
+
+  Leaves `catalog/` in place (refinement + the webapp still read it); `bundle/`
+  is the publishable OKF deliverable (`kcmd push --format okf`). Returns the
+  bundle path, or None if there is no catalog/ to convert.
+  """
+  catalog_dir = os.path.join(output_dir, "catalog")
+  bundle_dir = os.path.join(output_dir, "bundle")
+  if not os.path.isdir(catalog_dir):
+    return None
+
+  for dirpath, _subdirs, files in os.walk(catalog_dir):
+    for fn in files:
+      if not fn.endswith(".yaml") or fn in ("catalog.yaml", "index.yaml"):
+        continue
+      is_ref = fn.endswith(".ref.yaml")
+      base = fn[: -len(".ref.yaml")] if is_ref else fn[: -len(".yaml")]
+      with open(os.path.join(dirpath, fn)) as f:
+        entry = yaml.safe_load(f) or {}
+      if not isinstance(entry, dict):
+        continue
+
+      # Overview body (the `.md` body in OKF). Ref overviews may carry
+      # frontmatter; concept overviews are pure markdown.
+      ov_suffix = ".ref.overview.md" if is_ref else ".overview.md"
+      ov_path = os.path.join(dirpath, base + ov_suffix)
+      body = ""
+      if os.path.exists(ov_path):
+        with open(ov_path) as f:
+          _fm, body = _split_frontmatter(f.read())
+        body = _okf_citations_heading(body)
+
+      # Queries aspect sidecar (frontmatter-only) -> fold into the entry so it
+      # round-trips via x-kcmd on push.
+      q_path = os.path.join(dirpath, base + ".queries.md")
+      if os.path.exists(q_path):
+        with open(q_path) as f:
+          q_fm, _q_body = _split_frontmatter(f.read())
+        if q_fm:
+          entry.setdefault("aspects", {})[_QUERIES_ASPECT_KEY] = q_fm
+
+      rel = os.path.relpath(os.path.join(dirpath, base), catalog_dir).replace(
+          os.sep, "/"
+      )
+      out_rel = f"{rel}.ref.md" if is_ref else f"{rel}.md"
+      write_concept(os.path.join(bundle_dir, out_rel), entry, body)
+
+  write_indexes(bundle_dir, catalog_dir)
+  return bundle_dir
+
+
+def _titleize(slug: str) -> str:
+  return slug.replace("-", " ").replace("_", " ").strip().title()
+
+
+def _oneline(s: str) -> str:
+  """Collapse whitespace/newlines to single spaces and trim, so a value sits on
+
+  one Markdown list row (an embedded newline would break the row).
+  """
+  return " ".join((s or "").split())
+
+
+def _folder_meta(
+    catalog_dir: str | None, rel: str, fallback_title: str
+) -> tuple[str, str]:
+  """(title, description) for a folder, from its kcmd-native `index.yaml` if the
+
+  agent built one (doc/context_overlay), else a derived title + empty desc.
+  """
+  if catalog_dir:
+    idx = (
+        os.path.join(catalog_dir, rel, "index.yaml")
+        if rel
+        else os.path.join(catalog_dir, "index.yaml")
+    )
+    if os.path.exists(idx):
+      try:
+        with open(idx) as f:
+          data = yaml.safe_load(f) or {}
+        res = data.get("resource") or {}
+        return (res.get("displayName") or fallback_title), (
+            res.get("description") or ""
+        )
+      except (OSError, yaml.YAMLError):
+        pass
+  return fallback_title, ""
+
+
+def _concept_meta(md_path: str) -> tuple[str, str]:
+  """(title, description) for a concept .md, from its YAML frontmatter."""
+  try:
+    with open(md_path) as f:
+      fm, _body = _split_frontmatter(f.read())
+  except OSError:
+    fm = {}
+  base = os.path.basename(md_path)[: -len(".md")]
+  return (fm.get("title") or base), (fm.get("description") or "")
+
+
+def write_indexes(root_dir: str, catalog_dir: str | None = None) -> None:
+  """Regenerate reserved `index.md` directory listings across the bundle.
+
+  Non-root indexes carry no frontmatter; the bundle-root `index.md` declares
+  `okf_version` (the only place frontmatter is permitted in an index.md). Each
+  row is `* [<title>](<link>) - <description>` (GA4 bundle convention); the
+  folder's own title/description head the file so a consumer (e.g. `kcmd push
+  --format okf`) can synthesize a directory/index entry from the file alone.
+  `index.md` and `.ref.md` are not listed.
+  """
+  if not os.path.isdir(root_dir):
+    return
+  for directory, _subdirs, _files in os.walk(root_dir):
+    is_root = os.path.abspath(directory) == os.path.abspath(root_dir)
+    rel = (
+        ""
+        if is_root
+        else os.path.relpath(directory, root_dir).replace(os.sep, "/")
+    )
+    ftitle, fdesc = _folder_meta(
+        catalog_dir,
+        rel,
+        "Index" if is_root else _titleize(os.path.basename(directory)),
+    )
+
+    rows: list[str] = []
+    for name in sorted(os.listdir(directory)):
+      full = os.path.join(directory, name)
+      if os.path.isdir(full):
+        crel = name if is_root else f"{rel}/{name}"
+        ctitle, cdesc = _folder_meta(catalog_dir, crel, _titleize(name))
+        link = f"{name}/index.md"
+      elif (
+          name.endswith(".md")
+          and name != "index.md"
+          and not name.endswith(".ref.md")
+      ):
+        ctitle, cdesc = _concept_meta(full)
+        link = name
+      else:
+        continue
+      ctitle, cdesc = _oneline(ctitle), _oneline(cdesc)
+      rows.append(f"* [{ctitle}]({link})" + (f" - {cdesc}" if cdesc else ""))
+
+    lines = [f"# {_oneline(ftitle)}", ""]
+    if fdesc:
+      lines += [_oneline(fdesc), ""]
+    lines += rows if rows else ["_(empty)_"]
+    out = "\n".join(lines) + "\n"
+    if is_root:
+      out = f'---\nokf_version: "{OKF_VERSION}"\n---\n{out}'
+    with open(os.path.join(directory, "index.md"), "w") as f:
+      f.write(out)

--- a/agents/enrichment/src/requirements.txt
+++ b/agents/enrichment/src/requirements.txt
@@ -11,8 +11,13 @@ google-genai
 google-api-python-client
 google-auth
 google-cloud-bigquery
-mcp                # only needed if --repo uses the local stdio GitHub MCP server (the default hosted remote works without it)
+mcp                # needed if --repo uses the local stdio GitHub MCP server, and for the Confluence (Atlassian Rovo) source (the hosted remotes work without it)
 pypdf
 pyyaml
 requests
 absl-py
+httpx              # SharePoint source: Microsoft Graph REST client (--sharepoint_sites)
+msal               # SharePoint source: Microsoft auth token acquisition (scripts/setup_sharepoint.py)
+python-docx        # SharePoint source: extract text from .docx attachments
+openpyxl           # SharePoint source: extract text from .xlsx attachments
+python-pptx        # SharePoint source: extract text from .pptx attachments

--- a/agents/enrichment/src/tools/confluence_tools.py
+++ b/agents/enrichment/src/tools/confluence_tools.py
@@ -1,0 +1,769 @@
+"""Confluence input: agentic page understanding via the Atlassian Rovo MCP server.
+
+A sibling to github_tools.py: an ADK `LlmAgent` is given Atlassian's hosted
+remote MCP server (`https://mcp.atlassian.com/v1/mcp/authv2`) and asked to
+explore Confluence on its own — list spaces, run CQL, read pages — then
+distill the relevant pages into a set of *Confluence page cards*.
+
+Each card is emitted in the SAME router-descriptor doc shape every mode
+already consumes — `{name, url, content, descriptor}` — so the existing
+pipelines fold Confluence context in with zero per-mode plumbing, identical
+to how GitHub component cards are folded in:
+
+  * doc mode             — cards are appended as neutral per-doc cards and
+                           flow into the topic reduce → enumerate → write
+                           pipeline, so distinct pages surface as their own
+                           KB entries.
+  * table / overlay mode — cards join the candidate-document pool the
+                           relevance router scores per table, so a runbook
+                           or design doc that mentions a table grounds that
+                           table's overview.
+
+MCP server wiring:
+  * Default — Atlassian's hosted remote MCP at the URL above. Accepts
+    third-party MCP clients (unlike Microsoft Agent 365 SharePoint MCP).
+  * Auth (env-var path) — see _build_auth_header for the full precedence.
+    Briefly:
+      - `ATLASSIAN_EMAIL` + `ATLASSIAN_API_TOKEN` -> personal API token
+        (sent as Basic auth — this is what id.atlassian.com mints).
+      - `ATLASSIAN_API_TOKEN` alone -> service-account API key (Bearer).
+      - `ATLASSIAN_OAUTH_TOKEN` -> raw OAuth bearer (Bearer).
+    For any API-token path, your site admin must enable API-token auth on
+    the Rovo MCP server settings page.
+  * Auth (OAuth-via-mcp-remote path) — point `--mcp_config` at an
+    mcp.json that wraps `npx -y mcp-remote@latest <atlassian-mcp-url>`
+    over stdio. `mcp-remote` handles the OAuth dance itself and the env
+    vars above are not consulted on this path. Recommended for full tool
+    catalog access — API-token auth is a documented subset.
+  * Override — point at a different MCP server with `--mcp_config` (same
+    flag GitHub uses; the file selects by key — Confluence reads the
+    `_SERVER_KEY` entry, default `atlassian_remote`).
+
+Failure is non-fatal: if the server can't be reached, the token is
+missing/invalid, or the model returns nothing parseable, we log a warning
+and return an empty list. A run with `--confluence_space` set therefore
+degrades to "no Confluence context" rather than crashing the whole
+enrichment.
+"""
+
+import base64
+import json
+import os
+import re
+import typing as t
+import urllib.parse as _urlparse
+import uuid
+
+from engine import VertexGemini
+from google.adk.agents import llm_agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+# Atlassian's hosted remote Rovo MCP server. Accepts third-party MCP clients
+# via OAuth 2.1 or (if admin-enabled) API token authentication.
+_DEFAULT_REMOTE_URL = "https://mcp.atlassian.com/v1/mcp/authv2"
+# Token envs, checked in priority order. API token is the simplest path; OAuth
+# token is what `mcp-remote` writes after the interactive consent flow.
+_TOKEN_ENVS = ("ATLASSIAN_API_TOKEN", "ATLASSIAN_OAUTH_TOKEN")
+
+# Which server entry to use from a multi-server mcp.json. Defaults so a stock
+# mcp.json with a single Atlassian entry under any key still works.
+_SERVER_KEY = os.environ.get(
+    "KC_ENRICH_CONFLUENCE_MCP_SERVER", "atlassian_remote"
+)
+
+# Cap exploration turns. Confluence sites can be huge; this matches GitHub's
+# budget and is the hard ceiling on tool-driving turns.
+_MAX_EXPLORE_TURNS = 40
+
+
+# ---------------------------------------------------------------------------
+# URL classifier + source partitioner
+#
+# Lets the user drop Confluence URLs straight into --folders (or --docs)
+# alongside Drive / local-markdown entries; agent_runner.py calls
+# partition_sources() once before dispatch to lift the Confluence entries
+# out into the existing --confluence_space / --confluence_page_ids lists.
+# All downstream Drive/local routing in is_local_path() and the modes stays
+# unchanged, because by the time they see the lists, Confluence URLs are
+# already gone.
+# ---------------------------------------------------------------------------
+
+# Modern Cloud URL form: .../wiki/spaces/<KEY>/pages/<ID>/<title-slug>?...
+# Also matches .../wiki/spaces/<KEY>/blogposts/<ID>/... (same data model).
+_CONFLUENCE_PAGE_PATH_RE = re.compile(
+    r"^/wiki/spaces/([^/]+)/(?:pages|blogposts)/(\d+)(?:/|$)", re.IGNORECASE
+)
+# Space root: .../wiki/spaces/<KEY> or .../wiki/spaces/<KEY>/overview
+_CONFLUENCE_SPACE_PATH_RE = re.compile(
+    r"^/wiki/spaces/([^/?#]+)(?:/overview)?/?$", re.IGNORECASE
+)
+# Legacy "display" link: .../wiki/display/<KEY>[/<page-title>]
+# Page-by-title can't be resolved to a page ID without an API call; we
+# downgrade these to space-level (the agent will pick the page back up
+# when scoring titles against the topic).
+_CONFLUENCE_DISPLAY_PATH_RE = re.compile(
+    r"^/wiki/display/([^/]+)", re.IGNORECASE
+)
+# Tiny URL: .../wiki/x/<short> — needs a server roundtrip to resolve.
+_CONFLUENCE_TINY_PATH_RE = re.compile(r"^/wiki/x/", re.IGNORECASE)
+# Old action URL: .../wiki/pages/viewpage.action?pageId=<ID>
+_CONFLUENCE_VIEWPAGE_PATH_RE = re.compile(
+    r"^/wiki/pages/viewpage\.action$", re.IGNORECASE
+)
+
+
+def classify_confluence_url(s: str) -> dict | None:
+  """If `s` looks like a Confluence URL, return its parsed form; else None.
+
+  Returned dicts:
+    {'kind': 'page',    'page_id': '<id>', 'space': '<key>' | ''}
+    {'kind': 'space',   'space':   '<key>'}
+    {'kind': 'unknown', 'raw':     '<original>'}   # short URL / page-by-title
+
+  None means "not Confluence" — the caller routes it to the existing
+  Drive / local-markdown logic untouched.
+  """
+  s = (s or "").strip()
+  if not s.lower().startswith(("http://", "https://")):
+    return None
+  try:
+    u = _urlparse.urlparse(s)
+  except (ValueError, TypeError):
+    return None
+  path = u.path or ""
+  if "/wiki/" not in path.lower():
+    return None
+
+  # 1. Modern page URL — most common, check first.
+  m = _CONFLUENCE_PAGE_PATH_RE.match(path)
+  if m:
+    return {"kind": "page", "space": m.group(1), "page_id": m.group(2)}
+
+  # 2. Old action URL with pageId as a query param.
+  if _CONFLUENCE_VIEWPAGE_PATH_RE.match(path):
+    qs = _urlparse.parse_qs(u.query)
+    pids = qs.get("pageId") or qs.get("pageid")
+    if pids:
+      return {"kind": "page", "space": "", "page_id": pids[0]}
+
+  # 3. Space root / overview. If overview carries ?homepageId=, prefer the
+  #    page hint over the bare space — the user usually copied that URL
+  #    because they're pointing at a specific landing page.
+  m = _CONFLUENCE_SPACE_PATH_RE.match(path)
+  if m:
+    qs = _urlparse.parse_qs(u.query)
+    homes = qs.get("homepageId") or qs.get("homepageid")
+    if homes:
+      return {"kind": "page", "space": m.group(1), "page_id": homes[0]}
+    return {"kind": "space", "space": m.group(1)}
+
+  # 4. Legacy display URL → space-level (page-by-title can't be resolved).
+  m = _CONFLUENCE_DISPLAY_PATH_RE.match(path)
+  if m:
+    return {"kind": "space", "space": m.group(1)}
+
+  # 5. Tiny URL — needs API resolution.
+  if _CONFLUENCE_TINY_PATH_RE.match(path):
+    return {"kind": "unknown", "raw": s}
+
+  # /wiki/ in the path but an unrecognized shape — surface but skip.
+  return {"kind": "unknown", "raw": s}
+
+
+def partition_sources(
+    entries: list[str] | None,
+    confluence_spaces: list[str] | None = None,
+    confluence_page_ids: list[str] | None = None,
+) -> tuple[list[str], list[str], list[str]]:
+  """Split a mixed `--folders`/`--docs` list, lifting Confluence URLs out.
+
+  For each entry:
+    - Confluence page URL  → append its page ID to confluence_page_ids.
+    - Confluence space URL → append its space key to confluence_spaces.
+    - Anything else (Drive URL/ID, local path/file) → keep in the returned
+      filtered list, so the existing Drive/local routing handles it.
+
+  Deduplicates against whatever the user already passed via
+  --confluence_space / --confluence_page_ids, so a URL plus an explicit
+  flag for the same page doesn't cause duplicate work.
+
+  Original lists are NOT mutated; new lists are returned. Returns:
+    (filtered_entries, updated_spaces, updated_page_ids)
+  """
+  filtered: list[str] = []
+  spaces = list(confluence_spaces or [])
+  pages = list(confluence_page_ids or [])
+  seen_spaces = {x.strip() for x in spaces if x and x.strip()}
+  seen_pages = {x.strip() for x in pages if x and x.strip()}
+  for e in entries or []:
+    cls = classify_confluence_url(e)
+    if cls is None:
+      filtered.append(e)
+      continue
+    kind = cls.get("kind")
+    if kind == "page":
+      pid = str(cls.get("page_id", "")).strip()
+      if pid and pid not in seen_pages:
+        pages.append(pid)
+        seen_pages.add(pid)
+        print(
+            f"[Confluence] 🔗 Resolved {e} → page id {pid}"
+            + (f" (space {cls['space']})" if cls.get("space") else ""),
+            flush=True,
+        )
+    elif kind == "space":
+      sp = str(cls.get("space", "")).strip()
+      if sp and sp not in seen_spaces:
+        spaces.append(sp)
+        seen_spaces.add(sp)
+        print(
+            f"[Confluence] 🔗 Resolved {e} → space {sp}",
+            flush=True,
+        )
+    else:
+      print(
+          f"[Confluence] ⚠️  Could not classify URL {e!r} as a page or"
+          " space (likely a tiny URL like .../wiki/x/<short> or a legacy"
+          " page-by-title link). Pass --confluence_page_ids=<id> or use"
+          " the full /wiki/spaces/<KEY>/pages/<ID>/... URL instead.",
+          flush=True,
+      )
+  return filtered, spaces, pages
+
+
+def _short_args(args: dict) -> str:
+  """Compact one-line rendering of tool-call args for logging."""
+  parts = []
+  for k, v in (args or {}).items():
+    s = str(v)
+    if len(s) > 60:
+      s = s[:57] + "..."
+    parts.append(f"{k}={s}")
+  return ", ".join(parts)
+
+
+def _response_text(response: t.Any) -> str:
+  """Best-effort extraction of textual content from an MCP tool response.
+
+  Mirrors github_tools._response_text — MCP/ADK wrap tool results in varied
+  shapes (a dict with 'result'/'content', a list of content blocks, a bare
+  string). We only need the text length to gauge whether real content came
+  back, so we stringify defensively.
+  """
+  if response is None:
+    return ""
+  if isinstance(response, str):
+    return response
+  if isinstance(response, dict):
+    for key in ("text", "content", "result", "output"):
+      if key in response:
+        return _response_text(response[key])
+    return str(response)
+  if isinstance(response, (list, tuple)):
+    return "".join(_response_text(x) for x in response)
+  text_attr = getattr(response, "text", None)
+  if isinstance(text_attr, str):
+    return text_attr
+  return str(response)
+
+
+def _resolve_token() -> str:
+  """Return the first non-empty Atlassian token from the env, or ''."""
+  for env in _TOKEN_ENVS:
+    v = os.environ.get(env, "").strip()
+    if v:
+      return v
+  return ""
+
+
+def _build_auth_header() -> dict[str, str]:
+  """Build the right Authorization header for the connection's auth mode.
+
+  Three cases, checked in this order (only the built-in HTTP-transport path
+  uses this — the --mcp_config / OAuth-via-mcp-remote path doesn't touch
+  it, since `mcp-remote` presents the OAuth token to the server itself):
+
+    1. ATLASSIAN_EMAIL + ATLASSIAN_API_TOKEN both set
+       → personal API token: emit `Basic base64(email:token)`. This is the
+         documented header for tokens minted at
+         id.atlassian.com/manage-profile/security/api-tokens. Note that
+         the Rovo MCP server silently downgrades unrecognized auth to a
+         "Teamwork Graph only" tool subset instead of returning 401, so
+         getting this exactly right matters.
+    2. ATLASSIAN_API_TOKEN set without ATLASSIAN_EMAIL
+       → assumed to be a service-account API key: emit `Bearer <token>`.
+    3. ATLASSIAN_OAUTH_TOKEN set
+       → emit `Bearer <token>` (raw OAuth bearer, for callers that don't
+         want to run `mcp-remote` but already hold a token).
+
+  Returns `{}` if none of the above apply (caller short-circuits with a
+  warning so we never make an unauthenticated request).
+  """
+  email = os.environ.get("ATLASSIAN_EMAIL", "").strip()
+  api_token = os.environ.get("ATLASSIAN_API_TOKEN", "").strip()
+  oauth_token = os.environ.get("ATLASSIAN_OAUTH_TOKEN", "").strip()
+  if email and api_token:
+    creds = base64.b64encode(f"{email}:{api_token}".encode()).decode()
+    return {"Authorization": f"Basic {creds}"}
+  if api_token:
+    return {"Authorization": f"Bearer {api_token}"}
+  if oauth_token:
+    return {"Authorization": f"Bearer {oauth_token}"}
+  return {}
+
+
+def _expand_env(value: t.Any) -> t.Any:
+  """Recursively expand ${VAR} / $VAR in JSON-loaded values."""
+  if isinstance(value, str):
+    return os.path.expandvars(value)
+  if isinstance(value, list):
+    return [_expand_env(v) for v in value]
+  if isinstance(value, dict):
+    return {k: _expand_env(v) for k, v in value.items()}
+  return value
+
+
+def load_mcp_server_config(config_path: str | None) -> dict:
+  """Resolve the Atlassian MCP server launch spec.
+
+  Precedence:
+    1. `config_path` flag, else `KC_ENRICH_MCP_CONFIG` env — a JSON file
+       shaped like the GitHub sample (`{"mcpServers": {"<key>": {...}}}`).
+       `${VAR}` tokens are expanded. The `_SERVER_KEY` entry is selected;
+       if absent but the config defines exactly one server, that one is
+       used.
+    2. Built-in default (no config file): Atlassian's hosted REMOTE server
+       at `https://mcp.atlassian.com/v1/mcp/authv2`, authenticated with
+       whichever of ATLASSIAN_API_TOKEN / ATLASSIAN_OAUTH_TOKEN is set.
+
+  Returns a normalized dict, one of:
+    * stdio:  {"transport": "stdio", "command", "args", "env"}
+    * http:   {"transport": "http",  "url", "headers"}
+  """
+  path = config_path or os.environ.get("KC_ENRICH_MCP_CONFIG", "")
+  if path:
+    with open(os.path.expanduser(path)) as f:
+      raw = _expand_env(json.load(f))
+    servers = raw.get("mcpServers", raw)
+    if _SERVER_KEY in servers:
+      spec = servers[_SERVER_KEY]
+    elif len(servers) == 1:
+      only_key = next(iter(servers))
+      print(
+          f"[Confluence] ℹ️  MCP config has no '{_SERVER_KEY}'; using its"
+          f" only server '{only_key}'.",
+          flush=True,
+      )
+      spec = servers[only_key]
+    else:
+      raise ValueError(
+          f"MCP config '{path}' has no '{_SERVER_KEY}' server (found:"
+          f" {sorted(servers)}). Set KC_ENRICH_CONFLUENCE_MCP_SERVER to"
+          " the right key."
+      )
+    if spec.get("url"):
+      return {
+          "transport": "http",
+          "url": spec["url"],
+          "headers": spec.get("headers", {}),
+      }
+    return {
+        "transport": "stdio",
+        "command": spec["command"],
+        "args": spec.get("args", []),
+        "env": spec.get("env", {}),
+    }
+  # Built-in default: hosted remote MCP + auth header from env. See
+  # _build_auth_header for the precedence rules (Basic for personal API
+  # tokens with ATLASSIAN_EMAIL, Bearer for service-account API keys or
+  # raw OAuth tokens). The --mcp_config / mcp-remote OAuth path never
+  # reaches this branch.
+  return {
+      "transport": "http",
+      "url": os.environ.get("KC_ENRICH_CONFLUENCE_MCP_URL", _DEFAULT_REMOTE_URL),
+      "headers": _build_auth_header(),
+  }
+
+
+def _build_toolset(cfg: dict):
+  """Build an ADK McpToolset from a normalized config dict."""
+  from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+
+  if cfg["transport"] == "http":
+    from google.adk.tools.mcp_tool.mcp_session_manager import (
+        StreamableHTTPConnectionParams,
+    )
+
+    return McpToolset(
+        connection_params=StreamableHTTPConnectionParams(
+            url=cfg["url"], headers=cfg.get("headers", {})
+        )
+    )
+
+  from google.adk.tools.mcp_tool.mcp_session_manager import (
+      StdioConnectionParams,
+  )
+  from mcp import StdioServerParameters
+
+  child_env = {**os.environ, **(cfg.get("env") or {})}
+  return McpToolset(
+      connection_params=StdioConnectionParams(
+          server_params=StdioServerParameters(
+              command=cfg["command"],
+              args=cfg.get("args", []),
+              env=child_env,
+          ),
+          timeout=120.0,
+      )
+  )
+
+
+_EXPLORER_INSTRUCTION = """You are a senior technical writer indexing a Confluence corpus for a metadata-enrichment pipeline. You have tools from the Atlassian Rovo MCP server to bootstrap the site (`getAccessibleAtlassianResources`), browse Confluence (`getConfluenceSpaces`, `getPagesInConfluenceSpace`, `searchConfluenceUsingCql`), and read individual pages (`getConfluencePage`). Use them to UNDERSTAND the relevant pages, then describe each.
+
+SCOPE FOR THIS RUN:
+{scope_directive}
+FOCUS TOPIC for relevance scoring: {topic}
+
+EXPLORATION STRATEGY — follow this sequence; do NOT stop after only the prep steps:
+
+STEP 0 (always, first): Call `getAccessibleAtlassianResources()` ONCE to get the cloudId for this Atlassian site. EVERY subsequent Confluence tool call MUST pass this cloudId. Tools called without a cloudId, or with a placeholder like `site.atlassian.net`, will fail — do not guess the cloudId.
+
+STEP 1 (if page IDs were provided): For EACH ID, call `getConfluencePage(cloudId=..., pageId=...)`. These are the highest-priority inputs. If page IDs were ALL you were given, skip to OUTPUT after reading them.
+
+STEP 2 (if space keys were provided): For EACH space key:
+  a. Call `getConfluenceSpaces(cloudId=..., keys=[<key>])` to look up its numeric spaceId.
+  b. Call `getPagesInConfluenceSpace(cloudId=..., spaceId=...)` to enumerate pages. You MUST make this call — listing the space metadata in (a) is NOT enough on its own.
+  c. From the returned page list, pick up to 5 whose titles look most relevant to the focus topic.
+  d. For EACH picked page, call `getConfluencePage(cloudId=..., pageId=...)` to read it.
+
+STEP 3 (if CQL queries were provided): For EACH query, call `searchConfluenceUsingCql(cloudId=..., cql=...)` and then call `getConfluencePage` on the top results to actually read them.
+
+STEP 4 (optional — only if you have remaining tool budget): When a page you read references child pages of clear relevance, fetch them via `getConfluencePageDescendants` and read the ones that look relevant. Stop at depth 2 from any seed.
+
+STOP RULES — emit OUTPUT and end as soon as ALL of these are true:
+  - You have read at least one page via `getConfluencePage`.
+  - You have processed every explicit page ID / space / CQL query in scope.
+Do NOT make redundant verification calls (e.g. searching CQL for a page you already read). Do NOT keep exploring after the targeted scope is covered.
+
+For EACH page you actually read, emit ONE card with:
+  - id: the Confluence page ID (string, as returned by the tool).
+  - title: the page title verbatim.
+  - space: the space key the page lives in.
+  - url: the page's `_links.webui` / `_links.base` URL if present; otherwise an absolute Confluence URL constructed from the site base.
+  - summary: ONE sentence describing what the page is about.
+  - key_entities: concrete named things mentioned that a data catalog should know — table/dataset names, system names, KPIs, glossary-worthy terms, owning team names, runbook names. Use the exact spellings from the page.
+  - content_excerpt: the relevant prose, lightly cleaned. Quote verbatim. Cap at ~6000 chars per page; if longer, prefer sections that mention the focus topic or named data assets.
+
+GROUNDING (CRITICAL — do not hallucinate):
+- A card may ONLY be emitted for a page you actually read with the tools.
+- NEVER invent pages from the space name, the topic, or your prior knowledge. If the tools returned no content, output [].
+- Describe only what the read pages actually contain. Quote identifiers verbatim.
+
+OUTPUT: when done exploring, output ONLY a single JSON array of card objects (no prose before or after, no markdown fence). Keys exactly: id, title, space, url, summary, key_entities (array of strings), content_excerpt (string). If the corpus is empty, unreachable, or your tools returned no content, output [].
+"""
+
+
+def _page_card(card: dict) -> dict:
+  """Render one parsed page card into the shared router-descriptor doc shape."""
+  page_id = str(card.get("id") or "").strip()
+  title = (card.get("title") or "Untitled Confluence page").strip()
+  space = (card.get("space") or "").strip()
+  url = (card.get("url") or "").strip()
+  if not url and page_id:
+    # Best-effort fallback when the model omitted the URL.
+    url = f"confluence://page/{page_id}"
+  summary = (card.get("summary") or "").strip()
+  entities = card.get("key_entities") or []
+  if isinstance(entities, str):
+    entities = [entities]
+  entities = [str(e).strip() for e in entities if str(e).strip()]
+  excerpt = (card.get("content_excerpt") or "").strip()
+
+  entities_str = ", ".join(entities) if entities else "(none listed)"
+
+  content = (
+      f"# {title}\n\n"
+      f"**Source:** [Confluence: {space or 'page'} / {title}]({url})\n\n"
+      "## Identity\n"
+      f"- **Type:** Confluence page\n"
+      f"- **Space:** `{space or '(unknown)'}`\n"
+      f"- **Page ID:** `{page_id or '(unknown)'}`\n"
+      f"- **Summary:** {summary or '(not stated)'}\n\n"
+      "## Key Entities\n"
+      f"{entities_str}\n\n"
+      "## Content\n"
+      f"{excerpt or '(no excerpt captured)'}\n"
+  )
+  descriptor = (
+      f"Title: {title}\n"
+      f"Summary: {summary or 'Confluence page in space ' + (space or '?')}\n"
+      f"Key entities: {entities_str}"
+  )
+  return {
+      "name": title,
+      "url": url,
+      "content": content,
+      "descriptor": descriptor,
+  }
+
+
+def _parse_cards(raw_text: str) -> list[dict]:
+  """Leniently parse the explorer agent's JSON array of page cards."""
+  text = (raw_text or "").strip()
+  if not text:
+    return []
+  fence = re.match(r"^```(?:json)?\s*\n(.*)\n```$", text, re.S)
+  if fence:
+    text = fence.group(1).strip()
+  if not text.startswith("["):
+    m = re.search(r"\[.*\]", text, re.S)
+    if m:
+      text = m.group(0)
+  try:
+    data = json.loads(text)
+  except (ValueError, json.JSONDecodeError):
+    return []
+  if not isinstance(data, list):
+    return []
+  return [c for c in data if isinstance(c, dict)]
+
+
+async def gather_confluence_context(
+    spaces: list[str] | None,
+    cql_queries: list[str] | None,
+    page_ids: list[str] | None,
+    topic: str,
+    model: str,
+    usage_acc: dict,
+    mcp_config_path: str | None = None,
+) -> list[dict]:
+  """Agentically explore Confluence and return page cards.
+
+  Returns a list of router-descriptor dicts `{name, url, content, descriptor}`
+  (the caller assigns `id`). Always returns a list — on any failure it logs a
+  warning and returns `[]` so the enrichment run continues without Confluence
+  context.
+
+  Args:
+    spaces: optional Confluence space keys to list top-level pages from.
+    cql_queries: optional CQL queries to search; e.g.
+      `type=page AND label="runbook"`.
+    page_ids: optional explicit Confluence page IDs to read.
+    topic: the run's focus topic (passed to the agent for relevance scoring).
+    model: model name for the exploration agent (typically the run's --model).
+    usage_acc: token-usage accumulator (mutated in place).
+    mcp_config_path: optional path to an mcp.json describing the server.
+  """
+  spaces = [s.strip() for s in (spaces or []) if s and s.strip()]
+  cql_queries = [q.strip() for q in (cql_queries or []) if q and q.strip()]
+  page_ids = [p.strip() for p in (page_ids or []) if p and p.strip()]
+  if not (spaces or cql_queries or page_ids):
+    return []
+
+  try:
+    cfg = load_mcp_server_config(mcp_config_path)
+  except (OSError, ValueError, json.JSONDecodeError) as e:
+    print(
+        f"[Confluence] ⚠️  MCP config error, skipping Confluence source: {e}",
+        flush=True,
+    )
+    return []
+
+  # Built-in default path requires a token; explicit configs may carry their
+  # own auth in `headers`, so only warn-and-skip when both are missing.
+  if (
+      cfg["transport"] == "http"
+      and not cfg.get("headers", {}).get("Authorization")
+      and not _resolve_token()
+  ):
+    print(
+        "[Confluence] ⚠️  No Atlassian credentials in env (set"
+        " ATLASSIAN_EMAIL + ATLASSIAN_API_TOKEN for a personal API token,"
+        " ATLASSIAN_API_TOKEN alone for a service-account API key, or"
+        " ATLASSIAN_OAUTH_TOKEN for a raw OAuth bearer) and no"
+        " Authorization header in MCP config — skipping Confluence source.",
+        flush=True,
+    )
+    return []
+
+  scope_lines = []
+  if spaces:
+    scope_lines.append(f"SPACES: {', '.join(spaces)}")
+  if cql_queries:
+    scope_lines.append("CQL QUERIES:\n  - " + "\n  - ".join(cql_queries))
+  if page_ids:
+    scope_lines.append(f"EXPLICIT PAGE IDS: {', '.join(page_ids)}")
+  scope_directive = "\n".join(scope_lines) + "\n"
+
+  instruction = _EXPLORER_INSTRUCTION.format(
+      scope_directive=scope_directive, topic=topic
+  )
+
+  print(
+      "[Confluence] 📘 Exploring Confluence via Atlassian Rovo MCP"
+      f" ({cfg['transport']}): spaces={spaces or '(none)'},"
+      f" cql={len(cql_queries)} query(ies), pages={page_ids or '(none)'}",
+      flush=True,
+  )
+
+  toolset = None
+  try:
+    toolset = _build_toolset(cfg)
+    agent = llm_agent.LlmAgent(
+        name="ConfluenceUnderstandingAgent",
+        description=(
+            "Explores a Confluence corpus via Atlassian Rovo MCP tools and"
+            " emits structured page cards."
+        ),
+        model=VertexGemini(model=model),
+        instruction=instruction,
+        tools=[toolset],
+    )
+    runner = InMemoryRunner(agent=agent)
+    user_id = str(uuid.uuid4())
+    session = await runner.session_service.create_session(
+        app_name=runner.app_name, user_id=user_id
+    )
+    kickoff_bits = ["Explore the Confluence scope above and emit the JSON array of page cards."]
+    if page_ids:
+      kickoff_bits.append(
+          f"START by reading every page in EXPLICIT PAGE IDS via"
+          " getConfluencePage."
+      )
+    if spaces:
+      kickoff_bits.append(
+          "THEN for each space key, list its pages and read the most"
+          f" topic-relevant ones for: {topic}."
+      )
+    if cql_queries:
+      kickoff_bits.append(
+          "THEN run each CQL query via searchConfluenceUsingCql and read the"
+          " top results."
+      )
+    kickoff = " ".join(kickoff_bits)
+
+    raw_text = ""
+    turns = 0
+    n_tool_calls = 0
+    read_page_ids = set()
+    total_read_chars = 0
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=types.Content(
+            role="user", parts=[types.Part.from_text(text=kickoff)]
+        ),
+    ):
+      turns += 1
+      usage = getattr(event, "usage_metadata", None)
+      if usage and usage_acc is not None:
+        usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+        usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+      for fc in event.get_function_calls() or []:
+        n_tool_calls += 1
+        args = fc.args or {}
+        # Atlassian's MCP uses `id` for page reads, `spaceKey` for space lists,
+        # `cql` for searches — log them all.
+        ident = (
+            args.get("id")
+            or args.get("pageId")
+            or args.get("spaceKey")
+            or args.get("cql")
+            or ""
+        )
+        print(
+            f"[Confluence]    → tool {fc.name}({_short_args(args)})",
+            flush=True,
+        )
+        if ident and args.get("id"):
+          read_page_ids.add(str(args["id"]))
+        if ident and args.get("pageId"):
+          read_page_ids.add(str(args["pageId"]))
+      for fr in event.get_function_responses() or []:
+        resp_len = len(_response_text(fr.response))
+        total_read_chars += resp_len
+        print(f"[Confluence]    ← {fr.name}: {resp_len} chars", flush=True)
+      if event.content and event.content.parts:
+        for part in event.content.parts:
+          if part.text:
+            raw_text += part.text
+      if turns > _MAX_EXPLORE_TURNS * 4:
+        print(
+            "[Confluence] ⚠️  Exploration exceeded turn budget; using output"
+            " so far.",
+            flush=True,
+        )
+        break
+    print(
+        f"[Confluence] 🔧 MCP usage: {n_tool_calls} tool call(s),"
+        f" {total_read_chars} chars of content read.",
+        flush=True,
+    )
+  except Exception as e:  # pylint: disable=broad-except
+    print(
+        f"[Confluence] ⚠️  Atlassian MCP exploration failed"
+        f" ({type(e).__name__}: {e}) — continuing without Confluence"
+        " context.",
+        flush=True,
+    )
+    return []
+  finally:
+    if toolset is not None:
+      try:
+        await toolset.close()
+      except Exception:  # pylint: disable=broad-except
+        pass
+
+  # Hallucination guard: if the tools never returned real content, the
+  # model's cards are invented from priors.
+  if total_read_chars == 0:
+    print(
+        "[Confluence] ⛔ The Atlassian MCP server returned NO content"
+        f" ({n_tool_calls} tool call(s)). Not emitting any cards (would be"
+        " hallucinated). Check: the server is reachable, the token has read"
+        " access to these spaces, and the space/CQL/page IDs exist.",
+        flush=True,
+    )
+    return []
+
+  cards = _parse_cards(raw_text)
+  if not cards:
+    print(
+        "[Confluence] ⚠️  No parseable cards returned from exploration.",
+        flush=True,
+    )
+    return []
+
+  # If explicit page IDs were given, drop any card whose id wasn't actually
+  # fetched (mirror the github_tools grounding guard). Cards from broader
+  # space/CQL exploration are kept regardless — they are tool-grounded by
+  # the total_read_chars check above.
+  kept, dropped = [], []
+  for c in cards:
+    cid = str(c.get("id") or "").strip()
+    if page_ids and cid and cid not in read_page_ids:
+      dropped.append(c)
+    else:
+      kept.append(c)
+  if dropped:
+    print(
+        f"[Confluence] 🗑️  Dropped {len(dropped)} ungrounded card(s) (page"
+        " id not among the ones actually fetched):"
+        f" {[d.get('title') for d in dropped]}",
+        flush=True,
+    )
+  if not kept:
+    print(
+        "[Confluence] ⚠️  All cards were ungrounded — emitting none.",
+        flush=True,
+    )
+    return []
+
+  rendered = [_page_card(c) for c in kept]
+  print(
+      f"[Confluence] ✅ Derived {len(rendered)} page card(s):"
+      f" {[c['name'] for c in rendered]}",
+      flush=True,
+  )
+  return rendered

--- a/agents/enrichment/src/tools/sharepoint_tools.py
+++ b/agents/enrichment/src/tools/sharepoint_tools.py
@@ -1,0 +1,1535 @@
+"""SharePoint input: agentic page understanding via Microsoft Graph REST.
+
+A sibling to github_tools.py and confluence_tools.py — same shape, same
+output card type (`{name, url, content, descriptor}`), but the underlying
+transport is plain Microsoft Graph REST instead of MCP.
+
+Why no MCP for SharePoint? Microsoft's first-party Agent 365 SharePoint
+MCP server at
+`https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/`
+`mcp_SharePointRemoteServer` rejects third-party Entra-app tokens with
+`invalid_audience: Third-party audience cannot access first-party server`.
+The third-party-vs-first-party gate sits inside Entra itself, so no scope
+or permission addition fixes it from the client side. The public Graph
+REST API at `https://graph.microsoft.com/v1.0` is the well-trodden third-
+party path and accepts the same OAuth token cleanly. Same delegated
+scopes Microsoft documents for the Agent 365 server work here:
+  - `Sites.Read.All`
+  - `Files.Read.All`
+  - `User.Read`
+  - `offline_access`
+
+Tool surface (7 tools — the file-discovery path the explorer drives):
+
+  Site discovery   sp_get_site_by_path
+  Libraries        sp_list_libraries            sp_get_default_library
+  Folders/files    sp_list_folder_children      sp_search_files
+                   sp_get_file_metadata         sp_read_file_content
+
+Each tool is a plain async Python function (no `ToolContext`); it reads
+the OAuth bearer token from the `MICROSOFT_ACCESS_TOKEN` environment
+variable. The inner LlmAgent gets them as ADK `FunctionTool` wrappers.
+
+Authentication:
+  * Mint a token via the Azure CLI:
+      az login
+      az account get-access-token --resource https://graph.microsoft.com \\
+          --query accessToken --output tsv
+    Then export:
+      export MICROSOFT_ACCESS_TOKEN='eyJ0eXAiOi...'
+  * Or use MSAL / your existing Entra app — the token format is the
+    standard JWT bearer.
+
+Failure is non-fatal — mirrors the github_tools / confluence_tools
+contract. If the token is missing/expired, the Graph call fails, or the
+model returns nothing parseable, we log a warning and return `[]` so the
+rest of the enrichment run continues.
+
+Code provenance:
+  * The 12 tools' REST shapes (paths, params, response flattening) are
+    ported from KC's sharepoint_tools.py — see the new Google Doc tab
+    "SharePoint Setup (End-to-End)" for exact file + line citations.
+  * The agentic explorer-loop pattern (LlmAgent + InMemoryRunner +
+    cards) mirrors github_tools.gather_repo_context() and
+    confluence_tools.gather_confluence_context() in this same directory.
+"""
+
+import asyncio
+import base64
+import io
+import json
+import os
+import re
+import typing as t
+import urllib.parse as _urlparse
+import uuid
+
+import httpx
+from engine import VertexGemini
+from google.adk.agents import llm_agent
+from google.adk.runners import InMemoryRunner
+from google.adk.tools import FunctionTool
+from google.genai import types
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+_HTTP_TIMEOUT = 30.0
+
+# Token env. Keep this in sync with the README + the SharePoint Setup doc
+# tab. The token must carry delegated Sites.Read.All / Files.Read.All scopes.
+_TOKEN_ENV = "MICROSOFT_ACCESS_TOKEN"
+
+# MSAL cache for silent refresh. Must match the path the mint script
+# writes (see scripts/mint_sharepoint_token.py:_CACHE_PATH). When the
+# cache holds a valid refresh token, the agent refreshes its access
+# token silently on every Graph call — no more 1-hour cliffs.
+_MSAL_CACHE_PATH = os.path.expanduser(
+    "~/.cache/kc_agent/microsoft_token_cache.json"
+)
+# These two env vars are the ones the mint script reads — the agent
+# uses them to construct its own MSAL app instance for silent refresh.
+_CLIENT_ID_ENV = "MICROSOFT_CLIENT_ID"
+_TENANT_ID_ENV = "MICROSOFT_TENANT_ID"
+# Same scopes the mint script requests — silent refresh is per-scope-set.
+_GRAPH_SCOPES = [
+    "https://graph.microsoft.com/Sites.Read.All",
+    "https://graph.microsoft.com/Files.Read.All",
+    "https://graph.microsoft.com/User.Read",
+]
+
+# Named mime constants — used both in extractor dispatch + the binary
+# fallback set. Modern (Open XML) formats are the only ones we can extract
+# locally without heavy / GPL-licensed deps (libreoffice, antiword, …);
+# legacy .doc / .xls / .ppt stay in the binary-fallback path with a webUrl.
+_DOCX_MIME = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+_XLSX_MIME = (
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+)
+_PPTX_MIME = (
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+)
+_PDF_MIME = "application/pdf"
+
+# mimes we know how to extract locally — dispatch table keys.
+_EXTRACTABLE_MIMES = frozenset(
+    {_DOCX_MIME, _XLSX_MIME, _PPTX_MIME, _PDF_MIME}
+)
+
+# Office mimeTypes Graph returns as binary blobs. We CAN extract the
+# modern Open XML formats (_DOCX/_XLSX/_PPTX) + PDF locally with
+# python-docx / openpyxl / python-pptx / pypdf. Legacy formats stay on
+# the metadata-only / webUrl fallback because the binary file formats
+# need heavier deps (olefile / libreoffice / antiword). Other binary
+# mimes (zip / octet-stream) also stay on the fallback path.
+_OFFICE_BINARY_MIMES = frozenset({
+    _DOCX_MIME,
+    _XLSX_MIME,
+    _PPTX_MIME,
+    # Legacy Office — no local extractor
+    "application/msword",
+    "application/vnd.ms-excel",
+    "application/vnd.ms-powerpoint",
+    # Other binary types we shouldn't try to decode as UTF-8
+    _PDF_MIME,
+    "application/zip",
+    "application/octet-stream",
+})
+
+# mimeTypes safe to read as UTF-8 text.
+_TEXT_MIME_PREFIXES = (
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-yaml",
+    "application/yaml",
+)
+
+# Hard cap on inline file content (5 MB — matches Agent 365 MCP's
+# `readSmallTextFile` semantics and keeps huge files out of LLM context).
+_MAX_FILE_BYTES = 5_000_000
+
+# Cap exploration turns. Tracks the github_tools / confluence_tools budget.
+_MAX_EXPLORE_TURNS = 40
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_token() -> str:
+  """Return the SharePoint OAuth bearer from the env, or '' if not set.
+
+  Sync — used for the "is anything configured?" pre-flight check in
+  gather_sharepoint_context. For actually authenticating requests use
+  _get_live_token (async, consults MSAL cache + env)."""
+  return os.environ.get(_TOKEN_ENV, "").strip()
+
+
+async def _get_live_token() -> str:
+  """Return a live access token, preferring the MSAL cache (which can
+  silently refresh) over the raw env var (no refresh)."""
+  cached = await _REFRESHER.token()
+  if cached:
+    return cached
+  return _get_token()
+
+
+def _credentials_configured() -> bool:
+  """True iff at least one credential source is configured — either the
+  raw env var, or an MSAL cache file plus the client/tenant env vars
+  needed to load it. Used by agent_runner's trigger gate to decide
+  whether to prompt the user to run setup_sharepoint.py."""
+  if _get_token():
+    return True
+  if (
+      os.path.exists(_MSAL_CACHE_PATH)
+      and os.environ.get(_CLIENT_ID_ENV, "").strip()
+      and os.environ.get(_TENANT_ID_ENV, "").strip()
+  ):
+    return True
+  return False
+
+
+def _short_args(args: dict) -> str:
+  """Compact one-line rendering of tool-call args for logging."""
+  parts = []
+  for k, v in (args or {}).items():
+    s = str(v)
+    if len(s) > 60:
+      s = s[:57] + "..."
+    parts.append(f"{k}={s}")
+  return ", ".join(parts)
+
+
+def _extract_error_info(response: t.Any) -> tuple[str, str] | None:
+  """If `response` is (or wraps) an error from one of our sp_* tools,
+
+  return `(error_code, message)`. Returns None for success responses.
+
+  Our sp_* tools always return `{"status": "error", "error": "<code>",
+  "message": "<msg>"}` on failure. ADK's FunctionTool layer may wrap that
+  in `{"result": ...}` or stash it inside a content-block list, so we
+  recurse through common envelope shapes to find the inner status dict.
+  """
+  if response is None:
+    return None
+  if isinstance(response, dict):
+    if response.get("status") == "error":
+      code = str(response.get("error", "unknown"))
+      msg = str(response.get("message", ""))[:300]
+      return (code, msg)
+    for key in ("result", "content", "output"):
+      if key in response:
+        inner = _extract_error_info(response[key])
+        if inner is not None:
+          return inner
+  if isinstance(response, (list, tuple)):
+    for x in response:
+      inner = _extract_error_info(x)
+      if inner is not None:
+        return inner
+  return None
+
+
+def _response_text(response: t.Any) -> str:
+  """Best-effort extraction of textual content from a tool response.
+
+  Mirrors github_tools._response_text — the function-call wrapper layer
+  can hand us back varied shapes (dict, list of content blocks, bare
+  string). We only need a length to decide "did real content come back?"
+  so we stringify defensively.
+  """
+  if response is None:
+    return ""
+  if isinstance(response, str):
+    return response
+  if isinstance(response, dict):
+    # Prefer recognized text-bearing keys; fall back to JSON dump so we
+    # measure the actual payload size accurately.
+    for key in ("body_text", "text", "content", "result", "output"):
+      if key in response:
+        return _response_text(response[key])
+    try:
+      return json.dumps(response)
+    except (TypeError, ValueError):
+      return str(response)
+  if isinstance(response, (list, tuple)):
+    return "".join(_response_text(x) for x in response)
+  text_attr = getattr(response, "text", None)
+  if isinstance(text_attr, str):
+    return text_attr
+  return str(response)
+
+
+def _ok(body: dict[str, t.Any]) -> bool:
+  return body.get("status") != "error"
+
+
+# ---------------------------------------------------------------------------
+# Auth refresher + httpx event hook
+#
+# Two credential sources, in priority order:
+#   1. MSAL cache at _MSAL_CACHE_PATH (populated by
+#      scripts/mint_sharepoint_token.py). With offline_access in the
+#      scopes — which we always request — MSAL silently refreshes the
+#      access token from the cached refresh token on every Graph call,
+#      so long-running enrichment jobs never hit the 1-hour cliff.
+#   2. Raw `MICROSOFT_ACCESS_TOKEN` env var — back-compat / CI path.
+#      No refresh capability; expires at the token's hard deadline (~1h).
+#
+# Same pattern as the GoogleCloudPlatform/knowledge-catalog PR c606b96
+# uses for Google ADC: register a request-event hook on httpx.AsyncClient
+# that runs before every request, checks whether the cached token is
+# still valid, refreshes it if not, and stamps the Authorization header.
+# ---------------------------------------------------------------------------
+
+
+class _MicrosoftAuthRefresher:
+  """Holds an MSAL PublicClientApplication + cache, exposes a single
+  `token()` method that returns a live access token (refreshing silently
+  if needed) or None if the agent should fall back to the env var path.
+  """
+
+  def __init__(self) -> None:
+    self._app = None
+    self._cache = None
+    self._account = None
+    self._lock = asyncio.Lock()  # serialize refreshes across concurrent calls
+    self._configured = False  # True after first successful _ensure_app
+    self._unavailable = False  # True if MSAL/cache aren't usable; stop trying
+
+  def _ensure_app(self) -> bool:
+    """Lazy-construct the MSAL app on first use. Returns True iff
+    MSAL is importable, the cache file exists and has at least one
+    account, and the required client/tenant ids are in env.
+    """
+    if self._configured:
+      return True
+    if self._unavailable:
+      return False
+    if not os.path.exists(_MSAL_CACHE_PATH):
+      self._unavailable = True
+      return False
+    client_id = os.environ.get(_CLIENT_ID_ENV, "").strip()
+    tenant_id = os.environ.get(_TENANT_ID_ENV, "").strip()
+    if not client_id or not tenant_id:
+      # Cache exists but we don't know which app/tenant to load it as.
+      # Print a one-line hint then disable to avoid noisy retries.
+      print(
+          f"[SharePoint] ⚠️  MSAL cache present at {_MSAL_CACHE_PATH}"
+          f" but ${_CLIENT_ID_ENV} or ${_TENANT_ID_ENV} is not set —"
+          " falling back to MICROSOFT_ACCESS_TOKEN. Export those two"
+          " env vars to enable silent refresh.",
+          flush=True,
+      )
+      self._unavailable = True
+      return False
+    try:
+      import msal  # noqa: PLC0415
+    except ImportError:
+      self._unavailable = True
+      return False
+    try:
+      cache = msal.SerializableTokenCache()
+      with open(_MSAL_CACHE_PATH, "r", encoding="utf-8") as f:
+        cache.deserialize(f.read())
+      authority = f"https://login.microsoftonline.com/{tenant_id}"
+      app = msal.PublicClientApplication(
+          client_id, authority=authority, token_cache=cache
+      )
+      accounts = app.get_accounts()
+      if not accounts:
+        self._unavailable = True
+        return False
+      self._app = app
+      self._cache = cache
+      self._account = accounts[0]
+      self._configured = True
+      return True
+    except (OSError, ValueError) as e:
+      print(
+          f"[SharePoint] ⚠️  MSAL cache at {_MSAL_CACHE_PATH} could not"
+          f" be loaded ({type(e).__name__}: {e}); falling back to"
+          " MICROSOFT_ACCESS_TOKEN env.",
+          flush=True,
+      )
+      self._unavailable = True
+      return False
+
+  def _save_cache(self) -> None:
+    """Persist cache if MSAL mutated it (refresh-token rotation)."""
+    if self._cache is None or not self._cache.has_state_changed:
+      return
+    try:
+      with open(_MSAL_CACHE_PATH, "w", encoding="utf-8") as f:
+        f.write(self._cache.serialize())
+    except OSError:
+      pass
+
+  async def token(self) -> str | None:
+    """Return a live access token from the MSAL cache, refreshing
+    silently if needed. None means MSAL isn't configured — caller
+    should fall back to the env var path.
+    """
+    if not self._ensure_app():
+      return None
+    async with self._lock:
+      # acquire_token_silent is sync (no I/O when fresh, sync HTTP when
+      # refreshing) — offload to a thread so we don't block the event
+      # loop during a real refresh round-trip.
+      result = await asyncio.to_thread(
+          self._app.acquire_token_silent, _GRAPH_SCOPES, self._account
+      )
+      if result and "access_token" in result:
+        self._save_cache()
+        return result["access_token"]
+      # Silent failed — refresh token expired / revoked / network. Don't
+      # try to do an interactive flow from inside the agent; tell the
+      # user to re-mint and disable further attempts this run.
+      print(
+          "[SharePoint] ⚠️  MSAL silent refresh failed (refresh token"
+          " expired or revoked). Re-run scripts/mint_sharepoint_token.py"
+          " to re-authenticate. Falling back to MICROSOFT_ACCESS_TOKEN"
+          " env var for the rest of this run.",
+          flush=True,
+      )
+      self._unavailable = True
+      return None
+
+
+# Module-singleton refresher — shared across all _api_call invocations
+# in a single agent run.
+_REFRESHER = _MicrosoftAuthRefresher()
+
+
+# ---------------------------------------------------------------------------
+# Local binary → text extractors
+#
+# Mirrors the pattern in KC's skills/documents.py:29-59 (pypdf for PDF,
+# python-docx for .docx, …) and drive_tools._extract_pdf_text:550-566 (pypdf
+# for Drive-hosted PDFs). All deps are lazy-imported so this module loads
+# cleanly without them installed; if the extractor's library is missing
+# the extractor returns a clear `[…]` stub and the caller falls back to
+# the metadata + webUrl path.
+#
+# IMPORTANT — no temp files. The byte payload arrives in-memory from
+# Graph (httpx → base64 string → bytes → io.BytesIO). Every extractor
+# operates on the BytesIO and never writes anything to disk; openpyxl
+# is opened with read_only=True specifically to suppress its workbook-
+# backup behavior. Memory footprint peaks at ~size_of_file bytes per
+# call (capped at the 5 MB _MAX_FILE_BYTES limit), released as soon
+# as the extractor returns. Nothing to clean up.
+# ---------------------------------------------------------------------------
+
+
+def _extract_docx(data: bytes) -> str:
+  """Extract text from a .docx (Open XML Word) blob using python-docx."""
+  try:
+    import docx  # type: ignore  # noqa: PLC0415
+  except ImportError:
+    return (
+        "[docx extraction skipped: install python-docx to enable text"
+        " extraction for Word files]"
+    )
+  try:
+    d = docx.Document(io.BytesIO(data))
+    return "\n".join(p.text for p in d.paragraphs)
+  except Exception as e:  # pylint: disable=broad-except
+    return f"[docx extraction failed: {type(e).__name__}: {e}]"
+
+
+def _extract_xlsx(data: bytes) -> str:
+  """Extract text from a .xlsx (Open XML Excel) blob using openpyxl.
+
+  Format: one section per sheet, each section a CSV-ish dump of the
+  populated cells. Mirrors how drive_tools handles Sheets (CSV export),
+  just done client-side.
+  """
+  try:
+    import openpyxl  # type: ignore  # noqa: PLC0415
+  except ImportError:
+    return (
+        "[xlsx extraction skipped: install openpyxl to enable text"
+        " extraction for Excel files]"
+    )
+  try:
+    wb = openpyxl.load_workbook(io.BytesIO(data), read_only=True, data_only=True)
+    sections: list[str] = []
+    for sheet in wb.worksheets:
+      rows: list[str] = []
+      for row in sheet.iter_rows(values_only=True):
+        if not any(c not in (None, "") for c in row):
+          continue
+        rows.append(
+            ",".join("" if c is None else str(c) for c in row)
+        )
+      if rows:
+        sections.append(f"## Sheet: {sheet.title}\n" + "\n".join(rows))
+    return "\n\n".join(sections) if sections else "[xlsx has no populated cells]"
+  except Exception as e:  # pylint: disable=broad-except
+    return f"[xlsx extraction failed: {type(e).__name__}: {e}]"
+
+
+def _extract_pptx(data: bytes) -> str:
+  """Extract text from a .pptx (Open XML PowerPoint) blob using python-pptx.
+
+  Format: one section per slide, each section being the concatenated
+  text from all shapes on that slide (titles, body text, notes).
+  """
+  try:
+    import pptx  # type: ignore  # noqa: PLC0415
+  except ImportError:
+    return (
+        "[pptx extraction skipped: install python-pptx to enable text"
+        " extraction for PowerPoint files]"
+    )
+  try:
+    prs = pptx.Presentation(io.BytesIO(data))
+    sections: list[str] = []
+    for i, slide in enumerate(prs.slides, start=1):
+      texts: list[str] = []
+      for shape in slide.shapes:
+        if shape.has_text_frame:
+          for para in shape.text_frame.paragraphs:
+            t = "".join(run.text for run in para.runs).strip()
+            if t:
+              texts.append(t)
+      notes = ""
+      if slide.has_notes_slide and slide.notes_slide.notes_text_frame:
+        notes = slide.notes_slide.notes_text_frame.text.strip()
+      if texts or notes:
+        block = f"## Slide {i}\n" + "\n".join(texts)
+        if notes:
+          block += f"\n\n### Notes\n{notes}"
+        sections.append(block)
+    return "\n\n".join(sections) if sections else "[pptx has no text content]"
+  except Exception as e:  # pylint: disable=broad-except
+    return f"[pptx extraction failed: {type(e).__name__}: {e}]"
+
+
+def _extract_pdf(data: bytes) -> str:
+  """Extract text from a PDF blob using pypdf.
+
+  Same pattern drive_tools._extract_pdf_text:550-566 uses for Drive PDFs.
+  Quality varies for scanned (image-only) PDFs and multi-column layouts;
+  for those the output may be empty or jumbled — extraction is non-fatal
+  but the resulting card content will be poor.
+  """
+  try:
+    from pypdf import PdfReader  # noqa: PLC0415
+  except ImportError:
+    return (
+        "[pdf extraction skipped: install pypdf to enable text extraction"
+        " for PDF files]"
+    )
+  try:
+    reader = PdfReader(io.BytesIO(data))
+    pages = [p.extract_text() or "" for p in reader.pages]
+    return "\n\n".join(pages)
+  except Exception as e:  # pylint: disable=broad-except
+    return f"[pdf extraction failed: {type(e).__name__}: {e}]"
+
+
+_EXTRACTORS: dict[str, t.Callable[[bytes], str]] = {
+    _DOCX_MIME: _extract_docx,
+    _XLSX_MIME: _extract_xlsx,
+    _PPTX_MIME: _extract_pptx,
+    _PDF_MIME: _extract_pdf,
+}
+
+
+async def _api_call(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, t.Any] | None = None,
+    json_body: dict[str, t.Any] | None = None,
+    expect_binary: bool = False,
+) -> dict[str, t.Any]:
+  """Shared Graph REST wrapper.
+
+  `path` is a Graph path like `/sites/...` (the function prepends
+  `_GRAPH_BASE`). Returns parsed JSON for normal calls or
+  `{status: 'success', content_b64, content_type, size_bytes}` when
+  `expect_binary=True`. Non-2xx returns a structured error dict — never
+  raises on HTTP errors (mirrors KC's contract).
+
+  Ported from KC sharepoint_tools._api_call (~lines 124-220).
+  """
+  token = await _get_live_token()
+  if not token:
+    return {
+        "status": "error",
+        "error": "not_connected",
+        "message": (
+            "Microsoft access token not set and MSAL cache not available."
+            " Run scripts/mint_sharepoint_token.py (one-time) to populate"
+            " the cache and enable silent refresh, or export"
+            f" {_TOKEN_ENV} with a Graph bearer token for a one-shot run."
+        ),
+    }
+
+  url = f"{_GRAPH_BASE}{path}" if path.startswith("/") else path
+  headers = {
+      "Authorization": f"Bearer {token}",
+      "Accept": "application/json",
+  }
+
+  try:
+    # follow_redirects=True is required for /items/<id>/content reads —
+    # Graph returns a 302 to a pre-signed sharepoint.com / CDN URL where
+    # the bytes actually live. httpx strips the Authorization header
+    # automatically when the redirect crosses hosts (the pre-signed URL
+    # carries its own signature in the query string, so it doesn't need
+    # the bearer and we don't want to leak it). Without this, every file
+    # read returns http_302 and the model hallucinates content_excerpt
+    # from the file name.
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT, follow_redirects=True
+    ) as client:
+      m = method.upper()
+      if m == "GET":
+        resp = await client.get(url, params=params, headers=headers)
+      elif m == "POST":
+        resp = await client.post(
+            url, params=params, headers=headers, json=json_body
+        )
+      else:
+        return {
+            "status": "error",
+            "error": "unsupported_method",
+            "message": f"Internal: method {method!r} is not supported.",
+        }
+  except httpx.RequestError as e:
+    return {
+        "status": "error",
+        "error": "transport_error",
+        "message": f"{type(e).__name__}: {e}",
+    }
+
+  if resp.status_code == 401:
+    return {
+        "status": "error",
+        "error": "token_expired",
+        "message": (
+            "Microsoft access token expired or invalid. Re-mint via"
+            f" `az account get-access-token ...` and re-export {_TOKEN_ENV}."
+        ),
+    }
+  if resp.status_code // 100 != 2:
+    detail = resp.text[:1000]
+    try:
+      body = resp.json()
+      msg = body.get("error", {}).get("message") or detail
+    except (ValueError, KeyError, TypeError):
+      msg = detail
+    return {
+        "status": "error",
+        "error": f"http_{resp.status_code}",
+        "message": msg,
+    }
+
+  if expect_binary:
+    return {
+        "status": "success",
+        "content_b64": base64.b64encode(resp.content).decode("ascii"),
+        "content_type": resp.headers.get("Content-Type"),
+        "size_bytes": len(resp.content),
+    }
+
+  if not resp.content:
+    return {"status": "success"}
+  try:
+    return resp.json()
+  except (ValueError, json.JSONDecodeError) as e:
+    return {
+        "status": "error",
+        "error": "non_json_response",
+        "message": (
+            f"{type(e).__name__}: {e}; first 500 chars: {resp.text[:500]}"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Response flatteners (mirror KC sharepoint_tools)
+# ---------------------------------------------------------------------------
+
+
+def _flatten_site(s: dict[str, t.Any]) -> dict[str, t.Any]:
+  return {
+      "id": s.get("id"),
+      "name": s.get("name"),
+      "display_name": s.get("displayName"),
+      "web_url": s.get("webUrl"),
+      "description": s.get("description"),
+  }
+
+
+def _flatten_drive(d: dict[str, t.Any]) -> dict[str, t.Any]:
+  return {
+      "id": d.get("id"),
+      "name": d.get("name"),
+      "description": d.get("description"),
+      "drive_type": d.get("driveType"),
+      "web_url": d.get("webUrl"),
+  }
+
+
+def _flatten_drive_item(item: dict[str, t.Any]) -> dict[str, t.Any]:
+  is_folder = "folder" in item
+  is_file = "file" in item
+  return {
+      "id": item.get("id"),
+      "name": item.get("name"),
+      "type": "folder" if is_folder else ("file" if is_file else "unknown"),
+      "mime_type": (item.get("file") or {}).get("mimeType"),
+      "size_bytes": item.get("size"),
+      "web_url": item.get("webUrl"),
+      "last_modified": item.get("lastModifiedDateTime"),
+      "child_count": (item.get("folder") or {}).get("childCount"),
+  }
+
+
+# ---------------------------------------------------------------------------
+# Tools — site discovery
+# (ports KC sharepoint_tools.py site discovery section, ~lines 226-311)
+# ---------------------------------------------------------------------------
+
+
+async def sp_get_site_by_path(
+    hostname: str, server_relative_path: str
+) -> dict[str, t.Any]:
+  """Resolve a SharePoint site by hostname + server-relative path.
+
+  Use when you have the exact site URL (e.g. from a shared link).
+
+  Args:
+    hostname: e.g. `contoso.sharepoint.com`.
+    server_relative_path: e.g. `sites/Marketing`. Leading slash stripped.
+  """
+  path = server_relative_path.lstrip("/")
+  body = await _api_call(
+      "GET",
+      # Graph syntax: /sites/{hostname}:/{path}: — trailing colon is required.
+      f"/sites/{_urlparse.quote(hostname)}:/{_urlparse.quote(path)}:",
+  )
+  if not _ok(body):
+    return body
+  return {"status": "success", "site": _flatten_site(body)}
+
+
+# ---------------------------------------------------------------------------
+# Tools — document libraries (drives)
+# (KC sharepoint_tools ~lines 314-366)
+# ---------------------------------------------------------------------------
+
+
+async def sp_list_libraries(site_id: str) -> dict[str, t.Any]:
+  """List document libraries (drives) in a SharePoint site.
+
+  Args:
+    site_id: Site id from `sp_get_site_by_path`.
+  """
+  body = await _api_call("GET", f"/sites/{_urlparse.quote(site_id)}/drives")
+  if not _ok(body):
+    return body
+  libs = [_flatten_drive(d) for d in body.get("value") or []]
+  return {"status": "success", "libraries": libs, "count": len(libs)}
+
+
+async def sp_get_default_library(site_id: str) -> dict[str, t.Any]:
+  """Get the default document library for a SharePoint site.
+
+  Most sites have exactly one library named "Documents" — this returns
+  it directly without enumerating all libraries.
+
+  Args:
+    site_id: Site id.
+  """
+  body = await _api_call("GET", f"/sites/{_urlparse.quote(site_id)}/drive")
+  if not _ok(body):
+    return body
+  return {"status": "success", "library": _flatten_drive(body)}
+
+
+# ---------------------------------------------------------------------------
+# Tools — folders + files
+# (KC sharepoint_tools ~lines 369-584)
+# ---------------------------------------------------------------------------
+
+
+async def sp_list_folder_children(
+    library_id: str, folder_id: str = "root", page_size: int = 25
+) -> dict[str, t.Any]:
+  """List files + subfolders inside a folder of a SharePoint library.
+
+  Args:
+    library_id: Drive id from `sp_list_libraries`.
+    folder_id: Folder id; default `"root"` (top of the library). For nested
+      folders, pass an id returned by a prior call.
+    page_size: Max items to return (1-200). Default 25.
+  """
+  size = max(1, min(200, page_size))
+  body = await _api_call(
+      "GET",
+      f"/drives/{_urlparse.quote(library_id)}/items/"
+      f"{_urlparse.quote(folder_id)}/children",
+      params={"$top": size},
+  )
+  if not _ok(body):
+    return body
+  items = [_flatten_drive_item(i) for i in body.get("value") or []]
+  return {"status": "success", "items": items, "count": len(items)}
+
+
+async def sp_search_files(
+    query: str, page_size: int = 25
+) -> dict[str, t.Any]:
+  """Search files + folders across all SharePoint sites the user can access.
+
+  This is tenant-wide — usually the fastest way to find a file when you
+  only have a name fragment.
+
+  Args:
+    query: Free-text search (matches filename + indexed content).
+    page_size: Max items to return (1-200). Default 25.
+
+  Returns each item with the standard drive_item fields plus `site_id`
+  and `library_id` (from sharepointIds), so downstream sp_* tools can
+  read the file content directly.
+  """
+  payload = {
+      "requests": [{
+          "entityTypes": ["driveItem"],
+          "query": {"queryString": query},
+          "from": 0,
+          "size": max(1, min(200, page_size)),
+      }]
+  }
+  body = await _api_call("POST", "/search/query", json_body=payload)
+  if not _ok(body):
+    return body
+  items: list[dict[str, t.Any]] = []
+  for resp_block in body.get("value") or []:
+    for hits_container in resp_block.get("hitsContainers") or []:
+      for hit in hits_container.get("hits") or []:
+        resource = hit.get("resource") or {}
+        flat = _flatten_drive_item(resource)
+        sp_ids = resource.get("sharepointIds") or {}
+        flat["site_id"] = sp_ids.get("siteId")
+        flat["library_id"] = sp_ids.get("listId")
+        items.append(flat)
+  return {"status": "success", "items": items, "count": len(items)}
+
+
+async def sp_get_file_metadata(
+    library_id: str, item_id: str
+) -> dict[str, t.Any]:
+  """Fetch metadata for a single file or folder.
+
+  Args:
+    library_id: Drive id.
+    item_id: File or folder id.
+  """
+  body = await _api_call(
+      "GET",
+      f"/drives/{_urlparse.quote(library_id)}/items/{_urlparse.quote(item_id)}",
+  )
+  if not _ok(body):
+    return body
+  flat = _flatten_drive_item(body)
+  flat["created_by"] = ((body.get("createdBy") or {}).get("user") or {}).get(
+      "displayName"
+  )
+  flat["last_modified_by"] = (
+      (body.get("lastModifiedBy") or {}).get("user") or {}
+  ).get("displayName")
+  flat["parent_id"] = (body.get("parentReference") or {}).get("id")
+  return {"status": "success", "item": flat}
+
+
+async def sp_read_file_content(
+    library_id: str, item_id: str
+) -> dict[str, t.Any]:
+  """Read a SharePoint file's content.
+
+  Dispatches by mimeType:
+    * text/* / json / xml / yaml   → decoded `body_text`.
+    * .docx / .xlsx / .pptx / PDF  → extracted locally via `_EXTRACTORS`
+      (python-docx / openpyxl / python-pptx / pypdf) into `body_text`.
+    * legacy Office / images / other binaries → metadata + `web_url`
+      only (no local extractor); the file is still cited via its link.
+
+  The 5 MB cap is enforced on both the Graph-reported size and the actual
+  downloaded byte count (Graph occasionally omits the size); over the cap
+  returns a `file_too_large` error so the agent falls back to the webUrl
+  instead of pulling the binary into the LLM context.
+
+  Args:
+    library_id: Drive id.
+    item_id: File id.
+  """
+  meta = await sp_get_file_metadata(library_id, item_id)
+  if not _ok(meta):
+    return meta
+  item = meta["item"]
+  mime = (item.get("mime_type") or "").lower()
+  name = item.get("name")
+  size = item.get("size_bytes") or 0
+  web_url = item.get("web_url")
+
+  if size > _MAX_FILE_BYTES:
+    return {
+        "status": "error",
+        "error": "file_too_large",
+        "message": (
+            f"File is {size} bytes (> {_MAX_FILE_BYTES} cap). Share the"
+            " webUrl with the user instead of trying to read inline."
+        ),
+        "size_bytes": size,
+        "web_url": web_url,
+    }
+
+  is_extractable_binary = mime in _EXTRACTABLE_MIMES
+  is_text = any(mime.startswith(p) for p in _TEXT_MIME_PREFIXES)
+  is_binary_no_extractor = (
+      mime in _OFFICE_BINARY_MIMES and not is_extractable_binary
+  )
+  is_unknown_binary = not is_text and not is_extractable_binary and (
+      mime not in _OFFICE_BINARY_MIMES
+  )
+
+  if is_binary_no_extractor or is_unknown_binary:
+    # Legacy Office (.doc/.xls/.ppt), images, zips, octet-stream, etc. —
+    # no local extractor; surface the webUrl so cards can at least cite
+    # the file's existence + link without inventing content.
+    return {
+        "status": "success",
+        "item_id": item_id,
+        "mime_type": mime,
+        "name": name,
+        "size_bytes": size,
+        "web_url": web_url,
+        "message": (
+            "Binary content not extracted (legacy Office / image / zip /"
+            " unknown binary; no local extractor for this mimeType). Open"
+            " via web_url for the user."
+        ),
+    }
+
+  body = await _api_call(
+      "GET",
+      f"/drives/{_urlparse.quote(library_id)}/items/"
+      f"{_urlparse.quote(item_id)}/content",
+      expect_binary=True,
+  )
+  if not _ok(body):
+    return body
+  try:
+    raw_bytes = base64.b64decode(body["content_b64"])
+  except (ValueError, KeyError):
+    raw_bytes = b""
+
+  # Graph sometimes omits `size` in metadata, so the pre-download cap above
+  # can be bypassed; re-enforce it on the actual payload before anything
+  # reaches an extractor or the LLM.
+  if len(raw_bytes) > _MAX_FILE_BYTES:
+    return {
+        "status": "error",
+        "error": "file_too_large",
+        "message": (
+            f"File is {len(raw_bytes)} bytes (> {_MAX_FILE_BYTES} cap)."
+            " Share the webUrl with the user instead of reading inline."
+        ),
+        "size_bytes": len(raw_bytes),
+        "web_url": web_url,
+    }
+
+  if is_extractable_binary:
+    # .docx / .xlsx / .pptx / .pdf — dispatch to a local extractor.
+    # Extractors are non-raising (return `[…]` stubs on failure) so the
+    # response shape stays consistent with the text path. The body_text
+    # may contain a stub if the extractor lib is missing, but that's
+    # both visible to the LLM and surfaced through total_read_chars so
+    # the hallucination guards still mostly do their job. (We also have
+    # the n_read_file_successes guard which counts an extractor-stub
+    # response as a "success" — worth tightening if stubs end up being
+    # a common silent-failure source.)
+    extractor = _EXTRACTORS[mime]
+    text = extractor(raw_bytes)
+  else:
+    # Plain text path (text/*, json, xml, yaml).
+    try:
+      text = raw_bytes.decode("utf-8", errors="replace")
+    except (UnicodeDecodeError, AttributeError):
+      text = ""
+
+  return {
+      "status": "success",
+      "item_id": item_id,
+      "mime_type": mime,
+      "name": name,
+      "web_url": web_url,
+      "body_text": text,
+  }
+
+
+# All tools, in the order the explorer prompt assumes.
+_ALL_TOOLS = [
+    # Site discovery
+    sp_get_site_by_path,
+    # Libraries
+    sp_list_libraries,
+    sp_get_default_library,
+    # Folders + files
+    sp_list_folder_children,
+    sp_search_files,
+    sp_get_file_metadata,
+    sp_read_file_content,
+]
+
+
+# ---------------------------------------------------------------------------
+# URL classifier + source partitioner (analogous to confluence_tools)
+#
+# Lets the user drop SharePoint URLs into --folders / --docs alongside
+# Drive / local-markdown / Confluence entries; agent_runner.py calls
+# partition_sources() to lift them out into typed --sharepoint_*
+# lists, so the existing Drive/local routing is_local_path() never sees
+# them and the existing per-mode code stays unchanged.
+# ---------------------------------------------------------------------------
+
+# Tenant hostname e.g. `contoso.sharepoint.com` (and variants like
+# `contoso-my.sharepoint.com` for OneDrive — those we also surface as
+# SharePoint, since the Graph endpoints handle both with the same tools).
+_SHAREPOINT_HOST_RE = re.compile(
+    r"^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.sharepoint\.com$", re.IGNORECASE
+)
+
+# .../sites/<sitename> (case-insensitive). Captures the sitename.
+_SHAREPOINT_SITE_PATH_RE = re.compile(
+    r"^/sites/([^/?#]+)", re.IGNORECASE
+)
+
+# Modern viewer URLs include a `sourcedoc` query param holding the file
+# guid in `{...}` brackets, e.g.
+# https://contoso.sharepoint.com/:w:/r/sites/X/_layouts/15/Doc.aspx?sourcedoc=%7BABC...%7D
+# We can't resolve sourcedoc to a Graph driveItem id without an API call,
+# so these get classified as "unknown" with a hint to use --sharepoint_search.
+_SHAREPOINT_VIEWER_PATH_RE = re.compile(
+    r"^/:[a-z]:/", re.IGNORECASE
+)
+
+
+def classify_sharepoint_url(s: str) -> dict | None:
+  """If `s` looks like a SharePoint URL, return its parsed form; else None.
+
+  Returned dicts:
+    {'kind': 'site',    'hostname': '<host>', 'site_path': 'sites/<name>'}
+    {'kind': 'unknown', 'raw':      '<original>'}   # viewer/sourcedoc links
+
+  None means "not SharePoint" — the caller routes the entry to the
+  existing Drive / local / Confluence logic unchanged.
+  """
+  s = (s or "").strip()
+  if not s.lower().startswith(("http://", "https://")):
+    return None
+  try:
+    u = _urlparse.urlparse(s)
+  except (ValueError, TypeError):
+    return None
+  host = (u.hostname or "").strip()
+  if not _SHAREPOINT_HOST_RE.match(host):
+    return None
+  path = u.path or ""
+
+  # 1. .../sites/<sitename>[/...] — site URL. We pass `sites/<name>` to
+  #    sp_get_site_by_path which is the most efficient lookup form.
+  m = _SHAREPOINT_SITE_PATH_RE.match(path)
+  if m:
+    return {
+        "kind": "site",
+        "hostname": host,
+        "site_path": f"sites/{m.group(1)}",
+    }
+
+  # 2. .../:w:/r/... or .../:b:/r/... — viewer / sharing link with
+  #    sourcedoc=. Can't be resolved to a driveItem id without a Graph
+  #    roundtrip; surface as unknown with a hint.
+  if _SHAREPOINT_VIEWER_PATH_RE.match(path):
+    return {"kind": "unknown", "raw": s}
+
+  # 3. *.sharepoint.com at the root or some other unrecognized shape.
+  return {"kind": "unknown", "raw": s}
+
+
+def _to_wire_site_ref(s: str) -> str | None:
+  """Normalize a single `--sharepoint_sites` entry to the wire format.
+
+  Accepts either:
+    * a full URL `https://<host>.sharepoint.com/sites/<NAME>[/...]`
+      (preferred — what users paste from the browser)
+    * the legacy wire format `<host>.sharepoint.com:sites/<NAME>`
+      (kept for back-compat — what the explorer prompt and
+      sp_get_site_by_path actually consume after this normalization)
+
+  Returns the wire-format string, or None if the input is empty / a
+  viewer-or-sharing URL we can't statically resolve to a site path.
+  """
+  s = (s or "").strip()
+  if not s:
+    return None
+  cls = classify_sharepoint_url(s)
+  if cls is not None:
+    # Input was a URL.
+    if cls.get("kind") == "site":
+      return f"{cls['hostname']}:{cls['site_path']}"
+    return None  # viewer / sharing / unknown shape — caller logs + skips
+  # Not a URL — pass through unchanged. Already in wire format (or some
+  # other shape the explorer prompt will reject downstream; we don't try
+  # to second-guess it here).
+  return s
+
+
+def partition_sources(
+    entries: list[str] | None,
+    sharepoint_sites: list[str] | None = None,
+    sharepoint_file_ids: list[str] | None = None,
+) -> tuple[list[str], list[str], list[str]]:
+  """Split a mixed `--folders`/`--docs` list, lifting SharePoint URLs out,
+  and normalize any URL-shaped entries in `sharepoint_sites` to the wire
+  format the explorer prompt expects.
+
+  For each entry in `entries`:
+    - SharePoint site URL → lifted into sharepoint_sites as
+      `<hostname>:sites/<NAME>`. gather_sharepoint_context resolves these
+      via sp_get_site_by_path.
+    - SharePoint viewer/sharing link → logged as unrecognized with a hint
+      (the agent can't resolve a sourcedoc GUID to a driveItem id without
+      an extra Graph roundtrip; recommend --sharepoint_search instead).
+    - Anything else → kept in the returned filtered list for the existing
+      Drive / local / Confluence routing to handle.
+
+  For each entry in `sharepoint_sites`:
+    - Full SharePoint URL → normalized to wire format and kept.
+    - Already wire format (`<host>.sharepoint.com:sites/<NAME>`) → kept as-is.
+    - Viewer/sharing URL or other unrecognized shape → dropped with a warning.
+
+  Returns (filtered_entries, updated_sharepoint_sites,
+  updated_sharepoint_file_ids). The original lists are NOT mutated.
+
+  Mirrors confluence_tools.partition_sources.
+  """
+  filtered: list[str] = []
+  sites: list[str] = []
+  files = list(sharepoint_file_ids or [])
+  seen_sites: set[str] = set()
+  seen_files = {x.strip() for x in files if x and x.strip()}
+
+  # Normalize user-supplied --sharepoint_sites entries (accept both URL
+  # and wire format).
+  for raw in sharepoint_sites or []:
+    wire = _to_wire_site_ref(raw)
+    if wire is None:
+      if (raw or "").strip():
+        print(
+            f"[SharePoint] ⚠️  Skipping --sharepoint_sites entry {raw!r}:"
+            " not a SharePoint site URL we can parse (looks like a"
+            " viewer/sharing link or non-SharePoint URL). Use the"
+            " browser-address-bar URL of the site, e.g."
+            " https://<host>.sharepoint.com/sites/<NAME>.",
+            flush=True,
+        )
+      continue
+    if wire not in seen_sites:
+      sites.append(wire)
+      seen_sites.add(wire)
+
+  # Lift SharePoint URLs out of --folders / --docs into sharepoint_sites
+  # (or surface a warning for viewer/sharing links we can't resolve).
+  for e in entries or []:
+    cls = classify_sharepoint_url(e)
+    if cls is None:
+      filtered.append(e)
+      continue
+    kind = cls.get("kind")
+    if kind == "site":
+      ref = f"{cls['hostname']}:{cls['site_path']}"
+      if ref and ref not in seen_sites:
+        sites.append(ref)
+        seen_sites.add(ref)
+        print(
+            f"[SharePoint] 🔗 Resolved {e} → site {ref}",
+            flush=True,
+        )
+    else:
+      print(
+          f"[SharePoint] ⚠️  Could not classify URL {e!r} as a site or"
+          " file (looks like a viewer / sharing link). Pass"
+          " --sharepoint_search='<file name>' to find it, or open the"
+          " file in SharePoint, copy the canonical /sites/<name>/... URL,"
+          " and pass that instead.",
+          flush=True,
+      )
+  return filtered, sites, files
+
+
+# ---------------------------------------------------------------------------
+# Agentic explorer (mirrors github_tools.gather_repo_context /
+# confluence_tools.gather_confluence_context)
+# ---------------------------------------------------------------------------
+
+_EXPLORER_INSTRUCTION = """You are a senior technical writer indexing a SharePoint corpus for a metadata-enrichment pipeline. You have tools that wrap Microsoft Graph REST to discover sites, list document libraries, browse folders, search files tenant-wide, and read individual file contents. Use them to UNDERSTAND the relevant files, then describe each one.
+
+SCOPE FOR THIS RUN:
+{scope_directive}
+FOCUS TOPIC for relevance scoring: {topic}
+
+EXPLORATION STRATEGY — follow this sequence; do NOT stop after only the prep steps:
+
+STEP 1 (if explicit file ids were provided): For EACH entry of the form `<library_id>/<item_id>`, call `sp_read_file_content(library_id=..., item_id=...)` directly. These are the highest-priority inputs.
+
+STEP 2 (if sites were provided as `<hostname>:<server_relative_path>`): For EACH:
+  a. Call `sp_get_site_by_path(hostname=..., server_relative_path=...)` to resolve the site_id.
+  b. Call `sp_get_default_library(site_id=...)` (or `sp_list_libraries` for multi-library sites) to find the library_id.
+  c. Call `sp_list_folder_children(library_id=..., folder_id="root")` to enumerate files. From the list, pick up to 5 file items whose names look most relevant to the focus topic.
+  d. For EACH picked file item, call `sp_read_file_content(library_id=..., item_id=...)` to read it.
+
+STEP 3 (if search queries were provided): For EACH query, call `sp_search_files(query=...)` and read the top results via `sp_read_file_content` using the `library_id` + `id` from each hit.
+
+STOP RULES — emit OUTPUT and end as soon as ALL of these are true:
+  - You have read at least one file via `sp_read_file_content`.
+  - You have processed every explicit file id / site / search query in scope.
+Do NOT make redundant verification calls. Do NOT keep exploring after the targeted scope is covered.
+
+For EACH file you actually read (i.e. the response had `body_text` or, for binary files, a `web_url`), emit ONE card with:
+  - id: the SharePoint item id.
+  - name: the file name verbatim.
+  - site: the site name or path the file lives in (if known).
+  - url: the `web_url` from the response.
+  - summary: ONE sentence describing what the file is about.
+  - key_entities: concrete named things mentioned that a data catalog should know — table/dataset names, system names, KPIs, glossary-worthy terms, owning team names. Use the exact spellings from the file.
+  - content_excerpt: the relevant prose, lightly cleaned. Quote verbatim. Cap at ~6000 chars per file. For binary files (Office docs / PDFs) where you only have metadata, set content_excerpt to a one-line description plus the message returned by the read tool.
+
+GROUNDING (CRITICAL — do not hallucinate):
+- A card may ONLY be emitted for a file you actually read (sp_read_file_content returned `body_text` or metadata).
+- NEVER invent files from the site name, the topic, or your prior knowledge. If the tools returned no content, output [].
+- Describe only what the read files actually contain. Quote identifiers verbatim.
+
+OUTPUT: when done exploring, output ONLY a single JSON array of card objects (no prose before or after, no markdown fence). Keys exactly: id, name, site, url, summary, key_entities (array of strings), content_excerpt (string). If the corpus is empty, unreachable, or your tools returned no content, output [].
+"""
+
+
+def _file_card(card: dict) -> dict:
+  """Render one parsed file card into the shared router-descriptor doc shape."""
+  item_id = str(card.get("id") or "").strip()
+  name = (card.get("name") or "Untitled SharePoint file").strip()
+  site = (card.get("site") or "").strip()
+  url = (card.get("url") or "").strip()
+  if not url and item_id:
+    url = f"sharepoint://item/{item_id}"
+  summary = (card.get("summary") or "").strip()
+  entities = card.get("key_entities") or []
+  if isinstance(entities, str):
+    entities = [entities]
+  entities = [str(e).strip() for e in entities if str(e).strip()]
+  excerpt = (card.get("content_excerpt") or "").strip()
+
+  entities_str = ", ".join(entities) if entities else "(none listed)"
+
+  content = (
+      f"# {name}\n\n"
+      f"**Source:** [SharePoint: {site or 'file'} / {name}]({url})\n\n"
+      "## Identity\n"
+      f"- **Type:** SharePoint file\n"
+      f"- **Site:** `{site or '(unknown)'}`\n"
+      f"- **Item ID:** `{item_id or '(unknown)'}`\n"
+      f"- **Summary:** {summary or '(not stated)'}\n\n"
+      "## Key Entities\n"
+      f"{entities_str}\n\n"
+      "## Content\n"
+      f"{excerpt or '(no excerpt captured)'}\n"
+  )
+  descriptor = (
+      f"Title: {name}\n"
+      f"Summary: {summary or 'SharePoint file in site ' + (site or '?')}\n"
+      f"Key entities: {entities_str}"
+  )
+  return {
+      "name": name,
+      "url": url,
+      "content": content,
+      "descriptor": descriptor,
+  }
+
+
+def _parse_cards(raw_text: str) -> list[dict]:
+  """Leniently parse the explorer agent's JSON array of file cards."""
+  text = (raw_text or "").strip()
+  if not text:
+    return []
+  fence = re.match(r"^```(?:json)?\s*\n(.*)\n```$", text, re.S)
+  if fence:
+    text = fence.group(1).strip()
+  if not text.startswith("["):
+    m = re.search(r"\[.*\]", text, re.S)
+    if m:
+      text = m.group(0)
+  try:
+    data = json.loads(text)
+  except (ValueError, json.JSONDecodeError):
+    return []
+  if not isinstance(data, list):
+    return []
+  return [c for c in data if isinstance(c, dict)]
+
+
+async def gather_sharepoint_context(
+    sites: list[str] | None,
+    search_queries: list[str] | None,
+    file_ids: list[str] | None,
+    topic: str,
+    model: str,
+    usage_acc: dict,
+) -> list[dict]:
+  """Agentically explore a SharePoint corpus and return file cards.
+
+  Returns a list of router-descriptor dicts `{name, url, content, descriptor}`
+  (caller assigns `id`). Always returns a list — on any failure logs a
+  warning and returns `[]` so the enrichment run continues without
+  SharePoint context.
+
+  Args:
+    sites: optional `<hostname>:<server_relative_path>` strings (e.g.
+      `contoso.sharepoint.com:sites/Marketing`).
+    search_queries: optional tenant-wide search strings; each one is run
+      via `sp_search_files` and the top hits are read.
+    file_ids: optional explicit `<library_id>/<item_id>` strings to read
+      verbatim — highest priority.
+    topic: the run's focus topic (used for relevance scoring inside the
+      explorer prompt).
+    model: model name for the inner exploration agent.
+    usage_acc: token-usage accumulator (mutated in place).
+  """
+  sites = [s.strip() for s in (sites or []) if s and s.strip()]
+  search_queries = [
+      q.strip() for q in (search_queries or []) if q and q.strip()
+  ]
+  file_ids = [f.strip() for f in (file_ids or []) if f and f.strip()]
+  if not (sites or search_queries or file_ids):
+    return []
+
+  if not _credentials_configured():
+    print(
+        "[SharePoint] ⚠️  No Microsoft credentials available — skipping"
+        " SharePoint source. Either populate the MSAL cache by running"
+        " `python3 toolbox/enrichment/scripts/setup_sharepoint.py` (one"
+        " time; enables silent refresh thereafter), or export"
+        f" ${_TOKEN_ENV} with a Graph bearer for a one-shot run.",
+        flush=True,
+    )
+    return []
+
+  scope_lines = []
+  if file_ids:
+    scope_lines.append(f"EXPLICIT FILE IDS: {', '.join(file_ids)}")
+  if sites:
+    scope_lines.append("SITES: " + ", ".join(sites))
+  if search_queries:
+    scope_lines.append(
+        "SEARCH QUERIES:\n  - " + "\n  - ".join(search_queries)
+    )
+  scope_directive = "\n".join(scope_lines) + "\n"
+
+  instruction = _EXPLORER_INSTRUCTION.format(
+      scope_directive=scope_directive, topic=topic
+  )
+
+  print(
+      "[SharePoint] 🗂️  Exploring SharePoint via Microsoft Graph REST:"
+      f" sites={sites or '(none)'}, search={len(search_queries)} query(ies),"
+      f" file_ids={file_ids or '(none)'}",
+      flush=True,
+  )
+
+  try:
+    agent = llm_agent.LlmAgent(
+        name="SharePointUnderstandingAgent",
+        description=(
+            "Explores a SharePoint corpus via Microsoft Graph REST tools"
+            " and emits structured file cards."
+        ),
+        model=VertexGemini(model=model),
+        instruction=instruction,
+        tools=[FunctionTool(t) for t in _ALL_TOOLS],
+    )
+    runner = InMemoryRunner(agent=agent)
+    user_id = str(uuid.uuid4())
+    session = await runner.session_service.create_session(
+        app_name=runner.app_name, user_id=user_id
+    )
+    kickoff_bits = [
+        "Explore the SharePoint scope above and emit the JSON array of"
+        " file cards."
+    ]
+    if file_ids:
+      kickoff_bits.append(
+          "START by reading every entry in EXPLICIT FILE IDS via"
+          " sp_read_file_content (split on '/' to get library_id and"
+          " item_id)."
+      )
+    if sites:
+      kickoff_bits.append(
+          "THEN for each site, run sp_get_site_by_path →"
+          " sp_get_default_library → sp_list_folder_children → pick the"
+          " most relevant files for the topic and sp_read_file_content"
+          " each."
+      )
+    if search_queries:
+      kickoff_bits.append(
+          "THEN run each search via sp_search_files and"
+          " sp_read_file_content on the top hits."
+      )
+    kickoff = " ".join(kickoff_bits)
+
+    raw_text = ""
+    turns = 0
+    n_tool_calls = 0
+    n_errors = 0
+    n_successes = 0
+    n_read_file_attempts = 0
+    n_read_file_successes = 0
+    total_read_chars = 0
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=types.Content(
+            role="user", parts=[types.Part.from_text(text=kickoff)]
+        ),
+    ):
+      turns += 1
+      usage = getattr(event, "usage_metadata", None)
+      if usage and usage_acc is not None:
+        usage_acc["input"] += getattr(usage, "prompt_token_count", 0) or 0
+        usage_acc["output"] += getattr(usage, "candidates_token_count", 0) or 0
+      for fc in event.get_function_calls() or []:
+        n_tool_calls += 1
+        args = fc.args or {}
+        print(
+            f"[SharePoint]    → tool {fc.name}({_short_args(args)})",
+            flush=True,
+        )
+      for fr in event.get_function_responses() or []:
+        resp_len = len(_response_text(fr.response))
+        total_read_chars += resp_len
+        err = _extract_error_info(fr.response)
+        if err is not None:
+          n_errors += 1
+          if fr.name == "sp_read_file_content":
+            n_read_file_attempts += 1
+          print(
+              f"[SharePoint]    ← {fr.name}: {resp_len} chars"
+              f"  ⚠️  error: {err[0]} — {err[1]}",
+              flush=True,
+          )
+        else:
+          n_successes += 1
+          if fr.name == "sp_read_file_content":
+            n_read_file_attempts += 1
+            n_read_file_successes += 1
+          print(
+              f"[SharePoint]    ← {fr.name}: {resp_len} chars", flush=True
+          )
+      if event.content and event.content.parts:
+        for part in event.content.parts:
+          if part.text:
+            raw_text += part.text
+      if turns > _MAX_EXPLORE_TURNS * 4:
+        print(
+            "[SharePoint] ⚠️  Exploration exceeded turn budget; using"
+            " output so far.",
+            flush=True,
+        )
+        break
+    print(
+        f"[SharePoint] 🔧 Graph usage: {n_tool_calls} tool call(s)"
+        f" ({n_successes} ok, {n_errors} error),"
+        f" {total_read_chars} chars of content read.",
+        flush=True,
+    )
+  except Exception as e:  # pylint: disable=broad-except
+    print(
+        f"[SharePoint] ⚠️  Graph exploration failed"
+        f" ({type(e).__name__}: {e}) — continuing without SharePoint"
+        " context.",
+        flush=True,
+    )
+    return []
+
+  # Hallucination guard — if the tools never returned real content, any
+  # cards the model produced are invented from priors.
+  if total_read_chars == 0:
+    print(
+        "[SharePoint] ⛔ Graph returned NO content"
+        f" ({n_tool_calls} tool call(s)). Not emitting any cards (would be"
+        " hallucinated). Check: token has Sites.Read.All + Files.Read.All,"
+        " the sites/file ids exist, and the user has access.",
+        flush=True,
+    )
+    return []
+
+  # Second guard — if every successful-looking response was actually an
+  # error envelope, the model's output (if any) is built from error
+  # messages, not real content. The first guard misses this case because
+  # error envelopes have nonzero size.
+  if n_successes == 0 and n_errors > 0:
+    print(
+        f"[SharePoint] ⛔ All {n_errors} tool call(s) returned errors —"
+        " exploration aborted (see the per-call ← lines above for the"
+        " specific Graph error messages). Not emitting any cards (would"
+        " be hallucinated).",
+        flush=True,
+    )
+    return []
+
+  # Third guard — if sp_read_file_content was attempted but never
+  # successfully returned file content (e.g. every read 302'd to an
+  # unfollowed redirect), then any card the model emits has a fabricated
+  # `content_excerpt` derived from file names + the focus topic, not the
+  # actual file contents. The two prior guards both miss this because
+  # other tool calls (site / library / folder list) succeeded with real
+  # metadata. Without this guard, you get plausible-looking but
+  # hallucinated KB entries.
+  if n_read_file_attempts > 0 and n_read_file_successes == 0:
+    print(
+        f"[SharePoint] ⛔ {n_read_file_attempts} sp_read_file_content"
+        " call(s) attempted but NONE returned file content — every read"
+        " errored. Cards would have fabricated content_excerpts. Aborting."
+        " Check the per-call ← lines above for the specific error.",
+        flush=True,
+    )
+    return []
+
+  cards = _parse_cards(raw_text)
+  if not cards:
+    print(
+        "[SharePoint] ⚠️  No parseable cards returned from exploration.",
+        flush=True,
+    )
+    return []
+
+  rendered = [_file_card(c) for c in cards]
+  print(
+      f"[SharePoint] ✅ Derived {len(rendered)} file card(s):"
+      f" {[c['name'] for c in rendered]}",
+      flush=True,
+  )
+  return rendered

--- a/agents/mdcode/README.md
+++ b/agents/mdcode/README.md
@@ -28,6 +28,11 @@ More details are in the [docs/concept.md](docs/concept.md).
 
 *   **Optimized Layouts**: Automatically switches between **YAML Layout** (for data assets) and **Markdown Layout** (for human-centric Knowledge Bases).
 *   **Markdown Sidecars**: Detach long-form text (like overviews) into sidecar `.md` files to maintain clean and manageable YAML files.
+*   **OKF Bundles**: Opt into the **OKF Layout** with `--format okf` to
+    read/write an
+    [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+    bundle — one `.md` per concept (YAML frontmatter + body) plus reserved
+    `index.md` directory listings, rooted at `bundle/`.
 
 #### 4. Integration & Extensibility
 
@@ -72,6 +77,18 @@ More details are in the [docs/concept.md](docs/concept.md).
     glossary terms and categories via the same `pull`/`push` workflow.
     Glossaries also work as a `reference.scope` so other workspaces can ground
     enrichment in glossary terms without owning them.
+*   **OKF Layout (`--format okf`)**: `init`, `pull`, `push`, and `reference`
+    accept `--format okf` to read/write an
+    [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+    bundle — a directory of single-`.md` concepts (YAML frontmatter + body) with
+    reserved `index.md` listings, rooted at `bundle/` instead of `catalog/`.
+    `init --format okf` records `layout: okf` in the manifest so later commands
+    default to it. The full entry is preserved under a hidden `x-kcmd`
+    frontmatter key for lossless round-trip (consumers ignore unknown keys per
+    SPEC), and per-folder `index` entries are synthesized from the directory
+    tree on `push` so the catalog hierarchy is recreated — synthesis is skipped
+    for ingested sources (e.g. BigQuery `@bigquery` system entries), where
+    `index.md` stays navigation-only.
 
 ## Usage
 
@@ -122,12 +139,27 @@ kcmd init --glossary my-project-id.us-central1.glossary-a,glossary-b
 kcmd init --glossary my-project-id.us-central1
 ```
 
+**Note on layout (`--format`):** Independently of the source type, `init`,
+`pull`, `push`, and `reference` accept `--format <standard|documents|okf>` to
+override the on-disk layout. `--format okf` reads/writes an **OKF** bundle under
+`bundle/` (instead of `catalog/`); `init --format okf` records `layout: okf` in
+`catalog.yaml` so subsequent commands default to it. See **OKF Layout** under
+Directory Layout below.
+
+```bash
+# Initialize an Entry Group workspace that stores an OKF bundle under bundle/
+kcmd init --entry-group my-project-id.us-central1.my-eg-id --format okf
+```
+
 ### 2. Synchronization
 
 #### Pulling Metadata
 
 *   **`kcmd pull`**: Downloads editable metadata into the `catalog/` directory.
     *   Generates `.yaml` files in **YAML** mode or `.md` files in **Markdown** mode.
+    *   With `--format okf` (or `layout: okf` in the manifest), writes the **OKF
+        Layout** under `bundle/` instead — one `.md` per concept — and
+        regenerates the reserved `index.md` listings after the pull.
     *   **Entry Links**: When `snapshot.entryLinks` is declared, `pull` also
         calls `lookupEntryLinks` for every fetched entry and inlines the results
         into the entry YAML — column-level links (those with a `Schema.<field>`
@@ -140,6 +172,8 @@ kcmd init --glossary my-project-id.us-central1
     *   Honors `reference.snapshot.entryLinks` the same way as `pull` honors
         `snapshot.entryLinks`, so a `.ref.yaml` baseline can include the
         pre-edit link state for clean `diff`s.
+    *   Under `--format okf` the read-only mirror is written as `.ref.md`
+        siblings in `bundle/` (the OKF reference layer).
 
 #### Pushing Changes
 
@@ -160,6 +194,11 @@ kcmd init --glossary my-project-id.us-central1
         a workspace only reads links.
     *   `--force`: Overwrites service metadata, ignoring potential conflicts.
     *   `--validate-only`: Validates the local snapshot against the service without performing a push.
+    *   `--format okf`: Reads the **OKF Layout** from `bundle/`, reconstructing
+        each entry from its `x-kcmd` frontmatter. Per-folder `index` entries are
+        synthesized from the directory tree (so the hierarchy is recreated),
+        except for ingested sources (e.g. `@bigquery`), which can't hold custom
+        entries.
 
 > [!IMPORTANT] **`kcmd push` does NOT create Glossary, GlossaryCategory, or
 > GlossaryTerm resources.**
@@ -249,6 +288,31 @@ Entries are `.md` files containing both metadata and content.
                 └── page2.md            # Page 2
 ```
 
+#### OKF Layout (Bundle)
+
+With `--format okf`, each concept is a single `.md` file (YAML frontmatter +
+overview body) rooted at **`bundle/`** instead of `catalog/`. Reserved
+`index.md` files list each directory's children; only the bundle-root `index.md`
+carries `okf_version`. Read-only reference mirrors are `*.ref.md`.
+
+```text
+/
+├── catalog.yaml                       # manifest (layout: okf)
+└── bundle/
+    ├── index.md                       # root listing (carries okf_version)
+    └── bigquery/
+        └── my-project-id/
+            └── my-dataset-id/
+                ├── index.md           # directory listing (no frontmatter)
+                ├── table1.md          # concept: frontmatter + overview body
+                └── table1.ref.md      # read-only reference mirror
+```
+
+The full Dataplex entry (all aspects, links, `resource.parent`) is preserved
+under a hidden `x-kcmd` frontmatter key so the bundle round-trips losslessly;
+OKF consumers ignore the unknown key. Files authored without `x-kcmd` (hand-
+written OKF) still load, reconstructed from the SPEC frontmatter fields.
+
 ## Catalog Manifest (`catalog.yaml`)
 
 The manifest defines the synchronization scope, the types of metadata to manage, and optional reference layers for grounding.
@@ -298,6 +362,11 @@ reference:
     your `catalog/` folder. Supported types include `bq-dataset.*`,
     `entryGroup.*`, `kb.*`, `biglake-namespace.*`, and
     `glossary.<project>.<location>.<glossary-id>`.
+*   **`layout`** (optional) — overrides the on-disk layout (`standard` |
+    `documents` | `okf`); normally derived from the source type. Written by
+    `init --format` and honored by `--format` on the other commands. `okf` roots
+    the workspace at `bundle/` and stores one `.md` per concept (see **OKF
+    Layout** above).
 *   **`snapshot`** — The entry, aspect, and link types to manage locally.
     *   `entryLinks` (optional) — short aliases (`definition`, `synonym`,
         `related`, `schema-join`) or fully-qualified link type refs. When set,

--- a/agents/mdcode/src/libts/layout.ts
+++ b/agents/mdcode/src/libts/layout.ts
@@ -2,6 +2,7 @@
 //
 
 import {DocumentsLayout} from './layouts/documents';
+import {OkfLayout} from './layouts/okf';
 import {StandardLayout} from './layouts/standard';
 import {CatalogManifest} from './manifest';
 import * as md from './metadata';
@@ -9,12 +10,13 @@ import * as md from './metadata';
 export enum Layouts {
   STANDARD = 'standard',
   DOCUMENTS = 'documents',
+  OKF = 'okf',
 }
 
-// The on-disk root directory name used by each layout (kcmd-native layouts use
-// `catalog/`).
-export function rootDirForLayout(_layout: Layouts): string {
-  return 'catalog';
+// The on-disk root directory name used by each layout. OKF bundles live under
+// `bundle/`; the kcmd-native layouts use `catalog/`.
+export function rootDirForLayout(layout: Layouts): string {
+  return layout === Layouts.OKF ? 'bundle' : 'catalog';
 }
 
 export interface CatalogLayout {
@@ -27,7 +29,8 @@ export interface CatalogLayout {
   deleteEntry(name: string): Promise<void>;
   getEntryPaths(name: string): {local?: string; ref?: string} | undefined;
 
-  // Optional post-sync hook. Layouts that don't need it simply omit it.
+  // Optional post-sync hook (e.g. OKF regenerates reserved index.md listings
+  // after a pull). Layouts that don't need it simply omit it.
   finalize?(): Promise<void>;
 }
 
@@ -41,6 +44,8 @@ export function createLayout(
       return new StandardLayout(catalogPath, manifest);
     case Layouts.DOCUMENTS:
       return new DocumentsLayout(catalogPath);
+    case Layouts.OKF:
+      return new OkfLayout(catalogPath, manifest);
     default:
       throw new Error(`Unknown layout type: ${layout}`);
   }

--- a/agents/mdcode/src/libts/layouts/okf.ts
+++ b/agents/mdcode/src/libts/layouts/okf.ts
@@ -1,0 +1,653 @@
+// Implements the OKF (Open Knowledge Format) layout.
+//
+// OKF (github.com/GoogleCloudPlatform/knowledge-catalog okf/SPEC.md) represents
+// knowledge as a directory of markdown files, ONE per concept, each with a YAML
+// frontmatter block; reserved `index.md` files are directory listings (the
+// bundle-root `index.md` is the only place `okf_version` may appear).
+//
+// To round-trip Dataplex entries losslessly (a Dataplex entry has more than the
+// OKF-spec frontmatter fields can express — arbitrary aspects, entry links,
+// resource.parent, …) we ALSO stash the full `md.Entry` under a single hidden
+// `x-kcmd` frontmatter key. Per the spec, consumers ignore unknown keys, so the
+// file stays a valid OKF concept; kcmd reads `x-kcmd` to reconstruct the entry.
+// Files authored without `x-kcmd` (pure hand-written OKF) still load, lossily.
+
+import * as glob from 'glob';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'yaml';
+import {CatalogLayout} from '../layout';
+import type {CatalogManifest} from '../manifest';
+import * as md from '../metadata';
+
+const OVERVIEW_ASPECT_KEY = 'dataplex-types.global.overview';
+const GENERIC_ASPECT_KEY = 'dataplex-types.global.generic';
+const INDEX_ENTRY_TYPE = 'dataplex-types.global.generic';
+const DEFAULT_ENTRY_TYPE = 'dataplex-types.global.generic';
+const OKF_VERSION = '0.1';
+const STASH_KEY = 'x-kcmd';
+
+export class OkfLayout implements CatalogLayout {
+  private readonly _catalogPath: string;
+  private readonly _manifest?: CatalogManifest;
+
+  // Maps entry name to its file paths (modifiable and reference layers).
+  private readonly _index = new Map<string, {local?: string; ref?: string}>();
+  // OKF index.md files carry no frontmatter, so they are not concepts. We still
+  // synthesize a directory `index` entry per folder (id `<folder>/index`) so
+  // `kcmd push` recreates the Dataplex hierarchy. id -> its index.md path, or
+  // `null` for a directory that has entries but no index.md (synthetic, no
+  // backing file — its title is derived and it has no overview).
+  private readonly _indexPaths = new Map<string, string | null>();
+
+  constructor(catalogPath: string, manifest?: CatalogManifest) {
+    this._catalogPath = catalogPath;
+    this._manifest = manifest;
+  }
+
+  async init(): Promise<void> {
+    this._index.clear();
+    this._indexPaths.clear();
+    if (!fs.existsSync(this._catalogPath)) {
+      return;
+    }
+
+    const matches = await glob.glob('**/*.md', {
+      cwd: this._catalogPath,
+      absolute: true,
+      nodir: true,
+    });
+
+    // Synthetic directory `index` entries are only pushable into a user-managed
+    // entry group. Ingested sources (e.g. bq-dataset -> @bigquery system
+    // entries, table mode) can't hold custom entries, so we DON'T synthesize
+    // index entries there — the index.md files remain as navigation only.
+    const synthIndexEntries = !this._manifest?.source?.ingestedEntries;
+    // Directories (relative, '' = root) that contain at least one concept, so we
+    // can guarantee an index entry per directory even when a folder has no
+    // index.md file of its own.
+    const dirsWithEntries = new Set<string>();
+
+    for (const localPath of matches) {
+      // index.md files carry no frontmatter (they're directory listings), but we
+      // register a synthetic directory `index` entry so push recreates the
+      // Dataplex hierarchy. id: bundle-root -> "index"; sub -> "<folder>/index".
+      if (path.basename(localPath) === 'index.md') {
+        if (!synthIndexEntries) {
+          continue;
+        }
+        const rel = path
+          .relative(this._catalogPath, localPath)
+          .replace(/\\/g, '/');
+        const dir = path.dirname(rel);
+        const id = dir === '.' ? 'index' : `${dir}/index`;
+        this._indexPaths.set(id, localPath);
+        continue;
+      }
+      try {
+        const content = await fs.promises.readFile(localPath, 'utf8');
+        const {entry} = parseOkf(content);
+        // Name: prefer the stashed entry name (x-kcmd may differ from the path,
+        // e.g. context overlays) and fall back to a path-derived name so
+        // hand-authored / external OKF files (no x-kcmd, no resource URI) — and
+        // even frontmatter-less markdown — still index.
+        const name =
+          entry?.name || deriveEntryName(localPath, this._catalogPath);
+        if (!name) {
+          continue;
+        }
+        const entryPaths = this._index.get(name) || {};
+        if (localPath.endsWith('.ref.md')) {
+          entryPaths.ref = localPath;
+        } else {
+          entryPaths.local = localPath;
+        }
+        this._index.set(name, entryPaths);
+        // Record this file's directory (and every ancestor) so we can ensure an
+        // index entry exists for each level of the tree.
+        const reldir = path
+          .dirname(path.relative(this._catalogPath, localPath))
+          .replace(/\\/g, '/');
+        for (const d of ancestorDirs(reldir)) {
+          dirsWithEntries.add(d);
+        }
+      } catch (err) {
+        // Skip unreadable/invalid files during indexing.
+      }
+    }
+
+    // Ensure every directory that holds concepts has an index entry. Folders
+    // whose own index.md is absent get a synthetic, file-less entry (null) so a
+    // leaf's `parent` never dangles. (kcmd-native bundles always have index.md;
+    // this guards arbitrary / hand-authored bundles.)
+    if (synthIndexEntries) {
+      for (const dir of dirsWithEntries) {
+        const id = dir === '' ? 'index' : `${dir}/index`;
+        if (!this._indexPaths.has(id)) {
+          this._indexPaths.set(id, null);
+        }
+      }
+    }
+  }
+
+  entryExists(name: string): boolean {
+    if (this._indexPaths.has(name)) {
+      const idx = this._indexPaths.get(name);
+      return idx == null || fs.existsSync(idx);
+    }
+    const entryPaths = this._index.get(name);
+    return (
+      !!entryPaths &&
+      ((!!entryPaths.local && fs.existsSync(entryPaths.local)) ||
+        (!!entryPaths.ref && fs.existsSync(entryPaths.ref)))
+    );
+  }
+
+  listEntries(): string[] {
+    return [...this._index.keys(), ...this._indexPaths.keys()];
+  }
+
+  async loadEntry(name: string): Promise<md.Entry> {
+    // Synthetic directory `index` entry: derived from the index.md (which has no
+    // frontmatter) plus the directory tree. `null` = no backing index.md file.
+    if (this._indexPaths.has(name)) {
+      return this._synthIndexEntry(name, this._indexPaths.get(name) ?? null);
+    }
+
+    const entryPaths = this._index.get(name);
+    if (!entryPaths) {
+      throw new Error(`Entry not found: ${name}`);
+    }
+
+    let mergedEntry: md.Entry | undefined;
+
+    // Reference layer first, local overrides it (mirrors StandardLayout).
+    if (entryPaths.ref && fs.existsSync(entryPaths.ref)) {
+      mergedEntry = await this._loadLayer(entryPaths.ref);
+    }
+    if (entryPaths.local && fs.existsSync(entryPaths.local)) {
+      const localEntry = await this._loadLayer(entryPaths.local);
+      if (!mergedEntry) {
+        mergedEntry = localEntry;
+      } else {
+        mergedEntry.type = localEntry.type;
+        mergedEntry.resource = {
+          ...mergedEntry.resource,
+          ...localEntry.resource,
+        };
+        if (localEntry.aspects) {
+          mergedEntry.aspects = mergedEntry.aspects ?? {};
+          for (const [key, value] of Object.entries(localEntry.aspects)) {
+            mergedEntry.aspects[key] = value;
+          }
+        }
+        if (localEntry.links) {
+          mergedEntry.links = localEntry.links;
+        }
+      }
+    }
+
+    if (!mergedEntry) {
+      throw new Error(`Entry files missing for: ${name}`);
+    }
+    // A path-derived (stash-less / frontmatter-less) entry has no name of its
+    // own — use the index key (its path-derived name) so push targets it.
+    if (!mergedEntry.name) {
+      mergedEntry.name = name;
+    }
+    return mergedEntry;
+  }
+
+  private async _loadLayer(entryPath: string): Promise<md.Entry> {
+    const content = await fs.promises.readFile(entryPath, 'utf8');
+    const parsed = parseOkf(content);
+    const body = parsed.body;
+    // A frontmatter-less markdown file is still a valid concept (body-only):
+    // treat it as a default generic entry whose body is the overview.
+    const entry =
+      parsed.entry ?? ({type: DEFAULT_ENTRY_TYPE, resource: {}} as md.Entry);
+    // The markdown body IS the overview aspect content.
+    const bodyTrimmed = body.trim();
+    if (bodyTrimmed) {
+      entry.aspects = entry.aspects ?? {};
+      entry.aspects[OVERVIEW_ASPECT_KEY] =
+        entry.aspects[OVERVIEW_ASPECT_KEY] ?? {};
+      entry.aspects[OVERVIEW_ASPECT_KEY].content = bodyTrimmed;
+      entry.aspects[OVERVIEW_ASPECT_KEY].contentType = 'MARKDOWN';
+    }
+    return entry;
+  }
+
+  async saveEntry(name: string, entry: md.Entry): Promise<void> {
+    // Directory `index` entries are not materialized as frontmatter files —
+    // they're regenerated from the tree by finalize(). On pull, skip writing.
+    if (path.basename(name) === 'index') {
+      return;
+    }
+
+    const entryPath = path.join(this._catalogPath, `${name}.md`);
+    await fs.promises.mkdir(path.dirname(entryPath), {recursive: true});
+
+    const entryClone = JSON.parse(JSON.stringify(entry)) as md.Entry;
+
+    // Pull the overview content out to become the markdown body.
+    let body = '';
+    if (entryClone.aspects?.[OVERVIEW_ASPECT_KEY]) {
+      const aspect = entryClone.aspects[OVERVIEW_ASPECT_KEY];
+      if (aspect.content !== undefined) {
+        body = aspect.content;
+        delete aspect.content;
+        delete aspect.contentType;
+      }
+      if (Object.keys(aspect).length === 0) {
+        delete entryClone.aspects[OVERVIEW_ASPECT_KEY];
+      }
+    }
+
+    const fileContent = toOkf(entryClone, body);
+    await fs.promises.writeFile(entryPath, fileContent, 'utf8');
+
+    // Index by the entry's own name; the `.ref` suffix on `name` selects layer.
+    const entryName = entryClone.name;
+    const entryPaths = this._index.get(entryName) || {};
+    if (name.endsWith('.ref')) {
+      entryPaths.ref = entryPath;
+    } else {
+      entryPaths.local = entryPath;
+    }
+    this._index.set(entryName, entryPaths);
+  }
+
+  async deleteEntry(name: string): Promise<void> {
+    if (this._indexPaths.has(name)) {
+      this._indexPaths.delete(name);
+      return; // index.md is regenerated by finalize(); nothing else to remove.
+    }
+    const entryPaths = this._index.get(name);
+    const entryPath = entryPaths?.local || entryPaths?.ref;
+    if (!entryPath || !fs.existsSync(entryPath)) {
+      throw new Error(`Entry not found: ${name}`);
+    }
+    await fs.promises.unlink(entryPath);
+    this._index.delete(name);
+  }
+
+  getEntryPaths(name: string): {local?: string; ref?: string} | undefined {
+    if (this._indexPaths.has(name)) {
+      // Index entries are modifiable (pushable). For a file-less synthetic one,
+      // return a placeholder local path — loadEntry routes index ids to
+      // _synthIndexEntry, so this value is only used as a truthy modifiable flag.
+      const idx = this._indexPaths.get(name);
+      return {local: idx ?? path.join(this._catalogPath, `${name}.md`)};
+    }
+    return this._index.get(name);
+  }
+
+  // Build a directory `index` entry from its (frontmatter-free) index.md plus
+  // the manifest's source for parent linking. The index.md `# Title` + first
+  // paragraph become displayName/description; its body becomes the overview.
+  private async _synthIndexEntry(
+    id: string,
+    indexPath: string | null,
+  ): Promise<md.Entry> {
+    let raw = '';
+    if (indexPath) {
+      try {
+        raw = await fs.promises.readFile(indexPath, 'utf8');
+      } catch (err) {
+        raw = '';
+      }
+    }
+    // Drop the root index.md's okf_version frontmatter, if present.
+    const lines = raw.split(/\r?\n/);
+    let body = raw;
+    if (lines[0]?.trim() === '---') {
+      const end = lines.indexOf('---', 1);
+      if (end !== -1) {
+        body = lines.slice(end + 1).join('\n');
+      }
+    }
+    const bodyLines = body.split(/\r?\n/);
+    // Default title from the folder name (the segment before `/index`), so a
+    // file-less synthetic index still gets a sensible displayName.
+    let title = _titleFromIndexId(id);
+    let description = '';
+    const h = bodyLines.find((l) => l.startsWith('# '));
+    if (h) {
+      title = h.slice(2).trim();
+    }
+    // First non-empty, non-heading, non-list line is the folder description.
+    for (const l of bodyLines) {
+      const t = l.trim();
+      if (!t || t.startsWith('#') || t.startsWith('*') || t.startsWith('-')) {
+        continue;
+      }
+      description = t;
+      break;
+    }
+
+    // The index.md uses bundle-relative `*.md` links (correct for OKF). Those
+    // are meaningless in the Dataplex/Pantheon UI (they resolve to broken
+    // pantheon.corp.google.com/<file>.md URLs), so the KC index ENTRY's overview
+    // is de-linked to plain text. The on-disk OKF bundle keeps its links.
+    const aspects: Record<string, md.Aspect> = {
+      [GENERIC_ASPECT_KEY]: {
+        type: 'knowledge-base-index',
+        system: 'enrichment-agent',
+      },
+    };
+    const overview = _delinkMarkdown(body).trim();
+    if (overview) {
+      // Omit an empty overview aspect (a file-less synthetic index has no body);
+      // an empty `content` is rejected by Dataplex on push.
+      aspects[OVERVIEW_ASPECT_KEY] = {
+        content: overview,
+        contentType: 'MARKDOWN',
+      };
+    }
+    const entry: md.Entry = {
+      name: id,
+      type: INDEX_ENTRY_TYPE,
+      resource: {
+        displayName: _oneLine(title),
+        description: _oneLine(description),
+      },
+      aspects,
+    };
+
+    // Parent = the enclosing directory's index entry (root has none). Bake the
+    // full service name via the source so it matches the leaf entries' parents.
+    const parentId = _parentIndexId(id);
+    if (parentId && this._manifest) {
+      entry.resource.parent = this._manifest.source.serviceName(parentId);
+    }
+    return entry;
+  }
+
+  // Regenerate the reserved `index.md` directory listings across the whole
+  // bundle. Called after `pull` (Dataplex has no index concept, so we derive the
+  // listings from the on-disk tree). The bundle-root index carries okf_version.
+  async finalize(): Promise<void> {
+    await writeIndexes(this._catalogPath);
+  }
+}
+
+export function parseOkf(content: string): {
+  entry: md.Entry | null;
+  body: string;
+} {
+  const lines = content.split(/\r?\n/);
+  if (lines[0] !== '---') {
+    return {entry: null, body: content};
+  }
+  const endIndex = lines.indexOf('---', 1);
+  if (endIndex === -1) {
+    return {entry: null, body: content};
+  }
+
+  const frontmatter = lines.slice(1, endIndex).join('\n');
+  const metadata = yaml.parse(frontmatter) || {};
+  const body = lines.slice(endIndex + 1).join('\n');
+
+  // Faithful path: the full md.Entry is stashed under `x-kcmd`. Lossy path: no
+  // stash, reconstruct what we can from the spec fields.
+  const entry = (metadata[STASH_KEY] ?? {}) as md.Entry;
+  // Type precedence: a valid 3-part Dataplex type in the frontmatter wins; else
+  // keep the stashed type (x-kcmd); else default to generic. This tolerates
+  // OKF-native type labels (e.g. `type: "BigQuery Dataset"`) on hand-authored
+  // files by falling back to generic instead of pushing an unknown type.
+  if (
+    typeof metadata.type === 'string' &&
+    metadata.type.split('.').length === 3
+  ) {
+    entry.type = metadata.type;
+  } else if (!entry.type) {
+    entry.type = DEFAULT_ENTRY_TYPE;
+  }
+  entry.resource = entry.resource ?? {};
+  if (metadata.title !== undefined) {
+    entry.resource.displayName = metadata.title;
+  }
+  if (metadata.description !== undefined) {
+    entry.resource.description = metadata.description;
+  }
+  if (metadata.resource !== undefined && entry.resource.name === undefined) {
+    entry.resource.name = metadata.resource;
+  }
+  if (metadata.tags) {
+    entry.resource.labels = entry.resource.labels ?? {};
+    for (const tag of metadata.tags) {
+      entry.resource.labels[tag] = 'true';
+    }
+  }
+  if (metadata.timestamp) {
+    entry.resource.updateTime = entry.resource.updateTime ?? metadata.timestamp;
+    if (!entry.resource.createTime) {
+      entry.resource.createTime = metadata.timestamp;
+    }
+  }
+  // Lossy fallback: a pure-OKF file with no stash has no entry name; use the
+  // resource URI if present so it can still be indexed.
+  if (!entry.name && entry.resource.name) {
+    entry.name = entry.resource.name;
+  }
+
+  // A concept must have at least a type or a name to be a real entry; otherwise
+  // (e.g. a root index.md carrying only okf_version) it is not an entry.
+  if (!entry.type && !entry.name) {
+    return {entry: null, body};
+  }
+  return {entry, body};
+}
+
+export function toOkf(entry: md.Entry, body: string): string {
+  const entryClone = JSON.parse(JSON.stringify(entry)) as Record<string, any>;
+
+  const tags: string[] = [];
+  if (entry.resource?.labels) {
+    for (const [k, v] of Object.entries(entry.resource.labels)) {
+      if (v === 'true') {
+        tags.push(k);
+      }
+    }
+  }
+
+  const metadata: Record<string, any> = {
+    type: entry.type,
+    title: entry.resource?.displayName ?? entry.resource?.name,
+    description: entry.resource?.description ?? undefined,
+    tags: tags.length ? tags : undefined,
+    timestamp:
+      entry.resource?.updateTime ?? entry.resource?.createTime ?? undefined,
+    resource: entry.resource?.name ?? undefined,
+    // Faithful round-trip stash (consumers ignore unknown keys per SPEC).
+    [STASH_KEY]: entryClone,
+  };
+
+  const frontmatter = yaml.stringify(metadata).trim();
+  return `---\n${frontmatter}\n---\n${body.endsWith('\n') ? body : body + '\n'}`;
+}
+
+// Walks the bundle tree and writes an `index.md` directory listing per folder.
+// Non-root indexes carry no frontmatter; the bundle-root index declares
+// okf_version (the only place frontmatter is permitted in an index.md).
+export async function writeIndexes(rootDir: string): Promise<void> {
+  if (!fs.existsSync(rootDir)) {
+    return;
+  }
+  const dirs: string[] = [];
+  const walk = (d: string) => {
+    dirs.push(d);
+    for (const e of fs.readdirSync(d, {withFileTypes: true})) {
+      if (e.isDirectory()) {
+        walk(path.join(d, e.name));
+      }
+    }
+  };
+  walk(rootDir);
+
+  for (const dir of dirs) {
+    const isRoot = path.resolve(dir) === path.resolve(rootDir);
+    // GA4-style rows: `* [<title>](<link>) - <description>`.
+    const rows: string[] = [];
+    const entries = fs
+      .readdirSync(dir, {withFileTypes: true})
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const e of entries) {
+      let title: string;
+      let desc: string;
+      let link: string;
+      if (e.isDirectory()) {
+        link = `${e.name}/index.md`;
+        ({title, desc} = _folderMeta(
+          path.join(dir, e.name, 'index.md'),
+          e.name,
+        ));
+      } else if (
+        e.name.endsWith('.md') &&
+        e.name !== 'index.md' &&
+        !e.name.endsWith('.ref.md')
+      ) {
+        link = e.name;
+        ({title, desc} = _conceptMeta(path.join(dir, e.name)));
+      } else {
+        continue;
+      }
+      title = _oneLine(title);
+      desc = _oneLine(desc);
+      rows.push(`* [${title}](${link})` + (desc ? ` - ${desc}` : ''));
+    }
+
+    const {title: ftitle, desc: fdesc} = isRoot
+      ? {title: 'Index', desc: ''}
+      : _folderMeta(path.join(dir, 'index.md'), path.basename(dir));
+    const lines = [`# ${_oneLine(ftitle)}`, ''];
+    if (fdesc) {
+      lines.push(_oneLine(fdesc), '');
+    }
+    if (rows.length) {
+      lines.push(...rows);
+    } else {
+      lines.push('_(empty)_');
+    }
+    let out = `${lines.join('\n')}\n`;
+    if (isRoot) {
+      out = `---\nokf_version: "${OKF_VERSION}"\n---\n${out}`;
+    }
+    fs.writeFileSync(path.join(dir, 'index.md'), out, 'utf8');
+  }
+}
+
+// Collapse all whitespace (incl. newlines) to single spaces and trim. Used to
+// keep index rows / metadata on one line.
+function _oneLine(s: string): string {
+  return (s || '').replace(/\s+/g, ' ').trim();
+}
+
+// De-link ONLY bundle-relative markdown links (`[text](foo.md)`, `[text](./a)`)
+// to plain text — these resolve to broken URLs in the Dataplex/Pantheon UI.
+// Real links with a scheme (http(s)://, mailto:, …) are kept clickable, so
+// genuine Citations URLs survive. Used on the KC index entry's overview only.
+function _delinkMarkdown(s: string): string {
+  return (s || '').replace(/\[([^\]]+)\]\(([^)]*)\)/g, (match, text, target) =>
+    /^[a-z][a-z0-9+.-]*:/i.test(target) ? match : text,
+  );
+}
+
+// Derive an entry name from a concept file's path (relative to the bundle root,
+// with the `.md` / `.ref.md` suffix stripped). Used as the name when a file has
+// no `x-kcmd`/`resource` stash, so hand-authored OKF bundles still index.
+function deriveEntryName(localPath: string, catalogPath: string): string {
+  let rel = path.relative(catalogPath, localPath).replace(/\\/g, '/');
+  if (rel.endsWith('.ref.md')) {
+    rel = rel.slice(0, -'.ref.md'.length);
+  } else if (rel.endsWith('.md')) {
+    rel = rel.slice(0, -'.md'.length);
+  }
+  return rel;
+}
+
+// A relative directory and all of its ancestors, with '' for the root.
+// 'a/b' -> ['a/b', 'a', '']; '.' or '' -> [''].
+function ancestorDirs(reldir: string): string[] {
+  const out: string[] = [];
+  let d = reldir === '.' ? '' : reldir;
+  while (d) {
+    out.push(d);
+    const i = d.lastIndexOf('/');
+    d = i >= 0 ? d.slice(0, i) : '';
+  }
+  out.push('');
+  return out;
+}
+
+// Default displayName for a directory `index` id, from the folder segment.
+// 'a/my_folder/index' -> 'My Folder'; 'index' -> 'Index'.
+function _titleFromIndexId(id: string): string {
+  const segs = id.split('/');
+  const folder = segs.length >= 2 ? segs[segs.length - 2] : 'Index';
+  return folder
+    .replace(/[-_]/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// The enclosing directory's index id for a given index id (root has none).
+function _parentIndexId(id: string): string | null {
+  if (id === 'index') {
+    return null;
+  }
+  const folder = id.endsWith('/index') ? id.slice(0, -'/index'.length) : '';
+  if (!folder) {
+    return null;
+  }
+  const slash = folder.lastIndexOf('/');
+  const parentFolder = slash >= 0 ? folder.slice(0, slash) : '';
+  return parentFolder ? `${parentFolder}/index` : 'index';
+}
+
+// (title, description) for a concept .md, from its YAML frontmatter.
+function _conceptMeta(mdPath: string): {title: string; desc: string} {
+  const fallback = path.basename(mdPath).slice(0, -3);
+  try {
+    const {entry} = parseOkf(fs.readFileSync(mdPath, 'utf8'));
+    return {
+      title: entry?.resource?.displayName || fallback,
+      desc: entry?.resource?.description || '',
+    };
+  } catch (err) {
+    return {title: fallback, desc: ''};
+  }
+}
+
+// (title, description) for a folder, read from its (frontmatter-free) index.md:
+// the `# Title` heading and the first non-heading/non-list paragraph.
+function _folderMeta(
+  indexPath: string,
+  fallbackTitle: string,
+): {title: string; desc: string} {
+  try {
+    const raw = fs.readFileSync(indexPath, 'utf8');
+    const lines = raw.split(/\r?\n/);
+    let body = lines;
+    if (lines[0]?.trim() === '---') {
+      const end = lines.indexOf('---', 1);
+      if (end !== -1) {
+        body = lines.slice(end + 1);
+      }
+    }
+    const h = body.find((l) => l.startsWith('# '));
+    let desc = '';
+    for (const l of body) {
+      const t = l.trim();
+      if (!t || t.startsWith('#') || t.startsWith('*') || t.startsWith('-')) {
+        continue;
+      }
+      desc = t;
+      break;
+    }
+    return {title: h ? h.slice(2).trim() : fallbackTitle, desc};
+  } catch (err) {
+    return {title: fallbackTitle, desc: ''};
+  }
+}

--- a/agents/mdcode/src/libts/manifest.ts
+++ b/agents/mdcode/src/libts/manifest.ts
@@ -15,7 +15,7 @@ export interface LocalEntryLink {
 
 const manifestSchema = z.object({
   scope: z.union([z.string(), z.array(z.string())]),
-  // Optional override of the on-disk layout (standard|documents). When
+  // Optional override of the on-disk layout (standard|documents|okf). When
   // absent, the layout is derived from the source type (see source.layout).
   layout: z.string().optional(),
   resourceAlias: z
@@ -90,7 +90,7 @@ export class CatalogManifest {
   readonly referenceManifest?: ReferenceManifest;
   readonly aliasMap: ResourceAlias;
   readonly entryLinkTypes?: string[];
-  // Optional layout override (standard|documents). Mutable so `init` can set
+  // Optional layout override (standard|documents|okf). Mutable so `init` can set
   // it from the `--format` flag before `save()`; `load()` reads it back.
   layout?: string;
 

--- a/agents/mdcode/src/libts/snapshot.ts
+++ b/agents/mdcode/src/libts/snapshot.ts
@@ -30,8 +30,8 @@ export class CatalogSnapshot {
     this.basePath = basePath;
     this.manifest = manifest;
 
-    // A manifest `layout:` override wins over the source default; the root dir
-    // name follows the chosen layout (catalog/ for the kcmd-native layouts).
+    // A manifest `layout:` override (e.g. okf) wins over the source default; the
+    // root dir name follows the chosen layout (okf -> bundle/, else catalog/).
     const layout = (manifest.layout as Layouts) ?? manifest.source.layout;
     const catalogPath = path.join(this.basePath, rootDirForLayout(layout));
     this._layout = createLayout(layout, catalogPath, manifest);
@@ -85,7 +85,7 @@ export class CatalogSnapshot {
     return this._layout.listEntries();
   }
 
-  // Optional post-sync finalization (layout-specific finalization
+  // Optional post-sync finalization (e.g. OKF regenerates index.md listings
   // after a pull). No-op for layouts that don't implement it.
   async finalize(): Promise<void> {
     await this._layout.finalize?.();

--- a/agents/mdcode/src/tool/commands.ts
+++ b/agents/mdcode/src/tool/commands.ts
@@ -106,7 +106,7 @@ export async function pull(options?: PullOptions): Promise<number> {
   const result = await sync.pull(options);
 
   if (result.success) {
-    // layout finalize() runs after the pull; no-op for
+    // OKF regenerates reserved index.md listings after the pull; no-op for
     // other layouts.
     await snapshot.finalize();
     console.log('Successfully updated local snapshot.');
@@ -162,7 +162,7 @@ export async function reference(options?: ReferenceOptions): Promise<number> {
   const result = await sync.reference();
 
   if (result.success) {
-    // layout finalize() runs after pulling references.
+    // OKF regenerates reserved index.md listings after pulling references.
     await snapshot.finalize();
     console.log('Successfully updated local reference entries snapshot.');
     return 0;

--- a/agents/mdcode/src/tool/main.ts
+++ b/agents/mdcode/src/tool/main.ts
@@ -32,7 +32,7 @@ cli
   .option('--pull', 'Optionally pull catalog entries during initialization')
   .option(
     '--format <format>',
-    'On-disk layout: standard (default) | documents',
+    'On-disk layout: standard (default) | documents | okf',
   )
   .action(async (options) => {
     try {
@@ -48,7 +48,7 @@ cli
   .option('--dry-run', 'Perform a dry run without modifying local files')
   .option(
     '--format <format>',
-    'On-disk layout override: standard | documents',
+    'On-disk layout override: standard | documents | okf',
   )
   .action(async (options) => {
     let exitCode = 1;
@@ -69,7 +69,7 @@ cli
   .option('--dry-run', 'Perform a dry run without publishing to service')
   .option(
     '--format <format>',
-    'On-disk layout override: standard | documents',
+    'On-disk layout override: standard | documents | okf',
   )
   .action(async (options) => {
     let exitCode = 1;
@@ -99,7 +99,7 @@ cli
   .command('reference', 'Pull reference resource entries')
   .option(
     '--format <format>',
-    'On-disk layout override: standard | documents',
+    'On-disk layout override: standard | documents | okf',
   )
   .action(async (options) => {
     try {


### PR DESCRIPTION
Brings three features from the internal enrichment_agent_v3 prototype into agents/, layered on top of the existing GitHub-repo source / hybrid work:

- Confluence source: ingest spaces/pages via the Atlassian Rovo MCP server (--confluence_space; Confluence URLs in --docs/--folders are auto-lifted).
- SharePoint source: ingest sites/files via Microsoft Graph REST (--sharepoint_sites; .docx/.xlsx/.pptx/PDF extracted locally). Auth helpers under scripts/ + docs/sharepoint-setup.md.
- OKF output: --output_format=okf writes an Open Knowledge Format bundle/ (one .md per concept + index.md listings), publishable via `kcmd push --format okf`. agents/mdcode gains the OKF layout (okf.ts) and --format okf on init/pull/push/reference.

Notes:
- agents/mdcode top-level toolbox/mdcode is untouched (it handles OKF via the DocumentsLayout demo, out of scope here).
- doc_mode entry-less folder pruning (#103) and the gemini-2.5-flash light-model default are preserved.
- requirements.txt gains httpx, msal, python-docx, openpyxl, python-pptx.