### PR TITLE
okf: state that log.md is append-only history (SPEC 7)

### DIFF
--- a/okf/SPEC.md
+++ b/okf/SPEC.md
@@ -317,6 +317,11 @@ Date headings MUST use ISO 8601 `YYYY-MM-DD` form. Log entries are
 prose; the leading bold word (`**Update**`, `**Creation**`,
 `**Deprecation**`, etc.) is a convention, not a requirement.
 
+Log entries are append-only: producers SHOULD add new dated entries rather
+than editing or deleting past ones, so the log remains a faithful history. A
+correction SHOULD be recorded as a new entry that supersedes the earlier
+statement, not as a rewrite of it.
+
 ---
 
 ## 8. Citations


### PR DESCRIPTION
## What

Section 7 describes `log.md` as a chronological history but does not say whether past entries may be edited or deleted. This adds a sentence making the intent explicit.

## Clarification

- `log.md` entries are **append-only**: producers SHOULD add new dated entries rather than editing or deleting past ones, so the log stays a faithful history.
- A correction SHOULD be recorded as a new entry that supersedes the earlier statement, not as a rewrite.

Additive and backward-compatible (SPEC section 11 minor-version rules).

Addresses #89.
