### PR TITLE
docs: add Community & ecosystem tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,30 @@ This repository features tools, agents, and samples that demonstrate Knowledge C
 [![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fknowledge-catalog.git)
 
 
+## Community & ecosystem tools
+
+Open-source tools built by the community around OKF:
+
+**Editors**
+- [OWOX Model Canvas](https://github.com/OWOX/owox-model-canvas) — visual canvas / ERD editor; imports & exports OKF v0.1 and opens the GA4, Stack Overflow and Bitcoin samples. Apache-2.0, free live demo.
+- [OnyxWriter](https://github.com/activetwist/OnyxWriter) — local-first desktop editor (Tauri) for OKF bundles, with visual and raw editing.
+
+**Agent skills & toolkits**
+- [okf-knowledge](https://github.com/sniperunder123/okf-knowledge) — a portable `/okf` Claude Code skill to create, read, maintain and visualize bundles.
+- [okf-skills](https://github.com/scaccogatto/okf-skills) — a Claude Code toolkit to author, maintain, validate and visualize OKF bundles.
+- [okf-frontmatter](https://github.com/longsizhuo/okf-frontmatter) — a pure-Python agent skill that keeps repo docs under OKF with fast doc/schema lookup.
+
+**Validation & linting**
+- [okf-conformance](https://github.com/Sudhakaran88/okf-conformance) — a conformance criteria document plus an executable validator for OKF bundles.
+- [okf-lint](https://github.com/thisismydesign/okf-lint) — a linter for OKF bundles that catches conformance violations.
+
+**CLI**
+- [openknowledge](https://github.com/openknowledge-sh/openknowledge) — a Go CLI to create, inspect and publish OKF bundles (implements v0.1).
+
+**Generation & publishing**
+- [OKFy](https://github.com/0dust/OKFy) — turns existing docs into agent-readable OKF bundles.
+- [kiso](https://github.com/oak-invest/kiso) — a publishing engine that turns OKF bundles into static sites (with llms.txt and sitemap).
+
 ## Contributing
 
 See the contributing [instructions](CONTRIBUTING.md) to get started contributed.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open-source tools built by the community around OKF:
 
 **Editors**
 - [OWOX Model Canvas](https://github.com/OWOX/owox-model-canvas) — visual canvas / ERD editor; imports & exports OKF v0.1 and opens the GA4, Stack Overflow and Bitcoin samples. Apache-2.0, free live demo.
-- [OnyxWriter](https://github.com/activetwist/OnyxWriter) — local-first desktop editor (Tauri) for OKF bundles, with visual and raw editing.
+- [OnyxWriter](https://github.com/activetwist/OnyxWriter) — local-first desktop editor (Tauri) for OKF bundles: visual and raw editing, encrypted bundles, and MCP/CLI support.
 
 **Agent skills & toolkits**
 - [okf-knowledge](https://github.com/sniperunder123/okf-knowledge) — a portable `/okf` Claude Code skill to create, read, maintain and visualize bundles.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Open-source tools built by the community around OKF:
 **Generation & publishing**
 - [kiso](https://github.com/oak-invest/kiso) — a publishing engine that turns OKF bundles into static sites (with llms.txt and sitemap).
 - [KnowHub](https://github.com/smgam29/knowhub) — a model-agnostic pipeline that turns implementation documents (guides, PDFs, decks) into OKF bundles via cross-model extraction.
-- [OKFy](https://github.com/0dust/OKFy) — turns existing docs into agent-readable OKF bundles.
+- [OKFy](https://github.com/0dust/OKFy) — converts docs sites and local Markdown folders into OKF bundles, with validation, inspection, and an MCP server for agents.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Open-source tools built by the community around OKF:
 - [openknowledge](https://github.com/openknowledge-sh/openknowledge) — a Go CLI to create, inspect and publish OKF bundles (implements v0.1).
 
 **Generation & publishing**
-- [OKFy](https://github.com/0dust/OKFy) — turns existing docs into agent-readable OKF bundles.
 - [kiso](https://github.com/oak-invest/kiso) — a publishing engine that turns OKF bundles into static sites (with llms.txt and sitemap).
+- [KnowHub](https://github.com/smgam29/knowhub) — a model-agnostic pipeline that turns implementation documents (guides, PDFs, decks) into OKF bundles via cross-model extraction.
+- [OKFy](https://github.com/0dust/OKFy) — turns existing docs into agent-readable OKF bundles.
 
 ## Contributing
 


### PR DESCRIPTION
Adds a short **Community & ecosystem tools** section to the README, indexing the open-source tools that have grown around OKF since it shipped — editors, agent skills, linters/validators, a CLI, and publishers. One line each, matching the repo's style, grouped by function and alphabetical within each group.

Proposed in #166.

All listed tools are public, actively maintained, and specifically target Google's OKF (verified their repos/READMEs). Happy to adjust the inclusion bar (min activity, "must round-trip v0.1", etc.) or move this to a `COMMUNITY.md` if you'd prefer.

**Disclosure:** I contribute to OWOX Model Canvas, one of the listed editors. The intent is a neutral, useful index for the whole community — glad to hand the list and its criteria to a maintainer.