### PR TITLE
okf: fix visualize edges for absolute and titled cross-links

### DIFF
--- a/okf/src/reference_agent/viewer/generator.py
+++ b/okf/src/reference_agent/viewer/generator.py
@@ -9,7 +9,9 @@ from typing import Any
 from reference_agent.bundle.document import OKFDocument, OKFDocumentError
 
 _INDEX_NAME = "index.md"
-_LINK_RE = re.compile(r"\]\(([^)\s]+\.md)(?:#[A-Za-z0-9_\-]*)?\)")
+_LINK_RE = re.compile(
+    r"\]\(([^)\s]+\.md)(?:#[A-Za-z0-9_\-]*)?(?:\s+\"[^\"]*\"|\s+'[^']*')?\)"
+)
 _TYPE_PALETTE = {
     "BigQuery Dataset": "#8b5cf6",
     "BigQuery Table": "#3b82f6",
@@ -51,10 +53,16 @@ def _extract_links(body: str, doc_dir: Path, bundle_root: Path) -> list[str]:
     bundle_root_resolved = bundle_root.resolve()
     for m in _LINK_RE.finditer(body):
         target = m.group(1)
-        if "://" in target or target.startswith("/"):
+        if "://" in target:
             continue
+        if target.startswith("/"):
+            # SPEC recommends absolute bundle-relative links (rooted at the
+            # bundle), so resolve them from the bundle root rather than skipping.
+            base = bundle_root_resolved / target.lstrip("/")
+        else:
+            base = doc_dir / target
         try:
-            resolved = (doc_dir / target).resolve().relative_to(bundle_root_resolved)
+            resolved = base.resolve().relative_to(bundle_root_resolved)
         except ValueError:
             continue
         rel = resolved.as_posix()

--- a/okf/tests/test_viewer.py
+++ b/okf/tests/test_viewer.py
@@ -127,6 +127,56 @@ def test_cross_links_become_edges(tmp_path: Path):
     assert ("tables/events", "tables/users") in pairs
 
 
+def _make_linked_pair(root: Path, link: str) -> None:
+    """Two concepts, a/a.md -> b/b.md, where the link form is caller-supplied."""
+    _write(
+        root / "a" / "a.md",
+        f"""
+        ---
+        type: Reference
+        title: A
+        description: Source concept.
+        timestamp: '2026-05-28T00:00:00+00:00'
+        ---
+        Links to {link}.
+        """,
+    )
+    _write(
+        root / "b" / "b.md",
+        """
+        ---
+        type: Reference
+        title: B
+        description: Target concept.
+        timestamp: '2026-05-28T00:00:00+00:00'
+        ---
+        Leaf concept.
+        """,
+    )
+
+
+def test_titled_links_become_edges(tmp_path: Path):
+    """CommonMark link titles must not suppress edge extraction (issue #48)."""
+    bundle = tmp_path / "bundle"
+    _make_linked_pair(bundle, '[Bee](../b/b.md "a note")')
+    out = tmp_path / "viz.html"
+    generate_visualization(bundle, out)
+    data = _extract_bundle_data(out.read_text(encoding="utf-8"))
+    pairs = {(e["data"]["source"], e["data"]["target"]) for e in data["edges"]}
+    assert ("a/a", "b/b") in pairs
+
+
+def test_absolute_bundle_relative_links_become_edges(tmp_path: Path):
+    """SPEC-recommended absolute (/-rooted) links must produce edges (issue #48)."""
+    bundle = tmp_path / "bundle"
+    _make_linked_pair(bundle, "[Bee](/b/b.md)")
+    out = tmp_path / "viz.html"
+    generate_visualization(bundle, out)
+    data = _extract_bundle_data(out.read_text(encoding="utf-8"))
+    pairs = {(e["data"]["source"], e["data"]["target"]) for e in data["edges"]}
+    assert ("a/a", "b/b") in pairs
+
+
 def test_missing_link_targets_are_skipped(tmp_path: Path):
     bundle = tmp_path / "bundle"
     _write(


### PR DESCRIPTION
## What

The reference `visualize` tool extracts **0 edges** from bundles whose cross-links use either form that `okf/SPEC.md` treats as valid:

- **Absolute bundle-relative links** (e.g. `/tables/users.md`), which the SPEC's cross-linking guidance recommends, and
- **CommonMark link titles** (e.g. `[Users](users.md "the users table")`).

Only relative, untitled links produced edges, so otherwise spec-conformant bundles rendered as disconnected node clouds.

## Why

In `okf/src/reference_agent/viewer/generator.py`:

- `_extract_links` skipped every `/`-prefixed target (`if "://" in target or target.startswith("/")`), dropping the recommended absolute form.
- `_LINK_RE` left no room for a link title, so `](path.md "title")` — valid CommonMark — did not match at all.

## Fix

- Resolve `/`-prefixed targets against the bundle root instead of skipping them.
- Allow an optional CommonMark title (`"..."` or `'...'`) in the link-extraction regex.

Both changes are confined to link extraction; node and edge building are unchanged. External (`://`) links are still ignored, and dangling links still produce no edge.

## Tests

Adds two regression tests to `okf/tests/test_viewer.py`:

- `test_titled_links_become_edges`
- `test_absolute_bundle_relative_links_become_edges`

Each fails on the current code (0 edges) and passes with this change. Full viewer suite: 8 passed.

## Notes

Addresses #48. This is a deliberately small, test-covered change scoped only to the visualizer's edge extraction, offered as a focused alternative to the broader #66 (which also reworks SPEC text across the codebase). Happy to adjust scope if maintainers prefer.
