### PR TITLE
okf: allow okf_version on standalone concept files (SPEC 11)

### DIFF
--- a/okf/SPEC.md
+++ b/okf/SPEC.md
@@ -395,6 +395,13 @@ only place frontmatter is permitted in an `index.md`). Consumers that
 do not understand the declared version SHOULD attempt best-effort
 consumption rather than refusing the bundle.
 
+A single concept document distributed on its own — outside any bundle — MAY
+likewise declare `okf_version` in its own frontmatter. This lets a standalone
+file identify itself as OKF content without a surrounding bundle or a root
+`index.md`; consumers SHOULD treat such a file as a one-concept bundle. When
+the file is later placed inside a bundle that declares its own version at the
+root, the bundle-root declaration takes precedence.
+
 ---
 
 ## Appendix A — Minimal example bundle


### PR DESCRIPTION
## What

Clarifies SPEC section 11 so a **standalone concept document** — one distributed on its own, outside any bundle — MAY declare `okf_version` in its own frontmatter. This addresses the concrete, actionable ask in #57.

## Why

Section 11 currently permits `okf_version` only in a bundle-root `index.md`, leaving no way for a single standalone document to identify itself as OKF content. This says such a file MAY carry `okf_version` and SHOULD be treated as a one-concept bundle; once the file is placed in a bundle that declares its own root version, the bundle-root declaration takes precedence.

## Scope

The broader question in #57 — whether OKF should cover multi-concept documents — is a larger design discussion and is intentionally left out of this change. This PR covers only the standalone-file versioning part.

Additive and backward-compatible (SPEC section 11 minor-version rules). Addresses #57.
