### PR TITLE
mdcode: Semantic Model IR contract (M0)

### DIFF
--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -1,0 +1,113 @@
+// Defines the Semantic Model intermediate representation (IR).
+//
+// The IR is the in-memory contract for a semantic model. It represents
+// semantics only: a graph of entities (nodes) connected by relationships
+// (edges), plus model-level metrics.
+//
+
+/**
+ * A semantic model: a graph of entities (nodes) connected by relationships
+ * (edges), with model-level metrics defined over them.
+ *
+ * The IR is pure semantics. Deployment/target configuration lives in the
+ * project manifest (`catalog.yaml`), NOT here.
+ */
+export interface SemanticModel {
+  name: string;
+  description?: string;
+  entities: Entity[];
+  relationships: Relationship[];
+  metrics: Metric[];
+}
+
+/**
+ * A structured reference to a physical table backing an entity or an
+ * association (edge) table.
+ *
+ * Kept lean for now (BigQuery-shaped); additional platforms/fields can be added
+ * later. The YAML layer may accept a shorthand string (e.g. "proj.dataset.table")
+ * and normalize it into this structured form.
+ */
+export interface DataSource {
+  project?: string;
+  dataset?: string;
+  table: string;
+}
+
+/**
+ * An entity: a node in the semantic graph. Backed by a physical table
+ * (`dataSource`), identified by `keys`, and carrying its dimension `fields`.
+ */
+export interface Entity {
+  name: string;
+  dataSource: DataSource;
+  keys: string[];        // grain / primary key
+  description?: string;
+  synonyms?: string[];
+  fields: Field[];       // dimensions / attributes
+}
+
+/**
+ * A field: a dimension / attribute of an entity or relationship.
+ *
+ * Fields describe the data; aggregates are expressed as model-level `Metric`s,
+ * not fields.
+ */
+export interface Field {
+  name: string;
+  expression: string;              // column reference or scalar SQL expression
+  type?: string;                   // logical type; often inferable from source schema
+  description?: string;
+  synonyms?: string[];
+}
+
+/**
+ * A relationship: a directed edge in the semantic graph, from `source` to
+ * `destination`. May be backed by its own association (edge) table
+ * (`dataSource`); when absent, it is a direct foreign-key join. Carries its own
+ * `fields` (edge properties).
+ */
+export interface Relationship {
+  name: string;
+  source: RelationshipEnd;
+  destination: RelationshipEnd;
+  dataSource?: DataSource;  // association/edge table; absent => direct FK join
+  keys?: string[];          // edge key (when backed by an association table)
+  description?: string;
+  synonyms?: string[];
+  fields?: Field[];         // edge properties
+}
+
+/**
+ * One endpoint of a relationship.
+ *
+ * `joinKeys.relationshipColumns` are the columns on the edge/source table;
+ * `joinKeys.entityColumns` are the referenced columns on the endpoint entity
+ * (defaulting to that entity's `keys`).
+ */
+export interface RelationshipEnd {
+  entity: string;        // name-reference into SemanticModel.entities
+  joinKeys: JoinKeys;
+}
+
+export interface JoinKeys {
+  relationshipColumns: string[];
+  entityColumns: string[];
+}
+
+/**
+ * A metric: a model-level, named aggregate.
+ *
+ * Because it lives on the model rather than a single entity, a metric may span
+ * multiple entities — its `expression` can reference fields across the graph,
+ * joined via relationships. `entities` lists the entities the metric references
+ * (one for an entity-scoped metric, several for a cross-entity metric); the
+ * join path between them is resolved by consumers via the model's relationships.
+ */
+export interface Metric {
+  name: string;
+  expression: string;    // aggregate expression, may reference entity-qualified fields
+  entities: string[];    // entities referenced by the metric (>= 1)
+  description?: string;
+  synonyms?: string[];
+}


### PR DESCRIPTION
## What

Introduces the in-memory **intermediate representation (IR)** for a new
**Semantic Model** feature in `kcmd` (`toolbox/mdcode`). This is milestone
**M0**: it pins the *contract* before any pipeline wiring, so the (volatile)
authoring YAML syntax and the model's consumers can evolve independently.

No behavior change: this adds a standalone types module only. Nothing imports
the IR yet.

## Why

The existing `kcmd` pipeline is entry-centric (one file ⇔ one catalog entry). A
semantic model is a *graph* of entities connected by relationships, which needs a
compile step (author files → many entries **+ entry links**) that doesn't exist
yet. Two things about it are volatile — the authoring syntax, and the model's
consumers — so we put a stable IR in the middle. The IR represents **semantics
only**: a graph of entities (nodes) and relationships (edges), with model-level
metrics defined over them.

## Contents

`src/libts/semantic/ir.ts` — `SemanticModel` / `Entity` / `Field` /
`Relationship` / `RelationshipEnd` / `JoinKeys` / `Metric`. Metrics are
model-level and cross-entity-capable (`Metric.entities` lists the entities a
metric spans). Fields are dimensions/attributes; `DataSource` is kept lean for
now. The IR carries no behavior — it is the type contract only. Each type is
documented inline.

## Roadmap

- **M0 (this PR)** — the IR type contract.
- **M1** — entry-link primitive in the catalog client; compiler from the IR to
  catalog entries + entry links, and its inverse.
- **M2** — semantic-model source + layout; `pull`/`push` wiring; manifest init.
- **M3** — finalize the authoring YAML and its normalization into the IR.

## Verification

`tsc` typechecks clean (the full `src/libts/tsconfig.json` project).
