### PR TITLE
okf: bind trust tiers to current content

### DIFF
--- a/okf/SPEC.md
+++ b/okf/SPEC.md
@@ -388,6 +388,9 @@ verified:
   recently" is the latest `at`.
 - `verified` is independent of `generated.at`: content can change without
   re-confirmation, and facts can be re-confirmed without regeneration.
+- A verification event is **current** when no `generated.at` is present, or
+  when its `at` is at or after `generated.at`. Earlier events may remain as
+  history, but they do not confirm the current content.
 - A single verifier MAY be written as one `{ by, at }` mapping without the
   list dash. Consumers MUST treat a bare mapping as a one-element list:
 
@@ -397,11 +400,12 @@ verified: { by: human:ahormati, at: 2026-06-25T09:00:00Z }
 
 ### 5.3 Trust tiers
 
-Consumers derive a trust tier from `verified`, lowest to highest:
+Consumers derive a trust tier from **current** verification events (§5.2),
+lowest to highest:
 
-- No `verified` key ⇒ **unverified**.
-- `verified` by non-`human:` actors only ⇒ **machine-confirmed**.
-- `verified` by a `human:<id>` actor ⇒ **human-reviewed**.
+- No current verification event ⇒ **unverified**.
+- Current events by non-`human:` actors only ⇒ **machine-confirmed**.
+- A current event by a `human:<id>` actor ⇒ **human-reviewed**.
 
 A concept with no trust frontmatter is still consumable; consumers MUST
 NOT reject it (§11). Trust tiers are advisory signals, not access control.
@@ -932,7 +936,7 @@ executor:
 attester:
   resource: references/attesters/sql-equality.py
 generated: { by: reference_agent/gemini-2.5-pro, at: 2026-06-28T14:00:00Z }
-verified: { by: human:ahormati, at: 2026-06-25T09:00:00Z }
+verified: { by: human:ahormati, at: 2026-06-29T09:00:00Z }
 stale_after: 2026-12-31
 sources:
   - id: rev-policy
@@ -982,7 +986,7 @@ executor:
 attester:
   resource: references/attesters/dbt-binding.py
 generated: { by: reference_agent/gemini-2.5-pro, at: 2026-06-14T14:00:00Z }
-verified: { by: process:finance-nightly, at: 2026-06-12T08:00:00Z }
+verified: { by: process:finance-nightly, at: 2026-06-14T16:00:00Z }
 stale_after: 2026-06-15
 sources:
   - id: cost-alloc

--- a/okf/src/reference_agent/bundle/document.py
+++ b/okf/src/reference_agent/bundle/document.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import Any
 
 import yaml
@@ -79,14 +79,54 @@ def normalize_verified(frontmatter: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
-def trust_tier(frontmatter: dict[str, Any]) -> str:
-    """Derive a concept's trust tier from `verified` (OKF v0.2 §5.3).
+def _parse_event_time(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
-    - No `verified` key ⇒ "unverified".
-    - `verified` by non-`human:` actors only ⇒ "machine-confirmed".
-    - `verified` by a `human:<id>` actor ⇒ "human-reviewed".
+
+def current_verified_events(frontmatter: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return verification events that apply to the current content.
+
+    When `generated.at` is present, an event is current only when its valid
+    `at` timestamp is at or after that content-change timestamp. Without a
+    `generated.at`, no later content change is declared, so normalized events
+    retain the v0.2 behavior.
     """
     events = normalize_verified(frontmatter)
+    generated = frontmatter.get("generated")
+    if not isinstance(generated, dict) or "at" not in generated:
+        return events
+
+    generated_at = _parse_event_time(generated.get("at"))
+    if generated_at is None:
+        return []
+
+    current = []
+    for event in events:
+        verified_at = _parse_event_time(event.get("at"))
+        if verified_at is not None and verified_at >= generated_at:
+            current.append(event)
+    return current
+
+
+def trust_tier(frontmatter: dict[str, Any]) -> str:
+    """Derive a concept's trust tier from current verification events.
+
+    - No current verification event ⇒ "unverified".
+    - Current events by non-`human:` actors only ⇒ "machine-confirmed".
+    - A current event by a `human:<id>` actor ⇒ "human-reviewed".
+    """
+    events = current_verified_events(frontmatter)
     if not events:
         return "unverified"
     for event in events:

--- a/okf/tests/test_document.py
+++ b/okf/tests/test_document.py
@@ -7,6 +7,7 @@ import pytest
 from reference_agent.bundle.document import (
     OKFDocument,
     OKFDocumentError,
+    current_verified_events,
     is_stale,
     normalize_verified,
     trust_tier,
@@ -74,16 +75,75 @@ def test_normalize_verified_treats_bare_mapping_as_list():
 def test_trust_tier():
     assert trust_tier({}) == "unverified"
     assert trust_tier(
-        {"verified": [{"by": "process:finance-nightly", "at": "x"}]}
+        {
+            "verified": [
+                {
+                    "by": "process:finance-nightly",
+                    "at": "2026-06-26T02:00:00Z",
+                }
+            ]
+        }
     ) == "machine-confirmed"
     assert trust_tier(
         {"verified": [
-            {"by": "process:finance-nightly", "at": "x"},
-            {"by": "human:ahormati", "at": "y"},
+            {"by": "process:finance-nightly", "at": "2026-06-26T02:00:00Z"},
+            {"by": "human:ahormati", "at": "2026-06-27T09:00:00Z"},
         ]}
     ) == "human-reviewed"
     # A bare mapping is treated as a one-element list.
-    assert trust_tier({"verified": {"by": "human:ahormati", "at": "z"}}) == "human-reviewed"
+    assert trust_tier(
+        {
+            "verified": {
+                "by": "human:ahormati",
+                "at": "2026-06-27T09:00:00Z",
+            }
+        }
+    ) == "human-reviewed"
+
+
+def test_current_verified_events_excludes_checks_before_current_content():
+    frontmatter = {
+        "generated": {
+            "by": "reference_agent/gemini-2.5-pro",
+            "at": "2026-06-28T12:00:00Z",
+        },
+        "verified": [
+            {"by": "human:ahormati", "at": "2026-06-25T09:00:00Z"},
+            {"by": "process:finance-nightly", "at": "2026-06-29T02:00:00Z"},
+        ],
+    }
+
+    assert current_verified_events(frontmatter) == [
+        {"by": "process:finance-nightly", "at": "2026-06-29T02:00:00Z"}
+    ]
+    assert trust_tier(frontmatter) == "machine-confirmed"
+
+
+def test_trust_tier_is_unverified_when_all_checks_predate_current_content():
+    assert trust_tier(
+        {
+            "generated": {
+                "by": "reference_agent/gemini-2.5-pro",
+                "at": "2026-06-28T12:00:00Z",
+            },
+            "verified": {
+                "by": "human:ahormati",
+                "at": "2026-06-25T09:00:00Z",
+            },
+        }
+    ) == "unverified"
+
+
+def test_verified_events_remain_usable_when_generated_at_is_absent():
+    frontmatter = {
+        "verified": {
+            "by": "human:ahormati",
+            "at": "2026-06-25T09:00:00Z",
+        }
+    }
+
+    assert current_verified_events(frontmatter) == normalize_verified(frontmatter)
+    assert trust_tier(frontmatter) == "human-reviewed"
 
 
 def test_is_stale():


### PR DESCRIPTION
## Summary

- define a current verification event relative to `generated.at`
- derive trust tiers only from verification events that apply to current content
- retain the existing behavior when no generation timestamp is declared
- correct two appendix examples whose verification preceded their generation

## Why

OKF says `generated.at` marks the current content's last meaningful change and
allows content to change without re-confirmation. Trust tiers currently derive
from any `verified` event, so a human check can keep conferring
`human-reviewed` after the content it checked has changed.

This change preserves earlier verification events as history while preventing
them from confirming later content.

## Tests

- `cd okf && uv run --python 3.11 --with pytest --with pyyaml python -m pytest -q`
- 42 passed
