### PR TITLE
ConversationLearner: local human-in-the-loop proposal review UI

### DIFF
--- a/agents/conversation_learner/.gitignore
+++ b/agents/conversation_learner/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 *.pyc
 .env
 proposal.json
+reviews.json
+approved_proposals.json

--- a/agents/conversation_learner/README.md
+++ b/agents/conversation_learner/README.md
@@ -48,6 +48,28 @@ To attach a deterministic, run-stable `id` to each saved proposal, ask for them 
 
 > **Note on Observability**: The agent retrieves conversations from Cloud Logging using OpenTelemetry trace logs (`gen_ai.client.inference.operation.details`). These logs are only emitted for sessions that ran while **Observability was enabled** on the Reasoning Engine. Sessions started before Observability was activated will not appear.
 
+## Reviewing proposals (human-in-the-loop)
+
+`proposal.json` is a queue of *suggested* enrichments — a human reviews and approves them before the Enrichment Agent acts. A local Streamlit UI provides this step. It reads the JSON files directly (no cloud, no agent runtime needed), so its dependency is kept **separate** from `requirements.txt`:
+
+```bash
+# From the conversation_learner directory
+pip install -r requirements-review.txt
+streamlit run review_app.py
+```
+
+The UI lets you:
+- Filter by status, gap type, detection signal, confidence, and asset name.
+- Approve / reject each proposal, or **bulk-approve** all pending proposals above a confidence threshold.
+- See live counts and an **Analytics** tab (by status / gap type / confidence band).
+- **Export** the approved subset to `approved_proposals.json` — the hand-off the Enrichment Agent consumes.
+
+State is fully local:
+- Decisions are written to `reviews.json`, **keyed by each proposal's stable `id`** — so re-running the agent and regenerating `proposal.json` never clobbers your decisions.
+- If `proposal.json` was generated without ids, the UI computes the same id on the fly (id logic is shared via `proposal_id.py`), so review still works.
+
+> **Productionizing**: this demo keeps review state in local JSON. A hosted, multi-user deployment would move the lifecycle to a transactional store (e.g. Firestore or Cloud SQL) with audit fields (reviewer, timestamp) and RBAC, mirror it to BigQuery for dashboards/analytics, and add content-drift re-review. Out of scope here.
+
 ## Running Tests
 
 ```bash

--- a/agents/conversation_learner/agent.py
+++ b/agents/conversation_learner/agent.py
@@ -15,7 +15,6 @@
 """ConversationLearner agent for analyzing conversational trajectories."""
 
 import asyncio
-import hashlib
 import json
 import os
 from enum import Enum
@@ -33,6 +32,14 @@ import sys
 if os.path.dirname(os.path.abspath(__file__)) not in sys.path:
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from utils import get_consumer_project
+# Proposal identity/id live in a stdlib-only module so the local review UI can
+# share them without importing this agent's GCP/ADK runtime. Re-exported here so
+# `agent._proposal_id` etc. keep working for existing callers and tests.
+from proposal_id import (  # noqa: F401
+    _canonical_asset_name,
+    _proposal_id,
+    _proposal_identity,
+)
 
 consumer_project = get_consumer_project()
 
@@ -644,63 +651,6 @@ def _judge_conversation_sync(conversation_id: str, transcript: str) -> List[Dict
             flush=True,
         )
         return []
-
-
-def _canonical_asset_name(name: Optional[str], asset_type: str = "") -> str:
-    """Canonicalizes a BigQuery-style asset path so the same asset normalizes the
-    same whether or not the LLM included the project prefix.
-
-    References look like ``project.dataset.table.column`` (or any suffix). A
-    leading project component is dropped when detectable: a project id may contain
-    hyphens (BigQuery dataset/table/column identifiers may not), and a four-part
-    path is always ``project.dataset.table.column``. Glossary terms aren't paths,
-    so only their case/whitespace is normalized.
-
-    Residual limit: a hyphen-free project in an ambiguous three-part path
-    (``project.dataset.table`` vs ``dataset.table.column``) can't be told apart
-    and is left intact.
-    """
-    name = (name or "").strip().lower()
-    if not name or asset_type == "GLOSSARY_TERM":
-        return name
-    parts = name.split(".")
-    if len(parts) >= 2 and ("-" in parts[0] or len(parts) == 4):
-        parts = parts[1:]  # drop the leading project component
-    return ".".join(parts)
-
-
-def _proposal_identity(proposal: Dict[str, Any]) -> Tuple:
-    """The fields that define a unique proposal — used for BOTH cross-conversation
-    dedup and the optional proposal id, so the two never disagree.
-
-    Identity is asset type + canonical name + gap_type. It deliberately excludes
-    the proposed value (volatile LLM-generated text that varies run to run). The
-    asset name is canonicalized (see _canonical_asset_name) so the project prefix
-    being present or absent doesn't split one asset into two. A blank asset name
-    (e.g. uncataloged-asset discoveries) falls back to a hash of the enrichment
-    instruction so genuinely distinct finds are not merged.
-    """
-    asset = proposal.get("target_asset") or {}
-    atype = asset.get("type", "")
-    name = _canonical_asset_name(asset.get("name"), atype)
-    gap = (proposal.get("classification") or {}).get("gap_type", "")
-    if name:
-        return (atype, name, gap)
-    instr = proposal.get("enrichment_agent_instruction") or json.dumps(
-        proposal.get("proposed_enrichment", ""), sort_keys=True
-    )
-    return (atype, gap, hashlib.sha1(instr.encode()).hexdigest()[:12])
-
-
-def _proposal_id(proposal: Dict[str, Any]) -> str:
-    """Deterministic, run-stable id derived from a proposal's identity.
-
-    The same gap on the same asset yields the same id across runs (useful for
-    tracking, linking, and idempotent downstream processing). Uses hashlib, NOT
-    the builtin hash() (which is per-process salted and would not be reproducible).
-    """
-    canonical = "|".join(str(part) for part in _proposal_identity(proposal))
-    return "prop_" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
 
 
 def _aggregate_proposals(proposals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/agents/conversation_learner/proposal_id.py
+++ b/agents/conversation_learner/proposal_id.py
@@ -1,0 +1,83 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic, run-stable identity and id for enrichment proposals.
+
+Pure standard-library (no GCP / ADK dependencies) so this single definition can
+be shared by the agent (agent.py) and the standalone local review UI
+(review_store.py / review_app.py) without the UI having to import the agent's
+heavy runtime. Keeping one copy means agent-generated ids and UI-computed ids
+always match.
+"""
+
+import hashlib
+import json
+from typing import Any, Dict, Optional, Tuple
+
+
+def _canonical_asset_name(name: Optional[str], asset_type: str = "") -> str:
+    """Canonicalizes a BigQuery-style asset path so the same asset normalizes the
+    same whether or not the LLM included the project prefix.
+
+    References look like ``project.dataset.table.column`` (or any suffix). A
+    leading project component is dropped when detectable: a project id may contain
+    hyphens (BigQuery dataset/table/column identifiers may not), and a four-part
+    path is always ``project.dataset.table.column``. Glossary terms aren't paths,
+    so only their case/whitespace is normalized.
+
+    Residual limit: a hyphen-free project in an ambiguous three-part path
+    (``project.dataset.table`` vs ``dataset.table.column``) can't be told apart
+    and is left intact.
+    """
+    name = (name or "").strip().lower()
+    if not name or asset_type == "GLOSSARY_TERM":
+        return name
+    parts = name.split(".")
+    if len(parts) >= 2 and ("-" in parts[0] or len(parts) == 4):
+        parts = parts[1:]  # drop the leading project component
+    return ".".join(parts)
+
+
+def _proposal_identity(proposal: Dict[str, Any]) -> Tuple:
+    """The fields that define a unique proposal — used for BOTH cross-conversation
+    dedup and the optional proposal id, so the two never disagree.
+
+    Identity is asset type + canonical name + gap_type. It deliberately excludes
+    the proposed value (volatile LLM-generated text that varies run to run). The
+    asset name is canonicalized (see _canonical_asset_name) so the project prefix
+    being present or absent doesn't split one asset into two. A blank asset name
+    (e.g. uncataloged-asset discoveries) falls back to a hash of the enrichment
+    instruction so genuinely distinct finds are not merged.
+    """
+    asset = proposal.get("target_asset") or {}
+    atype = asset.get("type", "")
+    name = _canonical_asset_name(asset.get("name"), atype)
+    gap = (proposal.get("classification") or {}).get("gap_type", "")
+    if name:
+        return (atype, name, gap)
+    instr = proposal.get("enrichment_agent_instruction") or json.dumps(
+        proposal.get("proposed_enrichment", ""), sort_keys=True
+    )
+    return (atype, gap, hashlib.sha1(instr.encode()).hexdigest()[:12])
+
+
+def _proposal_id(proposal: Dict[str, Any]) -> str:
+    """Deterministic, run-stable id derived from a proposal's identity.
+
+    The same gap on the same asset yields the same id across runs (useful for
+    tracking, linking, and idempotent downstream processing). Uses hashlib, NOT
+    the builtin hash() (which is per-process salted and would not be reproducible).
+    """
+    canonical = "|".join(str(part) for part in _proposal_identity(proposal))
+    return "prop_" + hashlib.sha256(canonical.encode()).hexdigest()[:12]

--- a/agents/conversation_learner/requirements-review.txt
+++ b/agents/conversation_learner/requirements-review.txt
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dependencies for the LOCAL proposal review UI (review_app.py) ONLY.
+# Intentionally separate from requirements.txt so Streamlit is never bundled
+# into the deployed Agent Engine runtime. streamlit pulls in pandas (used for
+# the analytics charts).
+streamlit

--- a/agents/conversation_learner/review_app.py
+++ b/agents/conversation_learner/review_app.py
@@ -1,0 +1,183 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Streamlit human-in-the-loop review UI for ConversationLearner proposals.
+
+Fully local — no cloud, no agent runtime required:
+
+    pip install -r requirements-review.txt
+    streamlit run review_app.py
+
+Reads proposal.json, persists decisions to reviews.json (keyed by stable id),
+and exports the approved subset to approved_proposals.json (the hand-off to the
+Enrichment Agent).
+"""
+
+import os
+
+import pandas as pd
+import streamlit as st
+
+import review_store as rs
+
+GAP_COLORS = {
+    "LEXICAL_SYNONYM_GAP": "#6366f1",
+    "BUSINESS_LOGIC_GAP": "#d97706",
+    "STRUCTURAL_ROUTING_GAP": "#dc2626",
+    "UNCATALOGED_ASSET_DISCOVERY": "#0891b2",
+    "VALIDATED_CONTEXT": "#16a34a",
+}
+STATUS_BADGE = {"pending": "⏳ pending", "approved": "✅ approved", "rejected": "❌ rejected"}
+MAX_CARDS = 50
+
+st.set_page_config(page_title="ConversationLearner — Proposal Review",
+                   page_icon="🧠", layout="wide")
+
+
+@st.cache_data(show_spinner=False)
+def _load_proposals_cached(path, _mtime):
+    # _mtime is part of the cache key so the file is re-read when it changes.
+    return rs.load_proposals(path)
+
+
+def _badge(text, color):
+    return (f"<span style='background:{color};color:white;padding:2px 8px;"
+            f"border-radius:6px;font-size:0.75rem;font-weight:600'>{text}</span>")
+
+
+def _gap(p):
+    return (p.get("classification") or {}).get("gap_type", "?")
+
+
+def _signal(p):
+    return (p.get("classification") or {}).get("detection_signal", "?")
+
+
+def _asset_name(p):
+    return (p.get("target_asset") or {}).get("name") or ""
+
+
+def _conf(p):
+    return p.get("confidence_grade") or 0.0
+
+
+# --- load ---
+proposals_path = rs.DEFAULT_PROPOSALS_PATH
+if not os.path.exists(proposals_path):
+    st.error(f"No proposals found at {proposals_path}. Run the agent first "
+             f"(generate_learnings) to produce proposal.json.")
+    st.stop()
+
+proposals = _load_proposals_cached(proposals_path, os.path.getmtime(proposals_path))
+reviews = rs.load_reviews()
+merged = rs.merge(proposals, reviews)
+stats = rs.summary(merged)
+
+# --- header + metrics ---
+st.title("🧠 ConversationLearner — Proposal Review")
+st.caption("Review enrichment proposals, then export the approved set for the Enrichment Agent.")
+m = st.columns(4)
+m[0].metric("Total", stats["total"])
+m[1].metric("⏳ Pending", stats["by_status"].get("pending", 0))
+m[2].metric("✅ Approved", stats["by_status"].get("approved", 0))
+m[3].metric("❌ Rejected", stats["by_status"].get("rejected", 0))
+
+# --- sidebar: filters + bulk + export ---
+sb = st.sidebar
+sb.header("Filters")
+gap_opts = sorted({_gap(p) for p in merged})
+sig_opts = sorted({_signal(p) for p in merged})
+f_status = sb.multiselect("Status", list(rs.STATUSES), default=list(rs.STATUSES))
+f_gap = sb.multiselect("Gap type", gap_opts, default=gap_opts)
+f_sig = sb.multiselect("Detection signal", sig_opts, default=sig_opts)
+f_conf = sb.slider("Min confidence", 0.0, 1.0, 0.0, 0.05)
+f_query = sb.text_input("🔎 Asset contains")
+
+sb.divider()
+sb.subheader("Bulk action")
+bulk_thresh = sb.slider("Approve pending with confidence ≥", 0.0, 1.0, 0.9, 0.05)
+if sb.button("Apply bulk approve", use_container_width=True):
+    n = rs.bulk_approve(proposals, bulk_thresh)
+    sb.success(f"Approved {n} pending proposal(s).")
+    st.rerun()
+
+sb.divider()
+if sb.button("⬇ Export approved", type="primary", use_container_width=True):
+    n = rs.export_approved(proposals, reviews)
+    sb.success(f"Exported {n} approved → {os.path.basename(rs.DEFAULT_APPROVED_PATH)}")
+
+
+def _visible(p):
+    return (p["status"] in f_status
+            and _gap(p) in f_gap
+            and _signal(p) in f_sig
+            and _conf(p) >= f_conf
+            and f_query.lower() in _asset_name(p).lower())
+
+
+filtered = [p for p in merged if _visible(p)]
+
+tab_review, tab_analytics = st.tabs(["Review", "Analytics"])
+
+with tab_review:
+    st.caption(f"{len(filtered)} of {len(merged)} proposals match filters")
+    for p in filtered[:MAX_CARDS]:
+        gap = _gap(p)
+        pe = p.get("proposed_enrichment") or {}
+        ev = p.get("evidence") or {}
+        with st.container(border=True):
+            head = st.columns([4, 1])
+            with head[0]:
+                st.markdown(
+                    _badge(gap, GAP_COLORS.get(gap, "#555")) + " "
+                    + _badge(_signal(p), "#374151")
+                    + f" &nbsp; <b>{(p.get('target_asset') or {}).get('type', '?')}</b> "
+                    + f"· <code>{_asset_name(p)}</code>",
+                    unsafe_allow_html=True,
+                )
+                st.markdown(f"**Fix →** `{pe.get('action', '?')}`: {pe.get('value', '')}")
+                if p.get("current_context_flaw"):
+                    st.caption(f"Flaw: {p['current_context_flaw']}")
+            with head[1]:
+                st.metric("confidence", f"{_conf(p):.2f}")
+                st.progress(min(max(_conf(p), 0.0), 1.0))
+            with st.expander("Evidence"):
+                st.write(ev.get("reasoning", ""))
+                if ev.get("trajectory_quote"):
+                    st.code(ev["trajectory_quote"])
+            with st.expander("Enrichment instruction"):
+                st.write(p.get("enrichment_agent_instruction", ""))
+                golden_sql = (p.get("eval_candidate") or {}).get("golden_sql")
+                if golden_sql:
+                    st.code(golden_sql, language="sql")
+            act = st.columns([1, 1, 4])
+            if act[0].button("✅ Approve", key=f"a_{p['id']}", use_container_width=True):
+                rs.save_review(p["id"], "approved")
+                st.rerun()
+            if act[1].button("❌ Reject", key=f"r_{p['id']}", use_container_width=True):
+                rs.save_review(p["id"], "rejected")
+                st.rerun()
+            act[2].markdown(f"status: **{STATUS_BADGE.get(p['status'], p['status'])}**"
+                            + (f" — _{p['review_note']}_" if p.get("review_note") else ""))
+    if len(filtered) > MAX_CARDS:
+        st.info(f"Showing the first {MAX_CARDS} of {len(filtered)}. "
+                f"Refine filters or bulk-approve to narrow the queue.")
+
+with tab_analytics:
+    st.subheader("By status")
+    st.bar_chart(pd.Series(stats["by_status"], name="count"))
+    st.subheader("By gap type")
+    st.bar_chart(pd.Series(stats["by_gap_type"], name="count"))
+    st.subheader("By confidence band")
+    st.bar_chart(pd.Series(stats["by_confidence_band"], name="count"))

--- a/agents/conversation_learner/review_store.py
+++ b/agents/conversation_learner/review_store.py
@@ -1,0 +1,151 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""File-backed human review state for ConversationLearner proposals (HITL demo).
+
+Pure logic with no UI dependency (review_app.py is the Streamlit front-end), so
+it is unit-testable. Fully local: reads ``proposal.json``, persists decisions to
+``reviews.json`` keyed by the stable proposal id, and exports the approved subset
+to ``approved_proposals.json`` as the hand-off to the Enrichment Agent.
+
+Review state is keyed by the proposal id (not array position), so re-running the
+agent and regenerating ``proposal.json`` never clobbers existing decisions.
+"""
+
+import json
+import os
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+# Share the agent's exact id definition without importing its GCP/ADK runtime.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+from proposal_id import _proposal_id  # noqa: E402
+
+DEFAULT_PROPOSALS_PATH = os.path.join(_HERE, "proposal.json")
+DEFAULT_REVIEWS_PATH = os.path.join(_HERE, "reviews.json")
+DEFAULT_APPROVED_PATH = os.path.join(_HERE, "approved_proposals.json")
+
+STATUSES = ("pending", "approved", "rejected")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_json(path: str, data: Any) -> None:
+    """Atomic write so a crash mid-save can't corrupt the review state."""
+    tmp = f"{path}.tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
+
+
+def load_proposals(path: str = DEFAULT_PROPOSALS_PATH) -> List[Dict[str, Any]]:
+    """Loads proposals, ensuring each has a stable ``id`` (computed if absent).
+
+    Works whether ``proposal.json`` was generated with or without ``include_ids``
+    — a missing id is filled with the same value the agent would have produced.
+    """
+    with open(path) as f:
+        data = json.load(f)
+    proposals = data["proposals"] if isinstance(data, dict) else data
+    for p in proposals:
+        if not p.get("id"):
+            p["id"] = _proposal_id(p)
+    return proposals
+
+
+def load_reviews(path: str = DEFAULT_REVIEWS_PATH) -> Dict[str, Dict[str, Any]]:
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_review(proposal_id: str, status: str, note: str = "",
+                path: str = DEFAULT_REVIEWS_PATH) -> Dict[str, Dict[str, Any]]:
+    """Records one decision, merged by id (other entries untouched)."""
+    if status not in STATUSES:
+        raise ValueError(f"invalid status {status!r}; expected one of {STATUSES}")
+    reviews = load_reviews(path)
+    reviews[proposal_id] = {"status": status, "note": note, "reviewed_at": _now()}
+    _write_json(path, reviews)
+    return reviews
+
+
+def merge(proposals: List[Dict[str, Any]],
+          reviews: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Annotates each proposal with its current ``status`` and ``review_note``."""
+    merged = []
+    for p in proposals:
+        r = reviews.get(p["id"], {})
+        merged.append({**p, "status": r.get("status", "pending"),
+                       "review_note": r.get("note", "")})
+    return merged
+
+
+def bulk_approve(proposals: List[Dict[str, Any]], min_confidence: float,
+                 path: str = DEFAULT_REVIEWS_PATH) -> int:
+    """Approves every currently-pending proposal with confidence >= threshold.
+
+    Already-reviewed proposals (approved or rejected) are left as-is. Returns the
+    number newly approved.
+    """
+    reviews = load_reviews(path)
+    n = 0
+    for p in proposals:
+        if reviews.get(p["id"], {}).get("status", "pending") != "pending":
+            continue
+        if (p.get("confidence_grade") or 0) >= min_confidence:
+            reviews[p["id"]] = {"status": "approved",
+                                "note": f"bulk approve (confidence >= {min_confidence})",
+                                "reviewed_at": _now()}
+            n += 1
+    if n:
+        _write_json(path, reviews)
+    return n
+
+
+def export_approved(proposals: List[Dict[str, Any]], reviews: Dict[str, Dict[str, Any]],
+                    path: str = DEFAULT_APPROVED_PATH) -> int:
+    """Writes the approved subset (the Enrichment Agent hand-off). Returns count."""
+    approved = [p for p in proposals
+                if reviews.get(p["id"], {}).get("status") == "approved"]
+    _write_json(path, {"proposals": approved})
+    return len(approved)
+
+
+def _confidence_band(c: float) -> str:
+    c = c or 0
+    if c >= 0.8:
+        return "high (>=0.8)"
+    if c >= 0.5:
+        return "medium (0.5-0.8)"
+    return "low (<0.5)"
+
+
+def summary(merged: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate counts for the analytics view; operates on merge() output."""
+    return {
+        "total": len(merged),
+        "by_status": dict(Counter(p.get("status", "pending") for p in merged)),
+        "by_gap_type": dict(Counter((p.get("classification") or {}).get("gap_type", "?")
+                                    for p in merged)),
+        "by_confidence_band": dict(Counter(_confidence_band(p.get("confidence_grade"))
+                                           for p in merged)),
+    }

--- a/agents/conversation_learner/tests/test_review_store.py
+++ b/agents/conversation_learner/tests/test_review_store.py
@@ -1,0 +1,141 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for review_store (HITL review state). No GCP deps required."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+# Add agents/ so `conversation_learner` is importable as a package.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from conversation_learner import review_store as rs  # noqa: E402
+
+
+def _proposal(name="ds.t.col", gap="BUSINESS_LOGIC_GAP", atype="COLUMN", conf=0.9, pid=None):
+    p = {
+        "classification": {"detection_signal": "DIRECT_USER_CORRECTION", "gap_type": gap},
+        "target_asset": {"type": atype, "name": name},
+        "proposed_enrichment": {"action": "UPDATE_OVERVIEW_ASPECT", "value": "v"},
+        "confidence_grade": conf,
+        "enrichment_agent_instruction": "do X",
+    }
+    if pid:
+        p["id"] = pid
+    return p
+
+
+class TestReviewStore(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.proposals_path = os.path.join(self.tmp, "proposal.json")
+        self.reviews_path = os.path.join(self.tmp, "reviews.json")
+        self.approved_path = os.path.join(self.tmp, "approved.json")
+
+    def _dump(self, proposals):
+        with open(self.proposals_path, "w") as f:
+            json.dump({"proposals": proposals}, f)
+
+    # --- load_proposals ---
+
+    def test_load_computes_id_when_missing(self):
+        self._dump([_proposal()])
+        ps = rs.load_proposals(self.proposals_path)
+        self.assertTrue(ps[0]["id"].startswith("prop_"))
+
+    def test_load_keeps_existing_id(self):
+        self._dump([_proposal(pid="prop_custom")])
+        self.assertEqual(rs.load_proposals(self.proposals_path)[0]["id"], "prop_custom")
+
+    def test_load_accepts_bare_list(self):
+        with open(self.proposals_path, "w") as f:
+            json.dump([_proposal()], f)
+        self.assertEqual(len(rs.load_proposals(self.proposals_path)), 1)
+
+    # --- reviews persistence (merge by id) ---
+
+    def test_save_review_merges_by_id(self):
+        rs.save_review("prop_a", "approved", path=self.reviews_path)
+        rs.save_review("prop_b", "rejected", "bad", path=self.reviews_path)
+        reviews = rs.load_reviews(self.reviews_path)
+        self.assertEqual(reviews["prop_a"]["status"], "approved")
+        self.assertEqual(reviews["prop_b"]["status"], "rejected")
+        self.assertEqual(reviews["prop_b"]["note"], "bad")
+        self.assertIn("reviewed_at", reviews["prop_a"])
+
+    def test_save_review_rejects_invalid_status(self):
+        with self.assertRaises(ValueError):
+            rs.save_review("prop_a", "maybe", path=self.reviews_path)
+
+    def test_load_reviews_missing_file(self):
+        self.assertEqual(rs.load_reviews(self.reviews_path), {})
+
+    # --- merge ---
+
+    def test_merge_defaults_to_pending(self):
+        ps = [_proposal(pid="prop_a"), _proposal(name="ds.t.b", pid="prop_b")]
+        merged = {m["id"]: m for m in rs.merge(ps, {"prop_a": {"status": "approved"}})}
+        self.assertEqual(merged["prop_a"]["status"], "approved")
+        self.assertEqual(merged["prop_b"]["status"], "pending")
+
+    # --- bulk_approve ---
+
+    def test_bulk_approve_threshold_and_skips_reviewed(self):
+        self._dump([
+            _proposal(pid="p_hi", conf=0.95),
+            _proposal(name="ds.t.lo", pid="p_lo", conf=0.4),
+            _proposal(name="ds.t.rej", pid="p_rej", conf=0.99),
+        ])
+        ps = rs.load_proposals(self.proposals_path)
+        rs.save_review("p_rej", "rejected", path=self.reviews_path)  # already reviewed
+        n = rs.bulk_approve(ps, 0.8, path=self.reviews_path)
+        self.assertEqual(n, 1)  # only p_hi (p_lo below threshold, p_rej already reviewed)
+        reviews = rs.load_reviews(self.reviews_path)
+        self.assertEqual(reviews["p_hi"]["status"], "approved")
+        self.assertNotIn("p_lo", reviews)
+        self.assertEqual(reviews["p_rej"]["status"], "rejected")  # untouched
+
+    # --- export_approved ---
+
+    def test_export_approved_only(self):
+        ps = [_proposal(pid="p_a"), _proposal(name="ds.t.b", pid="p_b")]
+        n = rs.export_approved(ps, {"p_a": {"status": "approved"}, "p_b": {"status": "rejected"}},
+                               path=self.approved_path)
+        self.assertEqual(n, 1)
+        with open(self.approved_path) as f:
+            out = json.load(f)
+        self.assertEqual([p["id"] for p in out["proposals"]], ["p_a"])
+
+    # --- summary ---
+
+    def test_summary_counts(self):
+        merged = rs.merge(
+            [_proposal(pid="p_a", conf=0.9),
+             _proposal(name="ds.t.b", gap="STRUCTURAL_ROUTING_GAP", pid="p_b", conf=0.4)],
+            {"p_a": {"status": "approved"}},
+        )
+        s = rs.summary(merged)
+        self.assertEqual(s["total"], 2)
+        self.assertEqual(s["by_status"], {"approved": 1, "pending": 1})
+        self.assertEqual(s["by_gap_type"]["BUSINESS_LOGIC_GAP"], 1)
+        self.assertEqual(s["by_confidence_band"]["high (>=0.8)"], 1)
+        self.assertEqual(s["by_confidence_band"]["low (<0.5)"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
A fully-local **human-in-the-loop review** step for ConversationLearner proposals: a reviewer approves/rejects in a Streamlit UI before the Enrichment Agent acts. Built for the open-source demo — zero cloud dependency.

## Flow
`generate_learnings` → `streamlit run review_app.py` (filter, approve/reject, bulk-approve) → Export → `approved_proposals.json` (Enrichment Agent hand-off).

## Components
- **`review_app.py`** — Streamlit UI: live metrics, sidebar filters (status / gap type / detection signal / confidence / asset), color-coded proposal cards with confidence bars + evidence/instruction expanders, per-card approve/reject, **bulk-approve by confidence**, an **Analytics** tab (charts by status / gap type / confidence band), and **Export approved**.
- **`review_store.py`** — pure, UI-free, unit-tested logic. Review state persists to `reviews.json` **keyed by the stable proposal `id`**, so re-running the agent never clobbers decisions. Approved subset → `approved_proposals.json`.
- **`proposal_id.py`** — the proposal identity/id logic extracted into a **stdlib-only** module shared by `agent.py` and the UI, so the review tool requires neither `google-adk` nor `GOOGLE_CLOUD_PROJECT`. `agent.py` re-exports it (existing callers/tests unchanged).
- **`requirements-review.txt`** — `streamlit` only, **separate from `requirements.txt`** so it never bundles into the deployed Agent Engine runtime.

## Out of scope (documented as "Productionizing" in the README)
Transactional store, multi-user / RBAC / audit, BigQuery dashboards, content-drift re-review. The demo keeps review state in local JSON.

## Tests
92 passing (82 agent + 10 review_store). The app boots and the approve loop persists, verified via `streamlit.testing.v1.AppTest`.
