### PR TITLE
mdcode: load AI-first semantics model files into the Semantic Model IR

### DIFF
--- a/toolbox/mdcode/package.json
+++ b/toolbox/mdcode/package.json
@@ -16,7 +16,8 @@
     "build": "npm run build:libts && npm run build:tool",
     "compile": "npx tsc --noEmit",
     "test:libts": "npx bun test ./tests/libts/scenarios.ts",
-    "test": "npm run test:libts",
+    "test:semantic": "npx bun test ./tests/libts/semantic.bigquery.test.ts",
+    "test": "npm run test:libts && npm run test:semantic",
     "x:mcp": "npx @modelcontextprotocol/inspector dist/kcmd mcp"
   },
   "keywords": [],

--- a/toolbox/mdcode/package.json
+++ b/toolbox/mdcode/package.json
@@ -17,7 +17,8 @@
     "compile": "npx tsc --noEmit",
     "test:libts": "npx bun test ./tests/libts/scenarios.ts",
     "test:semantic": "npx bun test ./tests/libts/semantic.bigquery.test.ts",
-    "test": "npm run test:libts && npm run test:semantic",
+    "test:loader": "npx bun test ./tests/libts/semantic.loader.test.ts",
+    "test": "npm run test:libts && npm run test:semantic && npm run test:loader",
     "x:mcp": "npx @modelcontextprotocol/inspector dist/kcmd mcp"
   },
   "keywords": [],

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -1,0 +1,219 @@
+// Generates BigQuery property-graph DDL (with inline measures) from the
+// Semantic Model IR.
+//
+// The IR (./ir) is pure semantics. This module is its first consumer: it emits
+// a single `CREATE OR REPLACE PROPERTY GRAPH` statement over the entities'
+// existing base tables, with model-level metrics rendered as inline
+// `MEASURE(...)` properties.
+//
+// BigQuery graph measures bind an aggregate to exactly one table's KEY; the
+// cross-entity rollup happens at query time via GRAPH_EXPAND(...) + AGG(...).
+// A metric therefore lands on whichever single table its aggregate columns
+// reference; a metric whose aggregate genuinely spans multiple tables cannot be
+// expressed as one MEASURE and is skipped (reported in `warnings`).
+//
+// See: https://docs.cloud.google.com/bigquery/docs/graph-measures
+//
+
+import { SemanticModel, Entity, Field, Relationship, RelationshipEnd, Metric, DataSource } from './ir';
+
+export interface GenerateOptions {
+  project?: string;    // default project for the graph + unqualified table refs
+  dataset?: string;    // dataset the graph is created in (else inferred from entities)
+  graphName?: string;  // default: model.name
+}
+
+export interface GenerateResult {
+  ddl: string;         // CREATE OR REPLACE PROPERTY GRAPH ...
+  warnings: string[];  // skipped metrics, unresolved table refs, etc.
+}
+
+// Aggregate functions BigQuery accepts inside MEASURE(...).
+const SUPPORTED_AGGREGATES = ['SUM', 'AVG', 'COUNT', 'MIN', 'MAX'];
+
+/**
+ * Generates the BigQuery property-graph DDL for a semantic model.
+ *
+ * The generated statement references the entities' existing base tables; it does
+ * not create them. Returns the DDL plus any warnings collected while mapping the
+ * IR (e.g. metrics that could not be placed on a single table).
+ */
+export function generatePropertyGraph(model: SemanticModel, opts: GenerateOptions = {}): GenerateResult {
+  const warnings: string[] = [];
+
+  // Metrics are model-level; place each on the single entity its aggregate
+  // references. metricsByEntity: entity name -> measure property lines.
+  const metricsByEntity = new Map<string, string[]>();
+  for (const metric of model.metrics ?? []) {
+    placeMetric(metric, model, metricsByEntity, warnings);
+  }
+
+  const nodeTables = model.entities.map(
+    entity => renderNodeTable(entity, metricsByEntity.get(entity.name) ?? [], opts, warnings));
+
+  const entitiesByName = new Map(model.entities.map(e => [e.name, e]));
+  const edgeTables = model.relationships.map(
+    rel => renderEdgeTable(rel, entitiesByName, opts, warnings));
+
+  const graphName = qualifyGraph(model, opts);
+
+  const blocks: string[] = [
+    `CREATE OR REPLACE PROPERTY GRAPH ${graphName}`,
+    `NODE TABLES (\n${nodeTables.join(',\n')}\n)`,
+  ];
+  if (edgeTables.length) {
+    blocks.push(`EDGE TABLES (\n${edgeTables.join(',\n')}\n)`);
+  }
+
+  return { ddl: blocks.join('\n') + ';\n', warnings };
+}
+
+
+// Assigns a metric to the node table of the single entity its aggregate
+// references, recording a warning if it references zero or multiple entities.
+function placeMetric(metric: Metric, model: SemanticModel,
+                     metricsByEntity: Map<string, string[]>, warnings: string[]): void {
+  const referenced = referencedEntities(metric.expression, model);
+
+  if (referenced.length !== 1) {
+    const detail = referenced.length === 0
+      ? 'references no known entity'
+      : `spans multiple tables (${referenced.join(', ')})`;
+    warnings.push(`metric '${metric.name}' ${detail}; skipped (cannot be a single MEASURE)`);
+    return;
+  }
+
+  const entity = referenced[0];
+  const body = stripQualifier(metric.expression, entity);
+  if (!startsWithSupportedAggregate(body)) {
+    warnings.push(
+      `metric '${metric.name}' expression '${body}' does not begin with a supported ` +
+      `aggregate (${SUPPORTED_AGGREGATES.join(', ')}); emitting anyway`);
+  }
+
+  const lines = metricsByEntity.get(entity) ?? [];
+  lines.push(`MEASURE(${body}) AS ${metric.name}`);
+  metricsByEntity.set(entity, lines);
+}
+
+// Returns the model entity names whose `<name>.` qualifier appears in an expression.
+function referencedEntities(expression: string, model: SemanticModel): string[] {
+  return model.entities
+    .map(e => e.name)
+    .filter(name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(expression));
+}
+
+// Removes the `<entity>.` qualifier so the expression references table-local columns.
+function stripQualifier(expression: string, entity: string): string {
+  return expression.replace(new RegExp(`\\b${escapeRegExp(entity)}\\.`, 'g'), '');
+}
+
+function startsWithSupportedAggregate(body: string): boolean {
+  const fn = body.trimStart().match(/^([A-Za-z_]+)\s*\(/);
+  return !!fn && SUPPORTED_AGGREGATES.includes(fn[1].toUpperCase());
+}
+
+
+function renderNodeTable(entity: Entity, measures: string[],
+                         opts: GenerateOptions, warnings: string[]): string {
+  const table = qualifyTable(entity.dataSource, opts, warnings, `entity '${entity.name}'`);
+  const properties = [
+    ...entity.fields.map(f => renderFieldProperty(f, entity.name)),
+    ...measures,
+  ];
+
+  return [
+    `  ${table} AS ${entity.name}`,
+    `    KEY(${entity.keys.join(', ')})`,
+    `    PROPERTIES(\n${indentList(properties, 6)}\n    )`,
+  ].join('\n');
+}
+
+// Renders a field as a graph property: a bare column when the expression is just
+// the column, else `<expr> AS <name>`. Attaches a description when present.
+function renderFieldProperty(field: Field, entity: string): string {
+  const local = stripQualifier(field.expression, entity);
+  let prop = local === field.name ? field.name : `${local} AS ${field.name}`;
+  if (field.description) {
+    prop += ` OPTIONS(description=${quote(field.description)})`;
+  }
+  return prop;
+}
+
+
+function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
+                        opts: GenerateOptions, warnings: string[]): string {
+  // Backed by the association/junction table when present (the M:N shape),
+  // otherwise by the source entity's base table (direct foreign-key relationship,
+  // where the source table holds the join columns).
+  let backing: string;
+  if (rel.dataSource) {
+    backing = qualifyTable(rel.dataSource, opts, warnings, `relationship '${rel.name}'`);
+  } else {
+    const sourceEntity = entitiesByName.get(rel.source.entity);
+    if (!sourceEntity) {
+      warnings.push(`relationship '${rel.name}': unknown source entity '${rel.source.entity}'`);
+      backing = `\`${rel.source.entity}\``;
+    } else {
+      backing = qualifyTable(sourceEntity.dataSource, opts, warnings, `relationship '${rel.name}'`);
+    }
+  }
+
+  const lines = [
+    `  ${backing} AS ${rel.name}`,
+    `    SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`,
+    `    DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`,
+  ];
+
+  if (rel.fields && rel.fields.length) {
+    const properties = rel.fields.map(f => renderFieldProperty(f, rel.name));
+    lines.push(`    PROPERTIES(\n${indentList(properties, 6)}\n    )`);
+  }
+
+  return lines.join('\n');
+}
+
+function keys(end: RelationshipEnd): { rel: string; entity: string } {
+  return {
+    rel: end.joinKeys.relationshipColumns.join(', '),
+    entity: end.joinKeys.entityColumns.join(', '),
+  };
+}
+
+
+// Builds a backtick-quoted `project.dataset.table` reference, falling back to
+// opts for a missing project/dataset. Warns when neither yields a project or
+// dataset (the ref will be unqualified and likely invalid).
+function qualifyTable(ds: DataSource, opts: GenerateOptions,
+                      warnings: string[], context: string): string {
+  const project = ds.project ?? opts.project;
+  const dataset = ds.dataset ?? opts.dataset;
+  const parts = [project, dataset, ds.table].filter((p): p is string => !!p);
+  if (!project || !dataset) {
+    warnings.push(`${context}: table '${ds.table}' is missing a project and/or dataset`);
+  }
+  return `\`${parts.join('.')}\``;
+}
+
+// Builds the dataset-qualified graph name.
+function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
+  const name = opts.graphName ?? model.name;
+  const dataset = opts.dataset ?? model.entities[0]?.dataSource.dataset;
+  const project = opts.project ?? model.entities[0]?.dataSource.project;
+  const parts = [project, dataset, name].filter((p): p is string => !!p);
+  return `\`${parts.join('.')}\``;
+}
+
+
+function indentList(lines: string[], spaces: number): string {
+  const pad = ' '.repeat(spaces);
+  return lines.map(l => `${pad}${l}`).join(',\n');
+}
+
+function quote(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -16,6 +16,7 @@
 //
 
 import { SemanticModel, Entity, Field, Relationship, RelationshipEnd, Metric, DataSource } from './ir';
+import { referencedEntityNames, stripQualifier, dedupe } from './expr';
 
 export interface GenerateOptions {
   project?: string;    // default project for the graph + unqualified table refs
@@ -120,18 +121,7 @@ function placeMetric(metric: Metric, model: SemanticModel,
 // expression. String literals are ignored so a value like 'orders.x' is not
 // mistaken for a reference to the `orders` entity.
 function referencedEntities(expression: string, model: SemanticModel): string[] {
-  const scannable = blankStringLiterals(expression);
-  return (model.entities ?? [])
-    .map(e => e.name)
-    .filter(name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(scannable));
-}
-
-// Removes the `<entity>.` qualifier so the expression references table-local
-// columns, without touching text inside string literals (a literal such as
-// 'orders.x' is data, not a qualified column reference).
-function stripQualifier(expression: string, entity: string): string {
-  const re = new RegExp(`\\b${escapeRegExp(entity)}\\.`, 'g');
-  return mapOutsideStringLiterals(expression, seg => seg.replace(re, ''));
+  return referencedEntityNames(expression, (model.entities ?? []).map(e => e.name));
 }
 
 function startsWithSupportedAggregate(body: string): boolean {
@@ -218,10 +208,6 @@ function edgeKey(rel: Relationship, sourceEntity: Entity | undefined): string[] 
   ]);
 }
 
-function dedupe(items: string[]): string[] {
-  return [...new Set(items)];
-}
-
 function keys(end: RelationshipEnd): { rel: string; entity: string } {
   return {
     rel: end.joinKeys.relationshipColumns.join(', '),
@@ -285,37 +271,8 @@ function quote(s: string): string {
   return `"${escaped}"`;
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function sameSet(a: string[], b: string[]): boolean {
   if (a.length !== b.length) return false;
   const sa = new Set(a);
   return b.every(x => sa.has(x));
-}
-
-// Matches a single- or double-quoted SQL string literal, honoring backslash
-// escapes. (Triple-quoted / raw literals are uncommon in measure expressions and
-// are treated as ordinary text.)
-const STRING_LITERAL = /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g;
-
-// Replaces string-literal contents with blanks of equal length, so qualifier
-// scanning sees literal-free text without shifting any offsets.
-function blankStringLiterals(expression: string): string {
-  return expression.replace(STRING_LITERAL, m => ' '.repeat(m.length));
-}
-
-// Applies `fn` only to the parts of `expression` that lie outside string
-// literals, leaving each literal verbatim.
-function mapOutsideStringLiterals(expression: string, fn: (segment: string) => string): string {
-  let out = '';
-  let last = 0;
-  for (const m of expression.matchAll(STRING_LITERAL)) {
-    out += fn(expression.slice(last, m.index));
-    out += m[0];
-    last = m.index! + m[0].length;
-  }
-  out += fn(expression.slice(last));
-  return out;
 }

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -147,20 +147,19 @@ function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
   // otherwise by the source entity's base table (direct foreign-key relationship,
   // where the source table holds the join columns).
   let backing: string;
+  const sourceEntity = entitiesByName.get(rel.source.entity);
   if (rel.dataSource) {
     backing = qualifyTable(rel.dataSource, opts, warnings, `relationship '${rel.name}'`);
+  } else if (!sourceEntity) {
+    warnings.push(`relationship '${rel.name}': unknown source entity '${rel.source.entity}'`);
+    backing = `\`${rel.source.entity}\``;
   } else {
-    const sourceEntity = entitiesByName.get(rel.source.entity);
-    if (!sourceEntity) {
-      warnings.push(`relationship '${rel.name}': unknown source entity '${rel.source.entity}'`);
-      backing = `\`${rel.source.entity}\``;
-    } else {
-      backing = qualifyTable(sourceEntity.dataSource, opts, warnings, `relationship '${rel.name}'`);
-    }
+    backing = qualifyTable(sourceEntity.dataSource, opts, warnings, `relationship '${rel.name}'`);
   }
 
   const lines = [
     `  ${backing} AS ${rel.name}`,
+    `    KEY(${edgeKey(rel, sourceEntity).join(', ')})`,
     `    SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`,
     `    DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`,
   ];
@@ -171,6 +170,28 @@ function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
   }
 
   return lines.join('\n');
+}
+
+// The edge element key: the columns that uniquely identify an edge row. Graph
+// element tables must declare a key explicitly (base-table PRIMARY KEYs are not
+// assumed). Prefers the relationship's own `keys`; for a direct FK backed by the
+// source entity's table, uses that entity's keys; otherwise falls back to the
+// composite of both ends' join columns on the backing table.
+function edgeKey(rel: Relationship, sourceEntity: Entity | undefined): string[] {
+  if (rel.keys && rel.keys.length) {
+    return rel.keys;
+  }
+  if (!rel.dataSource && sourceEntity) {
+    return sourceEntity.keys;
+  }
+  return dedupe([
+    ...rel.source.joinKeys.relationshipColumns,
+    ...rel.destination.joinKeys.relationshipColumns,
+  ]);
+}
+
+function dedupe(items: string[]): string[] {
+  return [...new Set(items)];
 }
 
 function keys(end: RelationshipEnd): { rel: string; entity: string } {

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -123,9 +123,9 @@ function renderNodeTable(entity: Entity, measures: string[],
   ];
 
   return [
-    `  ${table} AS ${entity.name}`,
-    `    KEY(${entity.keys.join(', ')})`,
-    `    PROPERTIES(\n${indentList(properties, 6)}\n    )`,
+    line(1, `${table} AS ${entity.name}`),
+    line(2, `KEY(${entity.keys.join(', ')})`),
+    propertiesBlock(properties),
   ].join('\n');
 }
 
@@ -158,15 +158,15 @@ function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
   }
 
   const lines = [
-    `  ${backing} AS ${rel.name}`,
-    `    KEY(${edgeKey(rel, sourceEntity).join(', ')})`,
-    `    SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`,
-    `    DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`,
+    line(1, `${backing} AS ${rel.name}`),
+    line(2, `KEY(${edgeKey(rel, sourceEntity).join(', ')})`),
+    line(2, `SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`),
+    line(2, `DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`),
   ];
 
   if (rel.fields && rel.fields.length) {
     const properties = rel.fields.map(f => renderFieldProperty(f, rel.name));
-    lines.push(`    PROPERTIES(\n${indentList(properties, 6)}\n    )`);
+    lines.push(propertiesBlock(properties));
   }
 
   return lines.join('\n');
@@ -226,9 +226,20 @@ function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
 }
 
 
-function indentList(lines: string[], spaces: number): string {
-  const pad = ' '.repeat(spaces);
-  return lines.map(l => `${pad}${l}`).join(',\n');
+// All generated indentation flows through this single mechanism: one nesting
+// level == one INDENT. `line` indents one line to a depth; `list` indents a set
+// of lines and joins them comma-separated; `propertiesBlock` is the shared
+// `PROPERTIES( ... )` shape used by both node and edge tables. Keeping every
+// indent derived from `depth` (rather than hardcoded spaces) makes the output
+// indentation consistent by construction.
+const INDENT = '  ';
+const pad = (depth: number): string => INDENT.repeat(depth);
+const line = (depth: number, text: string): string => `${pad(depth)}${text}`;
+const list = (depth: number, lines: string[]): string =>
+  lines.map(l => line(depth, l)).join(',\n');
+
+function propertiesBlock(properties: string[]): string {
+  return `${line(2, 'PROPERTIES(')}\n${list(3, properties)}\n${line(2, ')')}`;
 }
 
 function quote(s: string): string {

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -41,18 +41,28 @@ const SUPPORTED_AGGREGATES = ['SUM', 'AVG', 'COUNT', 'MIN', 'MAX'];
 export function generatePropertyGraph(model: SemanticModel, opts: GenerateOptions = {}): GenerateResult {
   const warnings: string[] = [];
 
+  // The IR requires entities/relationships/metrics, but be defensive against a
+  // hand-built or partially-deserialized model rather than throwing on `.map`.
+  const entities = model.entities ?? [];
+  const relationships = model.relationships ?? [];
+  const metrics = model.metrics ?? [];
+
+  if (!entities.length) {
+    warnings.push('model has no entities; the generated NODE TABLES block will be empty and invalid');
+  }
+
   // Metrics are model-level; place each on the single entity its aggregate
   // references. metricsByEntity: entity name -> measure property lines.
   const metricsByEntity = new Map<string, string[]>();
-  for (const metric of model.metrics ?? []) {
+  for (const metric of metrics) {
     placeMetric(metric, model, metricsByEntity, warnings);
   }
 
-  const nodeTables = model.entities.map(
+  const nodeTables = entities.map(
     entity => renderNodeTable(entity, metricsByEntity.get(entity.name) ?? [], opts, warnings));
 
-  const entitiesByName = new Map(model.entities.map(e => [e.name, e]));
-  const edgeTables = model.relationships.map(
+  const entitiesByName = new Map(entities.map(e => [e.name, e]));
+  const edgeTables = relationships.map(
     rel => renderEdgeTable(rel, entitiesByName, opts, warnings));
 
   const graphName = qualifyGraph(model, opts);
@@ -65,7 +75,7 @@ export function generatePropertyGraph(model: SemanticModel, opts: GenerateOption
     blocks.push(`EDGE TABLES (\n${edgeTables.join(',\n')}\n)`);
   }
 
-  return { ddl: blocks.join('\n') + ';\n', warnings };
+  return { ddl: blocks.join('\n') + ';\n', warnings: dedupe(warnings) };
 }
 
 
@@ -74,6 +84,16 @@ export function generatePropertyGraph(model: SemanticModel, opts: GenerateOption
 function placeMetric(metric: Metric, model: SemanticModel,
                      metricsByEntity: Map<string, string[]>, warnings: string[]): void {
   const referenced = referencedEntities(metric.expression, model);
+
+  // The IR also declares metric.entities. Placement is driven by the qualifiers
+  // actually present in the expression (that is what we strip and attach), but a
+  // disagreement with the declared list signals an inconsistent model, so
+  // surface it rather than resolving silently.
+  if (metric.entities && !sameSet(metric.entities, referenced)) {
+    warnings.push(
+      `metric '${metric.name}' declares entities [${metric.entities.join(', ')}] but its ` +
+      `expression references [${referenced.join(', ') || 'none'}]; placing per the expression`);
+  }
 
   if (referenced.length !== 1) {
     const detail = referenced.length === 0
@@ -96,16 +116,22 @@ function placeMetric(metric: Metric, model: SemanticModel,
   metricsByEntity.set(entity, lines);
 }
 
-// Returns the model entity names whose `<name>.` qualifier appears in an expression.
+// Returns the model entity names whose `<name>.` qualifier appears in an
+// expression. String literals are ignored so a value like 'orders.x' is not
+// mistaken for a reference to the `orders` entity.
 function referencedEntities(expression: string, model: SemanticModel): string[] {
-  return model.entities
+  const scannable = blankStringLiterals(expression);
+  return (model.entities ?? [])
     .map(e => e.name)
-    .filter(name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(expression));
+    .filter(name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(scannable));
 }
 
-// Removes the `<entity>.` qualifier so the expression references table-local columns.
+// Removes the `<entity>.` qualifier so the expression references table-local
+// columns, without touching text inside string literals (a literal such as
+// 'orders.x' is data, not a qualified column reference).
 function stripQualifier(expression: string, entity: string): string {
-  return expression.replace(new RegExp(`\\b${escapeRegExp(entity)}\\.`, 'g'), '');
+  const re = new RegExp(`\\b${escapeRegExp(entity)}\\.`, 'g');
+  return mapOutsideStringLiterals(expression, seg => seg.replace(re, ''));
 }
 
 function startsWithSupportedAggregate(body: string): boolean {
@@ -157,11 +183,13 @@ function renderEdgeTable(rel: Relationship, entitiesByName: Map<string, Entity>,
     backing = qualifyTable(sourceEntity.dataSource, opts, warnings, `relationship '${rel.name}'`);
   }
 
+  const src = keys(rel.source);
+  const dst = keys(rel.destination);
   const lines = [
     line(1, `${backing} AS ${rel.name}`),
     line(2, `KEY(${edgeKey(rel, sourceEntity).join(', ')})`),
-    line(2, `SOURCE KEY(${keys(rel.source).rel}) REFERENCES ${rel.source.entity}(${keys(rel.source).entity})`),
-    line(2, `DESTINATION KEY(${keys(rel.destination).rel}) REFERENCES ${rel.destination.entity}(${keys(rel.destination).entity})`),
+    line(2, `SOURCE KEY(${src.rel}) REFERENCES ${rel.source.entity}(${src.entity})`),
+    line(2, `DESTINATION KEY(${dst.rel}) REFERENCES ${rel.destination.entity}(${dst.entity})`),
   ];
 
   if (rel.fields && rel.fields.length) {
@@ -219,8 +247,9 @@ function qualifyTable(ds: DataSource, opts: GenerateOptions,
 // Builds the dataset-qualified graph name.
 function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
   const name = opts.graphName ?? model.name;
-  const dataset = opts.dataset ?? model.entities[0]?.dataSource.dataset;
-  const project = opts.project ?? model.entities[0]?.dataSource.project;
+  const first = (model.entities ?? [])[0];
+  const dataset = opts.dataset ?? first?.dataSource.dataset;
+  const project = opts.project ?? first?.dataSource.project;
   const parts = [project, dataset, name].filter((p): p is string => !!p);
   return `\`${parts.join('.')}\``;
 }
@@ -242,10 +271,51 @@ function propertiesBlock(properties: string[]): string {
   return `${line(2, 'PROPERTIES(')}\n${list(3, properties)}\n${line(2, ')')}`;
 }
 
+// Renders a value as a BigQuery double-quoted string literal. Backslash and the
+// quote are escaped, and control characters that cannot appear raw inside a
+// quoted literal (newline, carriage return, tab) are escaped too, so a
+// multi-line description does not produce a broken literal.
 function quote(s: string): string {
-  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
 }
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = new Set(a);
+  return b.every(x => sa.has(x));
+}
+
+// Matches a single- or double-quoted SQL string literal, honoring backslash
+// escapes. (Triple-quoted / raw literals are uncommon in measure expressions and
+// are treated as ordinary text.)
+const STRING_LITERAL = /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g;
+
+// Replaces string-literal contents with blanks of equal length, so qualifier
+// scanning sees literal-free text without shifting any offsets.
+function blankStringLiterals(expression: string): string {
+  return expression.replace(STRING_LITERAL, m => ' '.repeat(m.length));
+}
+
+// Applies `fn` only to the parts of `expression` that lie outside string
+// literals, leaving each literal verbatim.
+function mapOutsideStringLiterals(expression: string, fn: (segment: string) => string): string {
+  let out = '';
+  let last = 0;
+  for (const m of expression.matchAll(STRING_LITERAL)) {
+    out += fn(expression.slice(last, m.index));
+    out += m[0];
+    last = m.index! + m[0].length;
+  }
+  out += fn(expression.slice(last));
+  return out;
 }

--- a/toolbox/mdcode/src/libts/semantic/expr.ts
+++ b/toolbox/mdcode/src/libts/semantic/expr.ts
@@ -1,0 +1,60 @@
+// Literal-aware helpers for the entity-qualified SQL expressions used across the
+// semantic-model layer.
+//
+// Expressions reference columns as `<Entity>.<column>`. Detecting and stripping
+// those qualifiers must ignore text inside string literals, so a value such as
+// 'orders.note' is treated as data, not as a reference to the `orders` entity.
+// Both the loader (metric-entity inference) and the BigQuery generator (measure
+// placement / qualifier stripping) share this one implementation.
+//
+
+// Matches a single- or double-quoted SQL string literal, honoring backslash
+// escapes. (Triple-quoted / raw literals are uncommon in these expressions and
+// are treated as ordinary text.)
+export const STRING_LITERAL = /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g;
+
+// Escapes a string so it can be embedded literally in a RegExp.
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Replaces string-literal contents with blanks of equal length, so scanning sees
+// literal-free text without shifting any offsets.
+export function blankStringLiterals(expression: string): string {
+  return expression.replace(STRING_LITERAL, m => ' '.repeat(m.length));
+}
+
+// Applies `fn` only to the parts of `expression` that lie outside string
+// literals, leaving each literal verbatim.
+export function mapOutsideStringLiterals(
+    expression: string, fn: (segment: string) => string): string {
+  let out = '';
+  let last = 0;
+  for (const m of expression.matchAll(STRING_LITERAL)) {
+    out += fn(expression.slice(last, m.index));
+    out += m[0];
+    last = m.index! + m[0].length;
+  }
+  out += fn(expression.slice(last));
+  return out;
+}
+
+// Returns the entity names whose `<name>.` qualifier appears in an expression,
+// ignoring text inside string literals.
+export function referencedEntityNames(expression: string, entityNames: string[]): string[] {
+  const scannable = blankStringLiterals(expression);
+  return entityNames.filter(
+    name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(scannable));
+}
+
+// Removes the `<entity>.` qualifier so an expression references table-local
+// columns, without touching text inside string literals.
+export function stripQualifier(expression: string, entity: string): string {
+  const re = new RegExp(`\\b${escapeRegExp(entity)}\\.`, 'g');
+  return mapOutsideStringLiterals(expression, seg => seg.replace(re, ''));
+}
+
+// Returns the input with duplicate entries removed, preserving first-seen order.
+export function dedupe(items: string[]): string[] {
+  return [...new Set(items)];
+}

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -1,0 +1,113 @@
+// Defines the Semantic Model intermediate representation (IR).
+//
+// The IR is the in-memory contract for a semantic model. It represents
+// semantics only: a graph of entities (nodes) connected by relationships
+// (edges), plus model-level metrics.
+//
+
+/**
+ * A semantic model: a graph of entities (nodes) connected by relationships
+ * (edges), with model-level metrics defined over them.
+ *
+ * The IR is pure semantics. Deployment/target configuration lives in the
+ * project manifest (`catalog.yaml`), NOT here.
+ */
+export interface SemanticModel {
+  name: string;
+  description?: string;
+  entities: Entity[];
+  relationships: Relationship[];
+  metrics: Metric[];
+}
+
+/**
+ * A structured reference to a physical table backing an entity or an
+ * association (edge) table.
+ *
+ * Kept lean for now (BigQuery-shaped); additional platforms/fields can be added
+ * later. The YAML layer may accept a shorthand string (e.g. "proj.dataset.table")
+ * and normalize it into this structured form.
+ */
+export interface DataSource {
+  project?: string;
+  dataset?: string;
+  table: string;
+}
+
+/**
+ * An entity: a node in the semantic graph. Backed by a physical table
+ * (`dataSource`), identified by `keys`, and carrying its dimension `fields`.
+ */
+export interface Entity {
+  name: string;
+  dataSource: DataSource;
+  keys: string[];        // grain / primary key
+  description?: string;
+  synonyms?: string[];
+  fields: Field[];       // dimensions / attributes
+}
+
+/**
+ * A field: a dimension / attribute of an entity or relationship.
+ *
+ * Fields describe the data; aggregates are expressed as model-level `Metric`s,
+ * not fields.
+ */
+export interface Field {
+  name: string;
+  expression: string;              // column reference or scalar SQL expression
+  type?: string;                   // logical type; often inferable from source schema
+  description?: string;
+  synonyms?: string[];
+}
+
+/**
+ * A relationship: a directed edge in the semantic graph, from `source` to
+ * `destination`. May be backed by its own association (edge) table
+ * (`dataSource`); when absent, it is a direct foreign-key join. Carries its own
+ * `fields` (edge properties).
+ */
+export interface Relationship {
+  name: string;
+  source: RelationshipEnd;
+  destination: RelationshipEnd;
+  dataSource?: DataSource;  // association/edge table; absent => direct FK join
+  keys?: string[];          // edge key (when backed by an association table)
+  description?: string;
+  synonyms?: string[];
+  fields?: Field[];         // edge properties
+}
+
+/**
+ * One endpoint of a relationship.
+ *
+ * `joinKeys.relationshipColumns` are the columns on the edge/source table;
+ * `joinKeys.entityColumns` are the referenced columns on the endpoint entity
+ * (defaulting to that entity's `keys`).
+ */
+export interface RelationshipEnd {
+  entity: string;        // name-reference into SemanticModel.entities
+  joinKeys: JoinKeys;
+}
+
+export interface JoinKeys {
+  relationshipColumns: string[];
+  entityColumns: string[];
+}
+
+/**
+ * A metric: a model-level, named aggregate.
+ *
+ * Because it lives on the model rather than a single entity, a metric may span
+ * multiple entities — its `expression` can reference fields across the graph,
+ * joined via relationships. `entities` lists the entities the metric references
+ * (one for an entity-scoped metric, several for a cross-entity metric); the
+ * join path between them is resolved by consumers via the model's relationships.
+ */
+export interface Metric {
+  name: string;
+  expression: string;    // aggregate expression, may reference entity-qualified fields
+  entities: string[];    // entities referenced by the metric (>= 1)
+  description?: string;
+  synonyms?: string[];
+}

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -12,6 +12,7 @@
 import * as yaml from 'yaml';
 import * as z from 'zod';
 import { SemanticModel, Entity, Field, Relationship, Metric, DataSource } from './ir';
+import { referencedEntityNames, dedupe } from './expr';
 
 export interface LoadOptions {
   dialect?: string;         // preferred expression dialect; default 'BIGQUERY'
@@ -130,6 +131,17 @@ function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): Seman
   const dialect = opts.dialect ?? DEFAULT_DIALECT;
 
   const entities = m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
+
+  const seenNames = new Set<string>();
+  for (const e of entities) {
+    if (seenNames.has(e.name)) {
+      warnings.push(
+        `model '${m.name}': duplicate dataset name '${e.name}'; ` +
+        `only one node table can carry that label (the graph will be invalid)`);
+    }
+    seenNames.add(e.name);
+  }
+
   const keysByEntity = new Map(entities.map(e => [e.name, e.keys]));
 
   const relationships = (m.relationships ?? []).map(
@@ -175,6 +187,11 @@ function convertRelationship(r: RelationshipDoc, keysByEntity: Map<string, strin
   if (!keysByEntity.has(r.to)) {
     warnings.push(`${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
   }
+  if (r.from_columns.length !== r.to_columns.length) {
+    warnings.push(
+      `${ctx}: from_columns (${r.from_columns.length}) and to_columns ` +
+      `(${r.to_columns.length}) have different lengths; the join keys will be mismatched`);
+  }
 
   // Fall back to the FK columns when the from dataset declares no primary key.
   const sourceKey = fromKeys && fromKeys.length ? fromKeys : r.from_columns;
@@ -196,7 +213,7 @@ function convertMetric(mt: MetricDoc, entityNames: string[],
                        warnings: string[], dialect: string): Metric {
   const ctx = `metric '${mt.name}'`;
   const expression = pickDialect(mt.expression, dialect, ctx, warnings);
-  const entities = referencedEntities(expression, entityNames);
+  const entities = referencedEntityNames(expression, entityNames);
   if (!entities.length) {
     warnings.push(`${ctx}: expression references no known entity; it may not be placeable downstream`);
   }
@@ -275,20 +292,4 @@ function withDefaults(ds: DataSource, opts: LoadOptions): DataSource {
 
 function unquote(part: string): string {
   return part.replace(/^[`"]/, '').replace(/[`"]$/, '');
-}
-
-// Returns the entity names whose `<name>.` qualifier appears in the expression.
-// This is a light scan (it does not exclude string literals); the BigQuery
-// generator applies the literal-aware placement when it lowers the metric.
-function referencedEntities(expression: string, entityNames: string[]): string[] {
-  return entityNames.filter(
-    name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(expression));
-}
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function dedupe(items: string[]): string[] {
-  return [...new Set(items)];
 }

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -1,0 +1,294 @@
+// Loads an open, vendor-neutral AI-first semantics format (YAML/JSON) into the
+// Semantic Model IR (./ir).
+//
+// The format describes a semantic model as datasets (entities), foreign-key
+// relationships, and model-level metrics, with entity-qualified SQL expressions
+// (`Entity.column`) supplied per SQL dialect. This module reads the subset of
+// that logical layer needed to normalize a model into the IR, so the rest of the
+// toolbox (e.g. the BigQuery property-graph generator) can consume models
+// authored in it. Fields outside the supported subset are accepted and ignored.
+//
+
+import * as yaml from 'yaml';
+import * as z from 'zod';
+import { SemanticModel, Entity, Field, Relationship, Metric, DataSource } from './ir';
+
+export interface LoadOptions {
+  dialect?: string;         // preferred expression dialect; default 'BIGQUERY'
+  defaultProject?: string;  // fallback when a dataset `source` omits the project
+  defaultDataset?: string;  // fallback when a dataset `source` omits the dataset
+}
+
+export interface LoadResult {
+  models: SemanticModel[];
+  warnings: string[];
+}
+
+const DEFAULT_DIALECT = 'BIGQUERY';
+const FALLBACK_DIALECT = 'ANSI_SQL';
+// The logical-layer schema version this loader was written against; a document
+// declaring a different version is loaded anyway, with a warning.
+const SUPPORTED_VERSION = '0.2.0.dev0';
+
+
+// An expression is supplied as one or more per-dialect variants; we collapse it
+// to a single string by picking a dialect. Unknown sibling keys are ignored.
+const expressionSchema = z.object({
+  dialects: z.array(z.object({
+    dialect: z.string(),
+    expression: z.string(),
+  })).min(1),
+});
+
+const fieldSchema = z.object({
+  name: z.string(),
+  expression: expressionSchema,
+});
+
+const datasetSchema = z.object({
+  name: z.string(),
+  source: z.string(),
+  primary_key: z.array(z.string()).optional(),
+  fields: z.array(fieldSchema).optional(),
+});
+
+const relationshipSchema = z.object({
+  name: z.string(),
+  from: z.string(),
+  to: z.string(),
+  from_columns: z.array(z.string()).min(1),
+  to_columns: z.array(z.string()).min(1),
+});
+
+const metricSchema = z.object({
+  name: z.string(),
+  expression: expressionSchema,
+  description: z.string().optional(),
+});
+
+const modelSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  datasets: z.array(datasetSchema).min(1),
+  relationships: z.array(relationshipSchema).optional(),
+  metrics: z.array(metricSchema).optional(),
+});
+
+const documentSchema = z.object({
+  version: z.string().optional(),
+  semantic_model: z.array(modelSchema).min(1),
+});
+
+type ExpressionDoc = z.infer<typeof expressionSchema>;
+type DatasetDoc = z.infer<typeof datasetSchema>;
+type FieldDoc = z.infer<typeof fieldSchema>;
+type RelationshipDoc = z.infer<typeof relationshipSchema>;
+type MetricDoc = z.infer<typeof metricSchema>;
+type ModelDoc = z.infer<typeof modelSchema>;
+
+
+/**
+ * Loads YAML or JSON text (a document in the AI-first semantics format) into the
+ * Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
+ */
+export function loadModels(text: string, opts: LoadOptions = {}): LoadResult {
+  let doc: unknown;
+  try {
+    doc = yaml.parse(text);
+  } catch (err: any) {
+    throw new Error(`Semantic model load error: could not parse input: ${err?.message ?? err}`);
+  }
+  return fromDocument(doc, opts);
+}
+
+/**
+ * Converts an already-parsed document object into the Semantic Model IR. Throws
+ * on a structurally invalid document; softer, lossy conversions are reported in
+ * `warnings` rather than thrown.
+ */
+export function fromDocument(doc: unknown, opts: LoadOptions = {}): LoadResult {
+  const result = documentSchema.safeParse(doc);
+  if (!result.success) {
+    throw new Error(`Semantic model load error: ${result.error.message}`);
+  }
+
+  const warnings: string[] = [];
+  const parsed = result.data;
+
+  if (parsed.version && parsed.version !== SUPPORTED_VERSION) {
+    warnings.push(
+      `document version '${parsed.version}' differs from the supported '${SUPPORTED_VERSION}'; ` +
+      `loading anyway`);
+  }
+
+  const models = parsed.semantic_model.map(m => convertModel(m, opts, warnings));
+  return { models, warnings: dedupe(warnings) };
+}
+
+
+function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): SemanticModel {
+  const dialect = opts.dialect ?? DEFAULT_DIALECT;
+
+  const entities = m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
+  const keysByEntity = new Map(entities.map(e => [e.name, e.keys]));
+
+  const relationships = (m.relationships ?? []).map(
+    r => convertRelationship(r, keysByEntity, warnings));
+
+  const entityNames = entities.map(e => e.name);
+  const metrics = (m.metrics ?? []).map(
+    mt => convertMetric(mt, entityNames, warnings, dialect));
+
+  const model: SemanticModel = { name: m.name, entities, relationships, metrics };
+  if (m.description) model.description = m.description;
+  return model;
+}
+
+function convertDataset(ds: DatasetDoc, opts: LoadOptions,
+                        warnings: string[], dialect: string): Entity {
+  const ctx = `dataset '${ds.name}'`;
+  const dataSource = parseSource(ds.source, opts, warnings, ctx);
+  const keys = ds.primary_key ?? [];
+  if (!keys.length) {
+    warnings.push(`${ctx}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
+  }
+  const fields = (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
+  return { name: ds.name, dataSource, keys, fields };
+}
+
+function convertField(f: FieldDoc, entityName: string, warnings: string[], dialect: string): Field {
+  const expression = pickDialect(f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
+  return { name: f.name, expression };
+}
+
+// Maps a foreign-key relationship onto the IR's direct-FK edge convention: the
+// source end carries the `from` dataset's own primary key (it identifies the
+// edge-backing table), while the destination end carries the FK columns
+// (`from_columns`) referencing the target's key columns (`to_columns`).
+function convertRelationship(r: RelationshipDoc, keysByEntity: Map<string, string[]>,
+                            warnings: string[]): Relationship {
+  const ctx = `relationship '${r.name}'`;
+  const fromKeys = keysByEntity.get(r.from);
+  if (fromKeys === undefined) {
+    warnings.push(`${ctx}: 'from' dataset '${r.from}' is not defined in the model`);
+  }
+  if (!keysByEntity.has(r.to)) {
+    warnings.push(`${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
+  }
+
+  // Fall back to the FK columns when the from dataset declares no primary key.
+  const sourceKey = fromKeys && fromKeys.length ? fromKeys : r.from_columns;
+
+  return {
+    name: r.name,
+    source: {
+      entity: r.from,
+      joinKeys: { relationshipColumns: sourceKey, entityColumns: sourceKey },
+    },
+    destination: {
+      entity: r.to,
+      joinKeys: { relationshipColumns: r.from_columns, entityColumns: r.to_columns },
+    },
+  };
+}
+
+function convertMetric(mt: MetricDoc, entityNames: string[],
+                       warnings: string[], dialect: string): Metric {
+  const ctx = `metric '${mt.name}'`;
+  const expression = pickDialect(mt.expression, dialect, ctx, warnings);
+  const entities = referencedEntities(expression, entityNames);
+  if (!entities.length) {
+    warnings.push(`${ctx}: expression references no known entity; it may not be placeable downstream`);
+  }
+  const metric: Metric = { name: mt.name, expression, entities };
+  if (mt.description) metric.description = mt.description;
+  return metric;
+}
+
+
+// Picks a single expression string from the per-dialect variants: the requested
+// dialect, else the portable ANSI_SQL fallback, else the first listed (warning on
+// either fallback). Dialect names are compared case-insensitively.
+function pickDialect(expr: ExpressionDoc, preferred: string,
+                     ctx: string, warnings: string[]): string {
+  const byName = (name: string) =>
+    expr.dialects.find(d => d.dialect.toUpperCase() === name.toUpperCase());
+
+  const exact = byName(preferred);
+  if (exact) return exact.expression;
+
+  const fallback = byName(FALLBACK_DIALECT);
+  if (fallback) {
+    warnings.push(`${ctx}: no '${preferred}' dialect; using '${FALLBACK_DIALECT}' expression`);
+    return fallback.expression;
+  }
+
+  const first = expr.dialects[0];
+  warnings.push(`${ctx}: no '${preferred}' or '${FALLBACK_DIALECT}' dialect; using '${first.dialect}' expression`);
+  return first.expression;
+}
+
+// Parses a dotted `source` string into a structured table reference. Handles
+// `project.dataset.table`, `dataset.table`, and bare `table`, filling a missing
+// project/dataset from options. A source that looks like a query (contains
+// whitespace) cannot be structured, so it is kept verbatim as the table name.
+function parseSource(source: string, opts: LoadOptions,
+                     warnings: string[], ctx: string): DataSource {
+  const trimmed = source.trim();
+
+  if (/\s/.test(trimmed)) {
+    warnings.push(`${ctx}: source looks like a query, not a table reference; keeping it verbatim`);
+    return withDefaults({ table: trimmed }, opts);
+  }
+
+  const parts = trimmed.split('.').map(unquote);
+  let project: string | undefined;
+  let dataset: string | undefined;
+  let table: string;
+
+  if (parts.length === 1) {
+    table = parts[0];
+  } else if (parts.length === 2) {
+    [dataset, table] = parts;
+  } else if (parts.length === 3) {
+    [project, dataset, table] = parts;
+  } else {
+    warnings.push(
+      `${ctx}: source '${trimmed}' has ${parts.length} dotted parts; ` +
+      `treating the first two as project/dataset and the rest as the table`);
+    project = parts[0];
+    dataset = parts[1];
+    table = parts.slice(2).join('.');
+  }
+
+  const ds: DataSource = { table };
+  if (project) ds.project = project;
+  if (dataset) ds.dataset = dataset;
+  return withDefaults(ds, opts);
+}
+
+function withDefaults(ds: DataSource, opts: LoadOptions): DataSource {
+  if (!ds.project && opts.defaultProject) ds.project = opts.defaultProject;
+  if (!ds.dataset && opts.defaultDataset) ds.dataset = opts.defaultDataset;
+  return ds;
+}
+
+function unquote(part: string): string {
+  return part.replace(/^[`"]/, '').replace(/[`"]$/, '');
+}
+
+// Returns the entity names whose `<name>.` qualifier appears in the expression.
+// This is a light scan (it does not exclude string literals); the BigQuery
+// generator applies the literal-aware placement when it lowers the metric.
+function referencedEntities(expression: string, entityNames: string[]): string[] {
+  return entityNames.filter(
+    name => new RegExp(`\\b${escapeRegExp(name)}\\.`).test(expression));
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function dedupe(items: string[]): string[] {
+  return [...new Set(items)];
+}

--- a/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
@@ -1,0 +1,136 @@
+// Tests for the BigQuery property-graph generator (src/libts/semantic/bigquery.ts).
+//
+
+import { describe, test, expect } from 'bun:test';
+import { generatePropertyGraph } from '../../src/libts/semantic/bigquery';
+import { SemanticModel } from '../../src/libts/semantic/ir';
+
+// A small sales model: customers -(place)- orders, plus an order_items fact
+// table joined to orders. Metrics exercise single-entity placement and the
+// cross-table skip path.
+const MODEL: SemanticModel = {
+  name: 'sales',
+  entities: [
+    {
+      name: 'customers',
+      dataSource: { project: 'proj', dataset: 'sales', table: 'customers' },
+      keys: ['customer_id'],
+      fields: [
+        { name: 'customer_id', expression: 'customers.customer_id' },
+        { name: 'region', expression: 'customers.region', description: 'Sales region' },
+      ],
+    },
+    {
+      name: 'orders',
+      dataSource: { project: 'proj', dataset: 'sales', table: 'orders' },
+      keys: ['order_id'],
+      fields: [
+        { name: 'order_id', expression: 'orders.order_id' },
+        { name: 'status', expression: 'orders.status' },
+      ],
+    },
+    {
+      name: 'order_items',
+      dataSource: { project: 'proj', dataset: 'sales', table: 'order_items' },
+      keys: ['order_item_id'],
+      fields: [
+        { name: 'order_item_id', expression: 'order_items.order_item_id' },
+        { name: 'amount', expression: 'order_items.amount' },
+      ],
+    },
+  ],
+  relationships: [
+    {
+      name: 'customer_orders',
+      source: {
+        entity: 'orders',
+        joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
+      },
+      destination: {
+        entity: 'customers',
+        joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
+      },
+    },
+  ],
+  metrics: [
+    { name: 'total_revenue', expression: 'SUM(order_items.amount)', entities: ['order_items'] },
+    { name: 'order_count', expression: 'COUNT(orders.order_id)', entities: ['orders'] },
+    // Genuinely cross-table: references two entities' columns in one aggregate.
+    { name: 'weird', expression: 'SUM(order_items.amount * customers.customer_id)',
+      entities: ['order_items', 'customers'] },
+  ],
+};
+
+describe('generatePropertyGraph', () => {
+  const { ddl, warnings } = generatePropertyGraph(MODEL);
+
+  test('emits a single CREATE OR REPLACE PROPERTY GRAPH', () => {
+    expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `proj.sales.sales`');
+    expect(ddl).toContain('NODE TABLES (');
+    expect(ddl).toContain('EDGE TABLES (');
+    expect(ddl.trim().endsWith(';')).toBe(true);
+  });
+
+  test('renders node tables with keys and properties', () => {
+    expect(ddl).toContain('`proj.sales.customers` AS customers');
+    expect(ddl).toContain('KEY(customer_id)');
+    // Bare column when expression is just the column.
+    expect(ddl).toContain('customer_id');
+    // Description carried into OPTIONS.
+    expect(ddl).toContain('region OPTIONS(description="Sales region")');
+  });
+
+  test('renders the edge table referencing node labels', () => {
+    expect(ddl).toContain('`proj.sales.orders` AS customer_orders');
+    expect(ddl).toContain('SOURCE KEY(customer_id) REFERENCES orders(customer_id)');
+    expect(ddl).toContain('DESTINATION KEY(customer_id) REFERENCES customers(customer_id)');
+  });
+
+  test('places single-entity metrics as inline MEASUREs (qualifier stripped)', () => {
+    expect(ddl).toContain('MEASURE(SUM(amount)) AS total_revenue');
+    expect(ddl).toContain('MEASURE(COUNT(order_id)) AS order_count');
+  });
+
+  test('skips a genuinely cross-table metric and warns', () => {
+    expect(ddl).not.toContain('weird');
+    expect(warnings.some(w => w.includes("metric 'weird'") && w.includes('multiple tables')))
+      .toBe(true);
+  });
+
+  test('no warnings for the placeable metrics', () => {
+    expect(warnings.some(w => w.includes("'total_revenue'"))).toBe(false);
+    expect(warnings.some(w => w.includes("'order_count'"))).toBe(false);
+  });
+});
+
+describe('generatePropertyGraph options and edge cases', () => {
+  test('falls back to opts for project/dataset and graph name', () => {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{
+        name: 'e',
+        dataSource: { table: 't' },
+        keys: ['id'],
+        fields: [{ name: 'id', expression: 'e.id' }],
+      }],
+      relationships: [],
+      metrics: [],
+    };
+    const { ddl } = generatePropertyGraph(model, { project: 'p', dataset: 'd', graphName: 'g' });
+    expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `p.d.g`');
+    expect(ddl).toContain('`p.d.t` AS e');
+    // No relationships => no EDGE TABLES block.
+    expect(ddl).not.toContain('EDGE TABLES');
+  });
+
+  test('warns when a table has no resolvable project/dataset', () => {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'], fields: [] }],
+      relationships: [],
+      metrics: [],
+    };
+    const { warnings } = generatePropertyGraph(model);
+    expect(warnings.some(w => w.includes('missing a project and/or dataset'))).toBe(true);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
@@ -1,136 +1,291 @@
-// Tests for the BigQuery property-graph generator (src/libts/semantic/bigquery.ts).
+// Behavior specification for the BigQuery property-graph generator
+// (src/libts/semantic/bigquery.ts).
+//
+// Each test names and documents one behavior of `generatePropertyGraph`. The two
+// fixtures below (a direct-FK chain and an M:N association) were executed against
+// a live BigQuery instance (project `sqlgen-testing`): the chain's node measures
+// were validated with GRAPH_EXPAND + AGG against a plain-SQL control, and the
+// association graph was traversed with a GQL MATCH. The "matches verified DDL"
+// tests pin the generator output to the exact text BigQuery accepted, so this
+// suite guards the behavior without needing a live instance.
 //
 
 import { describe, test, expect } from 'bun:test';
-import { generatePropertyGraph } from '../../src/libts/semantic/bigquery';
+import { generatePropertyGraph, GenerateOptions } from '../../src/libts/semantic/bigquery';
 import { SemanticModel } from '../../src/libts/semantic/ir';
 
-// A small sales model: customers -(place)- orders, plus an order_items fact
-// table joined to orders. Metrics exercise single-entity placement and the
-// cross-table skip path.
-const MODEL: SemanticModel = {
-  name: 'sales',
+// Target used for the live verification; kept so the golden DDL below is
+// reproducible byte-for-byte.
+const OPTS: GenerateOptions = { project: 'sqlgen-testing', dataset: 'bei_semantic_ir_verify' };
+
+// Direct-FK chain: order_items (root) -> orders -> customers, with node-level
+// measures. Verified live via GRAPH_EXPAND + AGG.
+const SALES: SemanticModel = {
+  name: 'sales_graph',
   entities: [
-    {
-      name: 'customers',
-      dataSource: { project: 'proj', dataset: 'sales', table: 'customers' },
-      keys: ['customer_id'],
+    { name: 'customers', dataSource: { table: 'customers' }, keys: ['customer_id'],
       fields: [
         { name: 'customer_id', expression: 'customers.customer_id' },
         { name: 'region', expression: 'customers.region', description: 'Sales region' },
-      ],
-    },
-    {
-      name: 'orders',
-      dataSource: { project: 'proj', dataset: 'sales', table: 'orders' },
-      keys: ['order_id'],
+      ] },
+    { name: 'orders', dataSource: { table: 'orders' }, keys: ['order_id'],
       fields: [
         { name: 'order_id', expression: 'orders.order_id' },
+        { name: 'customer_id', expression: 'orders.customer_id' },
         { name: 'status', expression: 'orders.status' },
-      ],
-    },
-    {
-      name: 'order_items',
-      dataSource: { project: 'proj', dataset: 'sales', table: 'order_items' },
-      keys: ['order_item_id'],
+      ] },
+    { name: 'order_items', dataSource: { table: 'order_items' }, keys: ['order_item_id'],
       fields: [
         { name: 'order_item_id', expression: 'order_items.order_item_id' },
+        { name: 'order_id', expression: 'order_items.order_id' },
         { name: 'amount', expression: 'order_items.amount' },
-      ],
-    },
+      ] },
   ],
   relationships: [
-    {
-      name: 'customer_orders',
-      source: {
-        entity: 'orders',
-        joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
-      },
-      destination: {
-        entity: 'customers',
-        joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
-      },
-    },
+    { name: 'orders_customers',
+      source:      { entity: 'orders',    joinKeys: { relationshipColumns: ['order_id'],    entityColumns: ['order_id'] } },
+      destination: { entity: 'customers', joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] } } },
+    { name: 'orderitems_orders',
+      source:      { entity: 'order_items', joinKeys: { relationshipColumns: ['order_item_id'], entityColumns: ['order_item_id'] } },
+      destination: { entity: 'orders',      joinKeys: { relationshipColumns: ['order_id'],      entityColumns: ['order_id'] } } },
   ],
   metrics: [
-    { name: 'total_revenue', expression: 'SUM(order_items.amount)', entities: ['order_items'] },
-    { name: 'order_count', expression: 'COUNT(orders.order_id)', entities: ['orders'] },
-    // Genuinely cross-table: references two entities' columns in one aggregate.
-    { name: 'weird', expression: 'SUM(order_items.amount * customers.customer_id)',
-      entities: ['order_items', 'customers'] },
+    { name: 'total_revenue', expression: 'SUM(order_items.amount)',          entities: ['order_items'] },
+    { name: 'item_count',    expression: 'COUNT(order_items.order_item_id)', entities: ['order_items'] },
+    { name: 'order_count',   expression: 'COUNT(orders.order_id)',           entities: ['orders'] },
   ],
 };
 
-describe('generatePropertyGraph', () => {
-  const { ddl, warnings } = generatePropertyGraph(MODEL);
+// M:N via an association table with its own key and an edge property. Verified
+// live via a GQL MATCH traversal.
+const SCHOOL: SemanticModel = {
+  name: 'school_graph',
+  entities: [
+    { name: 'students', dataSource: { table: 'students' }, keys: ['student_id'],
+      fields: [ { name: 'student_id', expression: 'students.student_id' },
+                { name: 'name', expression: 'students.name' } ] },
+    { name: 'courses', dataSource: { table: 'courses' }, keys: ['course_id'],
+      fields: [ { name: 'course_id', expression: 'courses.course_id' },
+                { name: 'title', expression: 'courses.title' } ] },
+  ],
+  relationships: [
+    { name: 'enrollment',
+      dataSource: { table: 'enrollment' },
+      keys: ['enrollment_id'],
+      source:      { entity: 'students', joinKeys: { relationshipColumns: ['student_id'], entityColumns: ['student_id'] } },
+      destination: { entity: 'courses',  joinKeys: { relationshipColumns: ['course_id'],  entityColumns: ['course_id'] } },
+      fields: [ { name: 'grade', expression: 'enrollment.grade', description: 'Letter grade' } ] },
+  ],
+  metrics: [],
+};
 
-  test('emits a single CREATE OR REPLACE PROPERTY GRAPH', () => {
-    expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `proj.sales.sales`');
-    expect(ddl).toContain('NODE TABLES (');
-    expect(ddl).toContain('EDGE TABLES (');
-    expect(ddl.trim().endsWith(';')).toBe(true);
-  });
 
-  test('renders node tables with keys and properties', () => {
-    expect(ddl).toContain('`proj.sales.customers` AS customers');
+describe('entities become node tables', () => {
+  const { ddl } = generatePropertyGraph(SALES, OPTS);
+
+  test('each entity is a node table keyed by its grain (the KEY measures lock to)', () => {
+    expect(ddl).toContain('`sqlgen-testing.bei_semantic_ir_verify.customers` AS customers');
     expect(ddl).toContain('KEY(customer_id)');
-    // Bare column when expression is just the column.
-    expect(ddl).toContain('customer_id');
-    // Description carried into OPTIONS.
+    expect(ddl).toContain('`sqlgen-testing.bei_semantic_ir_verify.order_items` AS order_items');
+    expect(ddl).toContain('KEY(order_item_id)');
+  });
+
+  test('a plain-column field emits a bare property (no redundant "col AS col")', () => {
+    // order_items.amount -> just `amount`, since the expression is only the column.
+    expect(ddl).toContain('\n      amount');
+    expect(ddl).not.toContain('amount AS amount');
+  });
+
+  test('a field description is preserved as OPTIONS(description=...)', () => {
     expect(ddl).toContain('region OPTIONS(description="Sales region")');
-  });
-
-  test('renders the edge table referencing node labels', () => {
-    expect(ddl).toContain('`proj.sales.orders` AS customer_orders');
-    expect(ddl).toContain('SOURCE KEY(customer_id) REFERENCES orders(customer_id)');
-    expect(ddl).toContain('DESTINATION KEY(customer_id) REFERENCES customers(customer_id)');
-  });
-
-  test('places single-entity metrics as inline MEASUREs (qualifier stripped)', () => {
-    expect(ddl).toContain('MEASURE(SUM(amount)) AS total_revenue');
-    expect(ddl).toContain('MEASURE(COUNT(order_id)) AS order_count');
-  });
-
-  test('skips a genuinely cross-table metric and warns', () => {
-    expect(ddl).not.toContain('weird');
-    expect(warnings.some(w => w.includes("metric 'weird'") && w.includes('multiple tables')))
-      .toBe(true);
-  });
-
-  test('no warnings for the placeable metrics', () => {
-    expect(warnings.some(w => w.includes("'total_revenue'"))).toBe(false);
-    expect(warnings.some(w => w.includes("'order_count'"))).toBe(false);
   });
 });
 
-describe('generatePropertyGraph options and edge cases', () => {
-  test('falls back to opts for project/dataset and graph name', () => {
+
+describe('model-level metrics become inline measures', () => {
+  const { ddl, warnings } = generatePropertyGraph(SALES, OPTS);
+
+  test('a single-entity metric becomes a table-local MEASURE (entity qualifier stripped)', () => {
+    // SUM(order_items.amount) -> MEASURE(SUM(amount)); the measure body must
+    // reference columns local to the table it is attached to.
+    expect(ddl).toContain('MEASURE(SUM(amount)) AS total_revenue');
+    expect(ddl).toContain('MEASURE(COUNT(order_item_id)) AS item_count');
+  });
+
+  test('a measure is attached to its owning entity, keeping it locked to that KEY', () => {
+    // order_count counts orders, so it must live on the `orders` node (locked to
+    // order_id) — not on the fan-out `order_items` table. Live verification
+    // confirmed this yields 3 orders for the "west" region, not 4 (the item
+    // count), proving joins do not inflate the measure.
+    const ordersBlock = ddl.slice(ddl.indexOf('AS orders\n'), ddl.indexOf('AS order_items'));
+    expect(ordersBlock).toContain('MEASURE(COUNT(order_id)) AS order_count');
+  });
+
+  test('a metric whose aggregate spans multiple tables is skipped and reported', () => {
+    // A BigQuery measure binds to a single table's KEY, so a genuinely
+    // cross-table aggregate cannot become one MEASURE.
+    const model: SemanticModel = {
+      ...SALES,
+      metrics: [{ name: 'weird', expression: 'SUM(order_items.amount * customers.customer_id)',
+                  entities: ['order_items', 'customers'] }],
+    };
+    const res = generatePropertyGraph(model, OPTS);
+    expect(res.ddl).not.toContain('weird');
+    expect(res.warnings.some(w => w.includes("metric 'weird'") && w.includes('multiple tables')))
+      .toBe(true);
+  });
+
+  test('placeable metrics produce no warnings', () => {
+    expect(warnings).toEqual([]);
+  });
+});
+
+
+describe('relationships become edge tables', () => {
+  test('every edge table declares an explicit element KEY (base-table PKs are not assumed)', () => {
+    // BigQuery rejects an edge table without a key unless the base table declares
+    // a PRIMARY KEY; semantic models over arbitrary tables cannot rely on that,
+    // so the generator always emits KEY(...). This was caught by live testing.
+    const { ddl } = generatePropertyGraph(SALES, OPTS);
+    expect(ddl).toContain('AS orders_customers\n    KEY(order_id)');
+    expect(ddl).toContain('AS orderitems_orders\n    KEY(order_item_id)');
+  });
+
+  test('a direct-FK edge is backed by the source entity table; REFERENCES target each endpoint KEY', () => {
+    const { ddl } = generatePropertyGraph(SALES, OPTS);
+    expect(ddl).toContain('`sqlgen-testing.bei_semantic_ir_verify.orders` AS orders_customers');
+    expect(ddl).toContain('SOURCE KEY(order_id) REFERENCES orders(order_id)');
+    expect(ddl).toContain('DESTINATION KEY(customer_id) REFERENCES customers(customer_id)');
+  });
+
+  test('an association edge is backed by its own table, keyed by rel.keys, and carries edge properties', () => {
+    const { ddl } = generatePropertyGraph(SCHOOL, OPTS);
+    expect(ddl).toContain('`sqlgen-testing.bei_semantic_ir_verify.enrollment` AS enrollment');
+    expect(ddl).toContain('AS enrollment\n    KEY(enrollment_id)');
+    expect(ddl).toContain('SOURCE KEY(student_id) REFERENCES students(student_id)');
+    expect(ddl).toContain('DESTINATION KEY(course_id) REFERENCES courses(course_id)');
+    expect(ddl).toContain('grade OPTIONS(description="Letter grade")');
+  });
+});
+
+
+describe('graph naming and options', () => {
+  test('graph name and unqualified table refs fall back to options', () => {
     const model: SemanticModel = {
       name: 'm',
-      entities: [{
-        name: 'e',
-        dataSource: { table: 't' },
-        keys: ['id'],
-        fields: [{ name: 'id', expression: 'e.id' }],
-      }],
+      entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'],
+                   fields: [{ name: 'id', expression: 'e.id' }] }],
       relationships: [],
       metrics: [],
     };
     const { ddl } = generatePropertyGraph(model, { project: 'p', dataset: 'd', graphName: 'g' });
     expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `p.d.g`');
     expect(ddl).toContain('`p.d.t` AS e');
-    // No relationships => no EDGE TABLES block.
-    expect(ddl).not.toContain('EDGE TABLES');
   });
 
-  test('warns when a table has no resolvable project/dataset', () => {
+  test('a model with no relationships omits the EDGE TABLES block', () => {
     const model: SemanticModel = {
       name: 'm',
       entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'], fields: [] }],
       relationships: [],
       metrics: [],
     };
-    const { warnings } = generatePropertyGraph(model);
+    const { ddl } = generatePropertyGraph(model, OPTS);
+    expect(ddl).not.toContain('EDGE TABLES');
+  });
+
+  test('a table with no resolvable project/dataset yields a warning', () => {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'], fields: [] }],
+      relationships: [],
+      metrics: [],
+    };
+    const { warnings } = generatePropertyGraph(model);  // no opts to fall back to
     expect(warnings.some(w => w.includes('missing a project and/or dataset'))).toBe(true);
   });
 });
+
+
+describe('emits DDL that BigQuery accepts (live-verified regression guard)', () => {
+  // The exact strings below were run against BigQuery and produced correct
+  // results. Any change to generator formatting must be re-verified before these
+  // goldens are updated.
+
+  test('direct-FK chain graph with node measures matches the verified DDL', () => {
+    const { ddl } = generatePropertyGraph(SALES, OPTS);
+    expect(ddl).toBe(VERIFIED_SALES_DDL);
+  });
+
+  test('M:N association graph with edge properties matches the verified DDL', () => {
+    const { ddl } = generatePropertyGraph(SCHOOL, OPTS);
+    expect(ddl).toBe(VERIFIED_SCHOOL_DDL);
+  });
+});
+
+
+const VERIFIED_SALES_DDL =
+`CREATE OR REPLACE PROPERTY GRAPH \`sqlgen-testing.bei_semantic_ir_verify.sales_graph\`
+NODE TABLES (
+  \`sqlgen-testing.bei_semantic_ir_verify.customers\` AS customers
+    KEY(customer_id)
+    PROPERTIES(
+      customer_id,
+      region OPTIONS(description="Sales region")
+    ),
+  \`sqlgen-testing.bei_semantic_ir_verify.orders\` AS orders
+    KEY(order_id)
+    PROPERTIES(
+      order_id,
+      customer_id,
+      status,
+      MEASURE(COUNT(order_id)) AS order_count
+    ),
+  \`sqlgen-testing.bei_semantic_ir_verify.order_items\` AS order_items
+    KEY(order_item_id)
+    PROPERTIES(
+      order_item_id,
+      order_id,
+      amount,
+      MEASURE(SUM(amount)) AS total_revenue,
+      MEASURE(COUNT(order_item_id)) AS item_count
+    )
+)
+EDGE TABLES (
+  \`sqlgen-testing.bei_semantic_ir_verify.orders\` AS orders_customers
+    KEY(order_id)
+    SOURCE KEY(order_id) REFERENCES orders(order_id)
+    DESTINATION KEY(customer_id) REFERENCES customers(customer_id),
+  \`sqlgen-testing.bei_semantic_ir_verify.order_items\` AS orderitems_orders
+    KEY(order_item_id)
+    SOURCE KEY(order_item_id) REFERENCES order_items(order_item_id)
+    DESTINATION KEY(order_id) REFERENCES orders(order_id)
+);
+`;
+
+const VERIFIED_SCHOOL_DDL =
+`CREATE OR REPLACE PROPERTY GRAPH \`sqlgen-testing.bei_semantic_ir_verify.school_graph\`
+NODE TABLES (
+  \`sqlgen-testing.bei_semantic_ir_verify.students\` AS students
+    KEY(student_id)
+    PROPERTIES(
+      student_id,
+      name
+    ),
+  \`sqlgen-testing.bei_semantic_ir_verify.courses\` AS courses
+    KEY(course_id)
+    PROPERTIES(
+      course_id,
+      title
+    )
+)
+EDGE TABLES (
+  \`sqlgen-testing.bei_semantic_ir_verify.enrollment\` AS enrollment
+    KEY(enrollment_id)
+    SOURCE KEY(student_id) REFERENCES students(student_id)
+    DESTINATION KEY(course_id) REFERENCES courses(course_id)
+    PROPERTIES(
+      grade OPTIONS(description="Letter grade")
+    )
+);
+`;

--- a/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.bigquery.test.ts
@@ -207,6 +207,56 @@ describe('graph naming and options', () => {
 });
 
 
+describe('robust handling of messy inputs (from code review)', () => {
+  test('a description with newlines/tabs/quotes escapes into a single valid string literal', () => {
+    // Raw newlines cannot appear inside a BigQuery double-quoted literal; they
+    // (and \t, ", \) must be escaped or the OPTIONS(description=...) is invalid.
+    const model: SemanticModel = {
+      name: 'm', relationships: [], metrics: [],
+      entities: [{ name: 'e', dataSource: { table: 't' }, keys: ['id'],
+        fields: [{ name: 'id', expression: 'e.id', description: 'line1\nline2\t"q"' }] }],
+    };
+    const { ddl } = generatePropertyGraph(model, OPTS);
+    expect(ddl).toContain('OPTIONS(description="line1\\nline2\\t\\"q\\"")');
+    expect(ddl).not.toContain('line1\nline2');  // no raw newline inside the literal
+  });
+
+  test('an entity qualifier inside a string literal is neither stripped nor counted as a reference', () => {
+    // Only order_items is genuinely referenced; 'orders.note' is data. The metric
+    // must place on order_items (not be flagged as spanning orders too), and the
+    // literal text must survive qualifier stripping unchanged.
+    const model: SemanticModel = {
+      ...SALES,
+      metrics: [{ name: 'flagged',
+        expression: "SUM(IF(order_items.amount > 0, order_items.amount, 0)) /* 'orders.note' */",
+        entities: ['order_items'] }],
+    };
+    const { ddl, warnings } = generatePropertyGraph(model, OPTS);
+    expect(ddl).toContain("MEASURE(SUM(IF(amount > 0, amount, 0)) /* 'orders.note' */) AS flagged");
+    expect(warnings.some(w => w.includes('flagged') && w.includes('multiple'))).toBe(false);
+  });
+
+  test("a metric whose declared entities disagree with its expression is reported", () => {
+    // The IR declares entities: ['orders'] but the expression aggregates
+    // order_items; the generator places per the expression and surfaces the
+    // discrepancy instead of resolving it silently.
+    const model: SemanticModel = {
+      ...SALES,
+      metrics: [{ name: 'mislabeled', expression: 'SUM(order_items.amount)', entities: ['orders'] }],
+    };
+    const { warnings } = generatePropertyGraph(model, OPTS);
+    expect(warnings.some(w => w.includes("metric 'mislabeled'") && w.includes('declares entities')))
+      .toBe(true);
+  });
+
+  test('a model with no entities is reported rather than silently emitting an invalid graph', () => {
+    const model: SemanticModel = { name: 'm', entities: [], relationships: [], metrics: [] };
+    const { warnings } = generatePropertyGraph(model, OPTS);
+    expect(warnings.some(w => w.includes('no entities'))).toBe(true);
+  });
+});
+
+
 describe('emits DDL that BigQuery accepts (live-verified regression guard)', () => {
   // The exact strings below were run against BigQuery and produced correct
   // results. Any change to generator formatting must be re-verified before these

--- a/toolbox/mdcode/tests/libts/semantic.loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.loader.test.ts
@@ -59,6 +59,31 @@ describe('dataset source strings parse into structured table refs', () => {
     });
     expect(warnings.some(w => w.includes('no primary_key'))).toBe(true);
   });
+
+  test('backtick- or double-quoted identifiers are unquoted', () => {
+    const { models } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: '`proj`.`ds`.`tbl`', primary_key: ['id'], fields: [] }] }],
+    });
+    expect(models[0].entities[0].dataSource).toEqual({ project: 'proj', dataset: 'ds', table: 'tbl' });
+  });
+
+  test('more than three dotted parts warns, keeping the remainder as the table', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'p.d.t.extra', primary_key: ['id'], fields: [] }] }],
+    });
+    expect(models[0].entities[0].dataSource).toEqual({ project: 'p', dataset: 'd', table: 't.extra' });
+    expect(warnings.some(w => w.includes('dotted parts'))).toBe(true);
+  });
+
+  test('an explicit project/dataset in the source is not overridden by defaults', () => {
+    const { models } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'realproj.realds.tbl', primary_key: ['id'], fields: [] }] }],
+    }, { defaultProject: 'P', defaultDataset: 'D' });
+    expect(models[0].entities[0].dataSource).toEqual({ project: 'realproj', dataset: 'realds', table: 'tbl' });
+  });
 });
 
 
@@ -104,6 +129,34 @@ describe('per-dialect expressions collapse to a single string', () => {
       { dialect: 'BIGQUERY', expression: 'BQ' },
     ]), { dialect: 'SNOWFLAKE' });
     expect(models[0].metrics[0].expression).toBe('SF');
+  });
+
+  test('dialect names are matched case-insensitively', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'BigQuery', expression: 'SUM(orders.a)' },
+    ]), { dialect: 'bigquery' });
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
+    expect(warnings.some(w => w.includes('dialect'))).toBe(false);
+  });
+
+  test('field expressions select their dialect independently of metrics', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [
+            { name: 'id', expression: expr('orders.id') },
+            { name: 'net', expression: {
+              dialects: [{ dialect: 'ANSI_SQL', expression: 'orders.gross - orders.tax' }] } },
+          ],
+        }],
+      }],
+    });
+    const fields = models[0].entities[0].fields;
+    expect(fields[0].expression).toBe('orders.id');                  // BIGQUERY, no fallback
+    expect(fields[1].expression).toBe('orders.gross - orders.tax');  // ANSI_SQL fallback
+    expect(warnings.some(w => w.includes("field 'orders.net'") && w.includes('ANSI_SQL'))).toBe(true);
   });
 });
 
@@ -156,6 +209,49 @@ describe('relationships map onto the direct-FK IR convention', () => {
     expect(warnings.some(w => w.includes("'to' dataset 'ghost'"))).toBe(true);
   });
 
+  test('a composite foreign key maps column-for-column', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'sales', source: 'sales', primary_key: ['sale_id'], fields: [] },
+          { name: 'stores', source: 'stores', primary_key: ['region', 'store_no'], fields: [] },
+        ],
+        relationships: [{
+          name: 'sales_stores', from: 'sales', to: 'stores',
+          from_columns: ['region', 'store_no'], to_columns: ['region', 'store_no'],
+        }],
+      }],
+    });
+    const rel = models[0].relationships[0];
+    // Source end carries the `from` dataset's own PK; destination end carries the
+    // full composite FK, column-for-column.
+    expect(rel.source.joinKeys).toEqual({
+      relationshipColumns: ['sale_id'], entityColumns: ['sale_id'] });
+    expect(rel.destination.joinKeys).toEqual({
+      relationshipColumns: ['region', 'store_no'], entityColumns: ['region', 'store_no'] });
+    expect(warnings.some(w => w.includes('different lengths'))).toBe(false);
+  });
+
+  test('the source end falls back to from_columns when the from dataset has no PK', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', fields: [] },  // no primary_key
+          { name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] },
+        ],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'customers',
+          from_columns: ['customer_id'], to_columns: ['customer_id'],
+        }],
+      }],
+    });
+    expect(models[0].relationships[0].source.joinKeys).toEqual({
+      relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] });
+    expect(warnings.some(w => w.includes('no primary_key'))).toBe(true);
+  });
+
   test('mismatched from_columns/to_columns arity warns (invalid join keys)', () => {
     const { warnings } = fromDocument({
       semantic_model: [{
@@ -185,6 +281,26 @@ describe('metrics infer their referenced entities from the expression', () => {
       }],
     });
     expect(models[0].metrics[0].entities).toEqual(['order_items']);
+  });
+
+  test('a metric spanning multiple entities lists them all, in first-seen order', () => {
+    // The loader records every referenced entity; the generator is what later
+    // decides such a metric cannot be a single MEASURE. No missing-entity warning.
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', primary_key: ['id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['id'], fields: [] },
+        ],
+        metrics: [{
+          name: 'ratio',
+          expression: expr('SUM(orders.amount) / COUNT(customers.id)'),
+        }],
+      }],
+    });
+    expect(models[0].metrics[0].entities).toEqual(['orders', 'customers']);
+    expect(warnings.some(w => w.includes('references no known entity'))).toBe(false);
   });
 
   test('a metric referencing no known entity warns', () => {
@@ -262,8 +378,45 @@ describe('document-level handling', () => {
     expect(warnings.some(w => w.includes("duplicate dataset name 'orders'"))).toBe(true);
   });
 
+  test('each semantic_model entry becomes its own IR model', () => {
+    const { models } = fromDocument({
+      semantic_model: [
+        { name: 'first', datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }] },
+        { name: 'second', datasets: [{ name: 'b', source: 'b', primary_key: ['id'], fields: [] }] },
+      ],
+    });
+    expect(models.map(m => m.name)).toEqual(['first', 'second']);
+  });
+
+  test('model and metric descriptions carry through to the IR', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm', description: 'a sales model',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'c', description: 'row count', expression: expr('COUNT(orders.id)') }],
+      }],
+    });
+    expect(models[0].description).toBe('a sales model');
+    expect(models[0].metrics[0].description).toBe('row count');
+  });
+
+  test('JSON text loads identically to YAML (yaml.parse accepts JSON)', () => {
+    const json = JSON.stringify({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] }],
+      }],
+    });
+    const { models } = loadModels(json);
+    expect(models[0].entities[0].dataSource).toEqual({ project: 'proj', dataset: 'ds', table: 'tbl' });
+  });
+
   test('a document without semantic_model throws', () => {
     expect(() => fromDocument({ foo: 'bar' })).toThrow(/Semantic model load error/);
+  });
+
+  test('an empty semantic_model array throws (min one model required)', () => {
+    expect(() => fromDocument({ semantic_model: [] })).toThrow(/Semantic model load error/);
   });
 
   test('unparseable input throws', () => {
@@ -273,6 +426,14 @@ describe('document-level handling', () => {
 
 
 // End-to-end: parse YAML text, then generate BigQuery DDL from the loaded model.
+//
+// This fixture was executed against a live BigQuery instance (project
+// `sqlgen-testing`): the generated `CREATE OR REPLACE PROPERTY GRAPH` was
+// accepted, and its measures were validated with GRAPH_EXPAND + AGG against a
+// plain-SQL control. For the `west` region the graph returned total_revenue 135
+// and order_count 3 (not 4) — confirming that the loaded `order_count` lands on
+// the `orders` node and is deduplicated per order despite the order_items
+// fan-out. These text assertions pin the same behavior without a live instance.
 const SALES_YAML = `
 version: 0.2.0.dev0
 semantic_model:
@@ -303,6 +464,8 @@ semantic_model:
     metrics:
       - name: total_revenue
         expression: { dialects: [{ dialect: BIGQUERY, expression: "SUM(order_items.amount)" }] }
+      - name: order_count
+        expression: { dialects: [{ dialect: BIGQUERY, expression: "COUNT(orders.order_id)" }] }
 `;
 
 describe('end-to-end: a loaded model generates BigQuery property-graph DDL', () => {
@@ -321,6 +484,14 @@ describe('end-to-end: a loaded model generates BigQuery property-graph DDL', () 
 
   test('the metric becomes an inline measure on its owning entity', () => {
     expect(ddl).toContain('MEASURE(SUM(amount)) AS total_revenue');
+  });
+
+  test('a count metric lands on its own entity node, not the fan-out table', () => {
+    // order_count counts orders, so it must sit on the `orders` node (keyed by
+    // order_id) — this is what makes GRAPH_EXPAND + AGG return 3 orders for the
+    // west region rather than 4 (the order_items count). Verified live.
+    const ordersBlock = ddl.slice(ddl.indexOf('AS orders\n'), ddl.indexOf('AS order_items'));
+    expect(ordersBlock).toContain('MEASURE(COUNT(order_id)) AS order_count');
   });
 
   test('relationships become edge tables referencing the node labels', () => {

--- a/toolbox/mdcode/tests/libts/semantic.loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.loader.test.ts
@@ -1,0 +1,281 @@
+// Behavior specification for the semantic-model loader
+// (src/libts/semantic/loader.ts).
+//
+// The loader reads the subset of an open, AI-first semantics format needed to
+// normalize a model into the IR. Each test names one behavior. Focused tests use
+// `fromDocument` with object literals; the end-to-end block parses YAML text and
+// runs the loaded model through the BigQuery generator to prove the full
+// file -> IR -> DDL path.
+//
+
+import { describe, test, expect } from 'bun:test';
+import { loadModels, fromDocument } from '../../src/libts/semantic/loader';
+import { generatePropertyGraph } from '../../src/libts/semantic/bigquery';
+
+// Shorthand for the format's per-dialect expression object.
+function expr(expression: string, dialect = 'BIGQUERY') {
+  return { dialects: [{ dialect, expression }] };
+}
+
+
+describe('dataset source strings parse into structured table refs', () => {
+  const { models } = fromDocument({
+    semantic_model: [{
+      name: 'm',
+      datasets: [
+        { name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] },
+        { name: 'b', source: 'ds.tbl', primary_key: ['id'], fields: [] },
+        { name: 'c', source: 'tbl', primary_key: ['id'], fields: [] },
+      ],
+    }],
+  }, { defaultProject: 'P', defaultDataset: 'D' });
+  const [a, b, c] = models[0].entities;
+
+  test('a three-part source becomes project.dataset.table', () => {
+    expect(a.dataSource).toEqual({ project: 'proj', dataset: 'ds', table: 'tbl' });
+  });
+
+  test('a two-part source becomes dataset.table, project from defaults', () => {
+    expect(b.dataSource).toEqual({ project: 'P', dataset: 'ds', table: 'tbl' });
+  });
+
+  test('a bare table fills both project and dataset from defaults', () => {
+    expect(c.dataSource).toEqual({ project: 'P', dataset: 'D', table: 'tbl' });
+  });
+
+  test('a query-like source is kept verbatim with a warning', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'SELECT 1 FROM t', primary_key: ['id'], fields: [] }] }],
+    });
+    expect(models[0].entities[0].dataSource.table).toBe('SELECT 1 FROM t');
+    expect(warnings.some(w => w.includes('looks like a query'))).toBe(true);
+  });
+
+  test('a dataset without a primary key warns (its KEY would be empty)', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'a', fields: [] }] }],
+    });
+    expect(warnings.some(w => w.includes('no primary_key'))).toBe(true);
+  });
+});
+
+
+describe('per-dialect expressions collapse to a single string', () => {
+  function metricDoc(dialectList: Array<{ dialect: string; expression: string }>) {
+    return {
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'mx', expression: { dialects: dialectList } }],
+      }],
+    };
+  }
+
+  test('the preferred dialect (BIGQUERY) is chosen with no warning', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'ANSI_SQL', expression: 'SUM(orders.a)' },
+      { dialect: 'BIGQUERY', expression: 'SUM(orders.b)' },
+    ]));
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.b)');
+    expect(warnings.some(w => w.includes('dialect'))).toBe(false);
+  });
+
+  test('ANSI_SQL is the fallback when the preferred dialect is absent', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'ANSI_SQL', expression: 'SUM(orders.a)' },
+    ]));
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
+    expect(warnings.some(w => w.includes("using 'ANSI_SQL'"))).toBe(true);
+  });
+
+  test('otherwise the first listed dialect is used, with a warning', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'SNOWFLAKE', expression: 'SUM(orders.a)' },
+    ]));
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
+    expect(warnings.some(w => w.includes("using 'SNOWFLAKE'"))).toBe(true);
+  });
+
+  test('an explicit dialect option overrides the default preference', () => {
+    const { models } = fromDocument(metricDoc([
+      { dialect: 'SNOWFLAKE', expression: 'SF' },
+      { dialect: 'BIGQUERY', expression: 'BQ' },
+    ]), { dialect: 'SNOWFLAKE' });
+    expect(models[0].metrics[0].expression).toBe('SF');
+  });
+});
+
+
+describe('relationships map onto the direct-FK IR convention', () => {
+  const { models } = fromDocument({
+    semantic_model: [{
+      name: 'm',
+      datasets: [
+        { name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] },
+        { name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] },
+      ],
+      relationships: [{
+        name: 'orders_customers', from: 'orders', to: 'customers',
+        from_columns: ['customer_id'], to_columns: ['customer_id'],
+      }],
+    }],
+  });
+  const rel = models[0].relationships[0];
+
+  test('the source end carries the from-dataset primary key', () => {
+    expect(rel.source).toEqual({
+      entity: 'orders',
+      joinKeys: { relationshipColumns: ['order_id'], entityColumns: ['order_id'] },
+    });
+  });
+
+  test('the destination end carries from_columns -> to_columns', () => {
+    expect(rel.destination).toEqual({
+      entity: 'customers',
+      joinKeys: { relationshipColumns: ['customer_id'], entityColumns: ['customer_id'] },
+    });
+  });
+
+  test('no association dataSource is set (it is a direct foreign key)', () => {
+    expect(rel.dataSource).toBeUndefined();
+  });
+
+  test('an unresolved from/to dataset produces a warning', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] }],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'ghost',
+          from_columns: ['g_id'], to_columns: ['id'],
+        }],
+      }],
+    });
+    expect(warnings.some(w => w.includes("'to' dataset 'ghost'"))).toBe(true);
+  });
+});
+
+
+describe('metrics infer their referenced entities from the expression', () => {
+  test('entities are derived from the qualifiers present in the expression', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'total_revenue', expression: expr('SUM(order_items.amount)') }],
+      }],
+    });
+    expect(models[0].metrics[0].entities).toEqual(['order_items']);
+  });
+
+  test('a metric referencing no known entity warns', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'weird', expression: expr('SUM(unknown.x)') }],
+      }],
+    });
+    expect(warnings.some(w => w.includes('references no known entity'))).toBe(true);
+  });
+});
+
+
+describe('document-level handling', () => {
+  test('a mismatched version warns but still loads', () => {
+    const { models, warnings } = fromDocument({
+      version: '9.9.9',
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'a', primary_key: ['id'], fields: [] }] }],
+    });
+    expect(models).toHaveLength(1);
+    expect(warnings.some(w => w.includes('differs from the supported'))).toBe(true);
+  });
+
+  test('unknown/extra fields outside the subset are ignored, not errors', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        ai_context: { instructions: 'ignored' },
+        custom_extensions: [{ vendor_name: 'X', data: '{}' }],
+        datasets: [{
+          name: 'a', source: 'a', primary_key: ['id'],
+          unique_keys: [['id']],
+          fields: [{
+            name: 'id', label: 'ignored', dimension: { is_time: false },
+            expression: expr('a.id'),
+          }],
+        }],
+      }],
+    });
+    expect(models[0].entities[0].fields[0].name).toBe('id');
+  });
+
+  test('a document without semantic_model throws', () => {
+    expect(() => fromDocument({ foo: 'bar' })).toThrow(/Semantic model load error/);
+  });
+
+  test('unparseable input throws', () => {
+    expect(() => loadModels('{ this is : not valid')).toThrow(/load error/);
+  });
+});
+
+
+// End-to-end: parse YAML text, then generate BigQuery DDL from the loaded model.
+const SALES_YAML = `
+version: 0.2.0.dev0
+semantic_model:
+  - name: sales_graph
+    datasets:
+      - name: customers
+        source: customers
+        primary_key: [customer_id]
+        fields:
+          - { name: customer_id, expression: { dialects: [{ dialect: BIGQUERY, expression: customers.customer_id }] } }
+          - { name: region, expression: { dialects: [{ dialect: BIGQUERY, expression: customers.region }] } }
+      - name: orders
+        source: orders
+        primary_key: [order_id]
+        fields:
+          - { name: order_id, expression: { dialects: [{ dialect: BIGQUERY, expression: orders.order_id }] } }
+          - { name: customer_id, expression: { dialects: [{ dialect: BIGQUERY, expression: orders.customer_id }] } }
+      - name: order_items
+        source: order_items
+        primary_key: [order_item_id]
+        fields:
+          - { name: order_item_id, expression: { dialects: [{ dialect: BIGQUERY, expression: order_items.order_item_id }] } }
+          - { name: order_id, expression: { dialects: [{ dialect: BIGQUERY, expression: order_items.order_id }] } }
+          - { name: amount, expression: { dialects: [{ dialect: BIGQUERY, expression: order_items.amount }] } }
+    relationships:
+      - { name: orders_customers, from: orders, to: customers, from_columns: [customer_id], to_columns: [customer_id] }
+      - { name: orderitems_orders, from: order_items, to: orders, from_columns: [order_id], to_columns: [order_id] }
+    metrics:
+      - name: total_revenue
+        expression: { dialects: [{ dialect: BIGQUERY, expression: "SUM(order_items.amount)" }] }
+`;
+
+describe('end-to-end: a loaded model generates BigQuery property-graph DDL', () => {
+  const { models, warnings } = loadModels(SALES_YAML, { defaultProject: 'p', defaultDataset: 'd' });
+  const { ddl } = generatePropertyGraph(models[0], { project: 'p', dataset: 'd' });
+
+  test('exactly one clean model loads (no warnings)', () => {
+    expect(models).toHaveLength(1);
+    expect(warnings).toEqual([]);
+  });
+
+  test('entities become keyed node tables over their base tables', () => {
+    expect(ddl).toContain('`p.d.customers` AS customers');
+    expect(ddl).toContain('KEY(order_item_id)');
+  });
+
+  test('the metric becomes an inline measure on its owning entity', () => {
+    expect(ddl).toContain('MEASURE(SUM(amount)) AS total_revenue');
+  });
+
+  test('relationships become edge tables referencing the node labels', () => {
+    expect(ddl).toContain('SOURCE KEY(order_id) REFERENCES orders(order_id)');
+    expect(ddl).toContain('DESTINATION KEY(customer_id) REFERENCES customers(customer_id)');
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic.loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic.loader.test.ts
@@ -155,6 +155,23 @@ describe('relationships map onto the direct-FK IR convention', () => {
     });
     expect(warnings.some(w => w.includes("'to' dataset 'ghost'"))).toBe(true);
   });
+
+  test('mismatched from_columns/to_columns arity warns (invalid join keys)', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['a', 'b'], fields: [] },
+        ],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'customers',
+          from_columns: ['x', 'y'], to_columns: ['a'],
+        }],
+      }],
+    });
+    expect(warnings.some(w => w.includes('different lengths'))).toBe(true);
+  });
 });
 
 
@@ -179,6 +196,25 @@ describe('metrics infer their referenced entities from the expression', () => {
       }],
     });
     expect(warnings.some(w => w.includes('references no known entity'))).toBe(true);
+  });
+
+  test('a qualifier inside a string literal is not counted as a reference', () => {
+    // 'customers.region' is data, not a column reference, so the metric must be
+    // attributed only to order_items.
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['id'], fields: [] },
+        ],
+        metrics: [{
+          name: 'tagged',
+          expression: expr("CONCAT(SUM(order_items.amount), 'customers.region')"),
+        }],
+      }],
+    });
+    expect(models[0].metrics[0].entities).toEqual(['order_items']);
   });
 });
 
@@ -211,6 +247,19 @@ describe('document-level handling', () => {
       }],
     });
     expect(models[0].entities[0].fields[0].name).toBe('id');
+  });
+
+  test('duplicate dataset names warn (only one node table can carry the label)', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'a', primary_key: ['id'], fields: [] },
+          { name: 'orders', source: 'b', primary_key: ['id'], fields: [] },
+        ],
+      }],
+    });
+    expect(warnings.some(w => w.includes("duplicate dataset name 'orders'"))).toBe(true);
   });
 
   test('a document without semantic_model throws', () => {


### PR DESCRIPTION
> ⚠️ **Tentative — the on-disk syntax is not final.** This loader reads an early,
> experimental YAML/JSON shape purely to get an end-to-end path working
> (file → IR → BigQuery). The field names, structure, dialect handling, and
> supported subset are all provisional and expected to change as the format
> settles. Nothing here is a committed schema or public contract; do not depend
> on the input shape. The stable surface is the IR, not this file format.

## Summary

Adds the first way to get a `SemanticModel` into the toolbox from a file. Until now
the IR (#218) could only be hand-built in objects; the BigQuery property-graph
generator (#219) was its only consumer. This adds a pure loader that reads an open,
vendor-neutral AI-first semantics format (YAML/JSON) and normalizes its logical layer
into the IR — giving us a full **file → IR → BigQuery DDL** path to experiment with.

New module: `src/libts/semantic/loader.ts`
- `loadModels(text, opts?)` — parse YAML or JSON file text into `{ models, warnings }`
- `fromDocument(doc, opts?)` — convert an already-parsed object (e.g. from
  `JSON.parse` or an embedded config) into the IR, skipping the text-parsing step

It follows the existing `manifest.ts` pattern (`yaml.parse` → zod `safeParse` → typed)
and the `{ result, warnings }` convention of the generator.

## Scope (a tentative subset, not the whole spec)

Only the core logical-layer fields needed for the end-to-end path. This is a starting
point, deliberately minimal, and will grow/change:

| Format | IR |
|---|---|
| `dataset` | `Entity` (`source` string parsed into project/dataset/table) |
| `field` | `Field` (per-dialect expression collapsed to one string) |
| `relationship` | `Relationship` (direct-FK: source end = `from` dataset's PK; destination end = `from_columns` → `to_columns`) |
| `metric` | `Metric` (referenced entities inferred from the expression) |

Fields outside the subset (`ai_context`, `custom_extensions`, `dimension`, `label`,
`unique_keys`, …) are accepted and ignored, so extra content never breaks a load.

Conversions that aren't 1:1 emit a warning rather than failing: query-shaped `source`
strings, dialect fallback (BIGQUERY → ANSI_SQL → first), missing `primary_key`, and
unresolved relationship endpoints.

## Testing

- `npm run compile` — clean
- `npm test` — all green (17 + 19 + 39). The 19 generator goldens are untouched.
- New `test:loader` suite (39 tests) covers every mapping rule, each warning, source
  edge cases (quoted identifiers, >3 dotted parts, defaults), case-insensitive and
  field-level dialect selection, composite foreign keys, multi-entity metric
  inference, multi-model documents, and JSON input.
- **End-to-end, verified against live BigQuery:** the sample model is loaded from YAML,
  generates a `CREATE OR REPLACE PROPERTY GRAPH` that BigQuery accepts, and its
  measures were validated with `GRAPH_EXPAND` + `AGG` against a plain-SQL control
  (west region: revenue 135, order_count 3 not 4 — confirming fan-out-safe measure
  placement). The suite pins the same output as text so it needs no live instance.

## Stacking

Stacked on #219 (BigQuery generator), which is stacked on #218 (IR). Should merge
**after** #219. The diff includes those commits until the parents merge.

## Known limitations (deliberate, low-severity follow-ups)

- The input syntax is provisional (see the note at the top) — expect it to change.
- `source`-string parsing uses simple heuristics (whitespace ⇒ treated as a query;
  split on `.`); quoted identifiers containing spaces or dots may be mis-split.
- When a `from` dataset declares no primary key, the source-end key falls back to the
  FK columns; a "no primary_key" warning is emitted but not one specific to this
  substitution.
- Scope is deliberately a subset; broader field coverage and an export path
  (IR → format) are future work.
