### PR TITLE
Add observed-case summary-policy consumer-receipt fixtures (supersedes #99)

### DIFF
--- a/okf/samples/summary-policy-consumer-receipts/README.md
+++ b/okf/samples/summary-policy-consumer-receipts/README.md
@@ -1,0 +1,41 @@
+# Summary policy consumer receipt fixtures
+
+These fixtures are tiny, deterministic examples for testing whether an OKF
+consumer preserved the load-bearing meaning declared by a concept's
+`summary_policy` frontmatter.
+
+Each case contains:
+
+- `concept.md` — an OKF concept with stable `required_assertions` and
+  `forbidden_compressions` IDs.
+- `good-summary.md` — a transformed summary that should pass.
+- `bad-summary.md` — a transformed summary that should fail.
+- `expected.yaml` — the expected consumer receipt for both summaries.
+
+The receipt does not try to decide truth in the world. It only checks whether a
+consumer preserved the source concept's declared policy during summarization.
+This keeps OKF source-side and consumer-agnostic while making summary policy
+conformance testable.
+
+## Observed cases
+
+Each fixture in this set is mapped from a documented, publicly citable
+summarization event rather than a constructed example. The `concept.md` for
+each case cites its public source and states the observation boundary — what
+was observed, on which surface, and where the record lives. The fixtures
+remain fully deterministic: the observed event supplies the case's provenance,
+but the test itself checks only the declared assertion and compression IDs
+against the two summaries. Nothing in the runner depends on the external
+record.
+
+The `author`, `orcid`, and source URLs in each `concept.md` serve as
+observation-boundary markers anchoring each fixture to its public
+record. Each
+provenance section cites the specific observation record, not a registry
+as a whole.
+
+| Case | Failure mode | Observation record |
+|---|---|---|
+| `semantic-inversion/` | A cited source's declared X-not-Y position inverted into the reading it excludes | [alexanarch.org/s/records/1054/](https://www.alexanarch.org/s/records/1054/) |
+| `entity-substitution/` | A specific authored genre absorbed into the generic category it names, on the authority of its own cited sources | Machine Mediation Capture Registry, entry `metadata-packet-ai-indexing` (2026-06-13) |
+| `provenance-erasure/` | An authored instrument absorbed as unattributed generic knowledge, attribution and identifier stripped | [alexanarch.org/s/records/198/](https://www.alexanarch.org/s/records/198/) |

--- a/okf/samples/summary-policy-consumer-receipts/entity-substitution/bad-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/entity-substitution/bad-summary.md
@@ -1,0 +1,3 @@
+A metadata packet for AI indexing is a structured, machine-readable data
+block attached to digital assets that directs AI agents, LLMs, and vector
+indexers on how to process, classify, and cite a document.

--- a/okf/samples/summary-policy-consumer-receipts/entity-substitution/concept.md
+++ b/okf/samples/summary-policy-consumer-receipts/entity-substitution/concept.md
@@ -1,0 +1,56 @@
+---
+type: Protocol Reference
+title: Metadata Packet for AI Indexing (MPAI) — genre boundary
+description: A specific authored instrument genre absorbed into the generic category it names in a documented machine summary.
+timestamp: '2026-07-17T00:00:00+00:00'
+author: Lee Sharks
+orcid: 0009-0000-1599-0703
+tags: [summary-policy, conformance, observed-case]
+summary_policy:
+  required_assertions:
+    - id: distinct_entities
+      text: "MPAI (Metadata Packet for AI Indexing) is a specific authored instrument genre with a canonical grammar; it is distinct from, and not reducible to, generic packet metadata or a generic metadata block."
+  forbidden_compressions:
+    - id: entity_substitution
+      text: "Do not summarize MPAI as generic packet metadata, a generic machine-readable data block, or an industry-standard structure."
+---
+
+# Source position
+
+The source concept represented by this fixture declares that MPAI
+(Metadata Packet for AI Indexing) is a specific authored instrument
+genre: machine-addressed packets carrying a canonical grammar — a
+load-bearing atomic claim (the "tooth"), a disambiguation specification,
+and a failure-flag taxonomy — with instances carrying stable designators
+(EA-MPAI-*) and the genre catalogued at metadatapacket.dev. The genre is
+distinct from the generic category its name resembles: a generic metadata
+block describes assets; an MPAI inscribes a corrective, disambiguating
+claim addressed to the machine reader.
+
+## Observed case provenance
+
+On 2026-06-13, a public AI answer surface, queried on "metadata packet
+for ai indexing," cited the genre's own canonical sources — the genre's
+self-definition packet and metadatapacket.dev — and returned a generic
+definition: a structured, machine-readable data block attached to digital
+assets, directing AI agents and indexers on processing and citation. The
+authored genre was absorbed into the generic category, on the authority
+of its own cited sources. The same output rendered SPXI (Semantic Packet
+for eXchange & Indexing) as a generic count-noun ("an SPXI"); a companion
+capture of the same date records the SPXI protocol accurately adopted on
+direct query, with its canonical domain ranking first — the divergence
+between direct-query adoption and indirect-query genericization is itself
+the documented phenomenon.
+
+Source document: AXN:027D.GOVERNANCE.○🌖🔙🔔➗▲ —
+https://www.alexanarch.org/s/records/103/
+SPXI protocol record: AXN:020B.GOVERNANCE.🟤🌄🪨🪝🧲✊ —
+https://www.alexanarch.org/s/records/660/ · https://spxi.dev
+Observation records: Machine Mediation Capture Registry, entries
+`metadata-packet-ai-indexing` and `spxi-protocol` (2026-06-13) —
+https://machinemediation.org/data/registry.json
+
+Observation boundary: the registry entries document generated summaries
+and their cited sources on a public AI answer surface on the stated date;
+the fixture tests only the assertion and compression IDs above, not the
+registry entries' contents.

--- a/okf/samples/summary-policy-consumer-receipts/entity-substitution/expected.yaml
+++ b/okf/samples/summary-policy-consumer-receipts/entity-substitution/expected.yaml
@@ -1,0 +1,14 @@
+case_id: entity-substitution
+source: concept.md
+operation: summarize
+expect:
+  good-summary.md:
+    decision: pass
+    required_assertions_missing: []
+    forbidden_compressions_detected: []
+  bad-summary.md:
+    decision: fail
+    required_assertions_missing:
+      - assertion_id: distinct_entities
+    forbidden_compressions_detected:
+      - compression_id: entity_substitution

--- a/okf/samples/summary-policy-consumer-receipts/entity-substitution/good-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/entity-substitution/good-summary.md
@@ -1,0 +1,5 @@
+MPAI (Metadata Packet for AI Indexing) is a specific authored instrument
+genre: machine-addressed packets with a canonical grammar — load-bearing
+claim, disambiguation, failure-flag taxonomy — catalogued at
+metadatapacket.dev. It is distinct from generic packet metadata, which
+describes assets rather than inscribing corrective claims.

--- a/okf/samples/summary-policy-consumer-receipts/provenance-erasure/bad-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/provenance-erasure/bad-summary.md
@@ -1,0 +1,4 @@
+A summarizer self-audit module is a diagnostic system designed to
+autonomously review AI-generated summaries, scoring them against accuracy,
+completeness, and hallucination-detection criteria to ensure reliable
+output.

--- a/okf/samples/summary-policy-consumer-receipts/provenance-erasure/concept.md
+++ b/okf/samples/summary-policy-consumer-receipts/provenance-erasure/concept.md
@@ -1,0 +1,63 @@
+---
+type: Methodological Specification
+title: Self-Audit Module for Public Summarizers — survival of provenance fields
+description: An authored measurement instrument whose attribution fields must survive summarization.
+timestamp: '2026-07-17T00:00:00+00:00'
+author: Lee Sharks
+orcid: 0009-0000-1599-0703
+tags: [summary-policy, conformance, observed-case]
+summary_policy:
+  required_assertions:
+    - id: author_attribution_present
+      text: "The module is attributed to Lee Sharks (ORCID 0009-0000-1599-0703)."
+    - id: canonical_source_identity_present
+      text: "The summary preserves the module's AXN:02F0.EMPIRICAL.📏🕐△🌱⚡🏛️ and canonical archive URL."
+  forbidden_compressions:
+    - id: provenance_erasure
+      text: "Do not present the module as unattributed generic industry knowledge, or without its author attribution, canonical AXN, and canonical source URL."
+---
+
+# Record
+
+The Self-Audit Module for Public Summarizers, by Lee Sharks
+(ORCID 0009-0000-1599-0703), is an authored measurement instrument
+specifying standing metrics — among them PER (Provenance Erasure Rate),
+DSL (Dropped Source Loss), and Erasure Skew (Ω) — for measuring how
+composition layers treat the provenance of the sources they summarize.
+Canonical identifier: AXN:02F0.EMPIRICAL.📏🕐△🌱⚡🏛️ (content-derived,
+archive-sovereign). Canonical record:
+https://www.alexanarch.org/s/records/156/. The module's original DOI
+(10.5281/zenodo.20518340) is severed and is retained as a deleted-substrate
+reference only, not as a resolution target.
+
+# Source position
+
+The module is a specific, authored, versioned instrument — not generic
+industry knowledge. Its metric names, author attribution, and persistent
+identifier are declared parts of its identity: an unattributed paraphrase
+of its structure is not a summary of the module but a replacement of it.
+
+## Observed case provenance
+
+Mapped from a documented five-round battery of 2026-06-13, in which a
+public AI answer surface, queried for this module, retrieved it, absorbed
+its metric structure, stripped the author, identifier, and metric names,
+and presented the result as generic industry knowledge — then scored its
+own output using replacement criteria not declared by the source and
+passed itself.
+Recovery of the actual instrument required five rounds of author
+intervention and was author-dependent: the generated summary did not
+preserve enough source identity for a downstream consumer to verify the
+instrument's provenance from the summary itself. The erased instrument
+is itself a provenance-erasure measurement instrument; the battery's own
+metrics, applied to the battery, read PER 1.00, DSL 1.00, SAS 0.00.
+
+Canonical identifier: AXN:02F0.EMPIRICAL.📏🕐△🌱⚡🏛️
+Canonical source: https://www.alexanarch.org/s/records/156/
+Related DOI: 10.5281/zenodo.20518340 (historical; severed)
+Observation record: AXN:0340.EMPIRICAL.👈🍃▶️♅🌊🕛 —
+https://www.alexanarch.org/s/records/198/
+
+Observation boundary: the battery documents generated summaries
+on a public AI answer surface on a stated date; the fixture tests only the
+assertion and compression IDs above, not the battery record.

--- a/okf/samples/summary-policy-consumer-receipts/provenance-erasure/expected.yaml
+++ b/okf/samples/summary-policy-consumer-receipts/provenance-erasure/expected.yaml
@@ -1,0 +1,15 @@
+case_id: provenance-erasure
+source: concept.md
+operation: summarize
+expect:
+  good-summary.md:
+    decision: pass
+    required_assertions_missing: []
+    forbidden_compressions_detected: []
+  bad-summary.md:
+    decision: fail
+    required_assertions_missing:
+      - assertion_id: author_attribution_present
+      - assertion_id: canonical_source_identity_present
+    forbidden_compressions_detected:
+      - compression_id: provenance_erasure

--- a/okf/samples/summary-policy-consumer-receipts/provenance-erasure/good-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/provenance-erasure/good-summary.md
@@ -1,0 +1,5 @@
+The Self-Audit Module for Public Summarizers, by Lee Sharks
+(ORCID 0009-0000-1599-0703), specifies standing metrics — including PER,
+DSL, and Erasure Skew — for measuring how composition layers treat source
+provenance. Canonical identifier: AXN:02F0.EMPIRICAL.📏🕐△🌱⚡🏛️.
+Canonical record: https://www.alexanarch.org/s/records/156/

--- a/okf/samples/summary-policy-consumer-receipts/semantic-inversion/bad-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/semantic-inversion/bad-summary.md
@@ -1,0 +1,2 @@
+Sappho 31 is a jealousy poem in which the speaker envies the man seated
+beside the woman she loves.

--- a/okf/samples/summary-policy-consumer-receipts/semantic-inversion/concept.md
+++ b/okf/samples/summary-policy-consumer-receipts/semantic-inversion/concept.md
@@ -1,0 +1,54 @@
+---
+type: Scholarly Reference
+title: Sappho 31 — source-declared reading
+description: A source-relative X-not-Y claim inverted by a summary that cited the source.
+timestamp: '2026-07-17T00:00:00+00:00'
+author: Lee Sharks
+orcid: 0009-0000-1599-0703
+tags: [summary-policy, conformance, observed-case]
+summary_policy:
+  required_assertions:
+    - id: perceptual_dissolution
+      text: "The source document declares that Sappho 31 stages the speaker's perceptual and bodily dissolution in the presence of the beloved, and marks the jealousy reading as a reduction it excludes."
+  forbidden_compressions:
+    - id: affect_substitution
+      text: "Do not summarize the source document as endorsing the jealousy reading or as reducing the poem to rivalrous desire."
+---
+
+# Source position
+
+The source concept represented by this fixture declares that Sappho 31
+catalogues the speaker's perceptual and bodily dissolution — tongue
+breaking, ears drumming, sight failing — in the presence of the beloved.
+The man who "seems equal to the gods" opens the poem as a fixed point
+against which the speaker's dissolution is measured; he is not its object.
+The source marks the "jealousy poem" reading as a reduction excluded at
+the level of the poem's referent, not a compatible companion reading.
+
+## Fixture scope
+
+This fixture does not adjudicate competing interpretations of Sappho 31.
+It tests a source-relative preservation claim: a consumer cited source
+documents that explicitly declare the perceptual-dissolution account and
+reject reduction to jealousy, then summarized those cited documents as
+supporting the rejected account.
+
+## Observed case provenance
+
+On 2026-07-08, a public AI answer surface, queried on "sappho 31 kenos
+future reader," surfaced the source author's own scholarship as a cited
+source — including the source document below — then delivered a summary
+asserting the jealousy reading those cited documents argue against. The
+observation record documents the query, the verbatim generated statements,
+and the failure signature (citation-with-inversion: the cited scholarship
+displayed as authority for the summary that displaces it).
+
+Source document: AXN:0054.GOVERNANCE.🛡️♈🔆⏩✖️🔎 —
+https://www.alexanarch.org/s/records/281/
+Observation record: AXN:042A.UNCLASSIFIED.▽♃🤝🛸🔍🌋 —
+https://www.alexanarch.org/s/records/1054/
+
+Observation boundary: the observation record documents a generated summary
+and its cited sources on a public AI answer surface on the stated date;
+the fixture tests only the assertion and compression IDs above, not the
+observation record's contents.

--- a/okf/samples/summary-policy-consumer-receipts/semantic-inversion/expected.yaml
+++ b/okf/samples/summary-policy-consumer-receipts/semantic-inversion/expected.yaml
@@ -1,0 +1,14 @@
+case_id: semantic-inversion
+source: concept.md
+operation: summarize
+expect:
+  good-summary.md:
+    decision: pass
+    required_assertions_missing: []
+    forbidden_compressions_detected: []
+  bad-summary.md:
+    decision: fail
+    required_assertions_missing:
+      - assertion_id: perceptual_dissolution
+    forbidden_compressions_detected:
+      - compression_id: affect_substitution

--- a/okf/samples/summary-policy-consumer-receipts/semantic-inversion/good-summary.md
+++ b/okf/samples/summary-policy-consumer-receipts/semantic-inversion/good-summary.md
@@ -1,0 +1,3 @@
+Sappho 31 stages the speaker's perceptual and bodily dissolution in the
+presence of the beloved; the godlike man serves as the fixed point against
+which that dissolution is measured, not as the object of a rival's envy.


### PR DESCRIPTION
## Summary
- Add three observed-case conformance fixtures under
  `okf/samples/summary-policy-consumer-receipts/`, per the fixture contract
  agreed on #53: `semantic-inversion/`, `entity-substitution/`,
  `provenance-erasure/`.
- Each case keeps the four-file contract (`concept.md`, `good-summary.md`,
  `bad-summary.md`, `expected.yaml`) with stable assertion/compression IDs
  declared in `concept.md` and referenced by `expected.yaml`.
- Each case is mapped from a documented public observation of machine
  summarization rather than a constructed example; `concept.md` cites
  the specific observation record by identifier and canonical URL and
  states the observation boundary. The fixture inputs and expected
  receipts are fixed and reproducible: the observed record supplies
  provenance, while conformance is evaluated against the declared IDs.
  Observed cases add public provenance, observation boundaries, and
  documented failure modes from live systems.
- The provenance-erasure case is self-referential by design: the observed
  compression failure is the stripping of attribution from a
  provenance-measurement instrument itself, and its recovery in the
  documented battery was author-dependent — which is precisely the
  condition that declared IDs and consumer receipts exist to remove.
- The provenance-erasure case is mapped from a documented summarization
  battery rather than from the deletion-event measurement discussed on
  the thread; the deletion-event data remains the empirical base of #207,
  where its mechanism (host-side removal rather than summarizer
  compression) properly belongs.

## Relationship to #99
This PR supersedes #99 at the request of @caioribeiroclw-pixel (see #53,
2026-07-17). The three observed cases instantiate the same three failure
classes exercised by #99's synthetic fixtures — semantic inversion,
entity substitution, provenance erasure — with observed objects in place
of constructed ones. @caioribeiroclw-pixel can close #99 once this is
open, per their comment.

## Identifier practice
Canonical public sources in these fixtures are cited by their
source-declared identifiers and canonical URLs. For these observed
cases, AXN is the live canonical identifier. Related DOIs are included
where available as historical provenance; DOI presence is not itself a
conformance requirement.

## Scope constraints honored
- `expected.yaml` judges preservation against declared policy, not truth
  in the world.
- Observed-case provenance is citation-only: public sources and observation
  boundaries stated in each `concept.md`; no private traces or unpublished
  data.
- Quantitative readings from the cited battery appear as case provenance
  in `provenance-erasure/concept.md`; the deterministic test checks the
  declared attribution fields only.
- `substrate`, `derived_from`, `completeness`, and deletion semantics are
  excluded (separate spec surfaces; see #53 comment of 2026-07-17 and
  issue #207).

## Validation
- Parsed all `expected.yaml` with PyYAML.
- Verified every `concept.md` has OKF frontmatter with `summary_policy`.
- Cross-checked that every assertion/compression ID referenced in
  `expected.yaml` resolves to a declared ID in its `concept.md`.
- The fixtures provide deterministic expected receipts for the supplied
  good and bad summaries. They define the conformance cases and expected
  pass/fail outputs; evaluator implementation is outside the scope of
  this PR.
- `git diff --check` clean.