### PR TITLE
ConversationLearner: optional stable proposal IDs

### DIFF
--- a/agents/conversation_learner/README.md
+++ b/agents/conversation_learner/README.md
@@ -44,6 +44,8 @@ generate learnings for projects/<project-number>/locations/us-central1/reasoning
 
 The agent will print the number of log entries retrieved, the unique conversation IDs found, and save enrichment proposals to `proposal.json`.
 
+To attach a deterministic, run-stable `id` to each saved proposal, ask for them — e.g. append `with proposal ids` to your prompt. The id is derived from the proposal's identity (asset type + asset name + gap type), so the same gap on the same asset yields the same id across runs. The (volatile) proposed wording is ignored, and the asset name is canonicalized so an optional `project.` prefix doesn't produce two different ids.
+
 > **Note on Observability**: The agent retrieves conversations from Cloud Logging using OpenTelemetry trace logs (`gen_ai.client.inference.operation.details`). These logs are only emitted for sessions that ran while **Observability was enabled** on the Reasoning Engine. Sessions started before Observability was activated will not appear.
 
 ## Running Tests

--- a/agents/conversation_learner/agent.py
+++ b/agents/conversation_learner/agent.py
@@ -15,6 +15,7 @@
 """ConversationLearner agent for analyzing conversational trajectories."""
 
 import asyncio
+import hashlib
 import json
 import os
 from enum import Enum
@@ -539,6 +540,8 @@ ORCHESTRATOR_INSTRUCTION = (
     "- If given a Reasoning Engine id (or full resource path) and a time filter, "
     "pass `reasoning_engine_id` plus either `days_ago` or `start_time`/`end_time` "
     "(ISO 8601).\n"
+    "- If the user asks for proposal IDs (e.g. 'with ids' / 'stable ids'), pass "
+    "`include_ids=true` (it defaults to false).\n"
     "Then report the tool's returned summary verbatim to the user. Do not call "
     "the tool more than once and do not call any other tools."
 )
@@ -643,28 +646,72 @@ def _judge_conversation_sync(conversation_id: str, transcript: str) -> List[Dict
         return []
 
 
+def _canonical_asset_name(name: Optional[str], asset_type: str = "") -> str:
+    """Canonicalizes a BigQuery-style asset path so the same asset normalizes the
+    same whether or not the LLM included the project prefix.
+
+    References look like ``project.dataset.table.column`` (or any suffix). A
+    leading project component is dropped when detectable: a project id may contain
+    hyphens (BigQuery dataset/table/column identifiers may not), and a four-part
+    path is always ``project.dataset.table.column``. Glossary terms aren't paths,
+    so only their case/whitespace is normalized.
+
+    Residual limit: a hyphen-free project in an ambiguous three-part path
+    (``project.dataset.table`` vs ``dataset.table.column``) can't be told apart
+    and is left intact.
+    """
+    name = (name or "").strip().lower()
+    if not name or asset_type == "GLOSSARY_TERM":
+        return name
+    parts = name.split(".")
+    if len(parts) >= 2 and ("-" in parts[0] or len(parts) == 4):
+        parts = parts[1:]  # drop the leading project component
+    return ".".join(parts)
+
+
+def _proposal_identity(proposal: Dict[str, Any]) -> Tuple:
+    """The fields that define a unique proposal — used for BOTH cross-conversation
+    dedup and the optional proposal id, so the two never disagree.
+
+    Identity is asset type + canonical name + gap_type. It deliberately excludes
+    the proposed value (volatile LLM-generated text that varies run to run). The
+    asset name is canonicalized (see _canonical_asset_name) so the project prefix
+    being present or absent doesn't split one asset into two. A blank asset name
+    (e.g. uncataloged-asset discoveries) falls back to a hash of the enrichment
+    instruction so genuinely distinct finds are not merged.
+    """
+    asset = proposal.get("target_asset") or {}
+    atype = asset.get("type", "")
+    name = _canonical_asset_name(asset.get("name"), atype)
+    gap = (proposal.get("classification") or {}).get("gap_type", "")
+    if name:
+        return (atype, name, gap)
+    instr = proposal.get("enrichment_agent_instruction") or json.dumps(
+        proposal.get("proposed_enrichment", ""), sort_keys=True
+    )
+    return (atype, gap, hashlib.sha1(instr.encode()).hexdigest()[:12])
+
+
+def _proposal_id(proposal: Dict[str, Any]) -> str:
+    """Deterministic, run-stable id derived from a proposal's identity.
+
+    The same gap on the same asset yields the same id across runs (useful for
+    tracking, linking, and idempotent downstream processing). Uses hashlib, NOT
+    the builtin hash() (which is per-process salted and would not be reproducible).
+    """
+    canonical = "|".join(str(part) for part in _proposal_identity(proposal))
+    return "prop_" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
+
+
 def _aggregate_proposals(proposals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Deduplicates proposals across conversations (lightweight aggregation pass).
 
-    Proposals targeting the same asset (type + normalized name) with the same
-    gap_type are treated as the same learning; the highest-confidence instance is
-    kept. A blank asset name (e.g. uncataloged-asset discoveries) falls back to a
-    hash of the enrichment instruction so genuinely distinct finds are not merged.
+    Proposals with the same identity (see _proposal_identity) are treated as the
+    same learning; the highest-confidence instance is kept.
     """
-    import hashlib
-    by_key: Dict[tuple, Dict[str, Any]] = {}
+    by_key: Dict[Tuple, Dict[str, Any]] = {}
     for p in proposals:
-        asset = p.get("target_asset") or {}
-        atype = asset.get("type", "")
-        name = (asset.get("name") or "").strip().lower()
-        gap = (p.get("classification") or {}).get("gap_type", "")
-        if name:
-            key = (atype, name, gap)
-        else:
-            instr = p.get("enrichment_agent_instruction") or json.dumps(
-                p.get("proposed_enrichment", ""), sort_keys=True
-            )
-            key = (atype, gap, hashlib.sha1(instr.encode()).hexdigest()[:12])
+        key = _proposal_identity(p)
         existing = by_key.get(key)
         if existing is None or (p.get("confidence_grade") or 0) > (existing.get("confidence_grade") or 0):
             by_key[key] = p
@@ -678,6 +725,7 @@ async def generate_learnings(
     start_time: Optional[str] = None,
     end_time: Optional[str] = None,
     project_id: str = consumer_project,
+    include_ids: bool = False,
 ) -> str:
     """Analyzes agent conversation trajectories and saves enrichment proposals.
 
@@ -692,6 +740,8 @@ async def generate_learnings(
         start_time: ISO 8601 start of an explicit time window.
         end_time: ISO 8601 end of an explicit time window.
         project_id: Google Cloud Project ID.
+        include_ids: When True, attach a deterministic, run-stable ``id`` to each
+            saved proposal (derived from its identity; see _proposal_id).
 
     Returns:
         A human-readable summary of what was analyzed and saved.
@@ -742,6 +792,8 @@ async def generate_learnings(
     results = await asyncio.gather(*[_judge(c, t) for c, t in transcripts.items()])
     raw_proposals = [p for sub in results for p in sub]
     deduped = _aggregate_proposals(raw_proposals)
+    if include_ids:
+        deduped = [{"id": _proposal_id(p), **p} for p in deduped]
 
     save_trajectory_analysis_result(json.dumps({"proposals": deduped}))
 

--- a/agents/conversation_learner/tests/test_agent.py
+++ b/agents/conversation_learner/tests/test_agent.py
@@ -31,10 +31,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from conversation_learner.agent import (  # noqa: E402
     _aggregate_proposals,
+    _canonical_asset_name,
     _conversation_filter,
     _format_message,
     _group_by_conversation,
     _parse_generic_payload,
+    _proposal_id,
     _reasoning_engine_filter,
     _redact_obj,
     _redact_sensitive,
@@ -681,6 +683,99 @@ class TestAggregateProposals(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# _canonical_asset_name
+# ---------------------------------------------------------------------------
+
+class TestCanonicalAssetName(unittest.TestCase):
+
+    def test_drops_hyphenated_project_prefix(self):
+        self.assertEqual(
+            _canonical_asset_name("weiyi-test-dataplex.weiyiaidataset.monthly_cloud_billing.cost"),
+            "weiyiaidataset.monthly_cloud_billing.cost",
+        )
+
+    def test_no_project_unchanged(self):
+        self.assertEqual(
+            _canonical_asset_name("weiyiaidataset.monthly_cloud_billing.cost"),
+            "weiyiaidataset.monthly_cloud_billing.cost",
+        )
+
+    def test_drops_four_part_project_without_hyphen(self):
+        self.assertEqual(_canonical_asset_name("proj.ds.tbl.col"), "ds.tbl.col")
+
+    def test_hyphenated_project_three_part_table(self):
+        self.assertEqual(
+            _canonical_asset_name("dataplex-demo.demo_concord_tables.analysis_x"),
+            "demo_concord_tables.analysis_x",
+        )
+
+    def test_project_plus_dataset(self):
+        self.assertEqual(_canonical_asset_name("weiyi-test-dataplex.weiyi_kb_0"), "weiyi_kb_0")
+
+    def test_single_component_unchanged(self):
+        self.assertEqual(_canonical_asset_name("weiyi_kb_0"), "weiyi_kb_0")
+
+    def test_glossary_term_not_path_stripped(self):
+        self.assertEqual(_canonical_asset_name("foo-bar.baz", "GLOSSARY_TERM"), "foo-bar.baz")
+
+    def test_lowercases_and_handles_empty(self):
+        self.assertEqual(_canonical_asset_name("DS.T.COL"), "ds.t.col")
+        self.assertEqual(_canonical_asset_name(None), "")
+
+
+# ---------------------------------------------------------------------------
+# _proposal_id
+# ---------------------------------------------------------------------------
+
+class TestProposalId(unittest.TestCase):
+
+    def _p(self, name="ds.t.col", gap="BUSINESS_LOGIC_GAP", atype="COLUMN", value="v", instr="do X"):
+        return {
+            "classification": {"detection_signal": "DIRECT_USER_CORRECTION", "gap_type": gap},
+            "target_asset": {"type": atype, "name": name},
+            "proposed_enrichment": {"action": "UPDATE_OVERVIEW_ASPECT", "value": value},
+            "confidence_grade": 0.9,
+            "enrichment_agent_instruction": instr,
+        }
+
+    def test_deterministic_and_prefixed(self):
+        self.assertEqual(_proposal_id(self._p()), _proposal_id(self._p()))
+        self.assertTrue(_proposal_id(self._p()).startswith("prop_"))
+
+    def test_independent_of_proposed_value(self):
+        # The whole point: re-phrased value must NOT change the id.
+        self.assertEqual(
+            _proposal_id(self._p(value="unit is thousands of dollars")),
+            _proposal_id(self._p(value="values are in 1000s of USD")),
+        )
+
+    def test_changes_with_gap_type(self):
+        self.assertNotEqual(
+            _proposal_id(self._p(gap="BUSINESS_LOGIC_GAP")),
+            _proposal_id(self._p(gap="STRUCTURAL_ROUTING_GAP")),
+        )
+
+    def test_changes_with_asset(self):
+        self.assertNotEqual(_proposal_id(self._p(name="ds.t.a")), _proposal_id(self._p(name="ds.t.b")))
+
+    def test_normalizes_asset_name_case(self):
+        self.assertEqual(_proposal_id(self._p(name="DS.T.COL")), _proposal_id(self._p(name="ds.t.col")))
+
+    def test_stable_across_project_prefix(self):
+        # The caveat fix: same asset with vs without the project prefix -> same id.
+        self.assertEqual(
+            _proposal_id(self._p(name="weiyi-test-dataplex.weiyiaidataset.monthly_cloud_billing.cost")),
+            _proposal_id(self._p(name="weiyiaidataset.monthly_cloud_billing.cost")),
+        )
+
+    def test_id_matches_dedup_identity(self):
+        # Two proposals the dedup collapses into one must share the same id.
+        a, b = self._p(value="x", instr="i1"), self._p(value="y", instr="i2")
+        self.assertEqual(_proposal_id(a), _proposal_id(b))
+        self.assertEqual(len(_aggregate_proposals([a, b])), 1)
+
+
+# ---------------------------------------------------------------------------
 # generate_learnings (per-conversation fan-out + dedup orchestration)
 # ---------------------------------------------------------------------------
 
@@ -771,6 +866,31 @@ class TestGenerateLearnings(unittest.TestCase):
             days_ago=7, project_id="test-project",
         ))
         self.assertIn("Unique conversations: 0", result)
+
+    def _run_one(self, mock_logging, mock_judge, include_ids):
+        mock_client = MagicMock()
+        mock_logging.Client.return_value = mock_client
+        mock_logging.DESCENDING = "DESCENDING"
+        mock_client.list_entries.return_value = [_make_log_entry("c1", gen_ai_labels=True)]
+        mock_judge.return_value = [self._proposal()]
+        asyncio.run(generate_learnings(
+            reasoning_engine_id="projects/p/locations/l/reasoningEngines/123",
+            days_ago=7, project_id="test-project", include_ids=include_ids,
+        ))
+        with open("proposal.json") as f:
+            return json.load(f)["proposals"]
+
+    @patch("conversation_learner.agent._judge_conversation_sync")
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_include_ids_adds_id_field(self, mock_logging, mock_judge):
+        proposals = self._run_one(mock_logging, mock_judge, include_ids=True)
+        self.assertTrue(proposals and all(p.get("id", "").startswith("prop_") for p in proposals))
+
+    @patch("conversation_learner.agent._judge_conversation_sync")
+    @patch("conversation_learner.agent.cloud_logging")
+    def test_no_ids_by_default(self, mock_logging, mock_judge):
+        proposals = self._run_one(mock_logging, mock_judge, include_ids=False)
+        self.assertTrue(proposals and all("id" not in p for p in proposals))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Adds an opt-in, deterministic **proposal ID** to ConversationLearner output (`generate_learnings(..., include_ids=True)`, or ask the agent for "proposal ids"). Off by default.

## Why
Stable IDs let downstream consumers track, link, and idempotently process proposals across runs. The ID should represent the *same* notion of "same proposal" the dedup already uses — so it's derived from the proposal's identity, not the volatile LLM-generated wording.

## Design
- **`_proposal_identity`** is now the single source of truth for identity — `(asset type, canonical asset name, gap_type)` — shared by both cross-conversation dedup and the ID, so they can't disagree.
- **`_proposal_id`** = `prop_` + `sha256(identity)[:12]`, via `hashlib` (not the per-process-salted builtin `hash()`).
- **`_canonical_asset_name`** drops a detectable leading project component (hyphenated first part, or a 4-part `project.dataset.table.column` path) so the same asset hashes the same with or without its `project.` prefix — which also tightens dedup. Glossary terms are left as-is. (Residual: a hyphen-free project in an ambiguous 3-part path can't be disambiguated.)
- The proposed **value is intentionally excluded** (re-phrased every run, so hashing it would make IDs unstable).
- `include_ids` defaults to false; IDs are attached after dedup.

## Tests
82 passing — canonicalization, ID determinism / value-independence / gap-sensitivity / project-prefix-stability, and `include_ids` on/off through `generate_learnings`.
