### PR TITLE
fix(fetcher): unescape HTML entities in extracted href links

### DIFF
--- a/okf/src/reference_agent/web/fetcher.py
+++ b/okf/src/reference_agent/web/fetcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from html import unescape as _html_unescape
 from urllib.parse import urldefrag, urljoin, urlparse
 from urllib.request import Request, urlopen
 
@@ -38,7 +39,7 @@ def _extract_links(html: str, base_url: str) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
     for match in _HREF_RE.finditer(html):
-        href = match.group(1).strip()
+        href = _html_unescape(match.group(1).strip())
         if not href:
             continue
         scheme = urlparse(href).scheme.lower()

--- a/okf/tests/test_web_fetcher.py
+++ b/okf/tests/test_web_fetcher.py
@@ -67,3 +67,21 @@ def test_fetch_and_parse_wraps_network_errors():
         with pytest.raises(FetchError) as exc:
             fetch_and_parse("https://example.com/dead")
         assert "connection refused" in str(exc.value)
+
+
+def test_fetch_and_parse_unescapes_html_entities_in_links():
+    # HTML attributes use &amp; for &. The fetcher must unescape before yielding
+    # links, otherwise agents receive a literally-encoded URL that many servers
+    # won't recognize as a valid query string.
+    html = (
+        b"<html><head><title>t</title></head><body>"
+        b'<a href="https://example.com/search?q=foo&amp;lang=en">link</a>'
+        b"</body></html>"
+    )
+    with patch("reference_agent.web.fetcher.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = _mock_response(
+            html, url="https://example.com/page"
+        )
+        page = fetch_and_parse("https://example.com/page")
+    assert "https://example.com/search?q=foo&lang=en" in page.links
+    assert not any("&amp;" in link for link in page.links)


### PR DESCRIPTION
Fixes #170 

Fix:
Add html.unescape() on each captured href before it is resolved and stored. This is a stdlib.

One new test covering the `&amp` → & conversion has been added as well.

Files changed:
- okf/src/reference_agent/web/fetcher.py — import and apply html.unescape on extracted hrefs
- okf/tests/test_web_fetcher.py — test_fetch_and_parse_unescapes_html_entities_in_links