### PR TITLE
ConversationLearner: fetch logs with page_size=1000

### DIFF
--- a/agents/conversation_learner/agent.py
+++ b/agents/conversation_learner/agent.py
@@ -234,7 +234,7 @@ def _fetch_and_group(
             datetime.now(timezone.utc) - timedelta(days=days_ago)
         ).isoformat()
         filter_str = _reasoning_engine_filter(re_id, start_time_str, end_time)
-    entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING))
+    entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING, page_size=1000))
     return entries, _group_by_conversation(entries)
 
 
@@ -268,7 +268,7 @@ def get_agent_trajectories(
         if conversation_id:
             output.append(f"--- Fetching Conversation: {conversation_id} ---")
             filter_str = _conversation_filter(conversation_id)
-            entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING))
+            entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING, page_size=1000))
 
             output.append("--- Chat History ---")
 
@@ -294,7 +294,7 @@ def get_agent_trajectories(
             re_id = reasoning_engine_id.split("/")[-1]
             filter_str = _reasoning_engine_filter(re_id, start_time_str, end_time)
 
-            entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING))
+            entries = list(client.list_entries(filter_=filter_str, order_by=cloud_logging.DESCENDING, page_size=1000))
 
             if not entries:
                 output.append("No messages found for this Reasoning Engine in the specified time range.")


### PR DESCRIPTION
## Summary
Pass `page_size=1000` to the three `cloud_logging` `list_entries` calls in the ConversationLearner agent so each paginated request pulls up to 1000 entries, cutting the number of API round-trips when fetching long conversations or wide time ranges.

## Changes
- `agents/conversation_learner/agent.py` — add `page_size=1000` to the `list_entries` calls in `_fetch_and_group` and the two branches of `get_agent_trajectories` (conversation-id and reasoning-engine).

## Notes
- Behavior is unchanged otherwise: `list(...)` still exhausts the iterator across all pages; this only reduces the number of HTTP requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
