### PR TITLE
okf: don't end a section at a fenced '#' comment line (bundle_tools)

### DIFF
--- a/okf/src/reference_agent/tools/bundle_tools.py
+++ b/okf/src/reference_agent/tools/bundle_tools.py
@@ -18,12 +18,20 @@ _FIELD_NAME_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_.]*)`")
 
 
 def _section_content_lines(body: str, heading: str) -> list[str]:
-    """Return non-blank lines under a top-level `# heading` section."""
+    """Return non-blank lines under a top-level `# heading` section.
+
+    Fenced code blocks are treated as content: a `#`-prefixed line inside a
+    fence is not mistaken for a heading, so it does not prematurely end the
+    section.
+    """
     in_section = False
+    in_fence = False
     out: list[str] = []
     for line in body.splitlines():
         stripped = line.strip()
-        if stripped.startswith("# "):
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+        elif not in_fence and stripped.startswith("# "):
             in_section = stripped == heading
             continue
         if in_section and stripped:

--- a/okf/tests/test_bundle_tools.py
+++ b/okf/tests/test_bundle_tools.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from reference_agent.tools.bundle_tools import write_concept_doc
+from reference_agent.tools.bundle_tools import (
+    _schema_field_names,
+    _section_content_lines,
+    write_concept_doc,
+)
 from reference_agent.tools.context import (
     clear_web_state,
     set_context,
@@ -148,3 +152,35 @@ def test_web_pass_skips_guard_for_non_bigquery_table_types(tmp_path):
         "# Citations\n[1] [Src](https://src)\n",
     )
     assert "error" not in result
+
+
+def test_section_survives_fenced_hash_comment():
+    body = (
+        "# Schema\n"
+        "- `id` STRING\n"
+        "```\n"
+        "# looks like a heading but is code\n"
+        "```\n"
+        "- `name` STRING\n"
+        "# Other\n"
+        "- ignored\n"
+    )
+    text = "\n".join(_section_content_lines(body, "# Schema"))
+    assert "`id`" in text
+    assert "`name`" in text
+    assert "ignored" not in text
+
+
+def test_schema_fields_survive_fenced_hash_comment():
+    body = (
+        "# Schema\n"
+        "- `id` STRING\n"
+        "```sql\n"
+        "# partition by ingestion day\n"
+        "SELECT 1\n"
+        "```\n"
+        "- `name` STRING\n"
+        "# Citations\n"
+        "[1] [BQ](https://bq)\n"
+    )
+    assert _schema_field_names(body) == {"id", "name"}


### PR DESCRIPTION
## Bug

`_section_content_lines` (in `okf/src/reference_agent/tools/bundle_tools.py`) treats **any** line whose stripped form starts with `# ` as a section heading — including `#` comment lines inside fenced code blocks (shell, Python, YAML, partition expressions, and so on). A code fence inside a `# Schema` or `# Citations` section therefore ends the section early.

Downstream, `_schema_field_names` and `_citation_entry_count` then under-read the section, and the web-pass augmentation guard in `write_concept_doc` can compare truncated field or citation sets — for example wrongly concluding that a rewrite drops fields, or missing a real shrinkage.

## Repro

For a `# Schema` section that lists `` `id` `` followed by a fenced code block whose first line is a `#` comment, then `` `name` ``, `_schema_field_names(body)` returns `{"id"}` — `name` is lost because the fenced `#` line is mistaken for a heading and ends the section. Expected `{"id", "name"}`.

## Fix

Track fenced code blocks (backtick and tilde fences) and only treat `# ` lines **outside** a fence as headings. Ordinary content and real headings behave exactly as before.

## Tests

Adds `test_section_survives_fenced_hash_comment` and `test_schema_fields_survive_fenced_hash_comment`, each failing before the change and passing after. Full `test_bundle_tools.py` and `test_viewer.py` remain green (22 passed).
