### PR TITLE
ConversationLearner: add non-interactive CLI entrypoint

### DIFF
--- a/agents/conversation_learner/README.md
+++ b/agents/conversation_learner/README.md
@@ -46,6 +46,48 @@ The agent will print the number of log entries retrieved, the unique conversatio
 
 To attach a deterministic, run-stable `id` to each saved proposal, ask for them — e.g. append `with proposal ids` to your prompt. The id is derived from the proposal's identity (asset type + asset name + gap type), so the same gap on the same asset yields the same id across runs. The (volatile) proposed wording is ignored, and the asset name is canonicalized so an optional `project.` prefix doesn't produce two different ids.
 
+### Running via CLI (non-interactive)
+
+For scripted/automated runs (cron, CI, pipelines) the agent ships a flag-based
+CLI that does the same work without the interactive REPL. It writes the same
+`proposal.json` (consumed by the review UI below). It supports two input styles.
+
+**Deterministic flags** — call the analysis directly (no LLM front-end), so it is
+fast and reproducible:
+
+```bash
+export GOOGLE_CLOUD_PROJECT="your-project-id"
+
+# From the agents/ directory:
+python -m conversation_learner \
+  --reasoning_engine_id projects/<project-number>/locations/us-central1/reasoningEngines/<engine-id> \
+  --days_ago 7 --include_ids
+
+# Or by a single conversation id:
+python -m conversation_learner --conversation_id <conversation-id>
+
+# Or run the script directly (works from any directory):
+python conversation_learner/cli.py --reasoning_engine_id <id> --days_ago 7
+```
+
+**Natural language (`--prompt`)** — routes the request through the LLM agent once
+(same parsing as `adk run`, but one-shot):
+
+```bash
+python -m conversation_learner \
+  --prompt "generate learnings for projects/<n>/locations/us-central1/reasoningEngines/<id> in the past 7 days with proposal ids"
+```
+
+Use `--output <path>` to write proposals somewhere other than `./proposal.json`
+(a directory is allowed — `proposal.json` is created inside it). Run
+`python -m conversation_learner --help` for the full flag list.
+
+Key flags: `--conversation_id`, `--reasoning_engine_id` (bare id or full resource
+path), `--days_ago`, `--start_time` / `--end_time` (ISO 8601), `--include_ids`,
+`--project` (default `$GOOGLE_CLOUD_PROJECT`), `--location`, `--output`. Provide
+either `--conversation_id`, or `--reasoning_engine_id` with one of `--days_ago` /
+`--start_time` (or use `--prompt`). The same ADC auth as `adk run` applies.
+
 > **Note on Observability**: The agent retrieves conversations from Cloud Logging using OpenTelemetry trace logs (`gen_ai.client.inference.operation.details`). These logs are only emitted for sessions that ran while **Observability was enabled** on the Reasoning Engine. Sessions started before Observability was activated will not appear.
 
 ## Reviewing proposals (human-in-the-loop)

--- a/agents/conversation_learner/__main__.py
+++ b/agents/conversation_learner/__main__.py
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Enables `python -m conversation_learner ...` (run from the agents/ directory)."""
+
+import sys
+
+from conversation_learner.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/conversation_learner/agent.py
+++ b/agents/conversation_learner/agent.py
@@ -430,7 +430,22 @@ def _redact_obj(obj):
     return obj
 
 
-def save_trajectory_analysis_result(result_json: str) -> str:
+# Where save_trajectory_analysis_result writes when no explicit path is given.
+# The CLI overrides this via set_default_output_path() so that BOTH the direct
+# generate_learnings() call and the LLM-driven tool call (which never passes a
+# path) honor --output. Defaults to "proposal.json" in the current directory,
+# matching the original `adk run` behavior.
+_DEFAULT_OUTPUT_PATH = "proposal.json"
+
+
+def set_default_output_path(path: str) -> None:
+    """Sets the default file path for saved proposals (process-wide)."""
+    global _DEFAULT_OUTPUT_PATH
+    if path:
+        _DEFAULT_OUTPUT_PATH = path
+
+
+def save_trajectory_analysis_result(result_json: str, output_path: Optional[str] = None) -> str:
     """
     Saves the final trajectory analysis result to a local file.
     Must be called to conclude the analysis.
@@ -467,9 +482,15 @@ def save_trajectory_analysis_result(result_json: str) -> str:
                 }
               ]
             }
+        output_path: Optional file path to write to. Defaults to
+            _DEFAULT_OUTPUT_PATH ("proposal.json" in the current directory unless
+            overridden by set_default_output_path()).
     """
     import re
-    filename = "proposal.json"
+    filename = output_path or _DEFAULT_OUTPUT_PATH
+    out_dir = os.path.dirname(filename)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
     try:
         parsed = json.loads(result_json)
     except json.JSONDecodeError:

--- a/agents/conversation_learner/cli.py
+++ b/agents/conversation_learner/cli.py
@@ -1,0 +1,239 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Non-interactive CLI for ConversationLearner.
+
+This is a scriptable entrypoint alongside the interactive ``adk run .`` REPL and
+the Agent Engine deployment (``deploy.py``). It supports two ways to drive the
+agent:
+
+* **Deterministic flags** (``--reasoning_engine_id`` / ``--conversation_id`` +
+  a time window) call :func:`agent.generate_learnings` directly — no LLM in the
+  loop, so it's fast and reproducible (good for cron/CI).
+* **``--prompt``** routes a natural-language request through the ADK
+  ``root_agent`` exactly once (the LLM extracts the parameters), mirroring
+  ``adk run`` non-interactively.
+
+Both paths fetch trajectories from Cloud Logging, run the per-conversation
+LLM-as-judge, dedup, and write ``proposal.json`` (location controlled by
+``--output``).
+
+Usage::
+
+    # From the agents/ directory:
+    python -m conversation_learner --reasoning_engine_id <id> --days_ago 7
+    # Or as a script from anywhere:
+    python conversation_learner/cli.py --conversation_id <id> --include_ids
+    python conversation_learner/cli.py --prompt "generate learnings for <re> in the past 7 days"
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+
+_APP_NAME = "conversation_learner"
+_USER_ID = "cli"
+
+# Summary prefixes generate_learnings returns on failure (it catches errors and
+# returns a message rather than raising). Used to set a non-zero exit code.
+_ERROR_PREFIXES = (
+    "API Error",
+    "An unexpected error occurred",
+    "Either conversation_id",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Builds the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="conversation_learner",
+        description=(
+            "Analyze agent conversation trajectories and write enrichment "
+            "proposals to proposal.json. Use deterministic flags, or --prompt "
+            "for a natural-language request routed through the LLM."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  python -m conversation_learner "
+            "--reasoning_engine_id projects/p/locations/l/reasoningEngines/123 "
+            "--days_ago 7 --include_ids\n"
+            "  python -m conversation_learner --conversation_id abc123\n"
+            "  python -m conversation_learner "
+            '--prompt "generate learnings for ...reasoningEngines/123 in the past 7 days"\n'
+        ),
+    )
+
+    # Natural-language mode.
+    parser.add_argument(
+        "--prompt",
+        help=(
+            "Natural-language request routed through the ADK agent (the LLM "
+            "extracts parameters). Mutually exclusive with the selector flags "
+            "below."
+        ),
+    )
+
+    # Deterministic selector flags.
+    parser.add_argument("--conversation_id", help="A single conversation id to analyze.")
+    parser.add_argument(
+        "--reasoning_engine_id",
+        help="Reasoning Engine id or full resource path to analyze.",
+    )
+    parser.add_argument(
+        "--days_ago", type=int, help="Look-back window in days (with --reasoning_engine_id)."
+    )
+    parser.add_argument("--start_time", help="ISO 8601 start of an explicit time window.")
+    parser.add_argument("--end_time", help="ISO 8601 end of an explicit time window.")
+    parser.add_argument(
+        "--include_ids",
+        action="store_true",
+        help="Attach a deterministic, run-stable id to each saved proposal.",
+    )
+
+    # Common config.
+    parser.add_argument(
+        "--project",
+        help="Google Cloud project (default: $GOOGLE_CLOUD_PROJECT).",
+    )
+    parser.add_argument(
+        "--location",
+        help="Vertex AI location (sets $GOOGLE_CLOUD_LOCATION; default: leave unchanged).",
+    )
+    parser.add_argument(
+        "--output",
+        help=(
+            "Where to write proposals (default: ./proposal.json). A directory is "
+            "allowed; proposal.json is written inside it."
+        ),
+    )
+    return parser
+
+
+def _resolve_output(raw: str | None) -> str:
+    """Resolves --output to a file path (writing into a directory if one is given)."""
+    if not raw:
+        return "proposal.json"
+    if raw.endswith(os.sep) or os.path.isdir(raw):
+        return os.path.join(raw, "proposal.json")
+    return raw
+
+
+def _ensure_package_importable() -> None:
+    """Puts agents/ (the package parent) on sys.path so `conversation_learner` imports."""
+    pkg_parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if pkg_parent not in sys.path:
+        sys.path.insert(0, pkg_parent)
+
+
+def _run_flags(args: argparse.Namespace) -> str:
+    """Deterministic path: call generate_learnings() directly."""
+    from conversation_learner import agent
+
+    return asyncio.run(
+        agent.generate_learnings(
+            conversation_id=args.conversation_id,
+            reasoning_engine_id=args.reasoning_engine_id,
+            days_ago=args.days_ago,
+            start_time=args.start_time,
+            end_time=args.end_time,
+            project_id=args.project,
+            include_ids=args.include_ids,
+        )
+    )
+
+
+async def _aprompt(prompt: str) -> str:
+    """Drives the ADK root_agent once and returns its final text response."""
+    from conversation_learner.agent import root_agent
+    from google.adk.runners import InMemoryRunner
+    from google.genai import types
+
+    runner = InMemoryRunner(agent=root_agent, app_name=_APP_NAME)
+    session = await runner.session_service.create_session(
+        app_name=_APP_NAME, user_id=_USER_ID
+    )
+    final = ""
+    async for event in runner.run_async(
+        user_id=_USER_ID,
+        session_id=session.id,
+        new_message=types.Content(role="user", parts=[types.Part(text=prompt)]),
+    ):
+        if event.is_final_response() and event.content and event.content.parts:
+            final = "".join(part.text or "" for part in event.content.parts)
+    return final
+
+
+def _run_prompt(prompt: str) -> str:
+    """Natural-language path: route the prompt through the LLM agent (one-shot)."""
+    return asyncio.run(_aprompt(prompt))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint. Returns a process exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    has_selector = (
+        any([args.conversation_id, args.reasoning_engine_id, args.start_time, args.end_time])
+        or args.days_ago is not None
+        or args.include_ids
+    )
+
+    # --- Validate the selected mode before touching env or importing the agent.
+    if args.prompt:
+        if has_selector:
+            parser.error(
+                "--prompt cannot be combined with --conversation_id / "
+                "--reasoning_engine_id / --days_ago / --start_time / --end_time / "
+                "--include_ids (they are extracted from the prompt instead)."
+            )
+    elif not (
+        args.conversation_id
+        or (args.reasoning_engine_id and (args.days_ago is not None or args.start_time))
+    ):
+        parser.error(
+            "provide --conversation_id, or --reasoning_engine_id with one of "
+            "--days_ago / --start_time (or use --prompt)."
+        )
+
+    # --- Resolve project and set Vertex env BEFORE importing the agent: agent.py
+    # reads GOOGLE_CLOUD_PROJECT at import time to build consumer_project /
+    # GEMINI_MODEL, and the judge client uses them.
+    project = args.project or os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if not project:
+        parser.error("--project is required (pass --project or set GOOGLE_CLOUD_PROJECT).")
+    args.project = project
+    os.environ["GOOGLE_CLOUD_PROJECT"] = project
+    if args.location:
+        os.environ["GOOGLE_CLOUD_LOCATION"] = args.location
+    os.environ.setdefault("GOOGLE_GENAI_USE_VERTEXAI", "True")
+
+    _ensure_package_importable()
+    from conversation_learner import agent
+
+    agent.set_default_output_path(_resolve_output(args.output))
+
+    if args.prompt:
+        summary = _run_prompt(args.prompt)
+    else:
+        summary = _run_flags(args)
+
+    print(summary)
+    return 1 if summary.startswith(_ERROR_PREFIXES) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/conversation_learner/tests/test_agent.py
+++ b/agents/conversation_learner/tests/test_agent.py
@@ -45,6 +45,7 @@ from conversation_learner.agent import (  # noqa: E402
     generate_learnings,
     get_agent_trajectories,
     save_trajectory_analysis_result,
+    set_default_output_path,
 )
 
 
@@ -891,6 +892,38 @@ class TestGenerateLearnings(unittest.TestCase):
     def test_no_ids_by_default(self, mock_logging, mock_judge):
         proposals = self._run_one(mock_logging, mock_judge, include_ids=False)
         self.assertTrue(proposals and all("id" not in p for p in proposals))
+
+
+# ---------------------------------------------------------------------------
+# Output path control (set_default_output_path + save output_path arg)
+# ---------------------------------------------------------------------------
+
+class TestOutputPath(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.orig_dir = os.getcwd()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+        set_default_output_path("proposal.json")  # restore the module default
+
+    def test_explicit_output_path_creates_parent_dirs(self):
+        target = os.path.join(self.tmpdir, "nested", "out.json")
+        save_trajectory_analysis_result(json.dumps({"proposals": []}), target)
+        self.assertTrue(os.path.exists(target))
+
+    def test_set_default_output_path_redirects_save(self):
+        set_default_output_path(os.path.join(self.tmpdir, "custom.json"))
+        save_trajectory_analysis_result(json.dumps({"proposals": []}))
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "custom.json")))
+        self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "proposal.json")))
+
+    def test_set_default_output_path_ignores_empty(self):
+        set_default_output_path("")  # no-op — keeps the existing default
+        save_trajectory_analysis_result(json.dumps({"proposals": []}))
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "proposal.json")))
 
 
 if __name__ == "__main__":

--- a/agents/conversation_learner/tests/test_cli.py
+++ b/agents/conversation_learner/tests/test_cli.py
@@ -1,0 +1,210 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ConversationLearner CLI."""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Required before importing the agent — get_consumer_project() reads this at module level.
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")
+
+# Add agents/ to sys.path so `conversation_learner` is importable as a package.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from conversation_learner import cli  # noqa: E402
+
+_RE = "projects/p/locations/l/reasoningEngines/123"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_output
+# ---------------------------------------------------------------------------
+
+class TestResolveOutput(unittest.TestCase):
+
+    def test_none_defaults_to_proposal_json(self):
+        self.assertEqual(cli._resolve_output(None), "proposal.json")
+
+    def test_empty_defaults_to_proposal_json(self):
+        self.assertEqual(cli._resolve_output(""), "proposal.json")
+
+    def test_file_path_passed_through(self):
+        self.assertEqual(cli._resolve_output("/a/b/out.json"), "/a/b/out.json")
+
+    def test_existing_directory_gets_proposal_json_appended(self):
+        d = tempfile.mkdtemp()
+        self.assertEqual(cli._resolve_output(d), os.path.join(d, "proposal.json"))
+
+    def test_trailing_sep_treated_as_directory(self):
+        raw = "some_dir" + os.sep
+        self.assertEqual(cli._resolve_output(raw), os.path.join("some_dir", "proposal.json"))
+
+
+# ---------------------------------------------------------------------------
+# Flags mode — dispatch to generate_learnings
+# ---------------------------------------------------------------------------
+
+class TestFlagsDispatch(unittest.TestCase):
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_reasoning_engine_and_days_forwarded(self, mock_gen):
+        mock_gen.return_value = "Total log entries retrieved: 3. Unique conversations: 1."
+        rc = cli.main(["--reasoning_engine_id", _RE, "--days_ago", "7", "--project", "test-project"])
+        self.assertEqual(rc, 0)
+        mock_gen.assert_called_once_with(
+            conversation_id=None,
+            reasoning_engine_id=_RE,
+            days_ago=7,
+            start_time=None,
+            end_time=None,
+            project_id="test-project",
+            include_ids=False,
+        )
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_conversation_id_forwarded(self, mock_gen):
+        mock_gen.return_value = "ok"
+        cli.main(["--conversation_id", "abc123", "--project", "test-project"])
+        kwargs = mock_gen.call_args.kwargs
+        self.assertEqual(kwargs["conversation_id"], "abc123")
+        self.assertIsNone(kwargs["reasoning_engine_id"])
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_include_ids_flag(self, mock_gen):
+        mock_gen.return_value = "ok"
+        cli.main(["--conversation_id", "abc", "--include_ids", "--project", "test-project"])
+        self.assertTrue(mock_gen.call_args.kwargs["include_ids"])
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_start_and_end_time_forwarded(self, mock_gen):
+        mock_gen.return_value = "ok"
+        cli.main([
+            "--reasoning_engine_id", _RE,
+            "--start_time", "2026-06-01T00:00:00Z",
+            "--end_time", "2026-06-17T00:00:00Z",
+            "--project", "test-project",
+        ])
+        kwargs = mock_gen.call_args.kwargs
+        self.assertEqual(kwargs["start_time"], "2026-06-01T00:00:00Z")
+        self.assertEqual(kwargs["end_time"], "2026-06-17T00:00:00Z")
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_error_summary_returns_nonzero(self, mock_gen):
+        mock_gen.return_value = "API Error: boom"
+        rc = cli.main(["--conversation_id", "abc", "--project", "test-project"])
+        self.assertEqual(rc, 1)
+
+
+# ---------------------------------------------------------------------------
+# Prompt mode — dispatch to the ADK agent
+# ---------------------------------------------------------------------------
+
+class TestPromptDispatch(unittest.TestCase):
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    @patch("conversation_learner.cli._run_prompt", return_value="done")
+    def test_prompt_routes_to_run_prompt(self, mock_prompt, mock_gen):
+        rc = cli.main(["--prompt", "generate learnings for X in the past 7 days", "--project", "test-project"])
+        self.assertEqual(rc, 0)
+        mock_prompt.assert_called_once_with("generate learnings for X in the past 7 days")
+        mock_gen.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class TestValidation(unittest.TestCase):
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_no_selectors_exits_2(self, mock_gen):
+        with self.assertRaises(SystemExit) as cm:
+            cli.main([])
+        self.assertEqual(cm.exception.code, 2)
+        mock_gen.assert_not_called()
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_reasoning_engine_without_window_exits_2(self, mock_gen):
+        with self.assertRaises(SystemExit) as cm:
+            cli.main(["--reasoning_engine_id", _RE, "--project", "test-project"])
+        self.assertEqual(cm.exception.code, 2)
+        mock_gen.assert_not_called()
+
+    @patch("conversation_learner.cli._run_prompt", return_value="x")
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_prompt_with_selector_exits_2(self, mock_gen, mock_prompt):
+        with self.assertRaises(SystemExit) as cm:
+            cli.main(["--prompt", "x", "--days_ago", "7", "--project", "test-project"])
+        self.assertEqual(cm.exception.code, 2)
+        mock_prompt.assert_not_called()
+        mock_gen.assert_not_called()
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_missing_project_exits_2(self, mock_gen):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GOOGLE_CLOUD_PROJECT", None)
+            with self.assertRaises(SystemExit) as cm:
+                cli.main(["--conversation_id", "abc"])
+            self.assertEqual(cm.exception.code, 2)
+        mock_gen.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Environment + output wiring
+# ---------------------------------------------------------------------------
+
+class TestEnvAndOutput(unittest.TestCase):
+
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_project_and_location_set_in_env(self, mock_gen):
+        mock_gen.return_value = "ok"
+        with patch.dict(os.environ, {}, clear=False):
+            cli.main([
+                "--conversation_id", "abc",
+                "--project", "my-proj",
+                "--location", "us-central1",
+            ])
+            self.assertEqual(os.environ["GOOGLE_CLOUD_PROJECT"], "my-proj")
+            self.assertEqual(os.environ["GOOGLE_CLOUD_LOCATION"], "us-central1")
+        self.assertEqual(mock_gen.call_args.kwargs["project_id"], "my-proj")
+
+    @patch("conversation_learner.agent.set_default_output_path")
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_output_file_path_sets_default(self, mock_gen, mock_set):
+        mock_gen.return_value = "ok"
+        cli.main(["--conversation_id", "abc", "--project", "test-project", "--output", "/tmp/out.json"])
+        mock_set.assert_called_once_with("/tmp/out.json")
+
+    @patch("conversation_learner.agent.set_default_output_path")
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_output_directory_appends_proposal_json(self, mock_gen, mock_set):
+        mock_gen.return_value = "ok"
+        d = tempfile.mkdtemp()
+        cli.main(["--conversation_id", "abc", "--project", "test-project", "--output", d])
+        mock_set.assert_called_once_with(os.path.join(d, "proposal.json"))
+
+    @patch("conversation_learner.agent.set_default_output_path")
+    @patch("conversation_learner.agent.generate_learnings", new_callable=AsyncMock)
+    def test_output_defaults_to_proposal_json(self, mock_gen, mock_set):
+        mock_gen.return_value = "ok"
+        cli.main(["--conversation_id", "abc", "--project", "test-project"])
+        mock_set.assert_called_once_with("proposal.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds a non-interactive CLI to `agents/conversation_learner`, alongside the existing `adk run` REPL and the Agent Engine deployment (`deploy.py`), so the agent can run from scripts / cron / CI.

Two input styles:

- **Deterministic flags** — `--reasoning_engine_id` / `--conversation_id` + a time window (`--days_ago` or `--start_time`/`--end_time`), plus `--include_ids`. Calls `generate_learnings()` directly (no LLM front-end), so it is fast and reproducible.
- **`--prompt`** — routes a natural-language request through the existing `root_agent` one-shot via ADK `InMemoryRunner` (mirrors `adk run`).

`--output` controls where `proposal.json` is written (a directory is allowed). It works in both modes via a module-level default, so `generate_learnings()`'s ADK tool signature is left unchanged.

## Why

The agent could previously only be driven interactively (`adk run .`) or deployed to Agent Engine. There was no scriptable entrypoint for automation/pipelines.

## Files

- `cli.py` (new) — argparse CLI: `build_parser()`, `_run_flags()`, `_run_prompt()`, `main()`.
- `__main__.py` (new) — enables `python -m conversation_learner`.
- `agent.py` — `set_default_output_path()` + an `output_path` fallback in `save_trajectory_analysis_result` (~6 lines; `generate_learnings` untouched).
- `tests/test_cli.py` (new) + output-path coverage added to `tests/test_agent.py`.
- `README.md` — "Running via CLI (non-interactive)" section.

No new dependencies (`argparse` / `asyncio` are stdlib).

## Usage

```bash
# Deterministic flags (from agents/)
python -m conversation_learner \
  --reasoning_engine_id projects/<project-number>/locations/us-central1/reasoningEngines/<engine-id> \
  --days_ago 20 --include_ids

# Natural language
python -m conversation_learner --prompt "generate learnings for <reasoning-engine> in the past 20 days"
```

## Testing

- `python -m unittest conversation_learner.tests.test_cli conversation_learner.tests.test_agent` — 104 tests pass.
- Verified all three invocation paths (`adk run`, CLI + flags, CLI + `--prompt`) against a live reasoning engine: each exits 0 and writes a valid `proposal.json`.
