### PR TITLE
fix(okf): align required frontmatter keys with OKF SPEC §4.1

### DIFF
--- a/okf/src/reference_agent/bundle/document.py
+++ b/okf/src/reference_agent/bundle/document.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import yaml
 
-REQUIRED_FRONTMATTER_KEYS = ("type", "title", "description", "timestamp")
+REQUIRED_FRONTMATTER_KEYS = ("type",)
 
 _FRONTMATTER_DELIM = "---"
 

--- a/okf/tests/test_document.py
+++ b/okf/tests/test_document.py
@@ -43,12 +43,24 @@ def test_unterminated_frontmatter_raises():
         OKFDocument.parse(src)
 
 
-def test_validate_rejects_missing_required_keys():
-    doc = OKFDocument(frontmatter={"type": "X", "title": "Y"})
+def test_validate_rejects_missing_type():
+    """Only 'type' is REQUIRED per OKF §4.1."""
+    doc = OKFDocument(
+        frontmatter={
+            "title": "Y",
+            "description": "Z",
+            "timestamp": "2026-05-27T00:00:00+00:00",
+        }
+    )
     with pytest.raises(OKFDocumentError) as exc:
         doc.validate()
-    assert "description" in str(exc.value)
-    assert "timestamp" in str(exc.value)
+    assert "type" in str(exc.value)
+
+
+def test_validate_accepts_minimal_frontmatter():
+    """Only 'type' is required — all other fields are optional per OKF §4.1."""
+    doc = OKFDocument(frontmatter={"type": "X"})
+    doc.validate()
 
 
 def test_validate_accepts_full_frontmatter():


### PR DESCRIPTION
OKF v0.1 §4.1 explicitly states that only `type` is REQUIRED; `title`,
  `description`, and `timestamp` are listed as Recommended. The reference
  implementation treated all four as REQUIRED, so any spec-minimal bundle
  whose concepts only declared `type` would be incorrectly rejected by
  `OKFDocument.validate()`.

  This hurts programmatic producers in particular — they often have no
  human-readable `title` / `description` available at generation time.