### PR TITLE
okf: resolve absolute (bundle-relative) links in the visualizer

### DIFF
--- a/okf/src/reference_agent/viewer/generator.py
+++ b/okf/src/reference_agent/viewer/generator.py
@@ -51,10 +51,16 @@ def _extract_links(body: str, doc_dir: Path, bundle_root: Path) -> list[str]:
     bundle_root_resolved = bundle_root.resolve()
     for m in _LINK_RE.finditer(body):
         target = m.group(1)
-        if "://" in target or target.startswith("/"):
+        if "://" in target:
             continue
+        # SPEC §5.1: absolute links begin with "/" and are interpreted
+        # relative to the bundle root.
+        if target.startswith("/"):
+            candidate = bundle_root_resolved / target.lstrip("/")
+        else:
+            candidate = doc_dir / target
         try:
-            resolved = (doc_dir / target).resolve().relative_to(bundle_root_resolved)
+            resolved = candidate.resolve().relative_to(bundle_root_resolved)
         except ValueError:
             continue
         rel = resolved.as_posix()

--- a/okf/tests/test_viewer.py
+++ b/okf/tests/test_viewer.py
@@ -127,6 +127,30 @@ def test_cross_links_become_edges(tmp_path: Path):
     assert ("tables/events", "tables/users") in pairs
 
 
+def test_absolute_links_become_edges(tmp_path: Path):
+    """SPEC §5.1: links beginning with "/" resolve against the bundle root."""
+    bundle = tmp_path / "bundle"
+    _make_bundle(bundle)
+    _write(
+        bundle / "references" / "glossary.md",
+        """
+        ---
+        type: Reference
+        title: Glossary
+        description: Uses absolute (bundle-relative) links.
+        timestamp: '2026-05-28T00:00:00+00:00'
+        ---
+        See [users](/tables/users.md) and [DAU](/references/metrics/dau.md#dau).
+        """,
+    )
+    out = tmp_path / "viz.html"
+    generate_visualization(bundle, out)
+    data = _extract_bundle_data(out.read_text(encoding="utf-8"))
+    pairs = {(e["data"]["source"], e["data"]["target"]) for e in data["edges"]}
+    assert ("references/glossary", "tables/users") in pairs
+    assert ("references/glossary", "references/metrics/dau") in pairs
+
+
 def test_missing_link_targets_are_skipped(tmp_path: Path):
     bundle = tmp_path / "bundle"
     _write(


### PR DESCRIPTION
## What

`_extract_links` in the viewer generator skipped any link target beginning with `/`, treating it like an external URL. But SPEC §5.1 explicitly supports the absolute (bundle-relative) link form — "Begin with `/`, interpreted relative to the bundle root" — so a spec-conformant bundle using that style renders with **zero edges** in the visualizer.

This resolves `/`-prefixed targets against the bundle root; relative links are unchanged, external URLs are still skipped.

## Why it matters

The absolute style is the one the spec recommends for links that should survive files being moved within their subdirectory, so bundles that follow that advice currently lose their entire graph. Found while visualizing a personal 42-concept bundle that uses absolute links throughout: 0 edges before this patch, 110 after.

## Test

Added `test_absolute_links_become_edges` alongside the existing link tests (mixed absolute links, including one with a `#fragment`). Full `test_viewer.py` suite passes: 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)