### PR TITLE
Fix viewer to resolve bundle-relative links (SPEC's recommended link form)

### DIFF
--- a/okf/src/reference_agent/viewer/generator.py
+++ b/okf/src/reference_agent/viewer/generator.py
@@ -51,10 +51,15 @@ def _extract_links(body: str, doc_dir: Path, bundle_root: Path) -> list[str]:
     bundle_root_resolved = bundle_root.resolve()
     for m in _LINK_RE.finditer(body):
         target = m.group(1)
-        if "://" in target or target.startswith("/"):
+        if "://" in target:
             continue
+        if target.startswith("/"):
+            base = bundle_root_resolved
+            target = target.lstrip("/")
+        else:
+            base = doc_dir
         try:
-            resolved = (doc_dir / target).resolve().relative_to(bundle_root_resolved)
+            resolved = (base / target).resolve().relative_to(bundle_root_resolved)
         except ValueError:
             continue
         rel = resolved.as_posix()

--- a/okf/tests/test_viewer.py
+++ b/okf/tests/test_viewer.py
@@ -127,6 +127,63 @@ def test_cross_links_become_edges(tmp_path: Path):
     assert ("tables/events", "tables/users") in pairs
 
 
+def test_bundle_relative_links_become_edges(tmp_path: Path):
+    # SPEC.md recommends absolute, bundle-root-relative links (starting with
+    # "/") over plain relative links for stability.
+    bundle = tmp_path / "bundle"
+    _write(
+        bundle / "datasets" / "my_dataset.md",
+        """
+        ---
+        type: BigQuery Dataset
+        title: My dataset
+        description: A test dataset.
+        timestamp: '2026-05-28T00:00:00+00:00'
+        ---
+        Parent dataset for [users](/tables/users.md).
+        """,
+    )
+    _write(
+        bundle / "tables" / "users.md",
+        """
+        ---
+        type: BigQuery Table
+        title: Users
+        description: User profiles.
+        timestamp: '2026-05-28T00:00:00+00:00'
+        ---
+        See [dataset](/datasets/my_dataset.md).
+        """,
+    )
+    out = tmp_path / "viz.html"
+    generate_visualization(bundle, out)
+    data = _extract_bundle_data(out.read_text(encoding="utf-8"))
+    pairs = {(e["data"]["source"], e["data"]["target"]) for e in data["edges"]}
+    assert ("datasets/my_dataset", "tables/users") in pairs
+    assert ("tables/users", "datasets/my_dataset") in pairs
+
+
+def test_bundle_relative_link_outside_bundle_is_skipped(tmp_path: Path):
+    bundle = tmp_path / "bundle"
+    _write(
+        bundle / "tables" / "lonely.md",
+        """
+        ---
+        type: BigQuery Table
+        title: Lonely
+        description: Has an out-of-bundle absolute link.
+        timestamp: '2026-05-28T00:00:00+00:00'
+        ---
+        Links to [outside](/../outside.md).
+        """,
+    )
+    out = tmp_path / "viz.html"
+    generate_visualization(bundle, out)
+    data = _extract_bundle_data(out.read_text(encoding="utf-8"))
+    assert data["edges"] == []
+    assert len(data["nodes"]) == 1
+
+
 def test_missing_link_targets_are_skipped(tmp_path: Path):
     bundle = tmp_path / "bundle"
     _write(


### PR DESCRIPTION
## Summary
- `viewer/generator.py`'s `_extract_links()` skipped every link target starting with `/`, but SPEC.md §5.1 explicitly recommends bundle-root-relative links (the `/`-prefixed form) over plain relative links for stability, and uses that form in its own examples.
- As a result, a bundle authored using the spec's *recommended* link style rendered with zero edges in the generated `viz.html` — only same-directory relative links (§5.2) were ever graphed.
- Fix: `/`-prefixed targets are now resolved against the bundle root instead of the source document's directory, then validated to stay within the bundle root (same traversal guard as before) before being turned into a graph edge.

## Test plan
- [x] Added `test_bundle_relative_links_become_edges` — confirms `/`-prefixed links between concepts now produce edges.
- [x] Added `test_bundle_relative_link_outside_bundle_is_skipped` — confirms an absolute-looking link that resolves outside the bundle root (e.g. `/../outside.md`) is still safely skipped, not turned into a path-traversal edge.
- [x] `pytest` — all 35 tests pass (8/8 in `tests/test_viewer.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)