### PR TITLE
okf: add optional agent-routing hint fields (SPEC 4.1)

### DIFF
--- a/okf/SPEC.md
+++ b/okf/SPEC.md
@@ -161,6 +161,16 @@ timestamp: <ISO 8601 datetime>     # Optional last-modified time
 SHOULD preserve unknown keys when round-tripping and SHOULD NOT reject
 documents with unrecognized fields.
 
+**Conventional agent-routing hints (optional):** to help a consumption agent
+decide whether and how to use a concept before reading its body, producers MAY
+include any of the following keys. They are hints, never gates — consumers
+MUST tolerate their absence and MUST NOT reject a document that omits them:
+
+- `purpose` — one line on what the concept is for.
+- `task` — the task or tasks the concept is most useful for (a string or a
+  list of strings).
+- `audience` — the intended reader or agent (a string or a list of strings).
+
 ### 4.2 Body
 
 The body is standard markdown. Producers SHOULD favor structural


### PR DESCRIPTION
## What

Adds an optional, additive frontmatter convention to SPEC section 4.1 for **agent-routing hints** — `purpose`, `task`, and `audience` — so a consumption agent can decide whether and how to use a concept before reading its body.

## Semantics

- `purpose` — one line on what the concept is for.
- `task` — the task(s) the concept is most useful for (string or list).
- `audience` — the intended reader/agent (string or list).

These are **hints, never gates**: consumers MUST tolerate their absence and MUST NOT reject a document that omits them. Section 4.1 already permits arbitrary producer keys; this names three with a shared meaning so producers and consumers can rely on them.

Backward-compatible additive convention (SPEC section 11 minor-version rules).

Addresses #96.
