### PR TITLE
mdcode: generate BigQuery property-graph DDL from the Semantic Model IR

### DIFF
--- a/toolbox/mdcode/package.json
+++ b/toolbox/mdcode/package.json
@@ -16,7 +16,8 @@
     "build": "npm run build:libts && npm run build:tool",
     "compile": "npx tsc --noEmit",
     "test:libts": "npx bun test ./tests/libts/scenarios.ts",
-    "test": "npm run test:libts",
+    "test:semantic": "npx bun test ./tests/libts/semantic.bigquery.test.ts",
+    "test": "npm run test:libts && npm run test:semantic",
     "x:mcp": "npx @modelcontextprotocol/inspector dist/kcmd mcp"
   },
   "keywords": [],

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -1,0 +1,219 @@
+// Generates BigQuery property-graph DDL (with inline measures) from the
+// Semantic Model IR.
+//
+// The IR (./ir) is pure semantics. This module is its first consumer: it emits
+// a single `CREATE OR REPLACE PROPERTY GRAPH` statement over the entities'
+// existing base tables, with model-level metrics rendered as inline
+// `MEASURE(...)` properties.
+//
+// BigQuery graph measures bind an aggregate to exactly one table's KEY; the
+// cross-entity rollup happens at query time via GRAPH_EXPAND(...) + AGG(...).
+// A metric therefore lands on whichever single table its aggregate columns
+// reference; a metric whose aggregate genuinely spans multiple tables cannot be
+// expressed as one MEASURE and is skipped (reported in `warnings`).
+//
+// See: https://docs.cloud.google.com/bigquery/docs/graph-measures
+//
+
+import { SemanticModel, Entity, Field, Relationship, RelationshipEnd, Metric, DataSource } from './ir';
+
+export interface GenerateOptions {
+  project?: string;    // default project for the graph + unqualified table refs
+  dataset?: string;    // dataset the graph is created in (else inferred from entities)
+  graphName?: string;  // default: model.name
+}
+
+export interface GenerateResult {
+  ddl: string;         // CREATE OR REPLACE PROPERTY GRAPH ...
+  warnings: string[];  // skipped metrics, unresolved table refs, etc.
+}
+
+// Aggregate functions BigQuery accepts inside MEASURE(...).
+const SUPPORTED_AGGREGATES = ['SUM', 'AVG', 'COUNT', 'MIN', 'MAX'];
+
+/**
+ * Generates the BigQuery property-graph DDL for a semantic model.
+ *
+ * The generated statement references the entities' existing base tables; it does
+ * not create them. Returns the DDL plus any warnings collected while mapping the
+ * IR (e.g. metrics that could not be placed on a single table).
+ */
+export function generatePropertyGraph(model: SemanticModel, opts: GenerateOptions = {}): GenerateResult {
+  const warnings: string[] = [];
+
+  // Metrics are model-level; place each on the single entity its aggregate
+  // references. metricsByEntity: entity name -> measure property lines.
+  const metricsByEntity = new Map<string, string[]>();
+  for (const metric of model.metrics ?? []) {
+    placeMetric(metric, model, metricsByEntity, warnings);
+  }
+
+  const nodeTables = model.entities.map(
+    entity => renderNodeTable(entity, metricsByEntity.get(entity.name) ?? [], opts, warnings));
+
+  const entitiesByName = new Map(model.entities.map(e => [e.name, e]));
+  const edgeTables = model.relationships.map(
+    rel => renderEdgeTable(rel, entitiesByName, opts, warnings));
+
+  const graphName = qualifyGraph(model, opts);
+
+  const blocks: string[] = [
+    `CREATE OR REPLACE PROPERTY GRAPH ${graphName}`,
+    `NODE TABLES (\n${nodeTables.join(',\n')}\n)`,
+  ];
+  if (edgeTables.length) {
+    blocks.push(`EDGE TABLES (\n${edgeTables.join(',\n')}\n)`);
+  }
+
+  return { ddl: blocks.join('\n') + ';\n', warnings };
+}
+
+
+// Assigns a metric to the node table of the single entity its aggregate
+// references, recording a warning if it references zero or multiple entities.
+function placeMetric(metric: Metric, model: SemanticModel,
+                     metricsByEntity: Map<string, string[]>, warnings: string[]): void {
+  const referenced = referencedEntities(metric.expression, model);
+
+  if (referenced.length !== 1) {
+    const detail = referenced.length === 0
+      ? 'references no known entity'
+      : `spans multiple tables (${referenced.join(', ')})`;
+    warnings.push(`metric '${metric.name}' ${detail}; skipped (cannot be a single MEASURE)`);
+    return;
+  }
+
+  const entity = referenced[0];
+  const body = stripQualifier(metric.expression, entity);
+  if (!startsWithSupportedAggregate(body)) {
+    warnings.push(
+      `metric '${metric.name}' expression '${body}' does not begin with a supported ` +
+      `aggregate (${SUPPORTED_AGGREGATES.join(', ')}); emitting anyway`);
+  }
+
+  const lines = metricsByEntity.get(entity) ?? [];
+  lines.push(`MEASURE(${body}) AS ${metric.name}`);
+  metricsByEntity.set(entity, lines);
+}
+
+// Returns the model entity names whose `<name>.` qualifier appears in an expression.
+function referencedEntities(expression: string, model: SemanticModel): string[] {
+  return model.entities
+    .map(e => e.name)
+    .filter(name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(expression));
+}
+
+// Removes the `<entity>.` qualifier so the expression references table-local columns.
+function stripQualifier(expression: string, entity: string): string {
+  return expression.replace(new RegExp(`\\b${escapeRegExp(entity)}\\.`, 'g'), '');
+}
+
+function startsWithSupportedAggregate(body: string): boolean {
+  const fn = body.trimStart().match(/^([A-Za-z_]+)\s*\(/);
+  return !!fn && SUPPORTED_AGGREGATES.includes(fn[1].toUpperCase());
+}
+
+
+function renderNodeTable(entity: Entity, measures: string[],
+                         opts: GenerateOptions, warnings: string[]): string {
+  const table = qualifyTable(entity.dataSource, opts, warnings, `entity '${entity.name}'`);
+  const properties = [
+    ...entity.fields.map(f => renderFieldProperty(f, entity.name)),
+    ...measures,
+  ];
+
+  return [
+    `  ${table} AS ${entity.name}`,
+    `    KEY(${entity.keys.join(', ')})`,
+    `    PROPERTIES(\n${indentList(properties, 6)}\n    )`,
+  ].join('\n');
+}
+
+// Renders a field as a graph property: a bare column when the expression is just
+// the column, else `<expr> AS <name>`. Attaches a description when present.
+function renderFieldProperty(field: Field, entity: string): string {
+  const local = stripQualifier(field.expression, entity);
+  let prop = local === field.name ? field.name : `${local} AS ${field.name}`;
+  if (field.description) {
+    prop += ` OPTIONS(description=${quote(field.description)})`;
+  }
+  return prop;
+}
+
+
+function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
+                        opts: GenerateOptions, warnings: string[]): string {
+  // Backed by the association/junction table when present (the M:N shape),
+  // otherwise by the source entity's base table (direct foreign-key relationship,
+  // where the source table holds the join columns).
+  let backing: string;
+  if (rel.dataSource) {
+    backing = qualifyTable(rel.dataSource, opts, warnings, `relationship '${rel.name}'`);
+  } else {
+    const sourceEntity = entitiesByName.get(rel.source.entity);
+    if (!sourceEntity) {
+      warnings.push(`relationship '${rel.name}': unknown source entity '${rel.source.entity}'`);
+      backing = `\`${rel.source.entity}\``;
+    } else {
+      backing = qualifyTable(sourceEntity.dataSource, opts, warnings, `relationship '${rel.name}'`);
+    }
+  }
+
+  const lines = [
+    `  ${backing} AS ${rel.name}`,
+    `    SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`,
+    `    DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`,
+  ];
+
+  if (rel.fields && rel.fields.length) {
+    const properties = rel.fields.map(f => renderFieldProperty(f, rel.name));
+    lines.push(`    PROPERTIES(\n${indentList(properties, 6)}\n    )`);
+  }
+
+  return lines.join('\n');
+}
+
+function keys(end: RelationshipEnd): { rel: string; entity: string } {
+  return {
+    rel: end.joinKeys.relationshipColumns.join(', '),
+    entity: end.joinKeys.entityColumns.join(', '),
+  };
+}
+
+
+// Builds a backtick-quoted `project.dataset.table` reference, falling back to
+// opts for a missing project/dataset. Warns when neither yields a project or
+// dataset (the ref will be unqualified and likely invalid).
+function qualifyTable(ds: DataSource, opts: GenerateOptions,
+                      warnings: string[], context: string): string {
+  const project = ds.project ?? opts.project;
+  const dataset = ds.dataset ?? opts.dataset;
+  const parts = [project, dataset, ds.table].filter((p): p is string => !!p);
+  if (!project || !dataset) {
+    warnings.push(`${context}: table '${ds.table}' is missing a project and/or dataset`);
+  }
+  return `\`${parts.join('.')}\``;
+}
+
+// Builds the dataset-qualified graph name.
+function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
+  const name = opts.graphName ?? model.name;
+  const dataset = opts.dataset ?? model.entities[0]?.dataSource.dataset;
+  const project = opts.project ?? model.entities[0]?.dataSource.project;
+  const parts = [project, dataset, name].filter((p): p is string => !!p);
+  return `\`${parts.join('.')}\``;
+}
+
+
+function indentList(lines: string[], spaces: number): string {
+  const pad = ' '.repeat(spaces);
+  return lines.map(l => `${pad}${l}`).join(',\n');
+}
+
+function quote(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -147,20 +147,19 @@ function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
   // otherwise by the source entity's base table (direct foreign-key relationship,
   // where the source table holds the join columns).
   let backing: string;
+  const sourceEntity = entitiesByName.get(rel.source.entity);
   if (rel.dataSource) {
     backing = qualifyTable(rel.dataSource, opts, warnings, `relationship '${rel.name}'`);
+  } else if (!sourceEntity) {
+    warnings.push(`relationship '${rel.name}': unknown source entity '${rel.source.entity}'`);
+    backing = `\`${rel.source.entity}\``;
   } else {
-    const sourceEntity = entitiesByName.get(rel.source.entity);
-    if (!sourceEntity) {
-      warnings.push(`relationship '${rel.name}': unknown source entity '${rel.source.entity}'`);
-      backing = `\`${rel.source.entity}\``;
-    } else {
-      backing = qualifyTable(sourceEntity.dataSource, opts, warnings, `relationship '${rel.name}'`);
-    }
+    backing = qualifyTable(sourceEntity.dataSource, opts, warnings, `relationship '${rel.name}'`);
   }
 
   const lines = [
     `  ${backing} AS ${rel.name}`,
+    `    KEY(${edgeKey(rel, sourceEntity).join(', ')})`,
     `    SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`,
     `    DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`,
   ];
@@ -171,6 +170,28 @@ function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
   }
 
   return lines.join('\n');
+}
+
+// The edge element key: the columns that uniquely identify an edge row. Graph
+// element tables must declare a key explicitly (base-table PRIMARY KEYs are not
+// assumed). Prefers the relationship's own `keys`; for a direct FK backed by the
+// source entity's table, uses that entity's keys; otherwise falls back to the
+// composite of both ends' join columns on the backing table.
+function edgeKey(rel: Relationship, sourceEntity: Entity | undefined): string[] {
+  if (rel.keys && rel.keys.length) {
+    return rel.keys;
+  }
+  if (!rel.dataSource && sourceEntity) {
+    return sourceEntity.keys;
+  }
+  return dedupe([
+    ...rel.source.joinKeys.relationshipColumns,
+    ...rel.destination.joinKeys.relationshipColumns,
+  ]);
+}
+
+function dedupe(items: string[]): string[] {
+  return [...new Set(items)];
 }
 
 function keys(end: RelationshipEnd): { rel: string; entity: string } {

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -123,9 +123,9 @@ function renderNodeTable(entity: Entity, measures: string[],
   ];
 
   return [
-    `  ${table} AS ${entity.name}`,
-    `    KEY(${entity.keys.join(', ')})`,
-    `    PROPERTIES(\n${indentList(properties, 6)}\n    )`,
+    line(1, `${table} AS ${entity.name}`),
+    line(2, `KEY(${entity.keys.join(', ')})`),
+    propertiesBlock(properties),
   ].join('\n');
 }
 
@@ -158,15 +158,15 @@ function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
   }
 
   const lines = [
-    `  ${backing} AS ${rel.name}`,
-    `    KEY(${edgeKey(rel, sourceEntity).join(', ')})`,
-    `    SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`,
-    `    DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`,
+    line(1, `${backing} AS ${rel.name}`),
+    line(2, `KEY(${edgeKey(rel, sourceEntity).join(', ')})`),
+    line(2, `SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`),
+    line(2, `DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`),
   ];
 
   if (rel.fields && rel.fields.length) {
     const properties = rel.fields.map(f => renderFieldProperty(f, rel.name));
-    lines.push(`    PROPERTIES(\n${indentList(properties, 6)}\n    )`);
+    lines.push(propertiesBlock(properties));
   }
 
   return lines.join('\n');
@@ -226,9 +226,20 @@ function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
 }
 
 
-function indentList(lines: string[], spaces: number): string {
-  const pad = ' '.repeat(spaces);
-  return lines.map(l => `${pad}${l}`).join(',\n');
+// All generated indentation flows through this single mechanism: one nesting
+// level == one INDENT. `line` indents one line to a depth; `list` indents a set
+// of lines and joins them comma-separated; `propertiesBlock` is the shared
+// `PROPERTIES( ... )` shape used by both node and edge tables. Keeping every
+// indent derived from `depth` (rather than hardcoded spaces) makes the output
+// indentation consistent by construction.
+const INDENT = '  ';
+const pad = (depth: number): string => INDENT.repeat(depth);
+const line = (depth: number, text: string): string => `${pad(depth)}${text}`;
+const list = (depth: number, lines: string[]): string =>
+  lines.map(l => line(depth, l)).join(',\n');
+
+function propertiesBlock(properties: string[]): string {
+  return `${line(2, 'PROPERTIES(')}\n${list(3, properties)}\n${line(2, ')')}`;
 }
 
 function quote(s: string): string {

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -41,18 +41,28 @@ const SUPPORTED_AGGREGATES = ['SUM', 'AVG', 'COUNT', 'MIN', 'MAX'];
 export function generatePropertyGraph(model: SemanticModel, opts: GenerateOptions = {}): GenerateResult {
   const warnings: string[] = [];
 
+  // The IR requires entities/relationships/metrics, but be defensive against a
+  // hand-built or partially-deserialized model rather than throwing on `.map`.
+  const entities = model.entities ?? [];
+  const relationships = model.relationships ?? [];
+  const metrics = model.metrics ?? [];
+
+  if (!entities.length) {
+    warnings.push('model has no entities; the generated NODE TABLES block will be empty and invalid');
+  }
+
   // Metrics are model-level; place each on the single entity its aggregate
   // references. metricsByEntity: entity name -> measure property lines.
   const metricsByEntity = new Map<string, string[]>();
-  for (const metric of model.metrics ?? []) {
+  for (const metric of metrics) {
     placeMetric(metric, model, metricsByEntity, warnings);
   }
 
-  const nodeTables = model.entities.map(
+  const nodeTables = entities.map(
     entity => renderNodeTable(entity, metricsByEntity.get(entity.name) ?? [], opts, warnings));
 
-  const entitiesByName = new Map(model.entities.map(e => [e.name, e]));
-  const edgeTables = model.relationships.map(
+  const entitiesByName = new Map(entities.map(e => [e.name, e]));
+  const edgeTables = relationships.map(
     rel => renderEdgeTable(rel, entitiesByName, opts, warnings));
 
   const graphName = qualifyGraph(model, opts);
@@ -65,7 +75,7 @@ export function generatePropertyGraph(model: SemanticModel, opts: GenerateOption
     blocks.push(`EDGE TABLES (\n${edgeTables.join(',\n')}\n)`);
   }
 
-  return { ddl: blocks.join('\n') + ';\n', warnings };
+  return { ddl: blocks.join('\n') + ';\n', warnings: dedupe(warnings) };
 }
 
 
@@ -74,6 +84,16 @@ export function generatePropertyGraph(model: SemanticModel, opts: GenerateOption
 function placeMetric(metric: Metric, model: SemanticModel,
                      metricsByEntity: Map<string, string[]>, warnings: string[]): void {
   const referenced = referencedEntities(metric.expression, model);
+
+  // The IR also declares metric.entities. Placement is driven by the qualifiers
+  // actually present in the expression (that is what we strip and attach), but a
+  // disagreement with the declared list signals an inconsistent model, so
+  // surface it rather than resolving silently.
+  if (metric.entities && !sameSet(metric.entities, referenced)) {
+    warnings.push(
+      `metric '${metric.name}' declares entities [${metric.entities.join(', ')}] but its ` +
+      `expression references [${referenced.join(', ') || 'none'}]; placing per the expression`);
+  }
 
   if (referenced.length !== 1) {
     const detail = referenced.length === 0
@@ -96,16 +116,22 @@ function placeMetric(metric: Metric, model: SemanticModel,
   metricsByEntity.set(entity, lines);
 }
 
-// Returns the model entity names whose `<name>.` qualifier appears in an expression.
+// Returns the model entity names whose `<name>.` qualifier appears in an
+// expression. String literals are ignored so a value like 'orders.x' is not
+// mistaken for a reference to the `orders` entity.
 function referencedEntities(expression: string, model: SemanticModel): string[] {
-  return model.entities
+  const scannable = blankStringLiterals(expression);
+  return (model.entities ?? [])
     .map(e => e.name)
-    .filter(name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(expression));
+    .filter(name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(scannable));
 }
 
-// Removes the `<entity>.` qualifier so the expression references table-local columns.
+// Removes the `<entity>.` qualifier so the expression references table-local
+// columns, without touching text inside string literals (a literal such as
+// 'orders.x' is data, not a qualified column reference).
 function stripQualifier(expression: string, entity: string): string {
-  return expression.replace(new RegExp(`\\b${escapeRegExp(entity)}\\.`, 'g'), '');
+  const re = new RegExp(`\\b${escapeRegExp(entity)}\\.`, 'g');
+  return mapOutsideStringLiterals(expression, seg => seg.replace(re, ''));
 }
 
 function startsWithSupportedAggregate(body: string): boolean {
@@ -157,11 +183,13 @@ function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
     backing = qualifyTable(sourceEntity.dataSource, opts, warnings, `relationship '${rel.name}'`);
   }
 
+  const src = keys(rel.source);
+  const dst = keys(rel.destination);
   const lines = [
     line(1, `${backing} AS ${rel.name}`),
     line(2, `KEY(${edgeKey(rel, sourceEntity).join(', ')})`),
-    line(2, `SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`),
-    line(2, `DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`),
+    line(2, `SOURCE KEY(${src.rel}) REFERENCES ${rel.source.entity}(${src.entity})`),
+    line(2, `DESTINATION KEY(${dst.rel}) REFERENCES ${rel.destination.entity}(${dst.entity})`),
   ];
 
   if (rel.fields && rel.fields.length) {
@@ -219,8 +247,9 @@ function qualifyTable(ds: DataSource, opts: GenerateOptions,
 // Builds the dataset-qualified graph name.
 function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
   const name = opts.graphName ?? model.name;
-  const dataset = opts.dataset ?? model.entities[0]?.dataSource.dataset;
-  const project = opts.project ?? model.entities[0]?.dataSource.project;
+  const first = (model.entities ?? [])[0];
+  const dataset = opts.dataset ?? first?.dataSource.dataset;
+  const project = opts.project ?? first?.dataSource.project;
   const parts = [project, dataset, name].filter((p): p is string => !!p);
   return `\`${parts.join('.')}\``;
 }
@@ -242,10 +271,51 @@ function propertiesBlock(properties: string[]): string {
   return `${line(2, 'PROPERTIES(')}\n${list(3, properties)}\n${line(2, ')')}`;
 }
 
+// Renders a value as a BigQuery double-quoted string literal. Backslash and the
+// quote are escaped, and control characters that cannot appear raw inside a
+// quoted literal (newline, carriage return, tab) are escaped too, so a
+// multi-line description does not produce a broken literal.
 function quote(s: string): string {
-  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
 }
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = new Set(a);
+  return b.every(x => sa.has(x));
+}
+
+// Matches a single- or double-quoted SQL string literal, honoring backslash
+// escapes. (Triple-quoted / raw literals are uncommon in measure expressions and
+// are treated as ordinary text.)
+const STRING_LITERAL = /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g;
+
+// Replaces string-literal contents with blanks of equal length, so qualifier
+// scanning sees literal-free text without shifting any offsets.
+function blankStringLiterals(expression: string): string {
+  return expression.replace(STRING_LITERAL, m => ' '.repeat(m.length));
+}
+
+// Applies `fn` only to the parts of `expression` that lie outside string
+// literals, leaving each literal verbatim.
+function mapOutsideStringLiterals(expression: string, fn: (segment: string) => string): string {
+  let out = '';
+  let last = 0;
+  for (const m of expression.matchAll(STRING_LITERAL)) {
+    out += fn(expression.slice(last, m.index));
+    out += m[0];
+    last = m.index! + m[0].length;
+  }
+  out += fn(expression.slice(last));
+  return out;
 }

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -1,0 +1,113 @@
+// Defines the Semantic Model intermediate representation (IR).
+//
+// The IR is the in-memory contract for a semantic model. It represents
+// semantics only: a graph of entities (nodes) connected by relationships
+// (edges), plus model-level metrics.
+//
+
+/**
+ * A semantic model: a graph of entities (nodes) connected by relationships
+ * (edges), with model-level metrics defined over them.
+ *
+ * The IR is pure semantics. Deployment/target configuration lives in the
+ * project manifest (`catalog.yaml`), NOT here.
+ */
+export interface SemanticModel {
+  name: string;
+  description?: string;
+  entities: Entity[];
+  relationships: Relationship[];
+  metrics: Metric[];
+}
+
+/**
+ * A structured reference to a physical table backing an entity or an
+ * association (edge) table.
+ *
+ * Kept lean for now (BigQuery-shaped); additional platforms/fields can be added
+ * later. The YAML layer may accept a shorthand string (e.g. "proj.dataset.table")
+ * and normalize it into this structured form.
+ */
+export interface DataSource {
+  project?: string;
+  dataset?: string;
+  table: string;
+}
+
+/**
+ * An entity: a node in the semantic graph. Backed by a physical table
+ * (`dataSource`), identified by `keys`, and carrying its dimension `fields`.
+ */
+export interface Entity {
+  name: string;
+  dataSource: DataSource;
+  keys: string[];        // grain / primary key
+  description?: string;
+  synonyms?: string[];
+  fields: Field[];       // dimensions / attributes
+}
+
+/**
+ * A field: a dimension / attribute of an entity or relationship.
+ *
+ * Fields describe the data; aggregates are expressed as model-level `Metric`s,
+ * not fields.
+ */
+export interface Field {
+  name: string;
+  expression: string;              // column reference or scalar SQL expression
+  type?: string;                   // logical type; often inferable from source schema
+  description?: string;
+  synonyms?: string[];
+}
+
+/**
+ * A relationship: a directed edge in the semantic graph, from `source` to
+ * `destination`. May be backed by its own association (edge) table
+ * (`dataSource`); when absent, it is a direct foreign-key join. Carries its own
+ * `fields` (edge properties).
+ */
+export interface Relationship {
+  name: string;
+  source: RelationshipEnd;
+  destination: RelationshipEnd;
+  dataSource?: DataSource;  // association/edge table; absent => direct FK join
+  keys?: string[];          // edge key (when backed by an association table)
+  description?: string;
+  synonyms?: string[];
+  fields?: Field[];         // edge properties
+}
+
+/**
+ * One endpoint of a relationship.
+ *
+ * `joinKeys.relationshipColumns` are the columns on the edge/source table;
+ * `joinKeys.entityColumns` are the referenced columns on the endpoint entity
+ * (defaulting to that entity's `keys`).
+ */
+export interface RelationshipEnd {
+  entity: string;        // name-reference into SemanticModel.entities
+  joinKeys: JoinKeys;
+}
+
+export interface JoinKeys {
+  relationshipColumns: string[];
+  entityColumns: string[];
+}
+
+/**
+ * A metric: a model-level, named aggregate.
+ *
+ * Because it lives on the model rather than a single entity, a metric may span
+ * multiple entities — its `expression` can reference fields across the graph,
+ * joined via relationships. `entities` lists the entities the metric references
+ * (one for an entity-scoped metric, several for a cross-entity metric); the
+ * join path between them is resolved by consumers via the model's relationships.
+ */
+export interface Metric {
+  name: string;
+  expression: string;    // aggregate expression, may reference entity-qualified fields
+  entities: string[];    // entities referenced by the metric (>= 1)
+  description?: string;
+  synonyms?: string[];
+}

--- a/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
@@ -1,0 +1,136 @@
+// Tests for the BigQuery property-graph generator (src/libts/semantic/bigquery.ts).
+//
+
+import { describe, test, expect } from 'bun:test';
+import { generatePropertyGraph } from '../../src/libts/semantic/bigquery';
+import { SemanticModel } from '../../src/libts/semantic/ir';
+
+// A small sales model: customers -(place)- orders, plus an order_items fact
+// table joined to orders. Metrics exercise single-entity placement and the
+// cross-table skip path.
+const MODEL: SemanticModel = {
+  name: 'sales',
+  entities: [
+    {
+      name: 'customers',
+      dataSource: { project: 'proj', dataset: 'sales', table: 'customers' },
+      keys: ['customer_id'],
+      fields: [
+        { name: 'customer_id', expression: 'customers.customer_id' },
+        { name: 'region', expression: 'customers.region', description: 'Sales region' },
+      ],
+    },
+    {
+      name: 'orders',
+      dataSource: { project: 'proj', dataset: 'sales', table: 'orders' },
+      keys: ['order_id'],
+      fields: [
+        { name: 'order_id', expression: 'orders.order_id' },
+        { name: 'status', expression: 'orders.status' },
+      ],
+    },
+    {
+      name: 'order_items',
+      dataSource: { project: 'proj', dataset: 'sales', table: 'order_items' },
+      keys: ['order_item_id'],
+      fields: [
+        { name: 'order_item_id', expression: 'order_items.order_item_id' },
+        { name: 'amount', expression: 'order_items.amount' },
+      ],
+    },
+  ],
+  relationships: [
+    {
+      name: 'customer_orders',
+      source: {
+        entity: 'orders',
+        joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
+      },
+      destination: {
+        entity: 'customers',
+        joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
+      },
+    },
+  ],
+  metrics: [
+    { name: 'total_revenue', expression: 'SUM(order_items.amount)', entities: ['order_items'] },
+    { name: 'order_count', expression: 'COUNT(orders.order_id)', entities: ['orders'] },
+    // Genuinely cross-table: references two entities' columns in one aggregate.
+    { name: 'weird', expression: 'SUM(order_items.amount * customers.customer_id)',
+      entities: ['order_items', 'customers'] },
+  ],
+};
+
+describe('generatePropertyGraph', () => {
+  const { ddl, warnings } = generatePropertyGraph(MODEL);
+
+  test('emits a single CREATE OR REPLACE PROPERTY GRAPH', () => {
+    expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `proj.sales.sales`');
+    expect(ddl).toContain('NODE TABLES (');
+    expect(ddl).toContain('EDGE TABLES (');
+    expect(ddl.trim().endsWith(';')).toBe(true);
+  });
+
+  test('renders node tables with keys and properties', () => {
+    expect(ddl).toContain('`proj.sales.customers` AS customers');
+    expect(ddl).toContain('KEY(customer_id)');
+    // Bare column when expression is just the column.
+    expect(ddl).toContain('customer_id');
+    // Description carried into OPTIONS.
+    expect(ddl).toContain('region OPTIONS(description="Sales region")');
+  });
+
+  test('renders the edge table referencing node labels', () => {
+    expect(ddl).toContain('`proj.sales.orders` AS customer_orders');
+    expect(ddl).toContain('SOURCE KEY(customer_id) REFERENCES orders(customer_id)');
+    expect(ddl).toContain('DESTINATION KEY(customer_id) REFERENCES customers(customer_id)');
+  });
+
+  test('places single-entity metrics as inline MEASUREs (qualifier stripped)', () => {
+    expect(ddl).toContain('MEASURE(SUM(amount)) AS total_revenue');
+    expect(ddl).toContain('MEASURE(COUNT(order_id)) AS order_count');
+  });
+
+  test('skips a genuinely cross-table metric and warns', () => {
+    expect(ddl).not.toContain('weird');
+    expect(warnings.some(w => w.includes("metric 'weird'") && w.includes('multiple tables')))
+      .toBe(true);
+  });
+
+  test('no warnings for the placeable metrics', () => {
+    expect(warnings.some(w => w.includes("'total_revenue'"))).toBe(false);
+    expect(warnings.some(w => w.includes("'order_count'"))).toBe(false);
+  });
+});
+
+describe('generatePropertyGraph options and edge cases', () => {
+  test('falls back to opts for project/dataset and graph name', () => {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{
+        name: 'e',
+        dataSource: { table: 't' },
+        keys: ['id'],
+        fields: [{ name: 'id', expression: 'e.id' }],
+      }],
+      relationships: [],
+      metrics: [],
+    };
+    const { ddl } = generatePropertyGraph(model, { project: 'p', dataset: 'd', graphName: 'g' });
+    expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `p.d.g`');
+    expect(ddl).toContain('`p.d.t` AS e');
+    // No relationships => no EDGE TABLES block.
+    expect(ddl).not.toContain('EDGE TABLES');
+  });
+
+  test('warns when a table has no resolvable project/dataset', () => {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'], fields: [] }],
+      relationships: [],
+      metrics: [],
+    };
+    const { warnings } = generatePropertyGraph(model);
+    expect(warnings.some(w => w.includes('missing a project and/or dataset'))).toBe(true);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
@@ -1,136 +1,291 @@
-// Tests for the BigQuery property-graph generator (src/libts/semantic/bigquery.ts).
+// Behavior specification for the BigQuery property-graph generator
+// (src/libts/semantic/bigquery.ts).
+//
+// Each test names and documents one behavior of `generatePropertyGraph`. The two
+// fixtures below (a direct-FK chain and an M:N association) were executed against
+// a live BigQuery instance (project `sqlgen-testing`): the chain's node measures
+// were validated with GRAPH_EXPAND + AGG against a plain-SQL control, and the
+// association graph was traversed with a GQL MATCH. The "matches verified DDL"
+// tests pin the generator output to the exact text BigQuery accepted, so this
+// suite guards the behavior without needing a live instance.
 //
 
 import { describe, test, expect } from 'bun:test';
-import { generatePropertyGraph } from '../../src/libts/semantic/bigquery';
+import { generatePropertyGraph, GenerateOptions } from '../../src/libts/semantic/bigquery';
 import { SemanticModel } from '../../src/libts/semantic/ir';
 
-// A small sales model: customers -(place)- orders, plus an order_items fact
-// table joined to orders. Metrics exercise single-entity placement and the
-// cross-table skip path.
-const MODEL: SemanticModel = {
-  name: 'sales',
+// Target used for the live verification; kept so the golden DDL below is
+// reproducible byte-for-byte.
+const OPTS: GenerateOptions = { project: 'sqlgen-testing', dataset: 'bei_semantic_ir_verify' };
+
+// Direct-FK chain: order_items (root) -> orders -> customers, with node-level
+// measures. Verified live via GRAPH_EXPAND + AGG.
+const SALES: SemanticModel = {
+  name: 'sales_graph',
   entities: [
-    {
-      name: 'customers',
-      dataSource: { project: 'proj', dataset: 'sales', table: 'customers' },
-      keys: ['customer_id'],
+    { name: 'customers', dataSource: { table: 'customers' }, keys: ['customer_id'],
       fields: [
         { name: 'customer_id', expression: 'customers.customer_id' },
         { name: 'region', expression: 'customers.region', description: 'Sales region' },
-      ],
-    },
-    {
-      name: 'orders',
-      dataSource: { project: 'proj', dataset: 'sales', table: 'orders' },
-      keys: ['order_id'],
+      ] },
+    { name: 'orders', dataSource: { table: 'orders' }, keys: ['order_id'],
       fields: [
         { name: 'order_id', expression: 'orders.order_id' },
+        { name: 'customer_id', expression: 'orders.customer_id' },
         { name: 'status', expression: 'orders.status' },
-      ],
-    },
-    {
-      name: 'order_items',
-      dataSource: { project: 'proj', dataset: 'sales', table: 'order_items' },
-      keys: ['order_item_id'],
+      ] },
+    { name: 'order_items', dataSource: { table: 'order_items' }, keys: ['order_item_id'],
       fields: [
         { name: 'order_item_id', expression: 'order_items.order_item_id' },
+        { name: 'order_id', expression: 'order_items.order_id' },
         { name: 'amount', expression: 'order_items.amount' },
-      ],
-    },
+      ] },
   ],
   relationships: [
-    {
-      name: 'customer_orders',
-      source: {
-        entity: 'orders',
-        joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
-      },
-      destination: {
-        entity: 'customers',
-        joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
-      },
-    },
+    { name: 'orders_customers',
+      source:      { entity: 'orders',    joinKeys: { relationshipColumns: ['order_id'],    entityColumns: ['order_id'] } },
+      destination: { entity: 'customers', joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] } } },
+    { name: 'orderitems_orders',
+      source:      { entity: 'order_items', joinKeys: { relationshipColumns: ['order_item_id'], entityColumns: ['order_item_id'] } },
+      destination: { entity: 'orders',      joinKeys: { relationshipColumns: ['order_id'],      entityColumns: ['order_id'] } } },
   ],
   metrics: [
-    { name: 'total_revenue', expression: 'SUM(order_items.amount)', entities: ['order_items'] },
-    { name: 'order_count', expression: 'COUNT(orders.order_id)', entities: ['orders'] },
-    // Genuinely cross-table: references two entities' columns in one aggregate.
-    { name: 'weird', expression: 'SUM(order_items.amount * customers.customer_id)',
-      entities: ['order_items', 'customers'] },
+    { name: 'total_revenue', expression: 'SUM(order_items.amount)',          entities: ['order_items'] },
+    { name: 'item_count',    expression: 'COUNT(order_items.order_item_id)', entities: ['order_items'] },
+    { name: 'order_count',   expression: 'COUNT(orders.order_id)',           entities: ['orders'] },
   ],
 };
 
-describe('generatePropertyGraph', () => {
-  const { ddl, warnings } = generatePropertyGraph(MODEL);
+// M:N via an association table with its own key and an edge property. Verified
+// live via a GQL MATCH traversal.
+const SCHOOL: SemanticModel = {
+  name: 'school_graph',
+  entities: [
+    { name: 'students', dataSource: { table: 'students' }, keys: ['student_id'],
+      fields: [ { name: 'student_id', expression: 'students.student_id' },
+                { name: 'name', expression: 'students.name' } ] },
+    { name: 'courses', dataSource: { table: 'courses' }, keys: ['course_id'],
+      fields: [ { name: 'course_id', expression: 'courses.course_id' },
+                { name: 'title', expression: 'courses.title' } ] },
+  ],
+  relationships: [
+    { name: 'enrollment',
+      dataSource: { table: 'enrollment' },
+      keys: ['enrollment_id'],
+      source:      { entity: 'students', joinKeys: { relationshipColumns: ['student_id'], entityColumns: ['student_id'] } },
+      destination: { entity: 'courses',  joinKeys: { relationshipColumns: ['course_id'],  entityColumns: ['course_id'] } },
+      fields: [ { name: 'grade', expression: 'enrollment.grade', description: 'Letter grade' } ] },
+  ],
+  metrics: [],
+};
 
-  test('emits a single CREATE OR REPLACE PROPERTY GRAPH', () => {
-    expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `proj.sales.sales`');
-    expect(ddl).toContain('NODE TABLES (');
-    expect(ddl).toContain('EDGE TABLES (');
-    expect(ddl.trim().endsWith(';')).toBe(true);
-  });
 
-  test('renders node tables with keys and properties', () => {
-    expect(ddl).toContain('`proj.sales.customers` AS customers');
+describe('entities become node tables', () => {
+  const { ddl } = generatePropertyGraph(SALES, OPTS);
+
+  test('each entity is a node table keyed by its grain (the KEY measures lock to)', () => {
+    expect(ddl).toContain('`sqlgen-testing.bei_semantic_ir_verify.customers` AS customers');
     expect(ddl).toContain('KEY(customer_id)');
-    // Bare column when expression is just the column.
-    expect(ddl).toContain('customer_id');
-    // Description carried into OPTIONS.
+    expect(ddl).toContain('`sqlgen-testing.bei_semantic_ir_verify.order_items` AS order_items');
+    expect(ddl).toContain('KEY(order_item_id)');
+  });
+
+  test('a plain-column field emits a bare property (no redundant "col AS col")', () => {
+    // order_items.amount -> just `amount`, since the expression is only the column.
+    expect(ddl).toContain('\n      amount');
+    expect(ddl).not.toContain('amount AS amount');
+  });
+
+  test('a field description is preserved as OPTIONS(description=...)', () => {
     expect(ddl).toContain('region OPTIONS(description="Sales region")');
-  });
-
-  test('renders the edge table referencing node labels', () => {
-    expect(ddl).toContain('`proj.sales.orders` AS customer_orders');
-    expect(ddl).toContain('SOURCE KEY(customer_id) REFERENCES orders(customer_id)');
-    expect(ddl).toContain('DESTINATION KEY(customer_id) REFERENCES customers(customer_id)');
-  });
-
-  test('places single-entity metrics as inline MEASUREs (qualifier stripped)', () => {
-    expect(ddl).toContain('MEASURE(SUM(amount)) AS total_revenue');
-    expect(ddl).toContain('MEASURE(COUNT(order_id)) AS order_count');
-  });
-
-  test('skips a genuinely cross-table metric and warns', () => {
-    expect(ddl).not.toContain('weird');
-    expect(warnings.some(w => w.includes("metric 'weird'") && w.includes('multiple tables')))
-      .toBe(true);
-  });
-
-  test('no warnings for the placeable metrics', () => {
-    expect(warnings.some(w => w.includes("'total_revenue'"))).toBe(false);
-    expect(warnings.some(w => w.includes("'order_count'"))).toBe(false);
   });
 });
 
-describe('generatePropertyGraph options and edge cases', () => {
-  test('falls back to opts for project/dataset and graph name', () => {
+
+describe('model-level metrics become inline measures', () => {
+  const { ddl, warnings } = generatePropertyGraph(SALES, OPTS);
+
+  test('a single-entity metric becomes a table-local MEASURE (entity qualifier stripped)', () => {
+    // SUM(order_items.amount) -> MEASURE(SUM(amount)); the measure body must
+    // reference columns local to the table it is attached to.
+    expect(ddl).toContain('MEASURE(SUM(amount)) AS total_revenue');
+    expect(ddl).toContain('MEASURE(COUNT(order_item_id)) AS item_count');
+  });
+
+  test('a measure is attached to its owning entity, keeping it locked to that KEY', () => {
+    // order_count counts orders, so it must live on the `orders` node (locked to
+    // order_id) — not on the fan-out `order_items` table. Live verification
+    // confirmed this yields 3 orders for the "west" region, not 4 (the item
+    // count), proving joins do not inflate the measure.
+    const ordersBlock = ddl.slice(ddl.indexOf('AS orders\n'), ddl.indexOf('AS order_items'));
+    expect(ordersBlock).toContain('MEASURE(COUNT(order_id)) AS order_count');
+  });
+
+  test('a metric whose aggregate spans multiple tables is skipped and reported', () => {
+    // A BigQuery measure binds to a single table's KEY, so a genuinely
+    // cross-table aggregate cannot become one MEASURE.
+    const model: SemanticModel = {
+      ...SALES,
+      metrics: [{ name: 'weird', expression: 'SUM(order_items.amount * customers.customer_id)',
+                  entities: ['order_items', 'customers'] }],
+    };
+    const res = generatePropertyGraph(model, OPTS);
+    expect(res.ddl).not.toContain('weird');
+    expect(res.warnings.some(w => w.includes("metric 'weird'") && w.includes('multiple tables')))
+      .toBe(true);
+  });
+
+  test('placeable metrics produce no warnings', () => {
+    expect(warnings).toEqual([]);
+  });
+});
+
+
+describe('relationships become edge tables', () => {
+  test('every edge table declares an explicit element KEY (base-table PKs are not assumed)', () => {
+    // BigQuery rejects an edge table without a key unless the base table declares
+    // a PRIMARY KEY; semantic models over arbitrary tables cannot rely on that,
+    // so the generator always emits KEY(...). This was caught by live testing.
+    const { ddl } = generatePropertyGraph(SALES, OPTS);
+    expect(ddl).toContain('AS orders_customers\n    KEY(order_id)');
+    expect(ddl).toContain('AS orderitems_orders\n    KEY(order_item_id)');
+  });
+
+  test('a direct-FK edge is backed by the source entity table; REFERENCES target each endpoint KEY', () => {
+    const { ddl } = generatePropertyGraph(SALES, OPTS);
+    expect(ddl).toContain('`sqlgen-testing.bei_semantic_ir_verify.orders` AS orders_customers');
+    expect(ddl).toContain('SOURCE KEY(order_id) REFERENCES orders(order_id)');
+    expect(ddl).toContain('DESTINATION KEY(customer_id) REFERENCES customers(customer_id)');
+  });
+
+  test('an association edge is backed by its own table, keyed by rel.keys, and carries edge properties', () => {
+    const { ddl } = generatePropertyGraph(SCHOOL, OPTS);
+    expect(ddl).toContain('`sqlgen-testing.bei_semantic_ir_verify.enrollment` AS enrollment');
+    expect(ddl).toContain('AS enrollment\n    KEY(enrollment_id)');
+    expect(ddl).toContain('SOURCE KEY(student_id) REFERENCES students(student_id)');
+    expect(ddl).toContain('DESTINATION KEY(course_id) REFERENCES courses(course_id)');
+    expect(ddl).toContain('grade OPTIONS(description="Letter grade")');
+  });
+});
+
+
+describe('graph naming and options', () => {
+  test('graph name and unqualified table refs fall back to options', () => {
     const model: SemanticModel = {
       name: 'm',
-      entities: [{
-        name: 'e',
-        dataSource: { table: 't' },
-        keys: ['id'],
-        fields: [{ name: 'id', expression: 'e.id' }],
-      }],
+      entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'],
+                   fields: [{ name: 'id', expression: 'e.id' }] }],
       relationships: [],
       metrics: [],
     };
     const { ddl } = generatePropertyGraph(model, { project: 'p', dataset: 'd', graphName: 'g' });
     expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `p.d.g`');
     expect(ddl).toContain('`p.d.t` AS e');
-    // No relationships => no EDGE TABLES block.
-    expect(ddl).not.toContain('EDGE TABLES');
   });
 
-  test('warns when a table has no resolvable project/dataset', () => {
+  test('a model with no relationships omits the EDGE TABLES block', () => {
     const model: SemanticModel = {
       name: 'm',
       entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'], fields: [] }],
       relationships: [],
       metrics: [],
     };
-    const { warnings } = generatePropertyGraph(model);
+    const { ddl } = generatePropertyGraph(model, OPTS);
+    expect(ddl).not.toContain('EDGE TABLES');
+  });
+
+  test('a table with no resolvable project/dataset yields a warning', () => {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'], fields: [] }],
+      relationships: [],
+      metrics: [],
+    };
+    const { warnings } = generatePropertyGraph(model);  // no opts to fall back to
     expect(warnings.some(w => w.includes('missing a project and/or dataset'))).toBe(true);
   });
 });
+
+
+describe('emits DDL that BigQuery accepts (live-verified regression guard)', () => {
+  // The exact strings below were run against BigQuery and produced correct
+  // results. Any change to generator formatting must be re-verified before these
+  // goldens are updated.
+
+  test('direct-FK chain graph with node measures matches the verified DDL', () => {
+    const { ddl } = generatePropertyGraph(SALES, OPTS);
+    expect(ddl).toBe(VERIFIED_SALES_DDL);
+  });
+
+  test('M:N association graph with edge properties matches the verified DDL', () => {
+    const { ddl } = generatePropertyGraph(SCHOOL, OPTS);
+    expect(ddl).toBe(VERIFIED_SCHOOL_DDL);
+  });
+});
+
+
+const VERIFIED_SALES_DDL =
+`CREATE OR REPLACE PROPERTY GRAPH \`sqlgen-testing.bei_semantic_ir_verify.sales_graph\`
+NODE TABLES (
+  \`sqlgen-testing.bei_semantic_ir_verify.customers\` AS customers
+    KEY(customer_id)
+    PROPERTIES(
+      customer_id,
+      region OPTIONS(description="Sales region")
+    ),
+  \`sqlgen-testing.bei_semantic_ir_verify.orders\` AS orders
+    KEY(order_id)
+    PROPERTIES(
+      order_id,
+      customer_id,
+      status,
+      MEASURE(COUNT(order_id)) AS order_count
+    ),
+  \`sqlgen-testing.bei_semantic_ir_verify.order_items\` AS order_items
+    KEY(order_item_id)
+    PROPERTIES(
+      order_item_id,
+      order_id,
+      amount,
+      MEASURE(SUM(amount)) AS total_revenue,
+      MEASURE(COUNT(order_item_id)) AS item_count
+    )
+)
+EDGE TABLES (
+  \`sqlgen-testing.bei_semantic_ir_verify.orders\` AS orders_customers
+    KEY(order_id)
+    SOURCE KEY(order_id) REFERENCES orders(order_id)
+    DESTINATION KEY(customer_id) REFERENCES customers(customer_id),
+  \`sqlgen-testing.bei_semantic_ir_verify.order_items\` AS orderitems_orders
+    KEY(order_item_id)
+    SOURCE KEY(order_item_id) REFERENCES order_items(order_item_id)
+    DESTINATION KEY(order_id) REFERENCES orders(order_id)
+);
+`;
+
+const VERIFIED_SCHOOL_DDL =
+`CREATE OR REPLACE PROPERTY GRAPH \`sqlgen-testing.bei_semantic_ir_verify.school_graph\`
+NODE TABLES (
+  \`sqlgen-testing.bei_semantic_ir_verify.students\` AS students
+    KEY(student_id)
+    PROPERTIES(
+      student_id,
+      name
+    ),
+  \`sqlgen-testing.bei_semantic_ir_verify.courses\` AS courses
+    KEY(course_id)
+    PROPERTIES(
+      course_id,
+      title
+    )
+)
+EDGE TABLES (
+  \`sqlgen-testing.bei_semantic_ir_verify.enrollment\` AS enrollment
+    KEY(enrollment_id)
+    SOURCE KEY(student_id) REFERENCES students(student_id)
+    DESTINATION KEY(course_id) REFERENCES courses(course_id)
+    PROPERTIES(
+      grade OPTIONS(description="Letter grade")
+    )
+);
+`;

--- a/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
@@ -207,6 +207,56 @@ describe('graph naming and options', () => {
 });
 
 
+describe('robust handling of messy inputs (from code review)', () => {
+  test('a description with newlines/tabs/quotes escapes into a single valid string literal', () => {
+    // Raw newlines cannot appear inside a BigQuery double-quoted literal; they
+    // (and \t, ", \) must be escaped or the OPTIONS(description=...) is invalid.
+    const model: SemanticModel = {
+      name: 'm', relationships: [], metrics: [],
+      entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'],
+        fields: [{ name: 'id', expression: 'e.id', description: 'line1\nline2\t"q"' }] }],
+    };
+    const { ddl } = generatePropertyGraph(model, OPTS);
+    expect(ddl).toContain('OPTIONS(description="line1\\nline2\\t\\"q\\"")');
+    expect(ddl).not.toContain('line1\nline2');  // no raw newline inside the literal
+  });
+
+  test('an entity qualifier inside a string literal is neither stripped nor counted as a reference', () => {
+    // Only order_items is genuinely referenced; 'orders.note' is data. The metric
+    // must place on order_items (not be flagged as spanning orders too), and the
+    // literal text must survive qualifier stripping unchanged.
+    const model: SemanticModel = {
+      ...SALES,
+      metrics: [{ name: 'flagged',
+        expression: "SUM(IF(order_items.amount > 0, order_items.amount, 0)) /* 'orders.note' */",
+        entities: ['order_items'] }],
+    };
+    const { ddl, warnings } = generatePropertyGraph(model, OPTS);
+    expect(ddl).toContain("MEASURE(SUM(IF(amount > 0, amount, 0)) /* 'orders.note' */) AS flagged");
+    expect(warnings.some(w => w.includes('flagged') && w.includes('multiple'))).toBe(false);
+  });
+
+  test("a metric whose declared entities disagree with its expression is reported", () => {
+    // The IR declares entities: ['orders'] but the expression aggregates
+    // order_items; the generator places per the expression and surfaces the
+    // discrepancy instead of resolving it silently.
+    const model: SemanticModel = {
+      ...SALES,
+      metrics: [{ name: 'mislabeled', expression: 'SUM(order_items.amount)', entities: ['orders'] }],
+    };
+    const { warnings } = generatePropertyGraph(model, OPTS);
+    expect(warnings.some(w => w.includes("metric 'mislabeled'") && w.includes('declares entities')))
+      .toBe(true);
+  });
+
+  test('a model with no entities is reported rather than silently emitting an invalid graph', () => {
+    const model: SemanticModel = { name: 'm', entities: [], relationships: [], metrics: [] };
+    const { warnings } = generatePropertyGraph(model, OPTS);
+    expect(warnings.some(w => w.includes('no entities'))).toBe(true);
+  });
+});
+
+
 describe('emits DDL that BigQuery accepts (live-verified regression guard)', () => {
   // The exact strings below were run against BigQuery and produced correct
   // results. Any change to generator formatting must be re-verified before these


### PR DESCRIPTION
## Summary

Adds the first consumer of the Semantic Model IR (#218): a pure generator that turns a `SemanticModel` into BigQuery **property-graph DDL with inline measures**.

- New module `toolbox/mdcode/src/libts/semantic/bigquery.ts` — `generatePropertyGraph(model, opts)` returns `{ ddl, warnings }`. No BigQuery API calls; it emits a single `CREATE OR REPLACE PROPERTY GRAPH` statement over the entities' existing base tables.
- Entities → `NODE TABLES` (keyed by grain); relationships → `EDGE TABLES` (explicit element `KEY`, since base-table PRIMARY KEYs are not assumed); model-level metrics → inline `MEASURE(...)` bound to the single table their aggregate references.
- A metric whose aggregate genuinely spans more than one table is skipped and reported in `warnings` (a measure binds to exactly one table's KEY).

## IR → DDL mapping

- **Table ref**: backtick-quoted `project.dataset.table`, falling back to options; warns when unresolvable.
- **Field → property**: entity qualifier stripped; bare column when the expression is just the column, else `<expr> AS <name>`; `OPTIONS(description=...)` when present.
- **Metric → MEASURE**: placed on the single referenced entity; qualifier stripped so the body is table-local.
- **Relationship → EDGE TABLE**: backed by its association table (M:N) or the source entity's table (direct FK); `SOURCE`/`DESTINATION KEY ... REFERENCES` target each endpoint's key.

## Verification

- Live-verified against BigQuery (`sqlgen-testing`): a direct-FK chain's node measures matched a plain-SQL control via `GRAPH_EXPAND` + `AGG` (measures stay locked to their KEY — no join fan-out inflation), and an M:N association graph traversed correctly via a GQL `MATCH`.
- The exact DDL BigQuery accepted is pinned as golden tests, so the suite guards behavior without a live instance.
- Robustness: escapes multi-line descriptions into valid string literals; qualifier detection/stripping ignores SQL string literals; cross-checks a metric's declared entities against its expression; tolerates partial models.

`npm run test:semantic` — 19 tests pass. `npm run compile` — clean.

## Notes

- **Stacked on #218** (the M0 IR contract). This branch includes the M0 commit; it should merge after #218. The generator-only changes are `bigquery.ts`, its test, and the `package.json` test wiring.
- Known limitations (documented in code): direct-FK edges assume join columns live on the source table (not statically verifiable without table schema); identifiers are not backtick-escaped for reserved words (escaping form unverified against graph labels).
