### PR TITLE
fix(viewer): percent-decode link targets in _extract_links

### DIFF
--- a/okf/src/reference_agent/viewer/generator.py
+++ b/okf/src/reference_agent/viewer/generator.py
@@ -5,6 +5,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
 
 from reference_agent.bundle.document import OKFDocument, OKFDocumentError
 
@@ -50,7 +51,10 @@ def _extract_links(body: str, doc_dir: Path, bundle_root: Path) -> list[str]:
     seen: set[str] = set()
     bundle_root_resolved = bundle_root.resolve()
     for m in _LINK_RE.finditer(body):
-        target = m.group(1)
+        # Targets may be percent-encoded per SPEC section 5 (e.g. file names
+        # with spaces become `weekly%20report.md`); decode before resolving
+        # so they match the on-disk file names.
+        target = unquote(m.group(1))
         if "://" in target or target.startswith("/"):
             continue
         try:

--- a/okf/tests/test_viewer.py
+++ b/okf/tests/test_viewer.py
@@ -163,3 +163,37 @@ def test_node_colors_match_palette(tmp_path: Path):
 def test_raises_when_bundle_missing(tmp_path: Path):
     with pytest.raises(FileNotFoundError):
         generate_visualization(tmp_path / "nope", tmp_path / "viz.html")
+
+
+def test_percent_encoded_links_become_edges(tmp_path: Path):
+    """File names with spaces are percent-encoded in links (SPEC section 5)."""
+    bundle = tmp_path / "bundle"
+    _write(
+        bundle / "notes" / "weekly report.md",
+        """
+        ---
+        type: Reference
+        title: Weekly report
+        description: A file name with spaces.
+        timestamp: '2026-05-28T00:00:00+00:00'
+        ---
+        Standalone note.
+        """,
+    )
+    _write(
+        bundle / "notes" / "summary.md",
+        """
+        ---
+        type: Reference
+        title: Summary
+        description: Links to a percent-encoded target.
+        timestamp: '2026-05-28T00:00:00+00:00'
+        ---
+        See the [weekly report](weekly%20report.md).
+        """,
+    )
+    out = tmp_path / "viz.html"
+    generate_visualization(bundle, out)
+    data = _extract_bundle_data(out.read_text(encoding="utf-8"))
+    pairs = {(e["data"]["source"], e["data"]["target"]) for e in data["edges"]}
+    assert ("notes/summary", "notes/weekly report") in pairs


### PR DESCRIPTION
Fixes #200

## Problem

Per SPEC §5, links to file names containing spaces are percent-encoded (e.g. `[report](weekly%20report.md)`). `_extract_links` in `okf/src/reference_agent/viewer/generator.py` resolves the raw regex capture without decoding it, so the emitted edge id is `notes/weekly%20report` while the concept node id derived from the on-disk path is `notes/weekly report`. The edge never matches a node and is dropped: a bundle whose file names contain spaces renders with **zero edges** even though every link is spec-conformant.

## Fix

Decode the captured target with `urllib.parse.unquote` before resolving it. Decoding happens **before** the scheme/absolute-path guards, so percent-encoded forms of external (`https%3A%2F%2F…`) or absolute (`%2F…`) targets are still skipped. Targets containing a literal `%` not followed by two hex digits are left untouched by `unquote`.

## Scope

Deliberately minimal:
- absolute bundle-relative links (`/Note.md`) remain unsupported by the viewer — that is #48 (PRs #66/#184);
- `_LINK_RE` still rejects literal unencoded spaces, which is consistent with markdown link syntax and with SPEC §5's encoding recommendation;
- the SPEC-side clarification of link encoding is tracked in #112/#186.

## Testing

`okf/tests/test_viewer.py`: 7 passed (6 existing + new regression test `test_percent_encoded_links_become_edges`, which fails without the fix).
