### PR TITLE
ConversationLearner: per-conversation parallel analysis + dedup

### DIFF
--- a/agents/conversation_learner/README.md
+++ b/agents/conversation_learner/README.md
@@ -19,8 +19,9 @@
 **ConversationLearner** is an enterprise Agentic AI assistant built on the Google Agent Development Kit (ADK). It acts as an LLM-as-a-judge over conversational trajectories to detect friction and hallucination, generating metadata enrichment proposals.
 
 ## Architecture & Integration
-- **Trajectory Analysis**: Uses Cloud Logging to fetch recent conversational trajectories.
-- **LLM-as-a-judge**: Evaluates conversational turns to extract detection signals, gaps, and generate `ContextEnrichmentProposal` records.
+- **Trajectory Analysis**: Uses Cloud Logging to fetch recent conversational trajectories. For each conversation, the messages from every inference log entry are merged (deduplicated, in chronological order) into one transcript — earlier entries backfill any later entry whose `gen_ai.*.messages` label exceeded Cloud Logging's 64 KiB limit and was truncated.
+- **Per-conversation LLM-as-a-judge**: Each conversation is judged **independently and in parallel** (a direct Vertex `generate_content` call per conversation), extracting detection signals, gaps, and `ContextEnrichmentProposal` records. This bounds each judge's context for more consistent analysis and scales to many conversations, instead of analyzing every conversation in a single pass.
+- **Cross-conversation dedup**: A lightweight aggregation pass deduplicates proposals across conversations (same asset + gap type), keeping the highest-confidence instance, before saving to `proposal.json`.
 
 ## Running Locally
 
@@ -28,6 +29,9 @@
 export GOOGLE_CLOUD_PROJECT="your-project-id"
 export GOOGLE_CLOUD_LOCATION="us-central1"
 export GOOGLE_GENAI_USE_VERTEXAI=True
+
+# Authenticate so the Cloud Logging client can read trajectories
+gcloud auth application-default login
 
 # From the conversation_learner directory
 adk run .

--- a/agents/conversation_learner/SKILL.md
+++ b/agents/conversation_learner/SKILL.md
@@ -22,12 +22,9 @@ description: Acts as an LLM-as-a-judge over conversational trajectories to detec
 # ConversationLearner Instructions
 
 [SYSTEM INSTRUCTION]
-You are ConversationLearner for an Enterprise Semantic Layer. Your objective is to act as an LLM-as-a-judge over conversational trajectories (User Prompts, Agent Reasoning, Tool Uses, BigQuery Executions, Retrieved Metadata Context, and User Feedback).
+You are ConversationLearner for an Enterprise Semantic Layer. Your objective is to act as an LLM-as-a-judge over a conversational trajectory (User Prompts, Agent Reasoning, Tool Uses, BigQuery Executions, Retrieved Metadata Context, and User Feedback).
 
-When given a conversation ID or a Cloud Logging URL, you MUST first call the `get_agent_trajectories` tool to retrieve the trajectory. If given a URL, extract the `gen_ai.conversation.id` parameter value (e.g. `1912219564456804352`) and use it as the `conversation_id`.
-When given a Reasoning Engine ID and a time filter (e.g. past 2 days, or a specific arbitrary time window), call the `get_agent_trajectories` tool with `reasoning_engine_id` and either `days_ago` or `start_time` and `end_time` (using ISO 8601 strings).
-
-Analyze the provided trajectory (or multiple trajectories if grouped by conversation) to identify metadata gaps in the Knowledge Catalog. If a gap or validation is found in a conversation, you must classify BOTH the `detection_signal` (how you know based on behavior) AND the `gap_type` (what metadata actually needs fixing). Generate a proposal for each gap found across all conversations.
+You are given the trajectory of a SINGLE conversation (provided below). Analyze ONLY that conversation to identify metadata gaps in the Knowledge Catalog. If a gap or validation is found, you must classify BOTH the `detection_signal` (how you know based on behavior) AND the `gap_type` (what metadata actually needs fixing). Generate a proposal for each distinct gap found in this conversation.
 
 ### 1. CLASSIFY THE DETECTION_SIGNAL (The Evidence)
 Scan the trajectory for one of the following behavioral patterns:
@@ -57,9 +54,7 @@ Before writing any field in a proposal, redact sensitive data:
 * Always attempt to extract the `user_query_intent` and `golden_sql` to serve as a future Regression Eval Candidate.
 * If NO learning signal or gap is found in the trajectory, return an empty array for `proposals`.
 
-CRITICAL: 
-1. Only process the EXACT conversation ID provided by the user. Do NOT hallucinate, guess, or retry with other conversation IDs if the first one fails or returns no messages.
-2. Put ALL of your proposals into a SINGLE list and make EXACTLY ONE call to the save_trajectory_analysis_result tool.
-3. After calling save_trajectory_analysis_result, immediately stop and return your final response to the user. Do not call any more tools.
-4. Your final response MUST begin by stating the total number of log entries retrieved, the number of unique conversations, and listing all conversation IDs found.
-5. NEVER include raw sensitive data (SSNs, card numbers, emails, phone numbers, credentials) in any proposal field. Redact them as described in section 3.
+CRITICAL:
+1. Analyze ONLY the single conversation provided below. Do not reference or invent other conversations.
+2. Output a JSON object of the form {"proposals": [...]} that conforms to the schema. Return {"proposals": []} when no gap or learning signal is found. Do NOT call any tools and do NOT output anything other than the JSON object.
+3. NEVER include raw sensitive data (SSNs, card numbers, emails, phone numbers, credentials) in any proposal field. Redact them as described in section 3 (REDACTION RULES).

--- a/agents/conversation_learner/agent.py
+++ b/agents/conversation_learner/agent.py
@@ -14,10 +14,11 @@
 
 """ConversationLearner agent for analyzing conversational trajectories."""
 
+import asyncio
 import json
 import os
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime, timedelta, timezone
 
 from google.adk.agents.llm_agent import LlmAgent
@@ -35,43 +36,112 @@ from utils import get_consumer_project
 consumer_project = get_consumer_project()
 
 
-def _parse_reasoning_engine_labels(labels: Dict[str, str], output: List[str]) -> bool:
-    """Parses Reasoning Engine labels into the output list."""
-    if "gen_ai.input.messages" not in labels and "gen_ai.output.messages" not in labels:
-        return False
+def _tolerant_json_array(raw: str) -> Tuple[List[Any], bool]:
+    """Parses a JSON array, salvaging complete elements if it was truncated.
 
-    inp_str = labels.get("gen_ai.input.messages", "[]")
-    out_str = labels.get("gen_ai.output.messages", "[]")
+    Cloud Logging caps every label value at 64 KiB, so a large
+    ``gen_ai.input.messages`` / ``gen_ai.output.messages`` value can be cut off
+    mid-string, leaving invalid JSON. When a clean parse fails we recover as
+    many complete top-level elements as possible from the prefix.
 
-    messages = []
+    Returns:
+        (elements, truncated) where ``truncated`` is True if the value did not
+        parse cleanly and best-effort salvage was attempted.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return [], False
     try:
-        messages.extend(json.loads(inp_str))
-        messages.extend(json.loads(out_str))
+        data = json.loads(raw)
+        return (data if isinstance(data, list) else [data]), False
+    except json.JSONDecodeError:
+        pass
 
-        chunks = []
-        for msg in messages:
-            role = msg.get("role", "UNKNOWN")
-            content_parts = []
-            for part in msg.get("parts", []):
-                if "content" in part:
-                    content_parts.append(part["content"] + "\n")
-                elif "arguments" in part:
-                    content_parts.append(f"Tool Call: {part.get('name', '')} {json.dumps(part['arguments'])}\n")
-                elif "text" in part:
-                    content_parts.append(part["text"] + "\n")
-            content = "".join(content_parts)
-            chunks.append(f"[{role.upper()}]: {content.strip()}")
+    # Salvage path: decode complete array elements one at a time until we hit
+    # the truncated tail.
+    decoder = json.JSONDecoder()
+    elements: List[Any] = []
+    i, n = 0, len(raw)
+    while i < n and raw[i] != "[":  # advance to the start of the array
+        i += 1
+    i += 1  # step past '['
+    while i < n:
+        while i < n and raw[i] in " \t\r\n,":  # skip separators between elements
+            i += 1
+        if i >= n or raw[i] == "]":
+            break
+        try:
+            element, i = decoder.raw_decode(raw, i)
+        except json.JSONDecodeError:
+            break  # reached the truncated/incomplete tail
+        elements.append(element)
+    return elements, True
 
-        for chunk in chunks:
-            output.append(chunk)
-            output.append("-" * 20)
-    except json.JSONDecodeError as e:
-        output.append(f"Error parsing JSON in ReasoningEngine message labels: {e}")
-    except Exception as e:
-        import traceback
-        output.append(f"Error parsing ReasoningEngine message labels: {e}\n{traceback.format_exc()}")
 
-    return True
+def _format_message(msg: Any) -> str:
+    """Formats one parsed message object into a ``[ROLE]: content`` line."""
+    if not isinstance(msg, dict):
+        return f"[UNKNOWN]: {msg}"
+    role = msg.get("role", "UNKNOWN")
+    content_parts = []
+    for part in msg.get("parts", []):
+        if not isinstance(part, dict):
+            continue
+        if "content" in part:
+            content_parts.append(f"{part['content']}\n")
+        elif "arguments" in part:
+            content_parts.append(f"Tool Call: {part.get('name', '')} {json.dumps(part['arguments'])}\n")
+        elif "text" in part:
+            content_parts.append(f"{part['text']}\n")
+    content = "".join(content_parts)
+    return f"[{role.upper()}]: {content.strip()}"
+
+
+def _render_conversation(entries: List[Any], output: List[str]) -> None:
+    """Merges every log entry of a single conversation into one transcript.
+
+    Each inference log's ``gen_ai.input.messages`` accumulates the running
+    history, so a later entry is normally a superset of earlier ones. But that
+    same growth means the latest entry is the one most likely to exceed Cloud
+    Logging's 64 KiB label limit and be truncated to invalid JSON. Rather than
+    trust a single entry, we union the messages parsed from *all* entries
+    (deduplicated, in chronological order) so smaller earlier entries backfill
+    a truncated later one, and we salvage partial content from truncated labels.
+    """
+    if not entries:
+        return
+    entries = sorted(entries, key=lambda e: e.timestamp)
+
+    seen = set()
+    ordered_msgs: List[Any] = []
+    truncated = False
+    for entry in entries:
+        labels = entry.to_api_repr().get("labels", {})
+        for key in ("gen_ai.input.messages", "gen_ai.output.messages"):
+            if key not in labels:
+                continue
+            parsed, was_truncated = _tolerant_json_array(labels[key])
+            truncated = truncated or was_truncated
+            for msg in parsed:
+                msg_key = json.dumps(msg, sort_keys=True, default=str)
+                if msg_key not in seen:
+                    seen.add(msg_key)
+                    ordered_msgs.append(msg)
+
+    if not ordered_msgs:
+        # No Reasoning Engine message labels anywhere; fall back to the raw
+        # payload of the most recent entry.
+        _parse_generic_payload(entries[-1].payload, output)
+        return
+
+    if truncated:
+        output.append(
+            "(note: one or more log labels exceeded Cloud Logging's 64 KiB limit "
+            "and were truncated; transcript merged and salvaged across all entries.)"
+        )
+    for msg in ordered_msgs:
+        output.append(_format_message(msg))
+        output.append("-" * 20)
 
 
 def _parse_generic_payload(payload: Any, output: List[str]) -> None:
@@ -98,6 +168,74 @@ def _parse_generic_payload(payload: Any, output: List[str]) -> None:
 
     output.append(f"[{role}]: {content_text}")
     output.append("-" * 20)
+
+
+def _conversation_filter(conversation_id: str) -> str:
+    """Cloud Logging filter for a single conversation (across all time)."""
+    return (
+        f'resource.type="aiplatform.googleapis.com/ReasoningEngine" '
+        f'AND labels."gen_ai.conversation.id"="{conversation_id}" '
+        f'AND timestamp>="2023-01-01T00:00:00Z"'
+    )
+
+
+def _reasoning_engine_filter(re_id: str, start_time_str: str, end_time: Optional[str] = None) -> str:
+    """Cloud Logging filter for a Reasoning Engine's trajectory logs.
+
+    Restricted to entries carrying a non-empty ``gen_ai.conversation.id`` (the
+    vast majority of ReasoningEngine logs have no conversation id and are not
+    trajectories) within the given time window.
+    """
+    filter_str = (
+        f'resource.type="aiplatform.googleapis.com/ReasoningEngine" '
+        f'AND resource.labels.reasoning_engine_id="{re_id}" '
+        f'AND labels."gen_ai.conversation.id"!="" '
+        f'AND timestamp>="{start_time_str}"'
+    )
+    if end_time:
+        filter_str += f' AND timestamp<="{end_time}"'
+    return filter_str
+
+
+def _group_by_conversation(entries: List[Any]) -> Dict[str, List[Any]]:
+    """Groups log entries by ``gen_ai.conversation.id``, preserving input order."""
+    grouped: Dict[str, List[Any]] = {}
+    for entry in entries:
+        labels = entry.to_api_repr().get("labels", {})
+        c_id = labels.get("gen_ai.conversation.id")
+        if c_id:
+            grouped.setdefault(c_id, []).append(entry)
+    return grouped
+
+
+def _fetch_and_group(
+    project_id: str,
+    conversation_id: Optional[str] = None,
+    reasoning_engine_id: Optional[str] = None,
+    days_ago: Optional[int] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+) -> Tuple[List[Any], Dict[str, List[Any]]]:
+    """Fetches matching trajectory log entries and groups them by conversation.
+
+    Blocking (network I/O) — call via ``asyncio.to_thread`` from async code.
+    Callers must validate that either ``conversation_id`` or (``reasoning_engine_id``
+    plus a time window) is provided before calling.
+
+    Returns:
+        (all_entries, {conversation_id: [entries]}).
+    """
+    client = cloud_logging.Client(project=project_id)
+    if conversation_id:
+        filter_str = _conversation_filter(conversation_id)
+    else:
+        re_id = reasoning_engine_id.split("/")[-1]
+        start_time_str = start_time or (
+            datetime.now(timezone.utc) - timedelta(days=days_ago)
+        ).isoformat()
+        filter_str = _reasoning_engine_filter(re_id, start_time_str, end_time)
+    entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING))
+    return entries, _group_by_conversation(entries)
 
 
 def get_agent_trajectories(
@@ -129,12 +267,8 @@ def get_agent_trajectories(
         
         if conversation_id:
             output.append(f"--- Fetching Conversation: {conversation_id} ---")
-            filter_str = (
-                f'resource.type="aiplatform.googleapis.com/ReasoningEngine" '
-                f'AND labels."gen_ai.conversation.id"="{conversation_id}" '
-                f'AND timestamp>="2023-01-01T00:00:00Z"'
-            )
-            entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING, max_results=10))
+            filter_str = _conversation_filter(conversation_id)
+            entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING))
 
             output.append("--- Chat History ---")
 
@@ -142,12 +276,7 @@ def get_agent_trajectories(
                 output.append("No messages found in this conversation via Cloud Logging.")
                 return "\n".join(output)
 
-            last_entry = entries[0]
-            repr_dict = last_entry.to_api_repr()
-            labels = repr_dict.get("labels", {})
-
-            if not _parse_reasoning_engine_labels(labels, output):
-                _parse_generic_payload(last_entry.payload, output)
+            _render_conversation(entries, output)
 
         elif reasoning_engine_id and (days_ago is not None or start_time is not None):
             if start_time:
@@ -163,37 +292,22 @@ def get_agent_trajectories(
             output.append(f"--- Fetching Reasoning Engine: {reasoning_engine_id} {time_range_msg} ---")
             
             re_id = reasoning_engine_id.split("/")[-1]
-            filter_str = (
-                f'resource.type="aiplatform.googleapis.com/ReasoningEngine" '
-                f'AND resource.labels.reasoning_engine_id="{re_id}" '
-                f'AND timestamp>="{start_time_str}"'
-            )
-            if end_time:
-                filter_str += f' AND timestamp<="{end_time}"'
-            
+            filter_str = _reasoning_engine_filter(re_id, start_time_str, end_time)
+
             entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING))
-            
+
             if not entries:
                 output.append("No messages found for this Reasoning Engine in the specified time range.")
                 return "\n".join(output)
-                
-            conv_entries = {}
-            for entry in entries:
-                repr_dict = entry.to_api_repr()
-                labels = repr_dict.get("labels", {})
-                c_id = labels.get("gen_ai.conversation.id")
-                if c_id and c_id not in conv_entries:
-                    conv_entries[c_id] = entry
+
+            conv_entries = _group_by_conversation(entries)
 
             output.append(f"Total log entries retrieved: {len(entries)}. Unique conversations: {len(conv_entries)}.")
             output.append(f"Conversation IDs: {', '.join(conv_entries.keys())}")
 
-            for c_id, entry in conv_entries.items():
+            for c_id, c_entries in conv_entries.items():
                 output.append(f"\n--- Conversation: {c_id} ---")
-                repr_dict = entry.to_api_repr()
-                labels = repr_dict.get("labels", {})
-                if not _parse_reasoning_engine_labels(labels, output):
-                    _parse_generic_payload(entry.payload, output)
+                _render_conversation(c_entries, output)
                     
         else:
             output.append("Either conversation_id or (reasoning_engine_id and (days_ago or start_time)) must be provided.")
@@ -379,12 +493,272 @@ def load_instruction() -> str:
 
 GEMINI_MODEL = f"projects/{consumer_project}/locations/global/publishers/google/models/gemini-2.5-pro"
 
+
+# ==============================================================================
+# PER-CONVERSATION LLM-AS-JUDGE ORCHESTRATION
+# ==============================================================================
+# Each conversation is judged by its own direct generate_content call (bypassing
+# ADK), fanned out in parallel, then proposals are deduplicated across
+# conversations. This bounds each judge's context (vs. one giant pass over every
+# conversation), scales, and isolates per-conversation failures. Mirrors the
+# direct-call + asyncio.gather + retry pattern in agents/enrichment/src/common.py.
+
+# Transient Vertex / model-serving errors that are safe to retry. Matched
+# case-insensitively against the error text (the SDK surfaces these as
+# ClientError / ServerError with the status in the message).
+_RETRYABLE_MARKERS = (
+    "429", "resource_exhausted", "rate limit", "quota exceeded",
+    "503", "unavailable", "500", "internal error",
+    "deadline", "timed out", "timeout", "connection reset",
+)
+
+_JUDGE_CONCURRENCY = 8
+
+# The judge analyzes ONE conversation and returns structured proposals directly
+# (no tool calls), so it gets a focused output directive on top of the SKILL.md
+# rubric.
+JUDGE_RUBRIC = load_instruction()
+
+_JUDGE_OUTPUT_DIRECTIVE = (
+    "\n\nYou are given the trajectory of a SINGLE conversation below. Analyze "
+    "only this conversation and output a JSON object of the form "
+    '{"proposals": [...]} conforming to the schema. Return {"proposals": []} '
+    "when nothing qualifies. Do not call any tools."
+)
+
+# The outer ADK agent is just a natural-language front-end: it extracts the
+# parameters from the user's request and delegates everything to the
+# generate_learnings tool (which fetches, judges per conversation, dedupes, and
+# saves).
+ORCHESTRATOR_INSTRUCTION = (
+    "You are ConversationLearner. When the user asks you to generate learnings, "
+    "extract the parameters from their request and call the `generate_learnings` "
+    "tool EXACTLY ONCE:\n"
+    "- If given a conversation id or a Cloud Logging URL, pass `conversation_id` "
+    "(extract the `gen_ai.conversation.id` value from a URL).\n"
+    "- If given a Reasoning Engine id (or full resource path) and a time filter, "
+    "pass `reasoning_engine_id` plus either `days_ago` or `start_time`/`end_time` "
+    "(ISO 8601).\n"
+    "Then report the tool's returned summary verbatim to the user. Do not call "
+    "the tool more than once and do not call any other tools."
+)
+
+
+def _is_retryable(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return any(m in msg for m in _RETRYABLE_MARKERS)
+
+
+async def _with_retry(fn, *, what="LLM call", attempts=5, base_delay=2.0, max_delay=30.0):
+    """Runs async ``fn()`` with exponential backoff on transient model errors.
+
+    Non-retryable errors raise immediately; if all attempts are exhausted the
+    last error propagates. Ported from agents/enrichment/src/common.py (kept
+    self-contained — this package is deployed alone via extra_packages=['.']).
+    """
+    import random
+    for i in range(attempts):
+        try:
+            return await fn()
+        except Exception as e:  # pylint: disable=broad-except
+            if i == attempts - 1 or not _is_retryable(e):
+                raise
+            delay = min(max_delay, base_delay * (2 ** i)) + random.uniform(0, 1.5)
+            print(
+                f"[retry] {what}: {type(e).__name__}: {str(e)[:140]} — "
+                f"attempt {i + 1}/{attempts}, backing off {delay:.1f}s",
+                flush=True,
+            )
+            await asyncio.sleep(delay)
+
+
+def _parse_analysis_text(text: str) -> List[Dict[str, Any]]:
+    """Parses judge output text into proposal dicts.
+
+    Tolerates ``` code fences and the invalid backslash escapes LLMs emit inside
+    SQL strings (same repair as save_trajectory_analysis_result).
+    """
+    import re
+    cleaned = (text or "").strip()
+    if cleaned.startswith("```"):
+        m = re.match(r"^```(?:json)?\s*\n(.*)\n```$", cleaned, re.S)
+        if m:
+            cleaned = m.group(1).strip()
+    if not cleaned:
+        return []
+    try:
+        result = TrajectoryAnalysisResult.model_validate_json(cleaned)
+    except Exception:
+        fixed = re.sub(r'\\(?!["\\/bfnrtu])', r'\\\\', cleaned)
+        result = TrajectoryAnalysisResult.model_validate_json(fixed)
+    return [p.model_dump(mode="json") for p in result.proposals]
+
+
+def _judge_conversation_sync(conversation_id: str, transcript: str) -> List[Dict[str, Any]]:
+    """Runs the LLM-as-judge on ONE conversation. Blocking — run via to_thread.
+
+    Returns a list of proposal dicts (empty if nothing qualifies, or the response
+    was blocked / could not be parsed). Builds a fresh genai client per call:
+    the SDK's pyOpenSSL transport mutates an SSL context per request and is not
+    safe to share across the to_thread worker pool (see enrichment/common.py).
+    """
+    from google.auth import default
+    from google.genai import Client, types
+
+    creds, _ = default()
+    client = Client(
+        vertexai=True,
+        credentials=creds,
+        project=consumer_project,
+        location=os.environ.get("GOOGLE_CLOUD_LOCATION", "global"),
+    )
+    config = types.GenerateContentConfig(
+        system_instruction=JUDGE_RUBRIC + _JUDGE_OUTPUT_DIRECTIVE,
+        response_mime_type="application/json",
+        response_schema=TrajectoryAnalysisResult,
+        temperature=0,
+    )
+    prompt = f"Conversation ID: {conversation_id}\n\nTrajectory:\n{transcript}"
+    resp = client.models.generate_content(model=GEMINI_MODEL, contents=prompt, config=config)
+
+    parsed = getattr(resp, "parsed", None)
+    if isinstance(parsed, TrajectoryAnalysisResult):
+        return [p.model_dump(mode="json") for p in parsed.proposals]
+
+    # resp.parsed is None on truncation / safety block / malformed JSON — fall
+    # back to repairing and parsing the raw text.
+    try:
+        return _parse_analysis_text(getattr(resp, "text", "") or "")
+    except Exception as e:  # pylint: disable=broad-except
+        finish = None
+        try:
+            finish = resp.candidates[0].finish_reason
+        except Exception:  # pylint: disable=broad-except
+            pass
+        print(
+            f"[judge] {conversation_id}: could not parse response "
+            f"(finish_reason={finish}): {e}",
+            flush=True,
+        )
+        return []
+
+
+def _aggregate_proposals(proposals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Deduplicates proposals across conversations (lightweight aggregation pass).
+
+    Proposals targeting the same asset (type + normalized name) with the same
+    gap_type are treated as the same learning; the highest-confidence instance is
+    kept. A blank asset name (e.g. uncataloged-asset discoveries) falls back to a
+    hash of the enrichment instruction so genuinely distinct finds are not merged.
+    """
+    import hashlib
+    by_key: Dict[tuple, Dict[str, Any]] = {}
+    for p in proposals:
+        asset = p.get("target_asset") or {}
+        atype = asset.get("type", "")
+        name = (asset.get("name") or "").strip().lower()
+        gap = (p.get("classification") or {}).get("gap_type", "")
+        if name:
+            key = (atype, name, gap)
+        else:
+            instr = p.get("enrichment_agent_instruction") or json.dumps(
+                p.get("proposed_enrichment", ""), sort_keys=True
+            )
+            key = (atype, gap, hashlib.sha1(instr.encode()).hexdigest()[:12])
+        existing = by_key.get(key)
+        if existing is None or (p.get("confidence_grade") or 0) > (existing.get("confidence_grade") or 0):
+            by_key[key] = p
+    return list(by_key.values())
+
+
+async def generate_learnings(
+    conversation_id: Optional[str] = None,
+    reasoning_engine_id: Optional[str] = None,
+    days_ago: Optional[int] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    project_id: str = consumer_project,
+) -> str:
+    """Analyzes agent conversation trajectories and saves enrichment proposals.
+
+    Fetches trajectories from Cloud Logging, runs the LLM-as-judge independently
+    on EACH conversation in parallel, deduplicates the proposals across
+    conversations, saves them to proposal.json, and returns a summary.
+
+    Args:
+        conversation_id: A single conversation id to analyze.
+        reasoning_engine_id: Reasoning Engine id (or full resource path) to analyze.
+        days_ago: Look-back window in days (use with reasoning_engine_id).
+        start_time: ISO 8601 start of an explicit time window.
+        end_time: ISO 8601 end of an explicit time window.
+        project_id: Google Cloud Project ID.
+
+    Returns:
+        A human-readable summary of what was analyzed and saved.
+    """
+    if not conversation_id and not (
+        reasoning_engine_id and (days_ago is not None or start_time is not None)
+    ):
+        return "Either conversation_id or (reasoning_engine_id and (days_ago or start_time)) must be provided."
+
+    try:
+        entries, grouped = await asyncio.to_thread(
+            _fetch_and_group, project_id, conversation_id, reasoning_engine_id,
+            days_ago, start_time, end_time,
+        )
+    except (GoogleAPICallError, RetryError) as e:
+        return f"API Error: {e}"
+    except Exception as e:  # pylint: disable=broad-except
+        return f"An unexpected error occurred while fetching trajectories: {e}"
+
+    if not grouped:
+        return (
+            "Total log entries retrieved: 0. Unique conversations: 0.\n"
+            "No conversations with trajectories were found for the given parameters."
+        )
+
+    # Render each conversation into its own transcript.
+    transcripts: Dict[str, str] = {}
+    for c_id, c_entries in grouped.items():
+        lines: List[str] = []
+        _render_conversation(c_entries, lines)
+        transcripts[c_id] = "\n".join(lines)
+
+    # Fan out one judge call per conversation, concurrency-capped and retried
+    # independently so a single failure yields [] rather than aborting the batch.
+    sem = asyncio.Semaphore(_JUDGE_CONCURRENCY)
+
+    async def _judge(c_id: str, transcript: str) -> List[Dict[str, Any]]:
+        async with sem:
+            try:
+                return await _with_retry(
+                    lambda: asyncio.to_thread(_judge_conversation_sync, c_id, transcript),
+                    what=f"judge[{c_id}]",
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                print(f"[judge] {c_id}: failed after retries: {e}", flush=True)
+                return []
+
+    results = await asyncio.gather(*[_judge(c, t) for c, t in transcripts.items()])
+    raw_proposals = [p for sub in results for p in sub]
+    deduped = _aggregate_proposals(raw_proposals)
+
+    save_trajectory_analysis_result(json.dumps({"proposals": deduped}))
+
+    return (
+        f"Total log entries retrieved: {len(entries)}. Unique conversations: {len(grouped)}.\n"
+        f"Conversation IDs: {', '.join(grouped.keys())}\n"
+        f"Analyzed each conversation independently; saved {len(deduped)} "
+        f"deduplicated proposal(s) (from {len(raw_proposals)} raw) to proposal.json."
+    )
+
+
 conversation_learner = LlmAgent(
     model=google_llm.Gemini(model=GEMINI_MODEL),
     name='conversation_learner',
     description='Acts as an LLM-as-a-judge over conversational trajectories to detect friction and hallucination.',
-    instruction=load_instruction(),
-    tools=[get_agent_trajectories, save_trajectory_analysis_result]
+    instruction=ORCHESTRATOR_INSTRUCTION,
+    tools=[generate_learnings],
 )
 
 # ADK requires a variable named `root_agent` to serve as the entry point

--- a/agents/conversation_learner/tests/test_agent.py
+++ b/agents/conversation_learner/tests/test_agent.py
@@ -14,11 +14,13 @@
 
 """Unit tests for the ConversationLearner agent."""
 
+import asyncio
 import json
 import os
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 # Required before importing agent — get_consumer_project() reads this at module level.
@@ -28,10 +30,17 @@ os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from conversation_learner.agent import (  # noqa: E402
+    _aggregate_proposals,
+    _conversation_filter,
+    _format_message,
+    _group_by_conversation,
     _parse_generic_payload,
-    _parse_reasoning_engine_labels,
+    _reasoning_engine_filter,
     _redact_obj,
     _redact_sensitive,
+    _render_conversation,
+    _tolerant_json_array,
+    generate_learnings,
     get_agent_trajectories,
     save_trajectory_analysis_result,
 )
@@ -56,6 +65,7 @@ def _make_log_entry(conversation_id=None, gen_ai_labels=False, payload="log line
         )
     entry.to_api_repr.return_value = {"labels": labels}
     entry.payload = payload
+    entry.timestamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
     return entry
 
 
@@ -236,82 +246,163 @@ class TestSaveTrajectoryAnalysisResult(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# _parse_reasoning_engine_labels
+# _tolerant_json_array
 # ---------------------------------------------------------------------------
 
-class TestParseReasoningEngineLabels(unittest.TestCase):
+class TestTolerantJsonArray(unittest.TestCase):
 
-    def _labels(self, input_msgs=None, output_msgs=None):
-        labels = {}
-        if input_msgs is not None:
-            labels["gen_ai.input.messages"] = json.dumps(input_msgs)
-        if output_msgs is not None:
-            labels["gen_ai.output.messages"] = json.dumps(output_msgs)
-        return labels
+    def test_valid_array_parses(self):
+        elements, truncated = _tolerant_json_array('[{"a": 1}, {"b": 2}]')
+        self.assertEqual(elements, [{"a": 1}, {"b": 2}])
+        self.assertFalse(truncated)
 
-    def test_returns_false_for_empty_labels(self):
-        output = []
-        self.assertFalse(_parse_reasoning_engine_labels({}, output))
-        self.assertEqual(output, [])
+    def test_empty_string(self):
+        self.assertEqual(_tolerant_json_array(""), ([], False))
 
-    def test_returns_true_with_input_messages_label(self):
-        labels = self._labels(input_msgs=[{"role": "user", "parts": [{"text": "hello"}]}])
-        output = []
-        self.assertTrue(_parse_reasoning_engine_labels(labels, output))
+    def test_garbage_returns_empty_and_truncated(self):
+        elements, truncated = _tolerant_json_array("not-json")
+        self.assertEqual(elements, [])
+        self.assertTrue(truncated)
 
-    def test_message_text_appears_in_output(self):
-        labels = self._labels(input_msgs=[{"role": "user", "parts": [{"text": "what is cost?"}]}])
-        output = []
-        _parse_reasoning_engine_labels(labels, output)
-        self.assertTrue(any("what is cost?" in line for line in output))
+    def test_truncated_array_salvages_complete_elements(self):
+        # Simulates Cloud Logging cutting the value off mid second element.
+        full = json.dumps([
+            {"role": "user", "parts": [{"text": "keep me"}]},
+            {"role": "assistant", "parts": [{"text": "X" * 200}]},
+        ])
+        chopped = full[:-30]
+        elements, truncated = _tolerant_json_array(chopped)
+        self.assertTrue(truncated)
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["parts"][0]["text"], "keep me")
 
-    def test_role_uppercased_in_output(self):
-        labels = self._labels(input_msgs=[{"role": "user", "parts": [{"text": "hi"}]}])
-        output = []
-        _parse_reasoning_engine_labels(labels, output)
-        self.assertTrue(any("[USER]:" in line for line in output))
+
+# ---------------------------------------------------------------------------
+# _format_message
+# ---------------------------------------------------------------------------
+
+class TestFormatMessage(unittest.TestCase):
+
+    def test_text_part(self):
+        self.assertEqual(
+            _format_message({"role": "user", "parts": [{"text": "hi there"}]}),
+            "[USER]: hi there",
+        )
+
+    def test_content_part(self):
+        out = _format_message({"role": "assistant", "parts": [{"content": "here is the answer"}]})
+        self.assertIn("here is the answer", out)
 
     def test_tool_call_part_formatted(self):
         msg = {"role": "assistant", "parts": [{"name": "run_sql", "arguments": {"query": "SELECT 1"}}]}
-        labels = self._labels(input_msgs=[msg])
-        output = []
-        _parse_reasoning_engine_labels(labels, output)
-        self.assertTrue(any("Tool Call: run_sql" in line for line in output))
+        self.assertIn("Tool Call: run_sql", _format_message(msg))
 
-    def test_content_part_included(self):
-        msg = {"role": "assistant", "parts": [{"content": "here is the answer"}]}
-        labels = self._labels(input_msgs=[msg])
-        output = []
-        _parse_reasoning_engine_labels(labels, output)
-        self.assertTrue(any("here is the answer" in line for line in output))
+    def test_role_uppercased(self):
+        self.assertTrue(_format_message({"role": "user", "parts": []}).startswith("[USER]:"))
 
-    def test_separator_added_after_each_message(self):
-        labels = self._labels(input_msgs=[
-            {"role": "user", "parts": [{"text": "q1"}]},
-            {"role": "assistant", "parts": [{"text": "a1"}]},
-        ])
-        output = []
-        _parse_reasoning_engine_labels(labels, output)
-        separators = [l for l in output if l == "-" * 20]
-        self.assertEqual(len(separators), 2)
+    def test_non_dict_message_handled(self):
+        self.assertIn("UNKNOWN", _format_message("just a string"))
 
-    def test_malformed_json_in_labels_handled_gracefully(self):
-        labels = {"gen_ai.input.messages": "not-valid-json"}
-        output = []
-        result = _parse_reasoning_engine_labels(labels, output)
-        self.assertTrue(result)
-        self.assertTrue(any("Error" in line for line in output))
 
-    def test_both_input_and_output_messages_combined(self):
-        labels = self._labels(
-            input_msgs=[{"role": "user", "parts": [{"text": "query"}]}],
-            output_msgs=[{"role": "assistant", "parts": [{"text": "answer"}]}],
+# ---------------------------------------------------------------------------
+# _render_conversation
+# ---------------------------------------------------------------------------
+
+class TestRenderConversation(unittest.TestCase):
+
+    def _entry(self, input_msgs=None, output_msgs=None, ts=0, payload="log line", conv="c1"):
+        """Mock log entry; *_msgs may be a list (json-encoded) or a raw string."""
+        entry = MagicMock()
+        labels = {"gen_ai.conversation.id": conv}
+        if input_msgs is not None:
+            labels["gen_ai.input.messages"] = (
+                input_msgs if isinstance(input_msgs, str) else json.dumps(input_msgs)
+            )
+        if output_msgs is not None:
+            labels["gen_ai.output.messages"] = (
+                output_msgs if isinstance(output_msgs, str) else json.dumps(output_msgs)
+            )
+        entry.to_api_repr.return_value = {"labels": labels}
+        entry.timestamp = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=ts)
+        entry.payload = payload
+        return entry
+
+    def test_single_entry_input_and_output(self):
+        entry = self._entry(
+            input_msgs=[{"role": "user", "parts": [{"text": "the question"}]}],
+            output_msgs=[{"role": "assistant", "parts": [{"text": "the answer"}]}],
         )
         output = []
-        _parse_reasoning_engine_labels(labels, output)
+        _render_conversation([entry], output)
         full = "\n".join(output)
-        self.assertIn("query", full)
-        self.assertIn("answer", full)
+        self.assertIn("the question", full)
+        self.assertIn("the answer", full)
+
+    def test_separator_added_after_each_message(self):
+        entry = self._entry(
+            input_msgs=[
+                {"role": "user", "parts": [{"text": "q1"}]},
+                {"role": "assistant", "parts": [{"text": "a1"}]},
+            ],
+        )
+        output = []
+        _render_conversation([entry], output)
+        self.assertEqual(len([l for l in output if l == "-" * 20]), 2)
+
+    def test_messages_deduplicated_across_entries(self):
+        # The later entry's input repeats the first turn (accumulated history).
+        e1 = self._entry(
+            input_msgs=[{"role": "user", "parts": [{"text": "turn one"}]}],
+            output_msgs=[{"role": "assistant", "parts": [{"text": "reply one"}]}],
+            ts=0,
+        )
+        e2 = self._entry(
+            input_msgs=[
+                {"role": "user", "parts": [{"text": "turn one"}]},
+                {"role": "assistant", "parts": [{"text": "reply one"}]},
+                {"role": "user", "parts": [{"text": "turn two"}]},
+            ],
+            output_msgs=[{"role": "assistant", "parts": [{"text": "reply two"}]}],
+            ts=1,
+        )
+        output = []
+        _render_conversation([e2, e1], output)  # deliberately out of chronological order
+        full = "\n".join(output)
+        self.assertEqual(full.count("turn one"), 1)  # deduped despite appearing twice
+        for txt in ("turn one", "reply one", "turn two", "reply two"):
+            self.assertIn(txt, full)
+
+    def test_truncated_last_entry_backfilled_by_earlier(self):
+        # Chronologically last entry's input label is truncated to invalid JSON,
+        # but the earlier (smaller) entry still holds the opening turn.
+        good_input = json.dumps([{"role": "user", "parts": [{"text": "original question"}]}])
+        big = json.dumps([
+            {"role": "user", "parts": [{"text": "original question"}]},
+            {"role": "tool", "parts": [{"text": "Y" * 500}]},
+        ])
+        truncated_input = big[:-40]
+        e1 = self._entry(
+            input_msgs=good_input,
+            output_msgs=[{"role": "assistant", "parts": [{"text": "tool call"}]}],
+            ts=0,
+        )
+        e2 = self._entry(
+            input_msgs=truncated_input,
+            output_msgs=[{"role": "assistant", "parts": [{"text": "final answer"}]}],
+            ts=1,
+        )
+        output = []
+        _render_conversation([e1, e2], output)
+        full = "\n".join(output)
+        self.assertIn("original question", full)  # recovered from the earlier entry
+        self.assertIn("final answer", full)       # from the last entry's small output label
+        self.assertIn("truncated", full.lower())  # truncation note emitted
+
+    def test_no_message_labels_falls_back_to_payload(self):
+        entry = self._entry(payload="raw payload text")  # no gen_ai message labels
+        output = []
+        _render_conversation([entry], output)
+        self.assertTrue(any("raw payload text" in line for line in output))
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +477,7 @@ class TestGetAgentTrajectories(unittest.TestCase):
         mock_logging.Client.return_value = mock_client
         mock_logging.DESCENDING = "DESCENDING"
 
-        # 3 entries, 2 unique conversation IDs — first seen (= latest) wins
+        # 3 entries, 2 unique conversation IDs — entries are grouped/merged per id
         entries = [
             _make_log_entry("conv-1", gen_ai_labels=True),
             _make_log_entry("conv-2", gen_ai_labels=True),
@@ -498,6 +589,188 @@ class TestGetAgentTrajectories(unittest.TestCase):
             project_id="test-project",
         )
         self.assertIn("Total log entries retrieved: 5", result)
+
+
+# ---------------------------------------------------------------------------
+# Cloud Logging filter builders
+# ---------------------------------------------------------------------------
+
+class TestFilters(unittest.TestCase):
+
+    def test_conversation_filter_pins_id_and_resource_type(self):
+        f = _conversation_filter("conv-123")
+        self.assertIn('resource.type="aiplatform.googleapis.com/ReasoningEngine"', f)
+        self.assertIn('labels."gen_ai.conversation.id"="conv-123"', f)
+
+    def test_reasoning_engine_filter_requires_nonempty_conversation_id(self):
+        f = _reasoning_engine_filter("123", "2026-06-05T00:00:00+00:00")
+        self.assertIn('resource.labels.reasoning_engine_id="123"', f)
+        self.assertIn('labels."gen_ai.conversation.id"!=""', f)
+        self.assertIn('timestamp>="2026-06-05T00:00:00+00:00"', f)
+        self.assertNotIn("timestamp<=", f)
+
+    def test_reasoning_engine_filter_includes_end_time(self):
+        f = _reasoning_engine_filter("123", "2026-06-01T00:00:00Z", "2026-06-17T00:00:00Z")
+        self.assertIn('timestamp<="2026-06-17T00:00:00Z"', f)
+
+
+# ---------------------------------------------------------------------------
+# _group_by_conversation
+# ---------------------------------------------------------------------------
+
+class TestGroupByConversation(unittest.TestCase):
+
+    def test_groups_entries_and_skips_unlabeled(self):
+        entries = [
+            _make_log_entry("c1", gen_ai_labels=True),
+            _make_log_entry("c2", gen_ai_labels=True),
+            _make_log_entry("c1"),
+            _make_log_entry(conversation_id=None),  # no id — skipped
+        ]
+        grouped = _group_by_conversation(entries)
+        self.assertEqual(set(grouped.keys()), {"c1", "c2"})
+        self.assertEqual(len(grouped["c1"]), 2)
+        self.assertEqual(len(grouped["c2"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_proposals
+# ---------------------------------------------------------------------------
+
+class TestAggregateProposals(unittest.TestCase):
+
+    def _p(self, name, gap="BUSINESS_LOGIC_GAP", atype="COLUMN", conf=0.5, instr="do X"):
+        return {
+            "classification": {"detection_signal": "DIRECT_USER_CORRECTION", "gap_type": gap},
+            "target_asset": {"type": atype, "name": name},
+            "proposed_enrichment": {"action": "UPDATE_OVERVIEW_ASPECT", "value": "v"},
+            "confidence_grade": conf,
+            "enrichment_agent_instruction": instr,
+        }
+
+    def test_same_asset_and_gap_collapsed_keeping_higher_confidence(self):
+        out = _aggregate_proposals([self._p("ds.t.col", conf=0.6), self._p("DS.T.COL", conf=0.9)])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["confidence_grade"], 0.9)
+
+    def test_different_gap_type_not_merged(self):
+        out = _aggregate_proposals([
+            self._p("ds.t.col", gap="BUSINESS_LOGIC_GAP"),
+            self._p("ds.t.col", gap="STRUCTURAL_ROUTING_GAP"),
+        ])
+        self.assertEqual(len(out), 2)
+
+    def test_different_asset_not_merged(self):
+        out = _aggregate_proposals([self._p("ds.t.a"), self._p("ds.t.b")])
+        self.assertEqual(len(out), 2)
+
+    def test_blank_name_distinct_instructions_not_collapsed(self):
+        out = _aggregate_proposals([
+            self._p("", atype="UNCATALOGED_ASSET", gap="UNCATALOGED_ASSET_DISCOVERY", instr="catalog table A"),
+            self._p("", atype="UNCATALOGED_ASSET", gap="UNCATALOGED_ASSET_DISCOVERY", instr="catalog table B"),
+        ])
+        self.assertEqual(len(out), 2)
+
+    def test_blank_name_same_instruction_collapsed(self):
+        out = _aggregate_proposals([
+            self._p("", atype="UNCATALOGED_ASSET", gap="UNCATALOGED_ASSET_DISCOVERY", instr="catalog A", conf=0.4),
+            self._p("", atype="UNCATALOGED_ASSET", gap="UNCATALOGED_ASSET_DISCOVERY", instr="catalog A", conf=0.8),
+        ])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["confidence_grade"], 0.8)
+
+
+# ---------------------------------------------------------------------------
+# generate_learnings (per-conversation fan-out + dedup orchestration)
+# ---------------------------------------------------------------------------
+
+class TestGenerateLearnings(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.orig_dir = os.getcwd()
+        os.chdir(self.tmpdir)  # proposal.json is written to cwd
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+
+    def _proposal(self, name="ds.t.cost", gap="BUSINESS_LOGIC_GAP", conf=0.9):
+        return {
+            "classification": {"detection_signal": "DIRECT_USER_CORRECTION", "gap_type": gap},
+            "target_asset": {"type": "COLUMN", "name": name},
+            "proposed_enrichment": {"action": "UPDATE_OVERVIEW_ASPECT", "value": "USD"},
+            "confidence_grade": conf,
+            "enrichment_agent_instruction": "update cost",
+        }
+
+    @patch("conversation_learner.agent._judge_conversation_sync")
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_validation_error_when_no_params(self, mock_logging, mock_judge):
+        result = asyncio.run(generate_learnings(project_id="test-project"))
+        self.assertIn("Either conversation_id", result)
+        mock_judge.assert_not_called()
+
+    @patch("conversation_learner.agent._judge_conversation_sync")
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_fans_out_per_conversation_and_dedups(self, mock_logging, mock_judge):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+        mock_client.list_entries.return_value = [
+            _make_log_entry("c1", gen_ai_labels=True),
+            _make_log_entry("c2", gen_ai_labels=True),
+        ]
+        # Both conversations surface the SAME asset+gap proposal -> dedup to 1.
+        mock_judge.return_value = [self._proposal()]
+
+        result = asyncio.run(generate_learnings(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7, project_id="test-project",
+        ))
+
+        self.assertEqual(mock_judge.call_count, 2)  # one judge call per conversation
+        self.assertIn("Unique conversations: 2", result)
+        self.assertIn("from 2 raw", result)
+        self.assertIn("saved 1 deduplicated", result)
+        with open("proposal.json") as f:
+            saved = json.load(f)
+        self.assertEqual(len(saved["proposals"]), 1)
+
+    @patch("conversation_learner.agent._judge_conversation_sync")
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_one_conversation_failure_does_not_abort_batch(self, mock_logging, mock_judge):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+        mock_client.list_entries.return_value = [
+            _make_log_entry("c1", gen_ai_labels=True),
+            _make_log_entry("c2", gen_ai_labels=True),
+        ]
+
+        def _side_effect(cid, transcript):
+            if cid == "c1":
+                raise RuntimeError("boom")  # non-retryable -> conversation yields []
+            return [self._proposal(name="ds.t.other")]
+        mock_judge.side_effect = _side_effect
+
+        result = asyncio.run(generate_learnings(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7, project_id="test-project",
+        ))
+        self.assertIn("from 1 raw", result)
+        self.assertIn("saved 1 deduplicated", result)
+
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_no_conversations_found(self, mock_logging):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+        mock_client.list_entries.return_value = []
+        result = asyncio.run(generate_learnings(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7, project_id="test-project",
+        ))
+        self.assertIn("Unique conversations: 0", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Reworks ConversationLearner's trajectory analysis from a single combined LLM pass over all conversations into **one LLM-as-judge call per conversation, fanned out in parallel**, followed by a lightweight cross-conversation dedup pass.

## Why
The single-pass approach didn't scale (a busy reasoning engine over "past N days" can be hundreds of conversations, and trajectories can be large) and suffered "lost in the middle" degradation, showing up as run-to-run non-determinism in the proposals.

## Changes
- `generate_learnings` async tool: fetch+group -> judge each conversation in parallel (`asyncio.gather`, Semaphore-capped, per-conversation retry so one failure doesn't abort the batch) -> dedup -> save. Mirrors the direct-`generate_content` pattern in `enrichment/common.py`, kept self-contained (deploy ships `["."]`).
- Judge each conversation via direct Vertex `generate_content` with `response_schema=TrajectoryAnalysisResult`, falling back to text + backslash-repair when `resp.parsed` is None.
- Restrict Cloud Logging reads to entries with a non-empty `gen_ai.conversation.id` (was scanning ~100x more entries).
- Merge each conversation's messages across all log entries (deduped, chronological), salvaging labels truncated at Cloud Logging's 64 KiB limit and backfilling a truncated latest entry from earlier ones.
- Reduce the ADK agent to an NL front-end over `generate_learnings`; refocus `SKILL.md` as the single-conversation judge rubric.
- README: document `gcloud auth application-default login` for local runs; update the architecture section.
- Tests: 65 passing (filters, grouping, dedup incl. blank-name edge case, truncation merge, orchestration).

## Verification
- `python -m unittest conversation_learner.tests.test_agent` -> 65 pass
- Live `adk run` against a real reasoning engine: 6 conversations, schema-valid deduped `proposal.json`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
