### PR TITLE
okf: refocus README title and intro on the format

### DIFF
--- a/okf/README.md
+++ b/okf/README.md
@@ -1,4 +1,4 @@
-# Reference Agent — an OKF proof of concept
+# Open Knowledge Format (OKF)
 
 ### 📖 [Read the Open Knowledge Format v0.1 specification → SPEC.md](SPEC.md)
 
@@ -33,14 +33,6 @@
 >   public dataset ([viz.html](bundles/stackoverflow/viz.html))
 > - [`bundles/crypto_bitcoin/`](bundles/crypto_bitcoin/) — Bitcoin
 >   blocks/transactions ([viz.html](bundles/crypto_bitcoin/viz.html))
-
-A reference agent that ingests metadata from a pluggable source and emits an
-**[OKF](SPEC.md) bundle**: a directory of markdown documents with YAML
-frontmatter that catalog tools, downstream agents, and humans can all read.
-
-Built on the Google [Agent Development Kit](https://adk.dev/) with Gemini as the
-model backend. BigQuery is the first source implementation; the
-`Source` interface is designed to grow.
 
 ## Why OKF?
 


### PR DESCRIPTION
## Summary

- Retitle `okf/README.md` from "Reference Agent — an OKF proof of concept" to "Open Knowledge Format (OKF)" so the doc reads as documentation of the format rather than of the bundled reference agent.
- Drop the two intro paragraphs immediately after the blockquote that described the reference agent ("A reference agent that ingests metadata…" and "Built on the Google Agent Development Kit…"). The blockquote already frames OKF as the contribution and the agent as a proof of concept, so those two paragraphs were redundant and pulled focus back onto the agent.
- No code, no other prose changed.

## Test plan

- [x] `okf/README.md` renders correctly on GitHub (title, blockquote, then straight into `## Why OKF?`).