### PR TITLE
docs: fix contributor test instructions and SPEC heading table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,9 @@ To get started contributing:
 1. Fork the repo, develop and test your code changes.
 1. Ensure that your code adheres to the existing style.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
-1. Ensure that all tests pass (e.g., by running `npm run test` in the TypeScript package directories).
+1. Ensure that all tests pass for the package(s) you touched:
+   - Python packages (e.g. `okf/`): `pip install -e ".[dev]"` then `pytest`.
+   - TypeScript packages that define a `test` script (e.g. `toolbox/mdcode`): `npm run test`.
 1. Submit a pull request.
 
 ## Contributor License Agreement

--- a/okf/SPEC.md
+++ b/okf/SPEC.md
@@ -170,11 +170,13 @@ prose, since structure aids both human reading and agent retrieval.
 There are no required body sections. The following section headings have
 **conventional** meaning and SHOULD be used when applicable:
 
-| Heading        | Purpose                                                |
-|----------------|--------------------------------------------------------|
-| `# Schema`     | Structured description of an asset's columns/fields.   |
-| `# Examples`   | Concrete usage examples, often as fenced code blocks.  |
-| `# Citations`  | External sources backing claims in the body. See §8.   |
+| Heading                  | Purpose                                                |
+|--------------------------|--------------------------------------------------------|
+| `# Schema`               | Structured description of an asset's columns/fields.   |
+| `# Examples`             | Concrete usage examples, often as fenced code blocks.  |
+| `# Common query patterns`| Representative queries against the asset, fenced as code. |
+| `# Joins`                | How this asset relates to or joins with others.        |
+| `# Citations`            | External sources backing claims in the body. See §8.   |
 
 ### 4.3 Example: a concept bound to a resource
 


### PR DESCRIPTION
## Summary

Two documentation fixes.

- **CONTRIBUTING.md** told contributors to run `npm run test` in "the TypeScript package directories", but `toolbox/enrichment` has no `test` script (only `mdcode` does), and the Python (`okf`) test suite wasn't mentioned at all. Replaced with per-package-type instructions.
- **SPEC.md §4.2** — the conventional-headings table listed only `# Schema` / `# Examples` / `# Citations`, but the spec's own §4.3 example uses `# Joins`, and the reference agent emits `# Common query patterns`. Added both to the table so the documented convention matches actual usage.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)