### PR TITLE
docs: add Chinese and Japanese README translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,27 @@
+[English](README.md) | [简体中文](README.zh-CN.md) | **日本語**
+
+# Knowledge Catalog
+
+[Knowledge Catalog](https://cloud.google.com/products/knowledge-catalog)（旧称 Dataplex）は、AI を活用したデータカタログおよびメタデータ管理プラットフォームです。構造化データと非構造化データを含むすべてのデータについて動的なナレッジグラフを提供し、AI エージェントにセマンティクスとビジネスコンテキストを提供します。
+
+このリポジトリには、Knowledge Catalog の機能を実演するツール、エージェント、サンプルのほか、コンテキスト管理、エンリッチメント、検索ソリューションを構築するためのリソースが含まれています。
+
+
+## はじめに
+
+[![Cloud Shell で開く](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fknowledge-catalog.git)
+
+
+## コントリビューション
+
+コントリビューションを開始するには、[手順](CONTRIBUTING.md)を参照してください。
+
+
+## ライセンス
+
+このリポジトリ内のすべてのソリューションは、[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) ライセンスの下で提供されています。詳細な利用条件については、[LICENSE](LICENSE.md)を参照してください。
+
+
+## 免責事項
+
+このリポジトリおよびその内容は、Google の公式プロダクトではありません。

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**English** | [简体中文](README.zh-CN.md) | [日本語](README.ja.md)
+
 # Knowledge Catalog
 
 [Knowledge Catalog](https://cloud.google.com/products/knowledge-catalog) (formerly Dataplex), is an AI-powered data catalog and metadata management platform. It provides a dynamic knowledge graph of all your data, structured and unstructured, to provide semantics and business context to AI agents

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,27 @@
+[English](README.md) | **简体中文** | [日本語](README.ja.md)
+
+# Knowledge Catalog
+
+[Knowledge Catalog](https://cloud.google.com/products/knowledge-catalog)（原 Dataplex）是一个由 AI 驱动的数据目录和元数据管理平台。它为所有结构化和非结构化数据提供动态知识图谱，从而为 AI 智能体提供语义和业务上下文。
+
+本仓库包含用于演示 Knowledge Catalog 功能的工具、智能体和示例，以及用于构建上下文管理、扩充和检索解决方案的资源。
+
+
+## 开始使用
+
+[![在 Cloud Shell 中打开](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fknowledge-catalog.git)
+
+
+## 贡献
+
+请参阅贡献[说明](CONTRIBUTING.md)以开始贡献。
+
+
+## 许可证
+
+本仓库中的所有解决方案均依据 [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) 许可证提供。有关更详细的条款和条件，请参阅 [LICENSE](LICENSE.md)。
+
+
+## 免责声明
+
+本仓库及其内容并非 Google 官方产品。


### PR DESCRIPTION
Adds complete Simplified Chinese and Japanese README translations and links all three language versions.

Validation: preserved all headings, links, and badge targets; all relative paths resolve, and the published files match the validated local versions exactly.

Documentation-only; no runtime tests run.