### PR TITLE
fix(web): decode HTML entities in href so multi-parameter URLs aren't broken

### DIFF
--- a/okf/src/reference_agent/web/fetcher.py
+++ b/okf/src/reference_agent/web/fetcher.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass
 from urllib.parse import urldefrag, urljoin, urlparse
 from urllib.request import Request, urlopen
 
+from bs4 import BeautifulSoup
 from markdownify import markdownify
 
 _USER_AGENT = "okf-reference-agent/0.1 (+https://github.com/amirhormati/open-knowledge-format)"
 _MAX_MARKDOWN_BYTES = 40 * 1024
 
 _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
-_HREF_RE = re.compile(r"""href\s*=\s*["']([^"'#\s]+)["']""", re.IGNORECASE)
 
 
 class FetchError(Exception):
@@ -35,10 +35,17 @@ def _extract_title(html: str) -> str | None:
 
 
 def _extract_links(html: str, base_url: str) -> list[str]:
+    # Parse href with an HTML parser rather than a raw-text regex so entities in
+    # attribute values are decoded per the HTML spec. Valid HTML must write `&`
+    # inside an href as `&amp;`, so a regex surfaces `?a=1&amp;b=2` verbatim and
+    # the agent later fetches a literally-broken URL. BeautifulSoup (already a
+    # dependency via markdownify) decodes it correctly — and, unlike a blanket
+    # html.unescape() on the raw string, it leaves query params such as
+    # `&copy=` / `&reg=` intact instead of turning them into `©` / `®`.
     seen: set[str] = set()
     out: list[str] = []
-    for match in _HREF_RE.finditer(html):
-        href = match.group(1).strip()
+    for anchor in BeautifulSoup(html, "html.parser").find_all("a", href=True):
+        href = anchor["href"].strip()
         if not href:
             continue
         scheme = urlparse(href).scheme.lower()

--- a/okf/tests/test_web_fetcher.py
+++ b/okf/tests/test_web_fetcher.py
@@ -67,3 +67,29 @@ def test_fetch_and_parse_wraps_network_errors():
         with pytest.raises(FetchError) as exc:
             fetch_and_parse("https://example.com/dead")
         assert "connection refused" in str(exc.value)
+
+
+# --- #170: HTML entities in href must be decoded --------------------------
+
+from reference_agent.web.fetcher import _extract_links
+
+
+def test_extract_links_decodes_encoded_ampersands():
+    # Valid HTML encodes `&` as `&amp;`; the extracted URL must use a real `&`.
+    html = '<a href="https://example.com/search?q=foo&amp;lang=en&amp;page=2">x</a>'
+    links = _extract_links(html, "https://example.com/")
+    assert "https://example.com/search?q=foo&lang=en&page=2" in links
+    assert not any("&amp;" in link for link in links)
+
+
+def test_extract_links_preserves_entity_like_query_params():
+    # `&amp;copy=`/`&amp;reg=` must decode to `&copy=`/`&reg=`, never to © / ®.
+    html = '<a href="https://example.com/s?a=1&amp;copy=2&amp;reg=3">x</a>'
+    links = _extract_links(html, "https://example.com/")
+    assert "https://example.com/s?a=1&copy=2&reg=3" in links
+
+
+def test_extract_links_decodes_numeric_entities():
+    html = '<a href="https://example.com/s?q=a&#38;b">x</a>'
+    links = _extract_links(html, "https://example.com/")
+    assert "https://example.com/s?q=a&b" in links


### PR DESCRIPTION
Fixes #170.

`_extract_links` scraped `href` values out of raw HTML with a regex, so HTML entities in attribute values were never decoded. Because valid HTML requires `&` inside an href to be written as `&amp;`, a link like

```html
<a href="https://example.com/search?q=foo&amp;lang=en">
```

was surfaced verbatim as `...?q=foo&amp;lang=en`, and `fetch_url` then requested a URL with a literal `&amp;` in the query string — which servers reject or misparse. This hits any correctly-encoded page (Google/GitHub search results, most CMS output).

**Fix:** parse `href` with BeautifulSoup — already a dependency via `markdownify` — instead of a raw-text regex. The HTML parser decodes attribute entities per the spec.

Notably, the tempting one-liner (`html.unescape(href)`) is *not* correct here: it uses HTML's text rules and over-decodes query params that match no-semicolon legacy entities, turning `?a=1&copy=2&reg=3` into `?a=1©=2®=3`. Parsing the attribute avoids that — `&amp;copy=` decodes to `&copy=`, not `©`. A regression test guards this.

Also removes the now-unused `_HREF_RE`, and as a side benefit the parser handles `href`s the regex missed (across newlines, unquoted, or after other attributes).

### Tests
All green (`PYTHONPATH=src pytest okf/tests/test_web_fetcher.py`, 7 passed):
- the multi-parameter repro from the issue,
- an entity-like-param guard (`&copy=` / `&reg=` stay literal, not `©` / `®`),
- a numeric-entity case (`&#38;`).

_Known limitation:_ genuinely malformed HTML with a bare `&copy=` (invalid — should be `&amp;copy=`) remains ambiguous; matching a browser's full "ambiguous ampersand" tokenizer rule would need a stricter parser. Out of scope for the reported (spec-conformant) case.
