### PR TITLE
Fix: resolve relative concept links in the graph viewer detail panel

### DIFF
--- a/okf/src/reference_agent/viewer/static/viz.js
+++ b/okf/src/reference_agent/viewer/static/viz.js
@@ -185,7 +185,7 @@
     const html = marked.parse(body, { breaks: false, gfm: true });
     const bodyEl = document.getElementById("detail-body");
     bodyEl.innerHTML = html;
-    rewriteInternalLinks(bodyEl);
+    rewriteInternalLinks(bodyEl, conceptId);
 
     const bl = backlinks[conceptId] || [];
     const blSection = document.getElementById("detail-backlinks");
@@ -213,21 +213,41 @@
     cy.animate({ center: { eles: node }, zoom: Math.max(cy.zoom(), 1.0) }, { duration: 200 });
   }
 
-  function rewriteInternalLinks(root) {
+  // Resolve a markdown-link href to a concept id, honoring both absolute
+  // ("/clinical/careplan.md") and relative ("../clinical/careplan.md",
+  // "founding-member-v1.md") links, the latter relative to currentId's dir.
+  function hrefToConceptId(href, currentId) {
+    let h = href.split("#")[0];
+    if (!h.endsWith(".md")) return null;
+    h = h.slice(0, -3);
+    let parts;
+    if (h.startsWith("/")) {
+      parts = h.slice(1).split("/");
+    } else {
+      parts = currentId.split("/").slice(0, -1).concat(h.split("/"));
+    }
+    const out = [];
+    for (const p of parts) {
+      if (p === "" || p === ".") continue;
+      if (p === "..") out.pop();
+      else out.push(p);
+    }
+    return out.join("/");
+  }
+
+  function rewriteInternalLinks(root, currentId) {
     root.querySelectorAll("a[href]").forEach((a) => {
       const href = a.getAttribute("href");
       if (!href) return;
-      if (href.startsWith("/") && href.endsWith(".md")) {
-        const target = href.slice(1, -3);
-        if (nodeIndex[target]) {
-          a.className = "internal";
-          a.setAttribute("href", "javascript:void(0)");
-          a.addEventListener("click", (e) => {
-            e.preventDefault();
-            showDetail(target);
-          });
-          return;
-        }
+      const target = hrefToConceptId(href, currentId || "");
+      if (target && nodeIndex[target]) {
+        a.className = "internal";
+        a.setAttribute("href", "javascript:void(0)");
+        a.addEventListener("click", (e) => {
+          e.preventDefault();
+          showDetail(target);
+        });
+        return;
       }
       a.className = "external";
       a.setAttribute("target", "_blank");


### PR DESCRIPTION
## Problem

In the bundled OKF graph viewer (`viz.html`), clicking a concept link inside the detail panel opened the raw `.md` file instead of selecting that concept in the graph — but only for **relative** links.

`rewriteInternalLinks` only recognised absolute links (`/tables/users.md`). Relative links — `users.md`, `../references/metrics/dau.md` — fell through to the external-link branch. This is an asymmetry with the rest of the toolchain:

- the Python edge extractor `_extract_links` (generator.py) **already resolves relative links**, so the graph *edges* render correctly;
- the OKF spec's own examples and the reference agent's output use relative links.

So a bundle authored with relative links draws the right graph, but its in-panel links don't navigate.

## Fix

Resolve each markdown-link href to a concept id relative to the current concept's directory — handling `.`, `..`, and `#anchor` — then select the node if it exists (falling back to external-link behaviour otherwise). This brings the click handler to parity with the already-supported/edge-extracted relative links. Absolute links keep working unchanged.

## Testing

`viz.js` is a browser-only static asset and the repo has no JS test harness, so no automated JS test is added (introducing one for a ~30-line fix seemed disproportionate — happy to add one if maintainers prefer). The relative-link contract is already covered on the Python side by `test_viewer.py::test_cross_links_become_edges`, which uses relative links. Manually verified that absolute, sibling, `..`-traversing, and `#anchor` links all resolve to the correct concept id, and that unresolved links still render as external.

🤖 Generated with [Claude Code](https://claude.com/claude-code)