### PR TITLE
docs: add Ecosystem / Adopters section with CATAAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This repository features tools, agents, and samples that demonstrate Knowledge C
 [![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fknowledge-catalog.git)
 
 
+## Ecosystem / Adopters
+
+Projects and products that produce or consume OKF bundles. To add yours, open a PR.
+
+- **[CATAAM](https://cataam.com)** — GRC and security platform. Its OKF Context Engine
+  compiles an organization's compliance graph — framework requirements, controls,
+  discovered cloud assets, automated tests, and iASM/ASM findings — into signed OKF
+  bundles that AI agents (via the Model Context Protocol) and auditors consume as a
+  portable, vendor-neutral view of compliance posture.
+
+
 ## Contributing
 
 See the contributing [instructions](CONTRIBUTING.md) to get started contributed.


### PR DESCRIPTION
Adds an "Ecosystem / Adopters" section to track projects producing or consuming OKF
bundles, seeded with CATAAM. CATAAM's OKF Context Engine serialises an org's compliance
graph (requirements, controls, assets, tests, findings) into signed OKF bundles delivered
to a customer Git repo or as downloadable exports, consumed by AI agents via MCP and by
auditors.

Happy to move this to a dedicated ADOPTERS.md if maintainers prefer.

What I committed

README.md — a new ## Ecosystem / Adopters section (placed after Getting Started, before Contributing) with the CATAAM entry:

▎ CATAAM (https://cataam.com) — GRC and security platform. Its OKF Context Engine compiles an organization's compliance graph … into signed OKF bundles that AI agents (via MCP) and auditors consume…