### PR TITLE
Add reference-agent validate: OKF v0.2 bundle conformance checker

### DIFF
--- a/okf/README.md
+++ b/okf/README.md
@@ -213,6 +213,32 @@ The HTML embeds the bundle as a JSON blob and uses
 both loaded from a CDN. No data leaves the page; the bundle is parsed
 once at generation time and serialized into the file.
 
+## Validate
+
+The `validate` subcommand checks a bundle against the OKF v0.2
+conformance rules in [SPEC.md](SPEC.md) §11 — deterministically, with no
+LLM or network access.
+
+```
+.venv/bin/python -m reference_agent validate --bundle ./bundles/<name>
+```
+
+Errors are base-conformance violations (unparseable or missing
+frontmatter, missing `type`, malformed reserved `index.md`/`log.md`
+files). Warnings cover SHOULD-level guidance and shape checks for the
+optional v0.2 frontmatter families (`sources`, `generated`, `verified`,
+`status`, `stale_after`), broken cross-links (which consumers must
+tolerate per §6), legacy v0.1 constructs (`timestamp`, body
+`# Citations`), and incomplete `Attested Computation` declarations.
+
+| Flag       | Default      | Description                                  |
+|------------|--------------|----------------------------------------------|
+| `--bundle` | *(required)* | Bundle root directory.                       |
+| `--strict` | off          | Exit non-zero on warnings as well as errors. |
+
+Exit codes: `0` clean (warnings may still print), `1` errors found (or
+warnings with `--strict`), `2` bundle directory not found.
+
 ## Tests
 
 ```

--- a/okf/src/reference_agent/bundle/validate.py
+++ b/okf/src/reference_agent/bundle/validate.py
@@ -1,0 +1,415 @@
+"""Deterministic conformance validation for OKF bundles (SPEC v0.2 §11)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from reference_agent.bundle.document import (
+    OKFDocument,
+    OKFDocumentError,
+    normalize_verified,
+)
+
+_STATUS_VALUES = {"draft", "stable", "deprecated"}
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_LINK_RE = re.compile(r"\]\(([^)\s]+\.md)(?:#[A-Za-z0-9_\-]*)?\)")
+_FOOTNOTE_RE = re.compile(r"\[\^([A-Za-z0-9_\-]+)\]")
+_INDEX_BULLET_RE = re.compile(r"^\*\s")
+_INDEX_ENTRY_RE = re.compile(r"^\*\s+\[[^\]]+\]\([^)\s]+\)")
+
+ATTESTED_COMPUTATION_TYPE = "Attested Computation"
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str  # "error" | "warning"
+    rule: str
+    path: str  # posix-style path relative to the bundle root
+    message: str
+
+
+@dataclass
+class ValidationReport:
+    findings: list[Finding] = field(default_factory=list)
+
+    def errors(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == "error"]
+
+    def warnings(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == "warning"]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors()
+
+
+def validate_bundle(bundle_root: Path) -> ValidationReport:
+    """Validate every markdown file under ``bundle_root``.
+
+    Errors are SPEC v0.2 §11 base-conformance violations; warnings cover
+    SHOULD-level rules and shape checks for optional frontmatter families
+    that are present. Broken links are warnings because consumers MUST
+    tolerate them (§6).
+    """
+    if not bundle_root.is_dir():
+        raise FileNotFoundError(f"Bundle directory not found: {bundle_root}")
+
+    report = ValidationReport()
+    md_files = sorted(bundle_root.rglob("*.md"))
+    existing = {p.relative_to(bundle_root).as_posix() for p in md_files}
+
+    for md_path in md_files:
+        rel = md_path.relative_to(bundle_root).as_posix()
+        raw = md_path.read_text(encoding="utf-8").lstrip("\ufeff")
+        if md_path.name == "index.md":
+            _check_index(raw, rel, md_path.parent == bundle_root, report)
+        elif md_path.name == "log.md":
+            _check_log(raw, rel, report)
+        else:
+            _check_concept(raw, rel, report, existing=existing)
+    return report
+
+
+def _has_frontmatter(raw: str) -> bool:
+    first = raw.splitlines()[0].strip() if raw else ""
+    return first == "---"
+
+
+def _strip_fences(body: str) -> str:
+    kept: list[str] = []
+    in_fence = False
+    for line in body.splitlines():
+        if line.lstrip().startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            kept.append(line)
+    return "\n".join(kept)
+
+
+def _parses_as_date(value: str) -> bool:
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _check_concept(
+    raw: str, rel: str, report: ValidationReport, *, existing: set[str]
+) -> None:
+    if not _has_frontmatter(raw):
+        report.findings.append(
+            Finding(
+                "error",
+                "frontmatter-missing",
+                rel,
+                "Concept document has no YAML frontmatter block (SPEC v0.2 §11).",
+            )
+        )
+        return
+    try:
+        doc = OKFDocument.parse(raw)
+    except OKFDocumentError as exc:
+        report.findings.append(
+            Finding("error", "frontmatter-unparseable", rel, str(exc))
+        )
+        return
+
+    fm = doc.frontmatter
+    type_value = fm.get("type")
+    if not isinstance(type_value, str) or not type_value.strip():
+        report.findings.append(
+            Finding(
+                "error",
+                "type-missing",
+                rel,
+                "Frontmatter must carry a non-empty `type` (SPEC v0.2 §11).",
+            )
+        )
+
+    _check_families(fm, rel, report)
+
+    body = _strip_fences(doc.body)
+    _check_links(body, rel, report, existing)
+    _check_footnotes(body, fm, rel, report)
+    if any(line.strip() == "# Citations" for line in body.splitlines()):
+        report.findings.append(
+            Finding(
+                "warning",
+                "citations-legacy",
+                rel,
+                "Body `# Citations` is an OKF v0.1 construct; use `sources` "
+                "frontmatter with footnotes (SPEC v0.2 §13).",
+            )
+        )
+    if isinstance(type_value, str) and type_value.strip() == ATTESTED_COMPUTATION_TYPE:
+        _check_attested(fm, body, rel, report)
+
+
+def _check_families(fm: dict[str, Any], rel: str, report: ValidationReport) -> None:
+    if "sources" in fm:
+        sources = fm["sources"]
+        if not isinstance(sources, list):
+            report.findings.append(
+                Finding(
+                    "warning",
+                    "sources-entry-missing-resource",
+                    rel,
+                    "`sources` must be a list of entries (SPEC v0.2 §5.1).",
+                )
+            )
+        else:
+            bad = [
+                i
+                for i, entry in enumerate(sources)
+                if not isinstance(entry, dict)
+                or not str(entry.get("resource") or "").strip()
+            ]
+            if bad:
+                report.findings.append(
+                    Finding(
+                        "warning",
+                        "sources-entry-missing-resource",
+                        rel,
+                        "`sources` entries missing a `resource` "
+                        f"(SPEC v0.2 §5.1): indices {bad}.",
+                    )
+                )
+    if "generated" in fm:
+        generated = fm["generated"]
+        if not isinstance(generated, dict) or not str(
+            generated.get("by") or ""
+        ).strip():
+            report.findings.append(
+                Finding(
+                    "warning",
+                    "generated-missing-by",
+                    rel,
+                    "`generated` must be a mapping with a non-empty `by` "
+                    "(SPEC v0.2 §5.4).",
+                )
+            )
+    if "verified" in fm:
+        verified = fm["verified"]
+        events = normalize_verified(fm)
+        malformed = not isinstance(verified, (dict, list))
+        if isinstance(verified, list) and len(events) != len(verified):
+            malformed = True
+        if any(
+            not str(event.get("by") or "").strip() or not event.get("at")
+            for event in events
+        ):
+            malformed = True
+        if malformed:
+            report.findings.append(
+                Finding(
+                    "warning",
+                    "verified-shape",
+                    rel,
+                    "`verified` must be a `{by, at}` mapping or a list of "
+                    "them (SPEC v0.2 §5.2).",
+                )
+            )
+    if "status" in fm and fm["status"] not in _STATUS_VALUES:
+        report.findings.append(
+            Finding(
+                "warning",
+                "status-invalid",
+                rel,
+                "`status` must be draft|stable|deprecated (SPEC v0.2 §5.5); "
+                f"got {fm['status']!r}.",
+            )
+        )
+    if "stale_after" in fm:
+        value = fm["stale_after"]
+        valid = isinstance(value, date) or (
+            isinstance(value, str)
+            and bool(_ISO_DATE_RE.match(value))
+            and _parses_as_date(value)
+        )
+        if not valid:
+            report.findings.append(
+                Finding(
+                    "warning",
+                    "stale-after-invalid",
+                    rel,
+                    "`stale_after` must be a `YYYY-MM-DD` date (SPEC v0.2 §5.5).",
+                )
+            )
+    if "timestamp" in fm:
+        report.findings.append(
+            Finding(
+                "warning",
+                "timestamp-legacy",
+                rel,
+                "`timestamp` is an OKF v0.1 legacy key; migrate to "
+                "`generated.at` (SPEC v0.2 §13).",
+            )
+        )
+
+
+def _resolve_link(target: str, rel_dir: PurePosixPath) -> str | None:
+    if target.startswith("/"):
+        parts = PurePosixPath(target[1:]).parts
+    else:
+        parts = (rel_dir / target).parts
+    resolved: list[str] = []
+    for part in parts:
+        if part == ".":
+            continue
+        if part == "..":
+            if not resolved:
+                return None
+            resolved.pop()
+        else:
+            resolved.append(part)
+    return "/".join(resolved)
+
+
+def _check_links(
+    body: str, rel: str, report: ValidationReport, existing: set[str]
+) -> None:
+    rel_dir = PurePosixPath(rel).parent
+    seen: set[str] = set()
+    for target in _LINK_RE.findall(body):
+        if "://" in target or target in seen:
+            continue
+        seen.add(target)
+        resolved = _resolve_link(target, rel_dir)
+        if resolved is None:
+            report.findings.append(
+                Finding(
+                    "warning",
+                    "link-broken",
+                    rel,
+                    f"Link `{target}` escapes the bundle root.",
+                )
+            )
+        elif resolved not in existing:
+            report.findings.append(
+                Finding(
+                    "warning",
+                    "link-broken",
+                    rel,
+                    f"Link target `{target}` not found in bundle "
+                    "(tolerated by consumers per SPEC v0.2 §6).",
+                )
+            )
+
+
+def _check_footnotes(
+    body: str, fm: dict[str, Any], rel: str, report: ValidationReport
+) -> None:
+    labels = set(_FOOTNOTE_RE.findall(body))
+    if not labels:
+        return
+    sources = fm.get("sources")
+    ids: set[str] = set()
+    if isinstance(sources, list):
+        ids = {
+            str(entry.get("id"))
+            for entry in sources
+            if isinstance(entry, dict) and entry.get("id")
+        }
+    unmatched = sorted(labels - ids)
+    if unmatched:
+        report.findings.append(
+            Finding(
+                "warning",
+                "footnote-unmatched",
+                rel,
+                "Footnote labels with no matching `sources[].id` "
+                f"(SPEC v0.2 §5.1): {', '.join(unmatched)}.",
+            )
+        )
+
+
+def _check_attested(
+    fm: dict[str, Any], body: str, rel: str, report: ValidationReport
+) -> None:
+    problems: list[str] = []
+    if not str(fm.get("runtime") or "").strip():
+        problems.append("missing `runtime` (§10.2)")
+    parameters = fm.get("parameters")
+    if parameters is not None and (
+        not isinstance(parameters, list)
+        or any(
+            not isinstance(p, dict) or not str(p.get("name") or "").strip()
+            for p in parameters
+        )
+    ):
+        problems.append("`parameters` must be a list of mappings with `name` (§10.2)")
+    has_inline = any(line.strip() == "# Computation" for line in body.splitlines())
+    if not str(fm.get("computation") or "").strip() and not has_inline:
+        problems.append("no `computation` path and no `# Computation` section (§10.2)")
+    if problems:
+        report.findings.append(
+            Finding(
+                "warning",
+                "attested-computation-incomplete",
+                rel,
+                "Attested Computation: " + "; ".join(problems) + ".",
+            )
+        )
+
+
+def _check_index(
+    raw: str, rel: str, is_root: bool, report: ValidationReport
+) -> None:
+    body = raw
+    if _has_frontmatter(raw):
+        if not is_root:
+            report.findings.append(
+                Finding(
+                    "error",
+                    "index-malformed",
+                    rel,
+                    "Only the bundle-root index.md may carry frontmatter "
+                    "(SPEC v0.2 §8, §12).",
+                )
+            )
+            return
+        try:
+            body = OKFDocument.parse(raw).body
+        except OKFDocumentError as exc:
+            report.findings.append(Finding("error", "index-malformed", rel, str(exc)))
+            return
+    for line in _strip_fences(body).splitlines():
+        if _INDEX_BULLET_RE.match(line) and not _INDEX_ENTRY_RE.match(line):
+            report.findings.append(
+                Finding(
+                    "error",
+                    "index-malformed",
+                    rel,
+                    "Index entry must be link-first `* [Title](url) - "
+                    f"description` (SPEC v0.2 §8): {line.strip()!r}.",
+                )
+            )
+
+
+def _check_log(raw: str, rel: str, report: ValidationReport) -> None:
+    body = raw
+    if _has_frontmatter(raw):
+        try:
+            body = OKFDocument.parse(raw).body
+        except OKFDocumentError as exc:
+            report.findings.append(Finding("error", "log-malformed", rel, str(exc)))
+            return
+    for line in _strip_fences(body).splitlines():
+        if line.startswith("## "):
+            heading = line[3:].strip()
+            if not (_ISO_DATE_RE.match(heading) and _parses_as_date(heading)):
+                report.findings.append(
+                    Finding(
+                        "error",
+                        "log-malformed",
+                        rel,
+                        "log.md date headings must be `## YYYY-MM-DD` "
+                        f"(SPEC v0.2 §9); got {heading!r}.",
+                    )
+                )

--- a/okf/src/reference_agent/bundle/validate.py
+++ b/okf/src/reference_agent/bundle/validate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -64,7 +64,25 @@ def validate_bundle(bundle_root: Path) -> ValidationReport:
 
     for md_path in md_files:
         rel = md_path.relative_to(bundle_root).as_posix()
-        raw = md_path.read_text(encoding="utf-8").lstrip("\ufeff")
+        try:
+            raw = md_path.read_text(encoding="utf-8").lstrip("\ufeff")
+        except UnicodeDecodeError as exc:
+            if md_path.name == "index.md":
+                rule = "index-malformed"
+            elif md_path.name == "log.md":
+                rule = "log-malformed"
+            else:
+                rule = "frontmatter-unparseable"
+            report.findings.append(
+                Finding(
+                    "error",
+                    rule,
+                    rel,
+                    "Not valid UTF-8 (SPEC v0.2 \u00a74: concept documents are "
+                    f"UTF-8): {exc}",
+                )
+            )
+            continue
         if md_path.name == "index.md":
             _check_index(raw, rel, md_path.parent == bundle_root, report)
         elif md_path.name == "log.md":
@@ -191,7 +209,7 @@ def _check_families(fm: dict[str, Any], rel: str, report: ValidationReport) -> N
                     "generated-missing-by",
                     rel,
                     "`generated` must be a mapping with a non-empty `by` "
-                    "(SPEC v0.2 §5.4).",
+                    "(SPEC v0.2 §5.2).",
                 )
             )
     if "verified" in fm:
@@ -221,13 +239,13 @@ def _check_families(fm: dict[str, Any], rel: str, report: ValidationReport) -> N
                 "warning",
                 "status-invalid",
                 rel,
-                "`status` must be draft|stable|deprecated (SPEC v0.2 §5.5); "
+                "`status` must be draft|stable|deprecated (SPEC v0.2 §5.4); "
                 f"got {fm['status']!r}.",
             )
         )
     if "stale_after" in fm:
         value = fm["stale_after"]
-        valid = isinstance(value, date) or (
+        valid = (isinstance(value, date) and not isinstance(value, datetime)) or (
             isinstance(value, str)
             and bool(_ISO_DATE_RE.match(value))
             and _parses_as_date(value)

--- a/okf/src/reference_agent/cli.py
+++ b/okf/src/reference_agent/cli.py
@@ -158,6 +158,22 @@ def _parser() -> argparse.ArgumentParser:
         "--name", default=None,
         help="Display name for the bundle (default: bundle directory name).",
     )
+
+    val = sub.add_parser(
+        "validate",
+        help="Validate an OKF bundle against SPEC.md conformance rules.",
+    )
+    val.add_argument(
+        "--bundle",
+        type=Path,
+        required=True,
+        help="Bundle root directory to validate.",
+    )
+    val.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on warnings as well as errors.",
+    )
     return p
 
 
@@ -183,6 +199,27 @@ def main(argv: list[str] | None = None) -> int:
             f"{stats['bytes']} bytes → {out}",
             file=sys.stderr,
         )
+        return 0
+
+    if args.command == "validate":
+        from reference_agent.bundle.validate import validate_bundle
+
+        try:
+            report = validate_bundle(args.bundle)
+        except FileNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        for finding in report.findings:
+            print(
+                f"{finding.severity}: {finding.rule}: {finding.path}: "
+                f"{finding.message}",
+                file=sys.stderr,
+            )
+        n_errors = len(report.errors())
+        n_warnings = len(report.warnings())
+        print(f"{n_errors} error(s), {n_warnings} warning(s)", file=sys.stderr)
+        if n_errors or (args.strict and n_warnings):
+            return 1
         return 0
 
     if args.command == "enrich":

--- a/okf/tests/test_validate.py
+++ b/okf/tests/test_validate.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from reference_agent.bundle.validate import validate_bundle
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text), encoding="utf-8")
+
+
+def _good_doc(title: str = "Orders") -> str:
+    return f"""\
+    ---
+    type: BigQuery Table
+    title: {title}
+    description: One row per order.
+    generated:
+      by: human:test
+      at: "2026-07-01T00:00:00+00:00"
+    ---
+
+    # Schema
+
+    Body text linking [customers](customers.md).
+    """
+
+
+def _make_bundle(root: Path) -> Path:
+    _write(root / "tables" / "orders.md", _good_doc())
+    _write(root / "tables" / "customers.md", _good_doc("Customers"))
+    _write(
+        root / "index.md",
+        """\
+        # Subdirectories
+
+        * [tables](tables/index.md) - Transactional tables.
+        """,
+    )
+    _write(
+        root / "tables" / "index.md",
+        """\
+        # BigQuery Table
+
+        * [Orders](orders.md) - One row per order.
+        * [Customers](customers.md) - One row per customer.
+        """,
+    )
+    return root
+
+
+def test_good_bundle_passes_clean(tmp_path: Path) -> None:
+    report = validate_bundle(_make_bundle(tmp_path / "b"))
+    assert report.findings == []
+    assert report.ok
+
+
+def test_raises_when_bundle_missing(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        validate_bundle(tmp_path / "nope")
+
+
+def test_missing_frontmatter_is_error_and_suppresses_type_check(
+    tmp_path: Path,
+) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(root / "tables" / "bare.md", "Just prose, no frontmatter.\n")
+    report = validate_bundle(root)
+    rules = [f.rule for f in report.errors()]
+    assert rules == ["frontmatter-missing"]
+    assert report.errors()[0].path == "tables/bare.md"
+    assert not report.ok
+
+
+def test_unterminated_frontmatter_is_unparseable(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(root / "tables" / "broken.md", "---\ntype: X\nno closing delim\n")
+    report = validate_bundle(root)
+    assert [f.rule for f in report.errors()] == ["frontmatter-unparseable"]
+    assert "Unterminated" in report.errors()[0].message
+
+
+def test_empty_type_is_error(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(root / "tables" / "untyped.md", "---\ntype: \"\"\ntitle: X\n---\n\nBody.\n")
+    report = validate_bundle(root)
+    assert [f.rule for f in report.errors()] == ["type-missing"]

--- a/okf/tests/test_validate.py
+++ b/okf/tests/test_validate.py
@@ -89,3 +89,91 @@ def test_empty_type_is_error(tmp_path: Path) -> None:
     _write(root / "tables" / "untyped.md", "---\ntype: \"\"\ntitle: X\n---\n\nBody.\n")
     report = validate_bundle(root)
     assert [f.rule for f in report.errors()] == ["type-missing"]
+
+
+def test_nonroot_index_frontmatter_is_error(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(
+        root / "tables" / "index.md",
+        """\
+        ---
+        okf_version: "0.2"
+        ---
+
+        # BigQuery Table
+
+        * [Orders](orders.md) - One row per order.
+        """,
+    )
+    report = validate_bundle(root)
+    assert [f.rule for f in report.errors()] == ["index-malformed"]
+    assert report.errors()[0].path == "tables/index.md"
+
+
+def test_root_index_frontmatter_is_allowed(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(
+        root / "index.md",
+        """\
+        ---
+        okf_version: "0.2"
+        ---
+
+        # Subdirectories
+
+        * [tables](tables/index.md) - Transactional tables.
+        """,
+    )
+    assert validate_bundle(root).findings == []
+
+
+def test_index_non_link_bullet_is_error(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(
+        root / "tables" / "index.md",
+        """\
+        # BigQuery Table
+
+        * Orders - not a link entry.
+        """,
+    )
+    report = validate_bundle(root)
+    assert [f.rule for f in report.errors()] == ["index-malformed"]
+    assert "link-first" in report.errors()[0].message
+
+
+def test_log_non_iso_heading_is_error(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(
+        root / "log.md",
+        """\
+        # Bundle history
+
+        ## May 22, 2026
+
+        - **Update**: something.
+        """,
+    )
+    report = validate_bundle(root)
+    assert [f.rule for f in report.errors()] == ["log-malformed"]
+    assert "May 22, 2026" in report.errors()[0].message
+
+
+def test_log_with_frontmatter_and_iso_headings_passes(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(
+        root / "log.md",
+        """\
+        ---
+        type: Log
+        title: History
+        ---
+
+        # Bundle history
+
+        ## 2026-07-01
+
+        - **Verified** the bundle.
+        """,
+    )
+    assert validate_bundle(root).findings == []

--- a/okf/tests/test_validate.py
+++ b/okf/tests/test_validate.py
@@ -223,3 +223,27 @@ def test_links_inside_fenced_code_are_ignored(tmp_path: Path) -> None:
     )
     _write(root / "tables" / "orders.md", doc)
     assert validate_bundle(root).findings == []
+
+
+def test_cli_validate_exit_codes(tmp_path: Path, capsys) -> None:
+    from reference_agent.cli import main
+
+    root = _make_bundle(tmp_path / "b")
+    assert main(["validate", "--bundle", str(root)]) == 0
+
+    _write(root / "tables" / "orders.md", _good_doc().replace("customers.md", "missing.md"))
+    assert main(["validate", "--bundle", str(root)]) == 0
+    assert main(["validate", "--bundle", str(root), "--strict"]) == 1
+    err = capsys.readouterr().err
+    assert "link-broken" in err
+    assert "warning(s)" in err
+
+    _write(root / "tables" / "bare.md", "no frontmatter\n")
+    assert main(["validate", "--bundle", str(root)]) == 1
+
+
+def test_cli_validate_missing_bundle_exits_2(tmp_path: Path, capsys) -> None:
+    from reference_agent.cli import main
+
+    assert main(["validate", "--bundle", str(tmp_path / "nope")]) == 2
+    assert "not found" in capsys.readouterr().err

--- a/okf/tests/test_validate.py
+++ b/okf/tests/test_validate.py
@@ -177,3 +177,49 @@ def test_log_with_frontmatter_and_iso_headings_passes(tmp_path: Path) -> None:
         """,
     )
     assert validate_bundle(root).findings == []
+
+
+def test_broken_relative_link_warns(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(root / "tables" / "orders.md", _good_doc().replace("customers.md", "missing.md"))
+    report = validate_bundle(root)
+    assert [f.rule for f in report.warnings()] == ["link-broken"]
+    assert report.errors() == []
+    assert report.ok
+
+
+def test_absolute_link_resolves_from_root(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(
+        root / "tables" / "orders.md",
+        _good_doc().replace("(customers.md)", "(/tables/customers.md)"),
+    )
+    assert validate_bundle(root).findings == []
+
+
+def test_link_escaping_bundle_root_warns(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    _write(
+        root / "tables" / "orders.md",
+        _good_doc().replace("(customers.md)", "(../../outside.md)"),
+    )
+    report = validate_bundle(root)
+    assert [f.rule for f in report.warnings()] == ["link-broken"]
+    assert "escapes" in report.warnings()[0].message
+
+
+def test_links_inside_fenced_code_are_ignored(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    doc = _good_doc() + textwrap.dedent(
+        """\
+
+        # Common query patterns
+
+        ```sql
+        -- see [ghost](ghost.md) inside a fence
+        SELECT 1;
+        ```
+        """
+    )
+    _write(root / "tables" / "orders.md", doc)
+    assert validate_bundle(root).findings == []

--- a/okf/tests/test_validate.py
+++ b/okf/tests/test_validate.py
@@ -84,6 +84,16 @@ def test_unterminated_frontmatter_is_unparseable(tmp_path: Path) -> None:
     assert "Unterminated" in report.errors()[0].message
 
 
+def test_non_utf8_file_is_error_not_crash(tmp_path: Path) -> None:
+    root = _make_bundle(tmp_path / "b")
+    (root / "tables" / "binary.md").write_bytes(b"\xff\xfe invalid")
+    report = validate_bundle(root)  # must return a report, never raise
+    errors = report.errors()
+    assert [f.rule for f in errors] == ["frontmatter-unparseable"]
+    assert errors[0].path == "tables/binary.md"
+    assert "UTF-8" in errors[0].message
+
+
 def test_empty_type_is_error(tmp_path: Path) -> None:
     root = _make_bundle(tmp_path / "b")
     _write(root / "tables" / "untyped.md", "---\ntype: \"\"\ntitle: X\n---\n\nBody.\n")

--- a/okf/tests/test_validate_families.py
+++ b/okf/tests/test_validate_families.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from reference_agent.bundle.validate import validate_bundle
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text), encoding="utf-8")
+
+
+def _doc_with(frontmatter_extra: str, body: str = "Body.\n") -> str:
+    return textwrap.dedent(
+        """\
+        ---
+        type: Reference
+        """
+    ) + textwrap.dedent(frontmatter_extra) + "---\n\n" + body
+
+
+def _one_doc_bundle(root: Path, doc: str) -> Path:
+    _write(root / "refs" / "thing.md", doc)
+    return root
+
+
+def _warning_rules(root: Path) -> list[str]:
+    report = validate_bundle(root)
+    assert report.errors() == []
+    return sorted(f.rule for f in report.warnings())
+
+
+def test_sources_entry_without_resource_warns(tmp_path: Path) -> None:
+    doc = _doc_with(
+        """\
+        sources:
+          - id: a
+            title: No resource here
+        """
+    )
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["sources-entry-missing-resource"]
+
+
+def test_generated_without_by_warns(tmp_path: Path) -> None:
+    doc = _doc_with(
+        """\
+        generated:
+          at: "2026-07-01T00:00:00+00:00"
+        """
+    )
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["generated-missing-by"]
+
+
+def test_bare_verified_mapping_is_conformant(tmp_path: Path) -> None:
+    doc = _doc_with(
+        """\
+        verified:
+          by: human:kliu
+          at: "2026-07-01"
+        """
+    )
+    assert _warning_rules(_one_doc_bundle(tmp_path / "b", doc)) == []
+
+
+def test_verified_entry_missing_at_warns(tmp_path: Path) -> None:
+    doc = _doc_with(
+        """\
+        verified:
+          - by: human:kliu
+        """
+    )
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["verified-shape"]
+
+
+def test_status_outside_enum_warns(tmp_path: Path) -> None:
+    doc = _doc_with("status: experimental\n")
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["status-invalid"]
+
+
+def test_stale_after_bad_date_warns(tmp_path: Path) -> None:
+    doc = _doc_with('stale_after: "2026-13-45"\n')
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["stale-after-invalid"]
+
+
+def test_yaml_native_stale_after_is_valid(tmp_path: Path) -> None:
+    doc = _doc_with("stale_after: 2026-12-31\n")
+    assert _warning_rules(_one_doc_bundle(tmp_path / "b", doc)) == []
+
+
+def test_timestamp_is_legacy_warning(tmp_path: Path) -> None:
+    doc = _doc_with('timestamp: "2026-05-28T14:30:00Z"\n')
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["timestamp-legacy"]
+
+
+def test_body_citations_section_is_legacy_warning(tmp_path: Path) -> None:
+    doc = _doc_with("", body="# Citations\n\n[1] [x](https://example.com)\n")
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["citations-legacy"]
+
+
+def test_footnote_without_matching_source_id_warns(tmp_path: Path) -> None:
+    doc = _doc_with(
+        """\
+        sources:
+          - id: gaq
+            resource: https://example.com/doc
+        """,
+        body="A claim.[^other]\n\n[^other]: dangling label.\n",
+    )
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["footnote-unmatched"]
+
+
+def test_footnote_matching_source_id_is_clean(tmp_path: Path) -> None:
+    doc = _doc_with(
+        """\
+        sources:
+          - id: gaq
+            resource: https://example.com/doc
+        """,
+        body="A claim.[^gaq]\n\n[^gaq]: see source.\n",
+    )
+    assert _warning_rules(_one_doc_bundle(tmp_path / "b", doc)) == []
+
+
+def test_attested_computation_missing_runtime_warns(tmp_path: Path) -> None:
+    doc = textwrap.dedent(
+        """\
+        ---
+        type: Attested Computation
+        parameters:
+          - name: start_date
+            type: DATE
+            required: true
+        ---
+
+        # Computation
+
+        ```sql
+        SELECT 1;
+        ```
+        """
+    )
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["attested-computation-incomplete"]
+
+
+def test_attested_computation_complete_is_clean(tmp_path: Path) -> None:
+    doc = textwrap.dedent(
+        """\
+        ---
+        type: Attested Computation
+        runtime: bigquery-sql
+        parameters:
+          - name: start_date
+            type: DATE
+            required: true
+        ---
+
+        # Computation
+
+        ```sql
+        SELECT 1;
+        ```
+        """
+    )
+    assert _warning_rules(_one_doc_bundle(tmp_path / "b", doc)) == []

--- a/okf/tests/test_validate_families.py
+++ b/okf/tests/test_validate_families.py
@@ -93,6 +93,12 @@ def test_yaml_native_stale_after_is_valid(tmp_path: Path) -> None:
     assert _warning_rules(_one_doc_bundle(tmp_path / "b", doc)) == []
 
 
+def test_yaml_native_datetime_stale_after_warns(tmp_path: Path) -> None:
+    doc = _doc_with("stale_after: 2026-09-23T00:00:00\n")
+    rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))
+    assert rules == ["stale-after-invalid"]
+
+
 def test_timestamp_is_legacy_warning(tmp_path: Path) -> None:
     doc = _doc_with('timestamp: "2026-05-28T14:30:00Z"\n')
     rules = _warning_rules(_one_doc_bundle(tmp_path / "b", doc))


### PR DESCRIPTION
## Motivation

OKF v0.2 shipped with rich structured frontmatter families — `sources`
(per-source credibility signals), `generated`, `verified`, `status`, and
`stale_after` — plus formalized conformance rules in
okf/SPEC.md §11. What it did **not**
ship with was any tooling to check a bundle against those rules: `mdcode`'s
`validate()` is an unimplemented stub, so nothing in the repo could tell an
author whether a hand-written or agent-produced bundle actually conforms.

This PR closes that gap with a deterministic conformance checker that any
author, CI job, or enrichment pipeline can run to catch base-conformance
violations before a bundle ships, and to surface SHOULD-level and
v0.2-family shape issues as warnings.

## What it adds

- **A validator module** (`reference_agent/bundle/validate.py`) — a report
  API plus the base-conformance and warning checks.
- **A `validate` CLI subcommand** — `python -m reference_agent validate
  --bundle <dir>`, with a `--strict` flag and meaningful exit codes.
- **31 tests** across `tests/test_validate.py` (17) and
  `tests/test_validate_families.py` (14), covering base-conformance errors,
  reserved-file (`index.md`/`log.md`) checks, link resolution, v0.2
  family-shape warnings, strict mode, and CLI exit codes.
- **A `## Validate` section in the okf README** documenting the subcommand,
  the errors-vs-warnings contract, the flag table, and exit codes.

## Design notes

- **Deterministic, offline.** No LLM, no network, no BigQuery — the checker
  reads local files only, so it is safe to run anywhere and gives identical
  results every time.
- **stdlib + pyyaml only.** Implementation depends on `re`, `dataclasses`,
  `datetime`, `pathlib`, and `typing`, plus YAML parsing already vendored
  through the bundle document layer. No new third-party dependencies.
- **Errors vs. warnings severity contract.** *Errors* are base-conformance
  violations that make a document unloadable or invalid: unparseable or
  missing frontmatter, missing `type`, and malformed reserved
  `index.md`/`log.md` files. Exit `1`. *Warnings* cover SHOULD-level
  guidance and shape checks for the optional v0.2 families (`sources`,
  `generated`, `verified`, `status`, `stale_after`), broken cross-links
  (which consumers must tolerate per §6), legacy v0.1 constructs
  (`timestamp`, body `# Citations`), and incomplete `Attested Computation`
  declarations. Warnings do not fail the run unless `--strict` is passed.
  Exit codes: `0` clean (warnings may still print), `1` errors (or warnings
  under `--strict`), `2` bundle directory not found.
- **Reuses existing bundle primitives.** Parsing goes through the existing
  `OKFDocument` / `OKFDocumentError` types, and `verified` normalization
  reuses `normalize_verified`, so the validator sees documents exactly as
  the rest of the reference agent does — no divergent second parser.

## Evidence — validator run over all four shipped bundles

Run at the branch HEAD (`d8c0ba8`) with the full suite green
(`python -m pytest -q` → **70 passed**). Output is verbatim; the `§` in the
stackoverflow messages renders as a codepage artifact in a non-UTF-8 console
but the emitted string is `§5.1`.

```
== acme_retail ==
0 error(s), 0 warning(s)

== crypto_bitcoin ==
0 error(s), 0 warning(s)

== ga4 ==
0 error(s), 0 warning(s)

== stackoverflow ==
warning: footnote-unmatched: references/content_licenses.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: references/joins/comments__posts.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: references/joins/post_links__posts.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: references/joins/posts__votes.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: references/joins/posts_answers__posts_questions.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: references/metrics/accepted_answer_rate.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: references/metrics/bad_question_flag_ratio.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: references/post_types.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: references/vote_types.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: tables/posts_questions.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
warning: footnote-unmatched: tables/votes.md: Footnote labels with no matching `sources[].id` (SPEC v0.2 §5.1): 1.
0 error(s), 11 warning(s)
```

**Reading the evidence.** Three of the four shipped bundles are clean
(0 errors, 0 warnings), and all four are error-free — the validator
certifies the shipped bundles' base conformance. The 11 warnings on
`stackoverflow` are not a regression: they are the validator correctly
surfacing a real, un-migrated v0.1 pattern — numeric footnote labels
(`[1]`) that predate v0.2's requirement that footnote labels join to a
`sources[].id`. That is exactly the kind of SHOULD-level drift the warning
tier is designed to flag without failing the bundle. Every finding above is
reproducible with the command in the README's `## Validate` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
