### PR TITLE
fix(okf): exclude reserved log.md from concept enumeration

### DIFF
--- a/okf/src/reference_agent/bundle/index.py
+++ b/okf/src/reference_agent/bundle/index.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Callable
 
 from reference_agent.bundle.document import OKFDocument
+from reference_agent.bundle.paths import RESERVED_FILENAMES
 from reference_agent.bundle.synthesizer import synthesize_description
 
 _INDEX_FILE = "index.md"
@@ -68,7 +69,7 @@ def regenerate_indexes(
         entries: list[tuple[str, str, str, str]] = []
 
         for child in sorted(directory.iterdir()):
-            if child.name == _INDEX_FILE:
+            if child.name in RESERVED_FILENAMES:
                 continue
             if child.is_file() and child.suffix == ".md":
                 doc = _load_doc(child)

--- a/okf/src/reference_agent/bundle/paths.py
+++ b/okf/src/reference_agent/bundle/paths.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+RESERVED_FILENAMES = frozenset({"index.md", "log.md"})
+
 _SEGMENT_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.\-]*")
 
 

--- a/okf/src/reference_agent/viewer/generator.py
+++ b/okf/src/reference_agent/viewer/generator.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any
 
 from reference_agent.bundle.document import OKFDocument, OKFDocumentError
+from reference_agent.bundle.paths import RESERVED_FILENAMES
 
-_INDEX_NAME = "index.md"
 _LINK_RE = re.compile(r"\]\(([^)\s]+\.md)(?:#[A-Za-z0-9_\-]*)?\)")
 _TYPE_PALETTE = {
     "BigQuery Dataset": "#8b5cf6",
@@ -69,7 +69,7 @@ def _extract_links(body: str, doc_dir: Path, bundle_root: Path) -> list[str]:
 def _walk_concepts(bundle_root: Path) -> list[Concept]:
     concepts: list[Concept] = []
     for md_path in sorted(bundle_root.rglob("*.md")):
-        if md_path.name == _INDEX_NAME:
+        if md_path.name in RESERVED_FILENAMES:
             continue
         rel = md_path.relative_to(bundle_root).with_suffix("")
         concept_id = "/".join(rel.parts)

--- a/okf/tests/test_index.py
+++ b/okf/tests/test_index.py
@@ -92,3 +92,20 @@ def test_regenerate_single_child_reuses_description(tmp_path: Path):
     root_index = (root / "index.md").read_text(encoding="utf-8")
     assert "(datasets/index.md) - The only dataset in this bundle." in root_index
     assert call_count == 0
+
+
+def test_regenerate_excludes_reserved_log_md(tmp_path: Path):
+    root = tmp_path / "bundle"
+    _write_doc(
+        root / "tables" / "users.md",
+        "BigQuery Table",
+        "users",
+        "Per-user dimension.",
+    )
+    (root / "tables" / "log.md").write_text("Added users.\n", encoding="utf-8")
+
+    regenerate_indexes(root, model="stub", synthesize=_stub_synth)
+
+    tables_index = (root / "tables" / "index.md").read_text(encoding="utf-8")
+    assert "[users](users.md)" in tables_index
+    assert "log.md" not in tables_index

--- a/okf/tests/test_viewer.py
+++ b/okf/tests/test_viewer.py
@@ -114,6 +114,22 @@ def test_index_md_is_not_a_concept(tmp_path: Path):
     }
 
 
+def test_log_md_is_not_a_concept(tmp_path: Path):
+    bundle = tmp_path / "bundle"
+    _make_bundle(bundle)
+    _write(bundle / "tables" / "log.md", "Added users on 2026-05-28.\n")
+    out = tmp_path / "viz.html"
+    generate_visualization(bundle, out)
+    data = _extract_bundle_data(out.read_text(encoding="utf-8"))
+    ids = {n["data"]["id"] for n in data["nodes"]}
+    assert ids == {
+        "datasets/my_dataset",
+        "tables/users",
+        "tables/events",
+        "references/metrics/dau",
+    }
+
+
 def test_cross_links_become_edges(tmp_path: Path):
     bundle = tmp_path / "bundle"
     _make_bundle(bundle)


### PR DESCRIPTION
SPEC §3.1 reserves both `index.md` and `log.md`, but the reference implementation only skipped `index.md`. A `log.md` showed up as an `Unknown` node in the viewer (`_walk_concepts`) and as a concept entry in generated `index.md` files (`regenerate_indexes`).

Centralizes the reserved names in one `RESERVED_FILENAMES` set in `bundle/paths.py` and uses it at both sites, instead of the per-module `"index.md"` literals that drifted and caused the miss.

Adds `test_log_md_is_not_a_concept` and `test_regenerate_excludes_reserved_log_md`