### PR TITLE
mdcode: add Semantic Model IR and model loader

### DIFF
--- a/toolbox/mdcode/package-lock.json
+++ b/toolbox/mdcode/package-lock.json
@@ -22,6 +22,7 @@
         "@modelcontextprotocol/inspector": "^0.21.2",
         "@types/bun": "^1.3.14",
         "@types/node": "^25.6.0",
+        "ajv": "^8.17.1",
         "bun": "^1.3.14",
         "bun-types": "^1.3.14",
         "memfs": "^4.57.2",
@@ -695,6 +696,30 @@
         "mcp-inspector-client": "bin/start.js"
       }
     },
+    "node_modules/@modelcontextprotocol/inspector-client/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-client/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/inspector-client/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -785,28 +810,6 @@
           "optional": false
         }
       }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/pkce-challenge": {
       "version": "5.0.1",
@@ -2124,16 +2127,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2156,28 +2158,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3343,10 +3323,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {

--- a/toolbox/mdcode/package.json
+++ b/toolbox/mdcode/package.json
@@ -16,7 +16,8 @@
     "build": "npm run build:libts && npm run build:tool",
     "compile": "npx tsc --noEmit",
     "test:libts": "npx bun test ./tests/libts/scenarios.ts",
-    "test": "npm run test:libts",
+    "test:semantic": "npx bun test ./tests/libts/semantic/",
+    "test": "npm run test:libts && npm run test:semantic",
     "x:mcp": "npx @modelcontextprotocol/inspector dist/kcmd mcp"
   },
   "keywords": [],
@@ -34,6 +35,7 @@
     "@modelcontextprotocol/inspector": "^0.21.2",
     "@types/bun": "^1.3.14",
     "@types/node": "^25.6.0",
+    "ajv": "^8.17.1",
     "bun": "^1.3.14",
     "bun-types": "^1.3.14",
     "memfs": "^4.57.2",

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -1,0 +1,213 @@
+// Defines the Semantic Model intermediate representation (IR).
+//
+// The IR is the in-memory contract for a semantic model. It represents
+// semantics only: a graph of entities (nodes) connected by relationships
+// (edges), plus model-level metrics.
+//
+
+/**
+ * AI-first annotations, from the open format's `ai_context`.
+ *
+ * The format allows either a bare instructions string (shorthand) or a
+ * structured object; the loader normalizes both to this one shape, so the IR
+ * always sees the structured form. The parts are grouped in a single object
+ * (mirroring the format, e.g. Apache Ossie's `ai_context`) rather than scattered
+ * as sibling fields, so nothing is lost and an emitter can still route each part
+ * to its own destination (e.g. `instructions` -> a Guidelines aspect,
+ * `synonyms` -> glossary links).
+ */
+export interface AiContext {
+  // Free-form guidance for AI consumers.
+  instructions?: string;
+  // Alternate names for the annotated object.
+  synonyms?: string[];
+  // Example questions / usages illustrating the annotated object.
+  examples?: string[];
+}
+
+/**
+ * A vendor-scoped extension block, carried verbatim from the open format's
+ * `custom_extensions` (e.g. Apache Ossie's `OSICustomExtension`).
+ *
+ * `data` is opaque to the IR — a vendor-serialized payload (typically a JSON
+ * string) — and is preserved unparsed so nothing is lost and a 1P round-trip
+ * stays lossless. Typed views over specific vendors are derived by the
+ * consumers that need them, from this same source (e.g. the GOOGLE block).
+ */
+export interface CustomExtension {
+  vendorName: string;
+  data: string;
+}
+
+/**
+ * A semantic model: a graph of entities (nodes) connected by relationships
+ * (edges), with model-level metrics defined over them.
+ *
+ * The IR is primarily semantics. Deployment/target configuration lives in the
+ * project manifest (`catalog.yaml`); when the open format carries it inline in a
+ * model-level GOOGLE `custom_extensions` block, that block rides along verbatim
+ * in `customExtensions` and is interpreted by the consumer that acts on it.
+ */
+export interface SemanticModel {
+  name: string;
+  description?: string;
+  // AI-first annotations for the model as a whole (instructions, synonyms,
+  // examples), kept separate from `description` so an emitter can route them to
+  // their own aspects rather than the entry description.
+  aiContext?: AiContext;
+  entities: Entity[];        // the open format's `datasets`
+  relationships: Relationship[];
+  metrics: Metric[];
+  // Vendor extension blocks carried verbatim (round-trip fidelity), including the
+  // model-level GOOGLE block. A typed deployment-target view is derived by the
+  // consumer that acts on it (e.g. the CLI push), not surfaced on the IR yet.
+  customExtensions?: CustomExtension[];
+}
+
+/**
+ * An entity: a node in the semantic graph. Backed by a physical table
+ * (`dataSource`), identified by `keys`, and carrying its dimension `fields`.
+ */
+export interface Entity {
+  name: string;
+  // A reference to the backing physical source, fully qualified so it identifies
+  // that source unambiguously. The IR treats it as an opaque identifier: it fixes
+  // neither a syntax (separators, number of parts, quoting) nor a naming scheme
+  // -- both are whatever the source system uses. Each producer normalizes it into
+  // its own canonical form, and downstream consumers map it to their target's
+  // addressing scheme.
+  dataSource: string;
+  keys: string[];        // grain / primary key
+  // Additional uniqueness constraints beyond the primary key; each inner array
+  // is one unique column set (maps to the Schema aspect's uniqueConstraints).
+  uniqueKeys?: string[][];
+  description?: string;
+  aiContext?: AiContext;
+  fields: Field[];       // dimensions / attributes
+  customExtensions?: CustomExtension[];
+}
+
+/**
+ * Dimension metadata on a field, mirroring the open format's `dimension` block
+ * (e.g. Apache Ossie's `OSIDimension`). An empty block still marks the field as
+ * a dimension, which enables temporal inference from `type` (see isTimeDimension).
+ */
+export interface Dimension {
+  // Explicit temporal-dimension flag. When unset, the effective role is inferred
+  // from a temporal `type` (see isTimeDimension).
+  isTime?: boolean;
+}
+
+/**
+ * A field: a dimension / attribute of an entity or relationship.
+ *
+ * Fields describe the data; aggregates are expressed as model-level `Metric`s,
+ * not fields.
+ *
+ * Expression fidelity: the format may supply an expression in several SQL
+ * dialects. We keep at most two forms — a target/canonical `expression` that is
+ * valid against the target (GoogleSQL/ANSI), and the original vendor SQL in
+ * `importedExpression` (with its `importedDialect`). At least one of the two is
+ * set. When only `importedExpression` is present, `expression` awaits a
+ * transpile pass (see ./transpile) that fills it from the imported form.
+ */
+export interface Field {
+  name: string;
+  expression?: string;             // target/canonical (GoogleSQL-valid) SQL
+  importedExpression?: string;     // original vendor SQL, verbatim
+  importedDialect?: string;        // dialect of `importedExpression` (e.g. 'SNOWFLAKE')
+  dimension?: Dimension;           // dimension metadata (e.g. temporal role)
+  label?: string;                  // human display label (distinct from name/description)
+  description?: string;
+  type?: DataType;                 // logical datatype (the open format's `datatype`)
+  aiContext?: AiContext;
+  customExtensions?: CustomExtension[];
+}
+
+/**
+ * The open format's `datatype` vocabulary, mirroring Apache Ossie's `DataType`:
+ * a CLOSED, case-sensitive set of logical types, independent of physical
+ * representation. It is optional (omit when unknown); a type outside the
+ * vocabulary is expressed as `Opaque` plus a `customExtensions` block, never an
+ * invented value. The loader enforces this set at parse time, so a `type` on the
+ * IR is always one of these.
+ */
+export const DATA_TYPES = [
+  'String', 'Integer', 'Decimal', 'Float', 'Boolean',
+  'Date', 'Time', 'DateTime', 'DateTimeTz', 'Opaque',
+] as const;
+
+export type DataType = typeof DATA_TYPES[number];
+
+// The temporal subset of DataType (Date / Time / DateTime / DateTimeTz); a field
+// of one of these types is a time dimension by default (see isTimeDimension).
+const TEMPORAL_TYPES: ReadonlySet<DataType> = new Set([
+  'Date', 'Time', 'DateTime', 'DateTimeTz',
+]);
+
+/**
+ * A field's effective temporal-dimension role, mirroring the open format's
+ * `is_time_dimension()` (e.g. Apache Ossie's `OSIField`): a field must carry
+ * `dimension` metadata to be a dimension at all; within it an explicit `isTime`
+ * takes precedence, otherwise the role defaults from a temporal `type`.
+ */
+export function isTimeDimension(field: Field): boolean {
+  if (!field.dimension) return false;
+  if (field.dimension.isTime !== undefined) return field.dimension.isTime;
+  return field.type !== undefined && TEMPORAL_TYPES.has(field.type);
+}
+
+/**
+ * A relationship: a directed foreign-key edge in the semantic graph, from
+ * `source` to `destination`. The join pairs the endpoints' columns positionally
+ * (`source.columns[i] = destination.columns[i]`): the source's foreign-key
+ * columns referencing the destination's key columns.
+ */
+export interface Relationship {
+  name: string;
+  source: RelationshipEnd;
+  destination: RelationshipEnd;
+  description?: string;
+  aiContext?: AiContext;
+  customExtensions?: CustomExtension[];
+}
+
+/**
+ * One endpoint of a relationship: the entity it attaches to and the columns on
+ * that entity's own table that participate in the join.
+ */
+export interface RelationshipEnd {
+  entity: string;        // name-reference into SemanticModel.entities
+  columns: string[];     // join columns on this endpoint's table
+}
+
+/**
+ * A metric: a model-level, named aggregate.
+ *
+ * Because it lives on the model rather than a single entity, a metric may span
+ * multiple entities — its `expression` can reference fields across the graph,
+ * joined via relationships. See `entity` for the single attach point and how
+ * it's derived.
+ *
+ * Expression fidelity mirrors `Field`: a target/canonical `expression` and/or
+ * the original vendor `importedExpression` (+ `importedDialect`).
+ */
+export interface Metric {
+  name: string;
+  expression?: string;   // target/canonical aggregate; may reference entity-qualified fields
+  importedExpression?: string; // original vendor SQL, verbatim
+  importedDialect?: string;    // dialect of `importedExpression`
+  // The single entity this metric attaches to -- the node it hangs off -- when
+  // its `expression` references exactly one. NOT part of the open format (Ossie's
+  // Metric has no such field): the loader DERIVES it by scanning the expression
+  // for known `entity.column` qualifiers (see referencedEntityNames). Omitted
+  // when the expression names no known entity (e.g. `COUNT(*)`; the loader warns)
+  // or references several -- a cross-entity metric whose join path consumers
+  // resolve from the model's relationships (the qualifiers stay inline in the
+  // expression).
+  entity?: string;
+  description?: string;
+  type?: DataType;       // logical datatype of the result (the open format's `datatype`)
+  aiContext?: AiContext;
+  customExtensions?: CustomExtension[];
+}

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -1,0 +1,480 @@
+// Loads an open, vendor-neutral AI-first semantics format (YAML/JSON) into the
+// Semantic Model IR (./ir).
+//
+// The format describes a semantic model as datasets (entities), foreign-key
+// relationships, and model-level metrics, with entity-qualified SQL expressions
+// (`Entity.column`) supplied per SQL dialect. This module reads the subset of
+// that logical layer needed to normalize a model into the IR, so the rest of the
+// toolbox (e.g. the BigQuery property-graph generator) can consume models
+// authored in it. Fields outside the supported subset are accepted and ignored.
+//
+
+import * as yaml from 'yaml';
+import * as z from 'zod';
+import {
+  SemanticModel, Entity, Field, Relationship, Metric, AiContext, CustomExtension,
+  DATA_TYPES,
+} from './ir';
+import { referencedEntityNames } from './sql_expr_utils';
+
+export interface LoadOptions {
+  dialect?: string;         // preferred expression dialect; default 'BIGQUERY'
+  defaultProject?: string;  // fallback when a dataset `source` omits the project
+  defaultDataset?: string;  // fallback when a dataset `source` omits the dataset
+}
+
+export interface LoadResult {
+  models: SemanticModel[];
+  warnings: string[];
+}
+
+const DEFAULT_DIALECT = 'BIGQUERY';
+const FALLBACK_DIALECT = 'ANSI_SQL';
+// The logical-layer schema version this loader was written against; a document
+// declaring a different version is loaded anyway, with a warning.
+const SUPPORTED_VERSION = '0.2.0.dev0';
+
+
+// An expression is supplied as one or more per-dialect variants; we collapse it
+// to at most two forms (target/canonical + imported) by picking dialects.
+// Unknown sibling keys are ignored.
+const expressionSchema = z.object({
+  dialects: z.array(z.object({
+    dialect: z.string(),
+    expression: z.string(),
+  })).min(1),
+});
+
+// The format's AI-first annotation. It appears at every level (model, dataset,
+// field, relationship, metric) and is either a bare instructions string or a
+// structured object. `examples` shapes vary across producers, so it is accepted
+// leniently and only string examples are carried into the IR description.
+const aiContextSchema = z.union([
+  z.string(),
+  z.object({
+    instructions: z.string().optional(),
+    synonyms: z.array(z.string()).optional(),
+    examples: z.array(z.any()).optional(),
+  }),
+]);
+
+// A vendor-scoped extension block: opaque `data` (a JSON string) tagged by
+// `vendor_name`. The spec allows these at every level (model, dataset, field,
+// relationship, metric). All are preserved verbatim on the IR (see
+// toCustomExtensions) for lossless round-trip; no vendor block is interpreted at
+// load time -- typed views (e.g. off the GOOGLE block) are a consumer concern.
+const customExtensionSchema = z.object({
+  vendor_name: z.string(),
+  data: z.string(),
+});
+
+// A field's dimension metadata; only the time flag is read today.
+const dimensionSchema = z.object({
+  is_time: z.boolean().optional(),
+});
+
+const fieldSchema = z.object({
+  name: z.string(),
+  expression: expressionSchema,
+  datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
+  description: z.string().optional(),
+  label: z.string().optional(),
+  dimension: dimensionSchema.optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+});
+
+const datasetSchema = z.object({
+  name: z.string(),
+  source: z.string(),
+  primary_key: z.array(z.string()).optional(),
+  unique_keys: z.array(z.array(z.string())).optional(),
+  description: z.string().optional(),
+  ai_context: aiContextSchema.optional(),
+  fields: z.array(fieldSchema).optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+});
+
+const relationshipSchema = z.object({
+  name: z.string(),
+  from: z.string(),
+  to: z.string(),
+  from_columns: z.array(z.string()).min(1),
+  to_columns: z.array(z.string()).min(1),
+  description: z.string().optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+});
+
+const metricSchema = z.object({
+  name: z.string(),
+  expression: expressionSchema,
+  datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
+  description: z.string().optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+});
+
+const modelSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+  datasets: z.array(datasetSchema).min(1),
+  relationships: z.array(relationshipSchema).optional(),
+  metrics: z.array(metricSchema).optional(),
+});
+
+const documentSchema = z.object({
+  version: z.string().optional(),
+  semantic_model: z.array(modelSchema).min(1),
+});
+
+type ExpressionDoc = z.infer<typeof expressionSchema>;
+type DatasetDoc = z.infer<typeof datasetSchema>;
+type FieldDoc = z.infer<typeof fieldSchema>;
+type RelationshipDoc = z.infer<typeof relationshipSchema>;
+type MetricDoc = z.infer<typeof metricSchema>;
+type ModelDoc = z.infer<typeof modelSchema>;
+type CustomExtensionDoc = z.infer<typeof customExtensionSchema>;
+type AiContextDoc = z.infer<typeof aiContextSchema>;
+
+// The AI-first `ai_context` normalized to the IR's common shape: a bare string
+// is read as `instructions`; a structured object keeps its parts. `examples` is
+// filtered to strings (producers vary; non-string examples are dropped).
+function normalizeAiContext(ai: AiContextDoc | undefined): AiContext {
+  if (ai === undefined) return {};
+  if (typeof ai === 'string') return { instructions: ai };
+  const out: AiContext = {};
+  if (ai.instructions) out.instructions = ai.instructions;
+  if (ai.synonyms && ai.synonyms.length) out.synonyms = [...new Set(ai.synonyms)];
+  if (ai.examples && ai.examples.length) {
+    const strings = ai.examples.filter((e): e is string => typeof e === 'string');
+    if (strings.length) out.examples = strings;
+  }
+  return out;
+}
+
+// Normalizes `ai_context` and returns it only when it carries something, so the
+// IR omits empty aiContext objects.
+function aiContextOrUndefined(ai: AiContextDoc | undefined): AiContext | undefined {
+  const ctx = normalizeAiContext(ai);
+  return (ctx.instructions || ctx.synonyms || ctx.examples) ? ctx : undefined;
+}
+
+// Preserves vendor `custom_extensions` verbatim on the IR (`vendor_name` ->
+// `vendorName`; `data` kept as the opaque, vendor-serialized string) so nothing
+// is lost and a 1P round-trip stays lossless. Typed views over specific vendors
+// are derived by the consumers that need them, not here.
+function toCustomExtensions(
+    exts: CustomExtensionDoc[] | undefined): CustomExtension[] | undefined {
+  if (!exts || !exts.length) return undefined;
+  return exts.map(e => ({ vendorName: e.vendor_name, data: e.data }));
+}
+
+// Composes a single description string from ordered parts, dropping empties.
+// Parts are separated by blank lines so a base description and derived markers
+// read as distinct paragraphs in the emitted metadata. AI-first annotations
+// (instructions / synonyms / examples) are NOT folded in here — they are carried
+// structurally on the IR (aiContext) so an emitter can route them to their own
+// aspects.
+function composeDescription(...parts: (string | undefined)[]): string | undefined {
+  const kept = parts
+    .map(p => (p === undefined ? undefined : p.trim()))
+    .filter((p): p is string => !!p);
+  return kept.length ? kept.join('\n\n') : undefined;
+}
+
+
+/**
+ * Loads YAML or JSON text (a document in the AI-first semantics format) into the
+ * Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
+ */
+export function loadModels(text: string, opts: LoadOptions = {}): LoadResult {
+  let doc: unknown;
+  try {
+    doc = yaml.parse(text);
+  } catch (err: any) {
+    throw new Error(`Semantic model load error: could not parse input: ${err?.message ?? err}`);
+  }
+  return fromDocument(doc, opts);
+}
+
+/**
+ * Converts an already-parsed document object into the Semantic Model IR. Throws
+ * on a structurally invalid document; softer, lossy conversions are reported in
+ * `warnings` rather than thrown.
+ */
+export function fromDocument(doc: unknown, opts: LoadOptions = {}): LoadResult {
+  const result = documentSchema.safeParse(doc);
+  if (!result.success) {
+    throw new Error(`Semantic model load error: ${result.error.message}`);
+  }
+
+  const warnings: string[] = [];
+  const parsed = result.data;
+
+  if (parsed.version && parsed.version !== SUPPORTED_VERSION) {
+    warnings.push(
+      `document version '${parsed.version}' differs from the supported '${SUPPORTED_VERSION}'; ` +
+      `loading anyway`);
+  }
+
+  const models = parsed.semantic_model.map(m => convertModel(m, opts, warnings));
+  return { models, warnings: [...new Set(warnings)] };
+}
+
+
+// Flags names that appear more than once within a scope. Uniqueness is required
+// for a valid graph: a duplicate dataset, field, metric, or relationship name
+// makes the generated nodes, properties, or edges ambiguous. Reported as
+// warnings (the loader stays lenient and never rejects a valid document); a
+// strict `validate` gate can promote these to errors later.
+function warnDuplicateNames(
+    names: string[], kind: string, scope: string, warnings: string[]): void {
+  const seen = new Set<string>();
+  for (const n of names) {
+    if (seen.has(n)) {
+      warnings.push(
+        `${scope}: duplicate ${kind} '${n}'; names must be unique ` +
+        `(the generated graph will be invalid)`);
+    }
+    seen.add(n);
+  }
+}
+
+function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): SemanticModel {
+  const dialect = opts.dialect ?? DEFAULT_DIALECT;
+
+  const entities = m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
+  warnDuplicateNames(entities.map(e => e.name), 'dataset name', `model '${m.name}'`, warnings);
+
+  const entityNames = entities.map(e => e.name);
+  const entityNameSet = new Set(entityNames);
+
+  const relationships = (m.relationships ?? []).map(
+    r => convertRelationship(r, entityNameSet));
+  warnDuplicateNames(
+    relationships.map(r => r.name), 'relationship name', `model '${m.name}'`, warnings);
+
+  const metrics = (m.metrics ?? []).map(
+    mt => convertMetric(mt, entityNames, warnings, dialect));
+  warnDuplicateNames(metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`, warnings);
+
+  const description = composeDescription(m.description);
+
+  const model: SemanticModel = { name: m.name, entities, relationships, metrics };
+  if (description) model.description = description;
+  const ai = aiContextOrUndefined(m.ai_context);
+  if (ai) model.aiContext = ai;
+  const ce = toCustomExtensions(m.custom_extensions);
+  if (ce) model.customExtensions = ce;
+  return model;
+}
+
+function convertDataset(ds: DatasetDoc, opts: LoadOptions,
+                        warnings: string[], dialect: string): Entity {
+  const ctxLabel = `dataset '${ds.name}'`;
+  const dataSource = parseSource(ds.source, opts, warnings, ctxLabel);
+  const keys = ds.primary_key ?? [];
+  if (!keys.length) {
+    warnings.push(`${ctxLabel}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
+  }
+  const fields = (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
+  warnDuplicateNames(fields.map(f => f.name), 'field name', `dataset '${ds.name}'`, warnings);
+
+  const entity: Entity = { name: ds.name, dataSource, keys, fields };
+  if (ds.unique_keys && ds.unique_keys.length) entity.uniqueKeys = ds.unique_keys;
+  const description = composeDescription(ds.description);
+  if (description) entity.description = description;
+  const ai = aiContextOrUndefined(ds.ai_context);
+  if (ai) entity.aiContext = ai;
+  const ce = toCustomExtensions(ds.custom_extensions);
+  if (ce) entity.customExtensions = ce;
+  return entity;
+}
+
+function convertField(f: FieldDoc, entityName: string, warnings: string[], dialect: string): Field {
+  const picked = pickDialect(f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
+
+  // `label`, `dimension`, and AI-first annotations are carried structurally on
+  // the IR (not folded into `description`) so an emitter can route each to its
+  // own destination and a 1P round-trip stays lossless.
+  const description = composeDescription(f.description);
+
+  const field: Field = { name: f.name };
+  if (picked.expression !== undefined) field.expression = picked.expression;
+  if (picked.importedExpression !== undefined) {
+    field.importedExpression = picked.importedExpression;
+    field.importedDialect = picked.importedDialect;
+  }
+  if (f.datatype) field.type = f.datatype;
+  if (f.label) field.label = f.label;
+  if (f.dimension) {
+    field.dimension = {};
+    if (f.dimension.is_time !== undefined) field.dimension.isTime = f.dimension.is_time;
+  }
+  if (description) field.description = description;
+  const ai = aiContextOrUndefined(f.ai_context);
+  if (ai) field.aiContext = ai;
+  const ce = toCustomExtensions(f.custom_extensions);
+  if (ce) field.customExtensions = ce;
+  return field;
+}
+
+// Maps an OSI foreign-key relationship onto the IR edge. `source.columns` are the
+// FK columns on the `from` table (`from_columns`); `destination.columns` are the
+// referenced key columns on the `to` table (`to_columns`), paired positionally.
+// The source entity's own primary key is not duplicated here -- downstream
+// consumers look it up from the entity. A malformed relationship (an endpoint not
+// declared in the model, or mismatched column arity) is a hard error, not a
+// warning: the resulting edge would be structurally invalid.
+function convertRelationship(r: RelationshipDoc, entityNames: Set<string>): Relationship {
+  const ctx = `relationship '${r.name}'`;
+  if (!entityNames.has(r.from)) {
+    throw new Error(`${ctx}: 'from' dataset '${r.from}' is not defined in the model`);
+  }
+  if (!entityNames.has(r.to)) {
+    throw new Error(`${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
+  }
+  if (r.from_columns.length !== r.to_columns.length) {
+    throw new Error(
+      `${ctx}: from_columns (${r.from_columns.length}) and to_columns ` +
+      `(${r.to_columns.length}) have different lengths; the join keys are mismatched`);
+  }
+
+  const relationship: Relationship = {
+    name: r.name,
+    source: { entity: r.from, columns: r.from_columns },
+    destination: { entity: r.to, columns: r.to_columns },
+  };
+  const description = composeDescription(r.description);
+  if (description) relationship.description = description;
+  const ai = aiContextOrUndefined(r.ai_context);
+  if (ai) relationship.aiContext = ai;
+  const ce = toCustomExtensions(r.custom_extensions);
+  if (ce) relationship.customExtensions = ce;
+  return relationship;
+}
+
+function convertMetric(mt: MetricDoc, entityNames: string[],
+                       warnings: string[], dialect: string): Metric {
+  const ctx = `metric '${mt.name}'`;
+  const picked = pickDialect(mt.expression, dialect, ctx, warnings);
+  // Infer referenced entities from whichever expression form we have; the
+  // imported form still carries the same entity qualifiers.
+  const exprForRefs = picked.expression ?? picked.importedExpression ?? '';
+  const referenced = referencedEntityNames(exprForRefs, entityNames);
+  if (!referenced.length) {
+    warnings.push(`${ctx}: expression references no known entity; it may not be placeable downstream`);
+  }
+  const metric: Metric = { name: mt.name };
+  // Attach only when the reference is unambiguous; a cross-entity metric is left
+  // unattached (its qualifiers stay inline in the expression for consumers).
+  if (referenced.length === 1) metric.entity = referenced[0];
+  if (picked.expression !== undefined) metric.expression = picked.expression;
+  if (picked.importedExpression !== undefined) {
+    metric.importedExpression = picked.importedExpression;
+    metric.importedDialect = picked.importedDialect;
+  }
+  if (mt.datatype) metric.type = mt.datatype;
+  const description = composeDescription(mt.description);
+  if (description) metric.description = description;
+  const ai = aiContextOrUndefined(mt.ai_context);
+  if (ai) metric.aiContext = ai;
+  const ce = toCustomExtensions(mt.custom_extensions);
+  if (ce) metric.customExtensions = ce;
+  return metric;
+}
+
+// Collapses an expression's per-dialect variants into at most two forms:
+//   - `expression`: a target/canonical form valid against the target. Preference
+//     is the requested dialect, else the portable canonical dialect (ANSI_SQL).
+//   - `importedExpression` (+ `importedDialect`): the original vendor SQL, kept
+//     verbatim so nothing is lost and a later transpile pass (see ./transpile)
+//     can fill `expression` from it.
+// Dialect names are compared case-insensitively. No transpilation is performed
+// here; chosen expressions are passed through verbatim. At least one form is set.
+//
+// The fallbacks differ in risk, so they are surfaced differently:
+//   - ANSI_SQL is the AI-first format's default expression language (ANSI
+//     SQL:2003 core), deliberately chosen to be valid across targets — BigQuery
+//     included. Using it as `expression` is the intended authoring path, not a
+//     lossy degradation, so it is reported as a single informational `note:`
+//     (worded field-agnostically so identical notes dedupe to one line).
+//   - When neither the target nor ANSI_SQL is present, `expression` is left
+//     unset and only `importedExpression` is populated; that is a genuine risk
+//     (needs transpilation) and is warned per field/metric, naming the dialect.
+interface PickedExpression {
+  expression?: string;
+  importedExpression?: string;
+  importedDialect?: string;
+}
+
+function pickDialect(expr: ExpressionDoc, preferred: string,
+                     ctx: string, warnings: string[]): PickedExpression {
+  const upper = (s: string) => s.toUpperCase();
+  const byName = (name: string) =>
+    expr.dialects.find(d => upper(d.dialect) === upper(name));
+
+  // The original vendor variant, if any: the first dialect that is neither the
+  // target nor the portable canonical. Kept as `importedExpression`.
+  const vendor = expr.dialects.find(
+    d => upper(d.dialect) !== upper(preferred) && upper(d.dialect) !== FALLBACK_DIALECT);
+
+  const out: PickedExpression = {};
+  if (vendor) {
+    out.importedExpression = vendor.expression;
+    out.importedDialect = vendor.dialect;
+  }
+
+  const exact = byName(preferred);
+  if (exact) {
+    out.expression = exact.expression;
+    return out;
+  }
+
+  const canonical = byName(FALLBACK_DIALECT);
+  if (canonical) {
+    out.expression = canonical.expression;
+    warnings.push(
+      `note: no '${preferred}' dialect for one or more expressions; using the portable ` +
+      `'${FALLBACK_DIALECT}' dialect verbatim ('${preferred}' accepts the ANSI core subset — ` +
+      `supply '${preferred}' variants only for ${preferred}-specific SQL)`);
+    return out;
+  }
+
+  // Neither target nor canonical: keep only the imported vendor form; the
+  // target `expression` awaits a transpile pass.
+  warnings.push(
+    `${ctx}: no '${preferred}' or '${FALLBACK_DIALECT}' dialect; keeping the ` +
+    `'${out.importedDialect}' expression as imported_expression (needs transpilation to '${preferred}')`);
+  return out;
+}
+
+// Normalizes a dotted `source` string into a canonical, fully-qualified
+// reference. Each identifier segment is unquoted, and a short reference has its
+// leading qualifiers prepended from options (a bare `table` gets both defaults;
+// a `dataset.table` gets the project). References that already carry three or
+// more segments are passed through untouched, so an already-qualified name keeps
+// whatever shape the source system gave it rather than being forced into fixed
+// slots. A source that looks like a query (contains whitespace) cannot be
+// qualified, so it is kept verbatim.
+function parseSource(source: string, opts: LoadOptions,
+                     warnings: string[], ctx: string): string {
+  const trimmed = source.trim();
+
+  if (/\s/.test(trimmed)) {
+    warnings.push(`${ctx}: source looks like a query, not a table reference; keeping it verbatim`);
+    return trimmed;
+  }
+
+  const parts = trimmed.split('.').map(unquote);
+  if (parts.length === 1 && opts.defaultDataset) parts.unshift(opts.defaultDataset);
+  if (parts.length < 3 && opts.defaultProject) parts.unshift(opts.defaultProject);
+  return parts.join('.');
+}
+
+function unquote(part: string): string {
+  return part.replace(/^[`"]/, '').replace(/[`"]$/, '');
+}

--- a/toolbox/mdcode/src/libts/semantic/sql_expr_utils.ts
+++ b/toolbox/mdcode/src/libts/semantic/sql_expr_utils.ts
@@ -1,0 +1,67 @@
+// Literal-aware helpers for the entity-qualified SQL expressions used across the
+// semantic-model layer.
+//
+// Expressions reference columns as `<Entity>.<column>`. Detecting and stripping
+// those qualifiers must ignore text inside string literals, so a value such as
+// 'orders.note' is treated as data, not as a reference to the `orders` entity.
+// Both the loader (metric-entity inference) and the BigQuery generator (measure
+// placement / qualifier stripping) share this one implementation.
+//
+
+// Matches a single- or double-quoted SQL string literal, honoring backslash
+// escapes. (Triple-quoted / raw literals are uncommon in these expressions and
+// are treated as ordinary text.)
+export const STRING_LITERAL = /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g;
+
+// Escapes a string so it can be embedded literally in a RegExp.
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Replaces string-literal contents with blanks of equal length, so scanning sees
+// literal-free text without shifting any offsets.
+export function blankStringLiterals(expression: string): string {
+  return expression.replace(STRING_LITERAL, m => ' '.repeat(m.length));
+}
+
+// Applies `fn` only to the parts of `expression` that lie outside string
+// literals, leaving each literal verbatim.
+export function mapOutsideStringLiterals(
+    expression: string, fn: (segment: string) => string): string {
+  let out = '';
+  let last = 0;
+  for (const m of expression.matchAll(STRING_LITERAL)) {
+    out += fn(expression.slice(last, m.index));
+    out += m[0];
+    last = m.index! + m[0].length;
+  }
+  out += fn(expression.slice(last));
+  return out;
+}
+
+// Builds a regex matching an `<entity>.` qualifier, including the BigQuery
+// backtick-quoted form (`` `entity`. ``). A negative lookbehind keeps the name
+// from matching inside a larger identifier (e.g. `customer_orders.`), and the
+// optional backticks let it match whether or not the identifier is quoted.
+function entityQualifier(name: string, flags = ''): RegExp {
+  return new RegExp(`(?<![\\w\`])\`?${escapeRegExp(name)}\`?\\.`, flags);
+}
+
+// Returns the entity names whose `<name>.` qualifier appears in an expression, in
+// the order they first appear, ignoring text inside string literals.
+export function referencedEntityNames(expression: string, entityNames: string[]): string[] {
+  const scannable = blankStringLiterals(expression);
+  const hits: Array<{ name: string; at: number }> = [];
+  for (const name of entityNames) {
+    const m = entityQualifier(name).exec(scannable);
+    if (m) hits.push({ name, at: m.index });
+  }
+  return hits.sort((a, b) => a.at - b.at).map(h => h.name);
+}
+
+// Removes the `<entity>.` qualifier (bare or backtick-quoted) so an expression
+// references table-local columns, without touching text inside string literals.
+export function stripQualifier(expression: string, entity: string): string {
+  const re = entityQualifier(entity, 'g');
+  return mapOutsideStringLiterals(expression, seg => seg.replace(re, ''));
+}

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/lineitem_databricks_ext.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/lineitem_databricks_ext.yaml
@@ -1,0 +1,56 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# Line-item model authored in a vendor dialect. Exercises: unique_keys on a
+# dataset with no primary_key, custom_extensions at field / relationship /
+# metric / model level, a COUNT(DISTINCT) metric, and a computed measure
+# (SUM(l_extendedprice * (1 - l_discount))) written with bare, unqualified
+# column references.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: lineitem
+    description: Line item shipping metrics
+    datasets:
+      - name: lineitem
+        source: samples.tpch.lineitem
+        fields:
+          - name: line_number
+            expression:
+              dialects:
+                - dialect: DATABRICKS
+                  expression: l_linenumber
+            custom_extensions:
+              - vendor_name: DATABRICKS
+                data: '{"_v": 1, "format": {"type": "number", "decimal_places": {"type": "exact", "places": 0}}}'
+      - name: orders
+        source: samples.tpch.orders
+        unique_keys:
+          - [o_orderkey]
+    relationships:
+      - name: lineitem_to_orders
+        from: lineitem
+        to: orders
+        from_columns: [l_orderkey]
+        to_columns: [o_orderkey]
+        custom_extensions:
+          - vendor_name: DATABRICKS
+            data: '{"_v": 1, "rely": {"at_most_one_match": true}}'
+    metrics:
+      - name: revenue
+        expression:
+          dialects:
+            - dialect: DATABRICKS
+              expression: SUM(l_extendedprice * (1 - l_discount))
+        description: Net revenue
+        custom_extensions:
+          - vendor_name: DATABRICKS
+            data: '{"_v": 1, "format": {"type": "currency", "currency_code": "USD", "decimal_places": {"type": "exact", "places": 2}}}'
+      - name: order_count
+        expression:
+          dialects:
+            - dialect: DATABRICKS
+              expression: COUNT(DISTINCT l_orderkey)
+    custom_extensions:
+      - vendor_name: DATABRICKS
+        data: '{"_v": 1, "filter": "l_returnflag = ''N''"}'

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/ossie/README.md
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/ossie/README.md
@@ -1,0 +1,20 @@
+# Vendored Apache Ossie reference examples
+
+`tpcds_semantic_model.yaml` is copied **unmodified** from the Apache Ossie
+project and is used here as an interop fixture: it proves the loader ingests a
+real, spec-owner-authored OSI document (v0.2.0.dev0).
+
+- Source: https://github.com/apache/ossie/blob/main/examples/tpcds_semantic_model.yaml
+- License: Apache License 2.0 (the file retains its original ASF license header).
+
+`osi-schema.json` is the OSI core JSON Schema (Draft 2020-12), copied unmodified
+from the same project. `osi_schema.test.ts` validates every YAML fixture in this
+tree against it, so a fixture that drifts from the spec (e.g. a dialect outside
+the OSI enum) fails the suite. This is the same JSON-Schema check the Apache
+validator (`validation/validate.py`) runs as its first step, done in-process with
+ajv so it needs no Python/PyPI dependency.
+
+- Source: https://github.com/apache/ossie/blob/main/core-spec/osi-schema.json
+- License: Apache License 2.0.
+
+These are test inputs only; they are not part of the shipped package.

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/ossie/osi-schema.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/ossie/osi-schema.json
@@ -1,0 +1,352 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/apache/ossie/core-spec/osi-schema.json",
+  "title": "Apache Ossie Core Metadata Specification",
+  "description": "JSON Schema for validating Apache Ossie semantic model definitions",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "0.2.0.dev0",
+      "description": "Apache Ossie specification version"
+    },
+    "semantic_model": {
+      "type": "array",
+      "description": "Collection of semantic model definitions",
+      "items": {
+        "$ref": "#/$defs/SemanticModel"
+      }
+    }
+  },
+  "required": ["version", "semantic_model"],
+  "additionalProperties": false,
+  "$defs": {
+    "Dialect": {
+      "type": "string",
+      "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL", "BIGQUERY"],
+      "description": "Supported SQL and expression language dialects"
+    },
+    "Vendor": {
+      "type": "string",
+      "examples": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA", "WISDOM"],
+      "description": "Vendor name for custom extensions. Any string value is accepted."
+    },
+    "AIContext": {
+      "description": "Additional context for AI tools",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "instructions": {
+              "type": "string",
+              "description": "Instructions for AI on how to use this entity"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Alternative names and terms"
+            },
+            "examples": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Sample questions or use cases"
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "CustomExtension": {
+      "type": "object",
+      "description": "Vendor-specific attributes for extensibility",
+      "properties": {
+        "vendor_name": {
+          "$ref": "#/$defs/Vendor"
+        },
+        "data": {
+          "type": "string",
+          "description": "JSON string containing vendor-specific data"
+        }
+      },
+      "required": ["vendor_name", "data"],
+      "additionalProperties": false
+    },
+    "DialectExpression": {
+      "type": "object",
+      "description": "Expression in a specific dialect",
+      "properties": {
+        "dialect": {
+          "$ref": "#/$defs/Dialect"
+        },
+        "expression": {
+          "type": "string",
+          "description": "SQL or dialect-specific expression"
+        }
+      },
+      "required": ["dialect", "expression"],
+      "additionalProperties": false
+    },
+    "Expression": {
+      "type": "object",
+      "description": "Expression definition with multi-dialect support",
+      "properties": {
+        "dialects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DialectExpression"
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["dialects"],
+      "additionalProperties": false
+    },
+    "DataType": {
+      "type": "string",
+      "enum": [
+        "String",
+        "Integer",
+        "Decimal",
+        "Float",
+        "Boolean",
+        "Date",
+        "Time",
+        "DateTime",
+        "DateTimeTz",
+        "Opaque"
+      ],
+      "description": "Logical data type for fields and metrics, independent of role (e.g. dimension vs fact) and physical representation. `Decimal` is exact base-10 with unspecified precision and scale; `Float` is approximate. `DateTime` has no timezone or offset, while `DateTimeTz` identifies an instant using offset or timezone context but does not guarantee preservation of a named timezone. Omit `datatype` when unknown; use `Opaque` plus `custom_extensions` for a known type outside the portable vocabulary."
+    },
+    "Dimension": {
+      "type": "object",
+      "description": "Dimension metadata",
+      "properties": {
+        "is_time": {
+          "type": "boolean",
+          "description": "Temporal-role marker. When true, consumers that distinguish time dimensions (e.g. for time-series analysis or temporal filtering) should treat this field as a time dimension. This is a *role* flag, independent of the field's data type: a field with `is_time: true` may carry any `datatype` (e.g. `Integer` for a year grain, `String` for a month name, as well as temporal data types). When `is_time` is unset, it defaults to `true` if `datatype` is one of `Date`, `Time`, `DateTime`, or `DateTimeTz`, and `false` otherwise. Set `is_time: false` explicitly to opt a temporal-typed column (such as an audit timestamp) out of time-dimension treatment."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Field": {
+      "type": "object",
+      "description": "Row-level attribute for grouping, filtering, and metric expressions",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the field within the dataset"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "dimension": {
+          "$ref": "#/$defs/Dimension"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label for categorization"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "datatype": {
+          "$ref": "#/$defs/DataType"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "expression"],
+      "additionalProperties": false
+    },
+    "Dataset": {
+      "type": "object",
+      "description": "Logical dataset representing a business entity (fact or dimension table)",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the dataset"
+        },
+        "source": {
+          "type": "string",
+          "description": "Reference to underlying physical table/view (database.schema.table) or query"
+        },
+        "primary_key": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Primary key columns (single or composite)"
+        },
+        "unique_keys": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": "Array of unique key definitions (each can be single or composite)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Field"
+          }
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "source"],
+      "additionalProperties": false
+    },
+    "Relationship": {
+      "type": "object",
+      "description": "Foreign key relationship between datasets",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the relationship"
+        },
+        "from": {
+          "type": "string",
+          "description": "Dataset on the many side of the relationship"
+        },
+        "to": {
+          "type": "string",
+          "description": "Dataset on the one side of the relationship"
+        },
+        "from_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Foreign key columns in the 'from' dataset"
+        },
+        "to_columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "Primary/unique key columns in the 'to' dataset"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "from", "to", "from_columns", "to_columns"],
+      "additionalProperties": false
+    },
+    "Metric": {
+      "type": "object",
+      "description": "Quantitative measure defined on business data",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the metric"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what the metric measures"
+        },
+        "datatype": {
+          "$ref": "#/$defs/DataType"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "expression"],
+      "additionalProperties": false
+    },
+    "SemanticModel": {
+      "type": "object",
+      "description": "Top-level container representing a complete semantic model",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the semantic model"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "ai_context": {
+          "$ref": "#/$defs/AIContext"
+        },
+        "datasets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Dataset"
+          },
+          "minItems": 1,
+          "description": "Collection of logical datasets"
+        },
+        "relationships": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Relationship"
+          },
+          "description": "Defines how datasets are connected"
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          },
+          "description": "Quantifiable measures spanning datasets"
+        },
+        "custom_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/CustomExtension"
+          }
+        }
+      },
+      "required": ["name", "datasets"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/ossie/tpcds_semantic_model.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/ossie/tpcds_semantic_model.yaml
@@ -1,0 +1,631 @@
+# yaml-language-server: $schema=../core-spec/osi-schema.json
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# TPC-DS Semantic Model Example
+# This example demonstrates the Ossie Core Metadata Spec using the TPC-DS benchmark schema
+# TPC-DS is a decision support benchmark with a realistic retail business model
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: tpcds_retail_model
+    description: TPC-DS retail semantic model for sales and customer analytics
+    ai_context:
+      instructions: "Use this semantic model for retail analytics. It provides comprehensive sales, customer, product, and store data from the TPC-DS benchmark. The model supports time-based analysis, customer segmentation, product performance, and store operations metrics."
+
+    datasets:
+      # Fact table: Store sales transactions
+      - name: store_sales
+        source: tpcds.public.store_sales
+        primary_key: [ss_item_sk, ss_ticket_number]  # Composite primary key
+        unique_keys:
+          - [ss_item_sk, ss_ticket_number]  # Composite key: item + ticket number uniquely identifies a line item
+        description: Fact table containing all store sales transactions
+        ai_context:
+          synonyms:
+            - "sales transactions"
+            - "store purchases"
+            - "retail sales"
+            - "POS data"
+
+        fields:
+          - name: ss_sold_date_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_sold_date_sk
+            description: Foreign key to date dimension
+            datatype: Integer
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "sale date"
+                - "transaction date"
+
+          - name: ss_item_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_item_sk
+            description: Foreign key to item dimension
+            datatype: Integer
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "product"
+                - "item"
+
+          - name: ss_customer_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_customer_sk
+            description: Foreign key to customer dimension
+            datatype: Integer
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "customer"
+                - "buyer"
+
+          - name: ss_store_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_store_sk
+            description: Foreign key to store dimension
+            datatype: Integer
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "store"
+                - "location"
+
+          - name: ss_quantity
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_quantity
+            description: Quantity of items sold
+            datatype: Integer
+            ai_context:
+              synonyms:
+                - "units sold"
+                - "quantity"
+
+          - name: ss_sales_price
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_sales_price
+            description: Sales price per unit
+            datatype: Decimal
+            ai_context:
+              synonyms:
+                - "unit price"
+                - "price"
+
+          - name: ss_ext_sales_price
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_ext_sales_price
+            description: Extended sales price (quantity * price)
+            datatype: Decimal
+            ai_context:
+              synonyms:
+                - "total price"
+                - "line total"
+
+          - name: ss_net_profit
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ss_net_profit
+            description: Net profit from the sale
+            datatype: Decimal
+            ai_context:
+              synonyms:
+                - "profit"
+                - "margin"
+
+      # Dimension table: Date
+      - name: date_dim
+        source: tpcds.public.date_dim
+        primary_key: [d_date_sk]  # Simple primary key
+        unique_keys:
+          - [d_date_sk]  # Simple key: single column
+        description: Date dimension with calendar attributes
+        ai_context:
+          synonyms:
+            - "calendar"
+            - "dates"
+            - "time periods"
+
+        fields:
+          - name: d_date_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_date_sk
+            description: Surrogate key for date
+            datatype: Integer
+            dimension:
+              is_time: false
+
+          - name: d_date
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_date
+            description: Actual date value
+            datatype: Date
+            dimension: {}
+            ai_context:
+              synonyms:
+                - "date"
+                - "calendar date"
+
+          - name: d_year
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_year
+            description: Year
+            datatype: Integer
+            dimension:
+              is_time: true
+            ai_context:
+              synonyms:
+                - "year"
+
+          # Declares temporal role via is_time without a datatype annotation.
+          # Both datatype and is_time are independently optional.
+          - name: d_quarter_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_quarter_name
+            description: Quarter name (e.g., 2024Q1)
+            dimension:
+              is_time: true
+            ai_context:
+              synonyms:
+                - "quarter"
+                - "fiscal quarter"
+
+          # Declares temporal role via is_time without a datatype annotation.
+          # Both datatype and is_time are independently optional.
+          - name: d_month_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: d_month_name
+            description: Month name
+            dimension:
+              is_time: true
+            ai_context:
+              synonyms:
+                - "month"
+
+      # Dimension table: Customer
+      - name: customer
+        source: tpcds.public.customer
+        primary_key: [c_customer_sk]  # Simple primary key
+        unique_keys:
+          - [c_customer_sk]  # Simple key: single column
+        description: Customer dimension with demographic information
+        ai_context:
+          synonyms:
+            - "customers"
+            - "shoppers"
+            - "buyers"
+
+        fields:
+          - name: c_customer_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_customer_sk
+            description: Surrogate key for customer
+            datatype: Integer
+            dimension:
+              is_time: false
+
+          - name: c_customer_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_customer_id
+            description: Business key for customer
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "customer ID"
+                - "customer number"
+
+          - name: c_first_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_first_name
+            description: Customer first name
+            datatype: String
+            dimension:
+              is_time: false
+
+          - name: c_last_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_last_name
+            description: Customer last name
+            datatype: String
+            dimension:
+              is_time: false
+
+          - name: customer_full_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_first_name || ' ' || c_last_name
+            description: Customer full name (computed field)
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "full name"
+                - "customer name"
+
+          - name: c_email_address
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_email_address
+            description: Customer email address
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "email"
+                - "contact"
+
+      # Dimension table: Item (Product)
+      - name: item
+        source: tpcds.public.item
+        primary_key: [i_item_sk]  # Simple primary key
+        unique_keys:
+          - [i_item_sk]  # Simple key: single column
+        description: Item/Product dimension with product attributes
+        ai_context:
+          synonyms:
+            - "products"
+            - "items"
+            - "merchandise"
+
+        fields:
+          - name: i_item_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_item_sk
+            description: Surrogate key for item
+            datatype: Integer
+            dimension:
+              is_time: false
+
+          - name: i_item_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_item_id
+            description: Business key for item
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "item ID"
+                - "product ID"
+                - "SKU"
+
+          - name: i_item_desc
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_item_desc
+            description: Item description
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "product description"
+                - "item name"
+
+          - name: i_brand
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_brand
+            description: Brand name
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "brand"
+                - "manufacturer"
+
+          - name: i_category
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_category
+            description: Item category
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "product category"
+                - "department"
+
+          - name: i_current_price
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: i_current_price
+            description: Current price of the item
+            datatype: Decimal
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "price"
+                - "list price"
+
+      # Dimension table: Store
+      - name: store
+        source: tpcds.public.store
+        primary_key: [s_store_sk]  # Simple primary key
+        unique_keys:
+          - [s_store_id]  # Simple key: single column
+        description: Store dimension with location and store attributes
+        ai_context:
+          synonyms:
+            - "stores"
+            - "retail locations"
+            - "branches"
+
+        fields:
+          - name: s_store_sk
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_store_sk
+            description: Surrogate key for store
+            datatype: Integer
+            dimension:
+              is_time: false
+
+          - name: s_store_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_store_id
+            description: Business key for store
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "store ID"
+                - "store number"
+
+          - name: s_store_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_store_name
+            description: Store name
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "store name"
+                - "location name"
+
+          - name: s_city
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_city
+            description: City where store is located
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "city"
+                - "location"
+
+          - name: s_state
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_state
+            description: State where store is located
+            datatype: String
+            dimension:
+              is_time: false
+            ai_context:
+              synonyms:
+                - "state"
+                - "region"
+
+          - name: s_number_employees
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: s_number_employees
+            description: Number of employees at the store
+            datatype: Integer
+            ai_context:
+              synonyms:
+                - "employee count"
+                - "staff size"
+
+    # Relationships between datasets
+    relationships:
+      - name: store_sales_to_date
+        from: store_sales
+        to: date_dim
+        from_columns: [ss_sold_date_sk]
+        to_columns: [d_date_sk]
+        ai_context:
+          synonyms:
+            - "sales date relationship"
+            - "when sale occurred"
+
+      - name: store_sales_to_customer
+        from: store_sales
+        to: customer
+        from_columns: [ss_customer_sk]
+        to_columns: [c_customer_sk]
+        ai_context:
+          synonyms:
+            - "customer purchase relationship"
+            - "who bought"
+
+      - name: store_sales_to_item
+        from: store_sales
+        to: item
+        from_columns: [ss_item_sk]
+        to_columns: [i_item_sk]
+        ai_context:
+          synonyms:
+            - "product sold relationship"
+            - "what was sold"
+
+      - name: store_sales_to_store
+        from: store_sales
+        to: store
+        from_columns: [ss_store_sk]
+        to_columns: [s_store_sk]
+        ai_context:
+          synonyms:
+            - "store location relationship"
+            - "where sale occurred"
+
+    # Semantic model-level metrics spanning multiple datasets
+    metrics:
+      - name: total_sales
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_ext_sales_price)
+        description: Total sales revenue across all transactions
+        datatype: Decimal
+        ai_context:
+          synonyms:
+            - "total revenue"
+            - "gross sales"
+            - "sales amount"
+
+      - name: total_profit
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_net_profit)
+        description: Total net profit from store sales
+        datatype: Decimal
+        ai_context:
+          synonyms:
+            - "net profit"
+            - "total earnings"
+            - "profit"
+
+      - name: customer_lifetime_value
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_ext_sales_price) / COUNT(DISTINCT customer.c_customer_sk)
+        description: Average lifetime sales value per customer
+        datatype: Decimal
+        ai_context:
+          synonyms:
+            - "CLV"
+            - "LTV"
+            - "customer value"
+            - "lifetime revenue"
+
+      - name: sales_by_brand
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_ext_sales_price)
+        description: Total sales by brand (requires grouping by item.i_brand)
+        datatype: Decimal
+        ai_context:
+          synonyms:
+            - "brand sales"
+            - "brand performance"
+            - "brand revenue"
+
+      - name: store_productivity
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(store_sales.ss_ext_sales_price) / NULLIF(SUM(store.s_number_employees), 0)
+        description: Sales per employee across stores
+        datatype: Decimal
+        ai_context:
+          synonyms:
+            - "sales per employee"
+            - "employee productivity"
+            - "revenue per employee"
+
+    custom_extensions:
+      - vendor_name: SALESFORCE
+        data: |
+          {
+            "tableau_workbook_id": "tpcds_retail_dashboard",
+            "einstein_enabled": true,
+            "crm_sync": {
+              "enabled": true,
+              "sync_frequency": "daily",
+              "customer_mapping": "customer.c_customer_id -> Account.AccountNumber"
+            },
+            "tableau_semantics": {
+              "published": true,
+              "version": "0.1.1"
+            }
+          }
+
+      - vendor_name: DBT
+        data: '{"project_name": "tpcds_analytics", "models_path": "models/semantic"}'

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_google_ext.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_google_ext.yaml
@@ -1,0 +1,58 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# Exercises the Google-specific and richer-typed loader paths that the other
+# fixtures don't: a model-level GOOGLE custom_extensions block carrying
+# `deploymentTargets`, per-field `datatype`, and a dataset `unique_keys` set.
+# Its expressions use the BIGQUERY dialect (the loader's default target), so it
+# is the fixture that exercises pickDialect's target-dialect-present path rather
+# than the ANSI_SQL fallback the other fixtures rely on.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: sales_typed
+    description: Sales orders with typed fields and a deployment target
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"deploymentTargets": ["projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph"]}'
+    datasets:
+      - name: orders
+        source: demo.sales.orders
+        primary_key: [o_orderkey]
+        unique_keys:
+          - [o_orderkey]
+          - [o_ordernumber]
+        fields:
+          - name: o_orderkey
+            datatype: Integer
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: o_orderkey
+          - name: o_ordernumber
+            datatype: String
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: o_ordernumber
+          - name: o_orderdate
+            datatype: Date
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: o_orderdate
+            dimension:
+              is_time: true
+          - name: o_totalprice
+            datatype: Decimal
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: o_totalprice
+    metrics:
+      - name: total_revenue
+        datatype: Decimal
+        expression:
+          dialects:
+            - dialect: BIGQUERY
+              expression: SUM(orders.o_totalprice)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.yaml
@@ -1,0 +1,81 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# Minimal star schema: orders (fact) -> customer (dimension). Exercises
+# ai_context at model / field / metric level, a time dimension (is_time), a
+# field label, and a COUNT(*) metric that carries no entity qualifier.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: sales
+    description: Sales orders with customer attributes
+    ai_context:
+      instructions: "Use this model for order analysis."
+    datasets:
+      - name: orders
+        source: samples.tpch.orders
+        primary_key: [o_orderkey]
+        description: One row per order
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+            description: Order identifier
+          - name: o_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_custkey
+          - name: o_orderdate
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderdate
+            label: Order Date
+            dimension:
+              is_time: true
+            ai_context:
+              synonyms: [order date, date]
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_totalprice
+      - name: customer
+        source: samples.tpch.customer
+        primary_key: [c_custkey]
+        fields:
+          - name: c_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_custkey
+          - name: c_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_name
+            description: Customer name
+    relationships:
+      - name: orders_to_customer
+        from: orders
+        to: customer
+        from_columns: [o_custkey]
+        to_columns: [c_custkey]
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)
+        description: Total order revenue
+        ai_context:
+          synonyms: [revenue, sales]
+      - name: order_count
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: COUNT(*)
+        description: Number of orders

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/vendor_dialects.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/vendor_dialects.yaml
@@ -1,0 +1,109 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# Exercises the VENDOR-DIALECT case: fields and metrics authored in a non-target,
+# non-canonical dialect (SNOWFLAKE / DATABRICKS) that BigQuery does not
+# accept verbatim. Keys are ANSI_SQL (portable across engines); the interesting
+# expressions carry only a vendor variant, so the loader keeps the
+# original as `importedExpression` (with `importedDialect`) for a later transpile
+# pass to rewrite into GoogleSQL.
+#
+# Every vendor expression here was transpiled with sqlglot and its GoogleSQL
+# output dry-run-validated against a real BigQuery instance (project
+# sqlgen-testing) — see the committed `.transpiled.golden.sql` for the outputs.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: vendor_sales
+    description: Orders and customers with vendor-dialect expressions
+    datasets:
+      - name: orders
+        source: samples.tpch.orders
+        primary_key: [o_orderkey]
+        description: One row per order
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+          - name: o_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_custkey
+          - name: order_status_label
+            description: Human-readable order status
+            expression:
+              dialects:
+                - dialect: SNOWFLAKE
+                  expression: "IFF(orders.o_orderstatus = 'F', 'fulfilled', 'open')"
+          - name: clerk_name
+            expression:
+              dialects:
+                - dialect: SNOWFLAKE
+                  expression: "NVL(orders.o_clerk, 'unknown')"
+          - name: comment_text
+            expression:
+              dialects:
+                - dialect: DATABRICKS
+                  expression: "orders.o_comment::text"
+          - name: price_float
+            expression:
+              dialects:
+                - dialect: DATABRICKS
+                  expression: "orders.o_totalprice::double"
+          - name: due_date
+            expression:
+              dialects:
+                - dialect: SNOWFLAKE
+                  expression: "DATEADD(day, 7, orders.o_orderdate)"
+          - name: ship_days
+            expression:
+              dialects:
+                - dialect: SNOWFLAKE
+                  expression: "DATEDIFF(day, orders.o_orderdate, orders.o_shipdate)"
+      - name: customer
+        source: samples.tpch.customer
+        primary_key: [c_custkey]
+        fields:
+          - name: c_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_custkey
+          - name: phone_is_numeric
+            expression:
+              dialects:
+                - dialect: SNOWFLAKE
+                  expression: "REGEXP_LIKE(customer.c_phone, '[0-9]+')"
+          - name: is_auto_segment
+            expression:
+              dialects:
+                - dialect: DATABRICKS
+                  expression: "customer.c_mktsegment ILIKE 'AUTO%'"
+    relationships:
+      - name: orders_to_customer
+        from: orders
+        to: customer
+        from_columns: [o_custkey]
+        to_columns: [c_custkey]
+    metrics:
+      - name: total_revenue
+        description: Total order revenue (portable control expression)
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)
+      - name: fulfilled_revenue
+        description: Revenue from fulfilled orders
+        expression:
+          dialects:
+            - dialect: SNOWFLAKE
+              expression: "SUM(IFF(orders.o_orderstatus = 'F', orders.o_totalprice, 0))"
+      - name: avg_price_known
+        description: Average order price, treating NULL as zero
+        expression:
+          dialects:
+            - dialect: SNOWFLAKE
+              expression: "AVG(NVL(orders.o_totalprice, 0))"

--- a/toolbox/mdcode/tests/libts/semantic/loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/loader.test.ts
@@ -1,0 +1,942 @@
+// Behavior specification for the semantic-model loader
+// (src/libts/semantic/loader.ts).
+//
+// The loader reads the subset of an open, AI-first semantics format needed to
+// normalize a model into the IR. Each test names one behavior. Focused tests use
+// `fromDocument` with object literals; document-level tests parse raw YAML/JSON
+// text via `loadModels`. This file asserts only the IR — the BigQuery generator
+// is covered by `bigquery.test.ts` (unit) and `bigquery.e2e.test.ts` (file -> DDL).
+//
+
+import { describe, test, expect } from 'bun:test';
+import { loadModels, fromDocument } from '../../../src/libts/semantic/loader';
+import { isTimeDimension, DATA_TYPES } from '../../../src/libts/semantic/ir';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Shorthand for the format's per-dialect expression object.
+function expr(expression: string, dialect = 'BIGQUERY') {
+  return { dialects: [{ dialect, expression }] };
+}
+
+
+describe('dataset source strings normalize to fully-qualified references', () => {
+  const { models } = fromDocument({
+    semantic_model: [{
+      name: 'm',
+      datasets: [
+        { name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] },
+        { name: 'b', source: 'ds.tbl', primary_key: ['id'], fields: [] },
+        { name: 'c', source: 'tbl', primary_key: ['id'], fields: [] },
+      ],
+    }],
+  }, { defaultProject: 'P', defaultDataset: 'D' });
+  const [a, b, c] = models[0].entities;
+
+  test('a three-part source becomes project.dataset.table', () => {
+    expect(a.dataSource).toBe('proj.ds.tbl');
+  });
+
+  test('a two-part source becomes dataset.table, project from defaults', () => {
+    expect(b.dataSource).toBe('P.ds.tbl');
+  });
+
+  test('a bare table fills both project and dataset from defaults', () => {
+    expect(c.dataSource).toBe('P.D.tbl');
+  });
+
+  test('a query-like source is kept verbatim with a warning', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'SELECT 1 FROM t', primary_key: ['id'], fields: [] }] }],
+    });
+    expect(models[0].entities[0].dataSource).toBe('SELECT 1 FROM t');
+    expect(warnings.some(w => w.includes('looks like a query'))).toBe(true);
+  });
+
+  test('a dataset without a primary key warns (its KEY would be empty)', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'a', fields: [] }] }],
+    });
+    expect(warnings.some(w => w.includes('no primary_key'))).toBe(true);
+  });
+
+  test('backtick- or double-quoted identifiers are unquoted', () => {
+    const { models } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: '`proj`.`ds`.`tbl`', primary_key: ['id'], fields: [] }] }],
+    });
+    expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
+  });
+
+  test('a four-part Lakehouse catalog name passes through untouched', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'proj.cat.ns.tbl', primary_key: ['id'], fields: [] }] }],
+    }, { defaultProject: 'P', defaultDataset: 'D' });
+    expect(models[0].entities[0].dataSource).toBe('proj.cat.ns.tbl');
+    expect(warnings).toEqual([]);
+  });
+
+  test('an explicit project/dataset in the source is not overridden by defaults', () => {
+    const { models } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'realproj.realds.tbl', primary_key: ['id'], fields: [] }] }],
+    }, { defaultProject: 'P', defaultDataset: 'D' });
+    expect(models[0].entities[0].dataSource).toBe('realproj.realds.tbl');
+  });
+});
+
+
+describe('per-dialect expressions collapse to a single string', () => {
+  function metricDoc(dialectList: Array<{ dialect: string; expression: string }>) {
+    return {
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'mx', expression: { dialects: dialectList } }],
+      }],
+    };
+  }
+
+  test('the preferred dialect (BIGQUERY) is chosen with no warning or provenance', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'ANSI_SQL', expression: 'SUM(orders.a)' },
+      { dialect: 'BIGQUERY', expression: 'SUM(orders.b)' },
+    ]));
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.b)');
+    expect(warnings.some(w => w.includes('dialect'))).toBe(false);
+    // Target dialect is already valid; no imported (vendor) form to preserve.
+    expect(models[0].metrics[0].importedExpression).toBeUndefined();
+  });
+
+  test('ANSI_SQL is the fallback when the preferred dialect is absent, with an informational note', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'ANSI_SQL', expression: 'SUM(orders.a)' },
+    ]));
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
+    expect(warnings.some(w => w.startsWith('note:') && w.includes("using the portable 'ANSI_SQL'"))).toBe(true);
+    // The portable canonical dialect targets BigQuery by design; no imported form.
+    expect(models[0].metrics[0].importedExpression).toBeUndefined();
+  });
+
+  test('a vendor-only expression is kept as imported_expression, with no target expression', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'SNOWFLAKE', expression: 'SUM(orders.a)' },
+    ]));
+    // No target/canonical form, so the target `expression` is left unset and the
+    // original vendor SQL is preserved for a later transpile pass.
+    expect(models[0].metrics[0].expression).toBeUndefined();
+    expect(models[0].metrics[0].importedExpression).toBe('SUM(orders.a)');
+    expect(models[0].metrics[0].importedDialect).toBe('SNOWFLAKE');
+    expect(warnings.some(w => w.includes("'SNOWFLAKE'") && w.includes('imported_expression'))).toBe(true);
+  });
+
+  test('an explicit dialect option overrides the default preference', () => {
+    const { models } = fromDocument(metricDoc([
+      { dialect: 'SNOWFLAKE', expression: 'SF' },
+      { dialect: 'BIGQUERY', expression: 'BQ' },
+    ]), { dialect: 'SNOWFLAKE' });
+    expect(models[0].metrics[0].expression).toBe('SF');
+  });
+
+  test('dialect names are matched case-insensitively', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'BigQuery', expression: 'SUM(orders.a)' },
+    ]), { dialect: 'bigquery' });
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
+    expect(warnings.some(w => w.includes('dialect'))).toBe(false);
+  });
+
+  test('field expressions select their dialect independently of metrics', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [
+            { name: 'id', expression: expr('orders.id') },
+            { name: 'net', expression: {
+              dialects: [{ dialect: 'ANSI_SQL', expression: 'orders.gross - orders.tax' }] } },
+            { name: 'label', expression: {
+              dialects: [{ dialect: 'SNOWFLAKE', expression: "IFF(orders.ok, 'y', 'n')" }] } },
+          ],
+        }],
+      }],
+    });
+    const fields = models[0].entities[0].fields;
+    expect(fields[0].expression).toBe('orders.id');                  // BIGQUERY, no fallback
+    expect(fields[1].expression).toBe('orders.gross - orders.tax');  // ANSI_SQL fallback
+    expect(fields[2].expression).toBeUndefined();                    // no target/canonical form
+    expect(fields[2].importedExpression).toBe("IFF(orders.ok, 'y', 'n')");  // SNOWFLAKE, kept as imported
+    // The canonical-fallback note is field-agnostic (so it dedupes); the point
+    // here is that the two fields still pick their expressions independently.
+    expect(warnings.some(w => w.includes("using the portable 'ANSI_SQL'"))).toBe(true);
+    // The imported (vendor) dialect is recorded only for the vendor field, so the
+    // transpile pass rewrites just that one.
+    expect(fields[0].importedDialect).toBeUndefined();
+    expect(fields[1].importedDialect).toBeUndefined();
+    expect(fields[2].importedDialect).toBe('SNOWFLAKE');
+  });
+});
+
+
+describe('relationships map onto the direct-FK IR convention', () => {
+  const { models } = fromDocument({
+    semantic_model: [{
+      name: 'm',
+      datasets: [
+        { name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] },
+        { name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] },
+      ],
+      relationships: [{
+        name: 'orders_customers', from: 'orders', to: 'customers',
+        from_columns: ['customer_id'], to_columns: ['customer_id'],
+      }],
+    }],
+  });
+  const rel = models[0].relationships[0];
+
+  test('the source end carries the from_columns (the FK columns)', () => {
+    expect(rel.source).toEqual({ entity: 'orders', columns: ['customer_id'] });
+  });
+
+  test('the destination end carries the to_columns (the referenced key columns)', () => {
+    expect(rel.destination).toEqual({ entity: 'customers', columns: ['customer_id'] });
+  });
+
+  test('a composite foreign key maps column-for-column', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'sales', source: 'sales', primary_key: ['sale_id'], fields: [] },
+          { name: 'stores', source: 'stores', primary_key: ['region', 'store_no'], fields: [] },
+        ],
+        relationships: [{
+          name: 'sales_stores', from: 'sales', to: 'stores',
+          from_columns: ['region', 'store_no'], to_columns: ['region', 'store_no'],
+        }],
+      }],
+    });
+    const rel = models[0].relationships[0];
+    expect(rel.source.columns).toEqual(['region', 'store_no']);
+    expect(rel.destination.columns).toEqual(['region', 'store_no']);
+  });
+
+  test('the source columns come from from_columns, not the from dataset PK', () => {
+    // The FK columns are taken straight from from_columns; the source entity's own
+    // primary key is looked up from the entity by downstream consumers, never
+    // duplicated onto the relationship (so a missing from-PK is irrelevant here).
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', fields: [] },  // no primary_key
+          { name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] },
+        ],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'customers',
+          from_columns: ['customer_id'], to_columns: ['customer_id'],
+        }],
+      }],
+    });
+    expect(models[0].relationships[0].source).toEqual({
+      entity: 'orders', columns: ['customer_id'] });
+  });
+
+  test('an unresolved to dataset is a hard error', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] }],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'ghost',
+          from_columns: ['g_id'], to_columns: ['id'],
+        }],
+      }],
+    })).toThrow(/'to' dataset 'ghost' is not defined/);
+  });
+
+  test('an unresolved from dataset is a hard error', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] }],
+        relationships: [{
+          name: 'r', from: 'ghost', to: 'customers',
+          from_columns: ['c_id'], to_columns: ['customer_id'],
+        }],
+      }],
+    })).toThrow(/'from' dataset 'ghost' is not defined/);
+  });
+
+  test('mismatched from_columns/to_columns arity is a hard error', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['a', 'b'], fields: [] },
+        ],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'customers',
+          from_columns: ['x', 'y'], to_columns: ['a'],
+        }],
+      }],
+    })).toThrow(/different lengths/);
+  });
+});
+
+
+describe('metrics infer their referenced entities from the expression', () => {
+  test('a single referenced entity becomes the metric attach entity', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'total_revenue', expression: expr('SUM(order_items.amount)') }],
+      }],
+    });
+    expect(models[0].metrics[0].entity).toBe('order_items');
+  });
+
+  test('a metric spanning multiple entities has no single attach entity', () => {
+    // A cross-entity metric references known entities but cannot hang off one
+    // node, so `entity` is left undefined -- not a missing-entity warning.
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', primary_key: ['id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['id'], fields: [] },
+        ],
+        metrics: [{
+          name: 'ratio',
+          expression: expr('SUM(orders.amount) / COUNT(customers.id)'),
+        }],
+      }],
+    });
+    expect(models[0].metrics[0].entity).toBeUndefined();
+    expect(warnings.some(w => w.includes('references no known entity'))).toBe(false);
+  });
+
+  test('a metric referencing no known entity warns', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'weird', expression: expr('SUM(unknown.x)') }],
+      }],
+    });
+    expect(warnings.some(w => w.includes('references no known entity'))).toBe(true);
+  });
+
+  test('a qualifier inside a string literal is not counted as a reference', () => {
+    // 'customers.region' is data, not a column reference, so the metric must be
+    // attributed only to order_items.
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['id'], fields: [] },
+        ],
+        metrics: [{
+          name: 'tagged',
+          expression: expr("CONCAT(SUM(order_items.amount), 'customers.region')"),
+        }],
+      }],
+    });
+    expect(models[0].metrics[0].entity).toBe('order_items');
+  });
+
+  test('a backtick-quoted entity qualifier is recognized (BigQuery quoting)', () => {
+    // BigQuery quotes identifiers with backticks; `orders`.amount must still be
+    // attributed to the orders entity, not dropped as unqualified.
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'rev', expression: expr('SUM(`orders`.amount)') }],
+      }],
+    });
+    expect(models[0].metrics[0].entity).toBe('orders');
+    expect(warnings.some(w => w.includes('references no known entity'))).toBe(false);
+  });
+});
+
+
+describe('document-level handling', () => {
+  test('a mismatched version warns but still loads', () => {
+    const { models, warnings } = fromDocument({
+      version: '9.9.9',
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'a', primary_key: ['id'], fields: [] }] }],
+    });
+    expect(models).toHaveLength(1);
+    expect(warnings.some(w => w.includes('differs from the supported'))).toBe(true);
+  });
+
+  test('unknown/extra fields outside the subset are ignored, not errors', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        ai_context: { instructions: 'ignored' },
+        custom_extensions: [{ vendor_name: 'X', data: '{}' }],
+        datasets: [{
+          name: 'a', source: 'a', primary_key: ['id'],
+          unique_keys: [['id']],
+          fields: [{
+            name: 'id', label: 'ignored', dimension: { is_time: false },
+            expression: expr('a.id'),
+          }],
+        }],
+      }],
+    });
+    expect(models[0].entities[0].fields[0].name).toBe('id');
+  });
+
+  test('duplicate dataset names warn (only one node table can carry the label)', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'a', primary_key: ['id'], fields: [] },
+          { name: 'orders', source: 'b', primary_key: ['id'], fields: [] },
+        ],
+      }],
+    });
+    expect(warnings.some(w => w.includes("duplicate dataset name 'orders'"))).toBe(true);
+  });
+
+  test('each semantic_model entry becomes its own IR model', () => {
+    const { models } = fromDocument({
+      semantic_model: [
+        { name: 'first', datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }] },
+        { name: 'second', datasets: [{ name: 'b', source: 'b', primary_key: ['id'], fields: [] }] },
+      ],
+    });
+    expect(models.map(m => m.name)).toEqual(['first', 'second']);
+  });
+
+  test('model and metric descriptions carry through to the IR', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm', description: 'a sales model',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'c', description: 'row count', expression: expr('COUNT(orders.id)') }],
+      }],
+    });
+    expect(models[0].description).toBe('a sales model');
+    expect(models[0].metrics[0].description).toBe('row count');
+  });
+
+  test('JSON text loads identically to YAML (yaml.parse accepts JSON)', () => {
+    const json = JSON.stringify({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] }],
+      }],
+    });
+    const { models } = loadModels(json);
+    expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
+  });
+
+  test('a document without semantic_model throws', () => {
+    expect(() => fromDocument({ foo: 'bar' })).toThrow(/Semantic model load error/);
+  });
+
+  test('an empty semantic_model array throws (min one model required)', () => {
+    expect(() => fromDocument({ semantic_model: [] })).toThrow(/Semantic model load error/);
+  });
+
+  test('unparseable input throws', () => {
+    expect(() => loadModels('{ this is : not valid')).toThrow(/load error/);
+  });
+});
+
+
+describe('richer IR fields carry through from the format', () => {
+  test('field and metric datatype populate the IR type', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [{ name: 'amount', datatype: 'Decimal', expression: expr('orders.amount') }],
+        }],
+        metrics: [{ name: 'total', datatype: 'Decimal', expression: expr('SUM(orders.amount)') }],
+      }],
+    });
+    expect(models[0].entities[0].fields[0].type).toBe('Decimal');
+    expect(models[0].metrics[0].type).toBe('Decimal');
+  });
+
+  test('an off-vocabulary datatype is rejected (closed, case-sensitive enum)', () => {
+    // Lowercase 'date' is not in the vocabulary (only 'Date' is); the closed
+    // enum makes this a hard parse error rather than a silently mis-typed field.
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [{ name: 'created', datatype: 'date', expression: expr('orders.created') }],
+        }],
+      }],
+    })).toThrow(/Semantic model load error/);
+  });
+
+  test('a dataset unique_keys becomes Entity.uniqueKeys', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          unique_keys: [['sku', 'region'], ['external_id']],
+          fields: [],
+        }],
+      }],
+    });
+    expect(models[0].entities[0].uniqueKeys).toEqual([['sku', 'region'], ['external_id']]);
+  });
+
+  test('the GOOGLE block is carried verbatim, not interpreted at load time', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        custom_extensions: [
+          { vendor_name: 'OTHER', data: '{"ignored": true}' },
+          { vendor_name: 'GOOGLE', data: JSON.stringify({
+            deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
+        ],
+        datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }],
+      }],
+    });
+    // GOOGLE gets no special treatment -- it rides along in customExtensions like
+    // any other vendor block; a typed deployment view is a consumer concern.
+    expect(models[0].customExtensions).toEqual([
+      { vendorName: 'OTHER', data: '{"ignored": true}' },
+      { vendorName: 'GOOGLE', data: JSON.stringify({
+        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
+    ]);
+  });
+
+  test('a malformed GOOGLE block is kept verbatim without warning (not parsed)', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        custom_extensions: [{ vendor_name: 'GOOGLE', data: '{not json' }],
+        datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }],
+      }],
+    });
+    // The loader never parses the block, so malformed JSON is not its concern.
+    expect(models[0].customExtensions).toEqual([{ vendorName: 'GOOGLE', data: '{not json' }]);
+    expect(warnings).toEqual([]);
+  });
+
+  test('ai_context instructions and synonyms are structural, not folded into description', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm', description: 'a sales model',
+        ai_context: { instructions: 'Prefer net revenue.', synonyms: ['sales', 'commerce'] },
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          ai_context: { instructions: 'One row per order.', synonyms: ['purchases'] },
+          fields: [{
+            name: 'amount', expression: expr('orders.amount'),
+            ai_context: { instructions: 'Gross, before tax.' },
+          }],
+        }],
+      }],
+    });
+    const model = models[0];
+    // Description stays the base text; instructions/synonyms live on aiContext.
+    expect(model.description).toBe('a sales model');
+    expect(model.aiContext?.instructions).toBe('Prefer net revenue.');
+    expect(model.aiContext?.synonyms).toEqual(['sales', 'commerce']);
+
+    // Dataset-level: no base description supplied, so it stays unset; instructions
+    // and synonyms are structural.
+    const entity = model.entities[0];
+    expect(entity.description).toBeUndefined();
+    expect(entity.aiContext?.instructions).toBe('One row per order.');
+    expect(entity.aiContext?.synonyms).toEqual(['purchases']);
+
+    // Field-level: instructions structural; no description text was supplied.
+    const field = entity.fields[0];
+    expect(field.description).toBeUndefined();
+    expect(field.aiContext?.instructions).toBe('Gross, before tax.');
+  });
+});
+
+
+describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
+  // A maximal document exercising every field the OSI core schema defines,
+  // including nested custom_extensions at every level and the required version
+  // const. It must load without throwing and without spurious warnings, and the
+  // supported semantics must land in the IR.
+  const doc = {
+    version: '0.2.0.dev0',
+    semantic_model: [{
+      name: 'sales',
+      description: 'Sales semantic model',
+      ai_context: { instructions: 'Prefer net.', synonyms: ['commerce'], examples: ['revenue by month'] },
+      custom_extensions: [{ vendor_name: 'GOOGLE', data: JSON.stringify({
+        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) }],
+      datasets: [
+        {
+          name: 'orders',
+          source: 'proj.ds.orders',
+          primary_key: ['order_id'],
+          unique_keys: [['external_id']],
+          description: 'One row per order',
+          ai_context: { instructions: 'Grain: order.', synonyms: ['purchases'] },
+          custom_extensions: [{ vendor_name: 'DBT', data: '{"model":"orders"}' }],
+          fields: [{
+            name: 'amount',
+            expression: { dialects: [{ dialect: 'BIGQUERY', expression: 'orders.amount' }] },
+            dimension: { is_time: false },
+            label: 'Order amount',
+            description: 'Gross amount',
+            datatype: 'Decimal',
+            ai_context: { instructions: 'Before tax.', synonyms: ['gross'] },
+            custom_extensions: [{ vendor_name: 'SNOWFLAKE', data: '{}' }],
+          }],
+        },
+        { name: 'customers', source: 'proj.ds.customers', primary_key: ['customer_id'], fields: [] },
+      ],
+      relationships: [{
+        name: 'orders_customers',
+        from: 'orders', to: 'customers',
+        from_columns: ['customer_id'], to_columns: ['customer_id'],
+        ai_context: { instructions: 'Each order has one customer.' },
+        custom_extensions: [{ vendor_name: 'COMMON', data: '{}' }],
+      }],
+      metrics: [{
+        name: 'total_amount',
+        expression: { dialects: [{ dialect: 'BIGQUERY', expression: 'SUM(orders.amount)' }] },
+        description: 'Total sales',
+        datatype: 'Decimal',
+        ai_context: { instructions: 'Sum of amounts.', synonyms: ['revenue'] },
+        custom_extensions: [{ vendor_name: 'GOODDATA', data: '{}' }],
+      }],
+    }],
+  };
+
+  test('a maximal spec document loads without throwing', () => {
+    expect(() => fromDocument(doc)).not.toThrow();
+  });
+
+  test('nested custom_extensions do not produce warnings (accepted, validated)', () => {
+    const { warnings } = fromDocument(doc);
+    // No vendor extension is acted upon at load time; all are accepted silently.
+    // No dialect fallbacks here either, so no notes.
+    expect(warnings).toEqual([]);
+  });
+
+  test('nested custom_extensions are preserved verbatim at every level', () => {
+    const { models } = fromDocument(doc);
+    const m = models[0];
+    // Model level: the raw GOOGLE block is kept verbatim, uninterpreted.
+    expect(m.customExtensions).toEqual([
+      { vendorName: 'GOOGLE', data: JSON.stringify({
+        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
+    ]);
+    // Dataset / field / relationship / metric levels: kept verbatim, data opaque.
+    expect(m.entities[0].customExtensions).toEqual([{ vendorName: 'DBT', data: '{"model":"orders"}' }]);
+    expect(m.entities[0].fields[0].customExtensions).toEqual([{ vendorName: 'SNOWFLAKE', data: '{}' }]);
+    expect(m.relationships[0].customExtensions).toEqual([{ vendorName: 'COMMON', data: '{}' }]);
+    expect(m.metrics[0].customExtensions).toEqual([{ vendorName: 'GOODDATA', data: '{}' }]);
+  });
+
+  test('every supported field maps into the IR', () => {
+    const { models } = fromDocument(doc);
+    const m = models[0];
+    expect(m.name).toBe('sales');
+    expect(m.description).toBe('Sales semantic model');
+    expect(m.aiContext?.examples).toEqual(['revenue by month']);
+    expect(m.aiContext?.instructions).toBe('Prefer net.');
+    expect(m.aiContext?.synonyms).toEqual(['commerce']);
+
+    const orders = m.entities[0];
+    expect(orders.dataSource).toBe('proj.ds.orders');
+    expect(orders.keys).toEqual(['order_id']);
+    expect(orders.uniqueKeys).toEqual([['external_id']]);
+    expect(orders.aiContext?.instructions).toBe('Grain: order.');
+    expect(orders.aiContext?.synonyms).toEqual(['purchases']);
+
+    const amount = orders.fields[0];
+    expect(amount.expression).toBe('orders.amount');
+    expect(amount.type).toBe('Decimal');
+    expect(amount.label).toBe('Order amount');
+    expect(amount.description).toBe('Gross amount');
+    expect(amount.dimension?.isTime).toBe(false);
+    expect(isTimeDimension(amount)).toBe(false);
+    expect(amount.aiContext?.instructions).toBe('Before tax.');
+    expect(amount.aiContext?.synonyms).toEqual(['gross']);
+
+    const rel = m.relationships[0];
+    expect(rel.source.entity).toBe('orders');
+    expect(rel.destination.entity).toBe('customers');
+    expect(rel.aiContext?.instructions).toBe('Each order has one customer.');
+
+    const metric = m.metrics[0];
+    expect(metric.expression).toBe('SUM(orders.amount)');
+    expect(metric.type).toBe('Decimal');
+    expect(metric.entity).toBe('orders');
+    expect(metric.aiContext?.instructions).toBe('Sum of amounts.');
+    expect(metric.aiContext?.synonyms).toEqual(['revenue']);
+  });
+
+  test('all seven spec dialects and ten datatypes are accepted', () => {
+    const dialects = ['ANSI_SQL', 'SNOWFLAKE', 'MDX', 'TABLEAU', 'DATABRICKS', 'MAQL', 'BIGQUERY'];
+    const datatypes = [...DATA_TYPES];  // the loader accepts exactly the IR vocabulary
+    const { models } = fromDocument({
+      version: '0.2.0.dev0',
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'd', source: 'd', primary_key: ['id'],
+          fields: datatypes.map((dt, i) => ({
+            name: `f${i}`, datatype: dt,
+            expression: { dialects: [{ dialect: dialects[i % dialects.length], expression: `d.c${i}` }] },
+          })),
+        }],
+      }],
+    });
+    expect(models[0].entities[0].fields.map(f => f.type)).toEqual(datatypes);
+  });
+});
+
+
+// Reads a real fixture file from tests/libts/semantic/fixtures and returns its
+// text, so these tests exercise the on-disk YAML path (loadModels) end to end
+// rather than hand-built object literals.
+function fixture(name: string): string {
+  return readFileSync(join(__dirname, 'fixtures', name), 'utf8');
+}
+
+describe('gold fixtures parse from disk (real YAML files)', () => {
+  test('star_orders_customer.yaml: happy path (ai_context, time dimension, metrics)', () => {
+    const { models, warnings } = loadModels(fixture('star_orders_customer.yaml'));
+    expect(models).toHaveLength(1);
+    const m = models[0];
+    expect(m.name).toBe('sales');
+    expect(m.aiContext?.instructions).toBe('Use this model for order analysis.');
+    expect(m.entities.map(e => e.name)).toEqual(['orders', 'customer']);
+    expect(m.entities[0].keys).toEqual(['o_orderkey']);
+    expect(m.relationships.map(r => r.name)).toEqual(['orders_to_customer']);
+
+    const orderdate = m.entities[0].fields.find(f => f.name === 'o_orderdate')!;
+    expect(orderdate.aiContext?.synonyms).toEqual(['order date', 'date']);
+    // label and time-dimension role are structural now, not folded into text.
+    expect(orderdate.label).toBe('Order Date');
+    expect(orderdate.dimension?.isTime).toBe(true);
+    expect(isTimeDimension(orderdate)).toBe(true);
+    expect(orderdate.description).toBeUndefined();
+
+    const revenue = m.metrics.find(mt => mt.name === 'total_revenue')!;
+    expect(revenue.expression).toBe('SUM(orders.o_totalprice)');
+    expect(revenue.entity).toBe('orders');
+    expect(revenue.aiContext?.synonyms).toEqual(['revenue', 'sales']);
+    // COUNT(*) references no entity -> warned, attach entity omitted.
+    const count = m.metrics.find(mt => mt.name === 'order_count')!;
+    expect(count.entity).toBeUndefined();
+    expect(warnings.some(w => w.includes("metric 'order_count'"))).toBe(true);
+  });
+
+  test('vendor_dialects.yaml: non-target dialects kept as imported_expression', () => {
+    const { models, warnings } = loadModels(fixture('vendor_dialects.yaml'));
+    const m = models[0];
+    expect(m.name).toBe('vendor_sales');
+
+    const label = m.entities[0].fields.find(f => f.name === 'order_status_label')!;
+    expect(label.expression).toBeUndefined();
+    expect(label.importedDialect).toBe('SNOWFLAKE');
+    expect(label.importedExpression).toContain('IFF(');
+
+    const fulfilled = m.metrics.find(mt => mt.name === 'fulfilled_revenue')!;
+    expect(fulfilled.expression).toBeUndefined();
+    expect(fulfilled.importedDialect).toBe('SNOWFLAKE');
+    expect(fulfilled.entity).toBe('orders');
+
+    // Portable control metric still resolves to a target expression.
+    const control = m.metrics.find(mt => mt.name === 'total_revenue')!;
+    expect(control.expression).toBe('SUM(orders.o_totalprice)');
+
+    expect(warnings.some(w =>
+      w.includes("field 'orders.order_status_label'") && w.includes('imported_expression'))).toBe(true);
+  });
+
+  test('lineitem_databricks_ext.yaml: unique_keys + no-primary-key warning', () => {
+    const { models, warnings } = loadModels(fixture('lineitem_databricks_ext.yaml'));
+    const m = models[0];
+    const orders = m.entities.find(e => e.name === 'orders')!;
+    expect(orders.keys).toEqual([]);
+    expect(orders.uniqueKeys).toEqual([['o_orderkey']]);
+    expect(warnings.some(w => w.includes("dataset 'lineitem'") && w.includes('no primary_key'))).toBe(true);
+
+    // custom_extensions are preserved verbatim at model / field / relationship / metric levels.
+    expect(m.customExtensions?.[0].vendorName).toBe('DATABRICKS');
+    const lineitem = m.entities.find(e => e.name === 'lineitem')!;
+    expect(lineitem.fields[0].customExtensions?.[0].vendorName).toBe('DATABRICKS');
+    expect(m.relationships[0].customExtensions?.[0].vendorName).toBe('DATABRICKS');
+    expect(m.metrics.find(mt => mt.name === 'revenue')!.customExtensions?.[0].data).toContain('currency');
+  });
+
+  test('sales_google_ext.yaml: GOOGLE block verbatim + datatypes + unique_keys', () => {
+    const { models } = loadModels(fixture('sales_google_ext.yaml'));
+    const m = models[0];
+    expect(m.customExtensions).toEqual([{
+      vendorName: 'GOOGLE',
+      data: '{"deploymentTargets": ["projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph"]}',
+    }]);
+    const orders = m.entities[0];
+    expect(orders.uniqueKeys).toEqual([['o_orderkey'], ['o_ordernumber']]);
+    expect(orders.fields.map(f => f.type)).toEqual(['Integer', 'String', 'Date', 'Decimal']);
+    expect(m.metrics[0].type).toBe('Decimal');
+    // Expressions are supplied in the BIGQUERY dialect (the default target), so
+    // they resolve directly as `expression` -- exercising pickDialect's
+    // target-dialect-present path, not the ANSI_SQL fallback. Nothing is left as
+    // an imported (needs-transpile) form.
+    expect(m.metrics[0].expression).toBe('SUM(orders.o_totalprice)');
+    expect(m.metrics[0].importedExpression).toBeUndefined();
+    expect(orders.fields.every(f => f.expression && !f.importedExpression)).toBe(true);
+  });
+
+  test('ossie/tpcds_semantic_model.yaml: the Apache reference example loads', () => {
+    // The unmodified spec-owner-authored example (interop proof).
+    const { models, warnings } = loadModels(fixture('ossie/tpcds_semantic_model.yaml'));
+    expect(models).toHaveLength(1);
+    const m = models[0];
+    expect(m.name).toBe('tpcds_retail_model');
+    expect(m.entities).toHaveLength(5);
+    expect(m.relationships).toHaveLength(4);
+    expect(m.metrics).toHaveLength(5);
+
+    // A cross-entity metric references more than one entity, so it has no
+    // single attach entity.
+    const clv = m.metrics.find(mt => mt.name === 'customer_lifetime_value')!;
+    expect(clv.entity).toBeUndefined();
+
+    // Every field and metric expression is ANSI_SQL -> resolves to a target
+    // expression, so nothing is left needing transpilation.
+    const needsTranspile = warnings.filter(w => w.includes('imported_expression'));
+    expect(needsTranspile).toEqual([]);
+  });
+});
+
+describe('duplicate names within a model warn (uniqueness checks)', () => {
+  test('duplicate field names within a dataset warn', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [
+            { name: 'amount', expression: expr('orders.amount') },
+            { name: 'amount', expression: expr('orders.amount2') },
+          ],
+        }],
+      }],
+    });
+    expect(warnings.some(w =>
+      w.includes("dataset 'orders'") && w.includes("duplicate field name 'amount'"))).toBe(true);
+  });
+
+  test('duplicate metric names within a model warn', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [{ name: 'amount', expression: expr('orders.amount') }] }],
+        metrics: [
+          { name: 'total', expression: expr('SUM(orders.amount)') },
+          { name: 'total', expression: expr('AVG(orders.amount)') },
+        ],
+      }],
+    });
+    expect(warnings.some(w =>
+      w.includes("model 'm'") && w.includes("duplicate metric name 'total'"))).toBe(true);
+  });
+
+  test('duplicate relationship names within a model warn', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', primary_key: ['o_id'],
+            fields: [{ name: 'c_id', expression: expr('orders.c_id') }] },
+          { name: 'customer', source: 'customer', primary_key: ['c_id'],
+            fields: [{ name: 'c_id', expression: expr('customer.c_id') }] },
+        ],
+        relationships: [
+          { name: 'o2c', from: 'orders', to: 'customer', from_columns: ['c_id'], to_columns: ['c_id'] },
+          { name: 'o2c', from: 'orders', to: 'customer', from_columns: ['c_id'], to_columns: ['c_id'] },
+        ],
+      }],
+    });
+    expect(warnings.some(w =>
+      w.includes("model 'm'") && w.includes("duplicate relationship name 'o2c'"))).toBe(true);
+  });
+});
+
+
+describe('field label and time-dimension role align with the format models', () => {
+  // Builds one field with the given extra props and returns its IR form.
+  function field(props: Record<string, unknown>) {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'd', source: 'd', primary_key: ['id'],
+          fields: [{ name: 'f', expression: expr('d.f'), ...props }],
+        }],
+      }],
+    });
+    return models[0].entities[0].fields[0];
+  }
+
+  test('label is preserved structurally, separate from description', () => {
+    const f = field({ label: 'Order Date', description: 'The order date' });
+    expect(f.label).toBe('Order Date');
+    expect(f.description).toBe('The order date');
+  });
+
+  test('a label alone is not mis-mapped into description', () => {
+    const f = field({ label: 'Order Date' });
+    expect(f.label).toBe('Order Date');
+    expect(f.description).toBeUndefined();
+  });
+
+  test('an explicit is_time:true makes it a time dimension', () => {
+    const f = field({ dimension: { is_time: true } });
+    expect(f.dimension?.isTime).toBe(true);
+    expect(isTimeDimension(f)).toBe(true);
+  });
+
+  test('an explicit is_time:false overrides a temporal datatype', () => {
+    const f = field({ dimension: { is_time: false }, datatype: 'Date' });
+    expect(f.dimension?.isTime).toBe(false);
+    expect(isTimeDimension(f)).toBe(false);
+  });
+
+  test('a temporal datatype infers a time dimension when is_time is unset', () => {
+    const f = field({ dimension: {}, datatype: 'Date' });
+    expect(f.dimension?.isTime).toBeUndefined();
+    expect(isTimeDimension(f)).toBe(true);
+  });
+
+  test('a temporal datatype with no dimension block is not a dimension', () => {
+    const f = field({ datatype: 'Date' });
+    expect(f.dimension).toBeUndefined();
+    expect(isTimeDimension(f)).toBe(false);
+  });
+
+  test('a non-temporal datatype with an empty dimension is not a time dimension', () => {
+    const f = field({ dimension: {}, datatype: 'String' });
+    expect(isTimeDimension(f)).toBe(false);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -1,0 +1,58 @@
+// Guardrail: every YAML fixture under tests/libts/semantic/fixtures must be a
+// structurally valid Apache OSI document.
+//
+// We validate against the vendored osi-schema.json (Draft 2020-12) with ajv —
+// the same JSON-Schema check the Apache validator (validation/validate.py) runs
+// as its first step, but in-process with no Python/PyPI dependency. This catches
+// fixtures drifting from the spec (e.g. a `dialect` value outside the OSI enum),
+// so the loader's own tests exercise only genuinely valid input. The schema and
+// its provenance live in fixtures/ossie/ (see that directory's README).
+//
+
+import { describe, test, expect } from 'bun:test';
+import Ajv2020 from 'ajv/dist/2020';
+import * as yaml from 'yaml';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const fixturesDir = join(__dirname, 'fixtures');
+const schema = JSON.parse(
+  readFileSync(join(fixturesDir, 'ossie', 'osi-schema.json'), 'utf8'));
+
+// Recursively collect every *.yaml/*.yml fixture, so a newly added fixture is
+// schema-checked automatically without editing this file.
+function yamlFixtures(dir: string): string[] {
+  const out: string[] = [];
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) out.push(...yamlFixtures(p));
+    else if (ent.name.endsWith('.yaml') || ent.name.endsWith('.yml')) out.push(p);
+  }
+  return out;
+}
+
+// strict:false: the schema is authored by a third party; we validate documents
+// against it, not the schema's own meta-style.
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+const fixtures = yamlFixtures(fixturesDir);
+
+describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () => {
+  test('at least one fixture is discovered', () => {
+    expect(fixtures.length).toBeGreaterThan(0);
+  });
+
+  for (const path of fixtures) {
+    const rel = path.slice(fixturesDir.length + 1);
+    test(`${rel} validates against the OSI schema`, () => {
+      const doc = yaml.parse(readFileSync(path, 'utf8'));
+      const ok = validate(doc);
+      if (!ok) {
+        const details = (validate.errors ?? [])
+          .map(e => `  ${e.instancePath || '(root)'} ${e.message}`).join('\n');
+        throw new Error(`OSI schema validation failed for ${rel}:\n${details}`);
+      }
+      expect(ok).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
First of a capability-layered series merging the semantic-model tooling from the `libei/knowledge-catalog` fork back into upstream. This PR is the foundation the rest of the series builds on; it has no downstream dependencies.

## What this PR adds

A destination-agnostic **Semantic Model IR** and a **loader** for the Open Semantic Interchange (OSI) / Apache Ossie format.

- **`src/libts/semantic/ir.ts`** — the in-memory contract: a graph of entities (nodes) and relationships (edges) with model-level metrics, AI-first annotations (`ai_context`), and verbatim vendor `custom_extensions` for round-trip fidelity. `datatype` is a closed, case-sensitive vocabulary mirroring Ossie's `DataType`.
- **`src/libts/semantic/loader.ts`** — parses OSI YAML/JSON into the IR. zod schemas form the faithful parse layer; the IR is the normalized/lowered layer (dialect selection, physical-source FQN normalization, `ai_context` normalization, metric-entity inference). Fail-loud on off-vocabulary datatypes; warns (never silently drops) on soft issues such as missing primary keys or unplaceable metrics.
- **`src/libts/semantic/sql_expr_utils.ts`** — literal-aware helpers for the entity-qualified SQL expressions used by metric-entity inference and qualifier stripping. Ignores text inside string literals and recognizes both bare and BigQuery backtick-quoted qualifiers.
- **Fixtures + tests** — real OSI models (TPC-DS and a star schema), a multi-dialect model exercising expression selection across ANSI / Snowflake / Databricks, and models carrying vendor `custom_extensions` blocks (Databricks, DBT, Google, Salesforce). Fixtures are validated against the vendored OSI JSON Schema (via `ajv`), plus loader unit tests.
- **`package.json`** — adds `ajv` (JSON Schema validation for the fixtures) and a `test:semantic` script wired into `test`; the `package-lock.json` churn is the transitive closure of that one dependency.

## Scope

IR + loader only. Downstream consumers — BigQuery property-graph DDL generation, the CLI push path, and Knowledge Catalog emit/pull — follow in later PRs in the series.

## Testing

- `npx tsc --noEmit` — clean
- `bun test tests/libts/semantic/` — 67 pass / 0 fail
