### PR TITLE
mdcode: add semantic-model scope and BigQuery Graph push

### DIFF
--- a/toolbox/mdcode/README.md
+++ b/toolbox/mdcode/README.md
@@ -149,6 +149,12 @@ kcmd init --bigquery-dataset <projectId>.<datasetId> \
 # Initialize a new catalog snapshot for a custom EntryGroup
 kcmd init --entry-group <projectId>.<locationId>.<entryGroupId>
 
+# Initialize a new catalog snapshot for a locally-authored Semantic Model.
+# The scope names the EntryGroup the model belongs to; the model is authored as
+# a single Apache Ossie document at
+# catalog/EntryGroups/<entryGroupId>/<model>.yaml.
+kcmd init --semantic-model <projectId>.<locationId>.<entryGroupId>
+
 # Pull the latest catalog snapshot from the Knowledge Catalog service
 # Reports any conflicts if there are pending changes that have not been
 # pushed to the catalog.
@@ -164,6 +170,14 @@ kcmd status
 # Supports dry run with the --dry-run flag.
 kcmd push
 ```
+
+For the semantic-model scope, `kcmd push` deploys the model's BigQuery Graph
+(`CREATE OR REPLACE PROPERTY GRAPH`) to the project and dataset named by the
+model's GOOGLE deployment target; pass `--validate-only` to print the generated
+DDL without executing it. This path additionally reads the target dataset's
+metadata (`bigquery.datasets.get`) to pin the query job's processing location.
+The call degrades gracefully when the permission is absent, so a narrower
+service account still works but falls back to BigQuery's own location inference.
 
 NOTE: The CLI uses `gcloud` to obtain authentication tokens, so ensure you are authenticated via `gcloud auth application-default login`.
 

--- a/toolbox/mdcode/README.md
+++ b/toolbox/mdcode/README.md
@@ -178,6 +178,10 @@ DDL without executing it. This path additionally reads the target dataset's
 metadata (`bigquery.datasets.get`) to pin the query job's processing location.
 The call degrades gracefully when the permission is absent, so a narrower
 service account still works but falls back to BigQuery's own location inference.
+A dataset `source` that omits its project is qualified with the scope's
+declared project (the `<projectId>` in the init scope), not the ambient
+`gcloud` project; write a fully-qualified `project.dataset.table` source when
+the tables live elsewhere.
 
 NOTE: The CLI uses `gcloud` to obtain authentication tokens, so ensure you are authenticated via `gcloud auth application-default login`.
 

--- a/toolbox/mdcode/src/libts/gcp/bigquery.ts
+++ b/toolbox/mdcode/src/libts/gcp/bigquery.ts
@@ -30,6 +30,12 @@ interface TableList {
   nextPageToken?: string;
 }
 
+export interface QueryResponse {
+  jobComplete?: boolean;
+  errors?: { reason?: string; message: string }[];
+  [key: string]: any;
+}
+
 
 export class BigQueryClient extends api.ApiClient {
 
@@ -66,5 +72,11 @@ export class BigQueryClient extends api.ApiClient {
 
       pageToken = res.result?.nextPageToken;
     } while (pageToken);
+  }
+
+  // Executes a SQL statement (including DDL) synchronously via jobs.query.
+  async query(project: string, sql: string): Promise<api.ApiResult<QueryResponse>> {
+    const name = `projects/${project}/queries`;
+    return await this._post<QueryResponse>(name, { query: sql, useLegacySql: false });
   }
 }

--- a/toolbox/mdcode/src/libts/gcp/bigquery.ts
+++ b/toolbox/mdcode/src/libts/gcp/bigquery.ts
@@ -32,6 +32,7 @@ interface TableList {
 
 export interface QueryResponse {
   jobComplete?: boolean;
+  jobReference?: { projectId?: string; jobId?: string; location?: string };
   errors?: { reason?: string; message: string }[];
   [key: string]: any;
 }
@@ -78,5 +79,17 @@ export class BigQueryClient extends api.ApiClient {
   async query(project: string, sql: string): Promise<api.ApiResult<QueryResponse>> {
     const name = `projects/${project}/queries`;
     return await this._post<QueryResponse>(name, { query: sql, useLegacySql: false });
+  }
+
+  // Fetches the status/results of a running query job. Used to poll until the
+  // job reports `jobComplete`, since jobs.query can return before a slow DDL
+  // statement has finished executing.
+  async getQueryResults(project: string, jobId: string, location?: string): Promise<api.ApiResult<QueryResponse>> {
+    const name = `projects/${project}/queries/${jobId}`;
+    const params: Record<string, any> = { maxResults: 0, timeoutMs: 10000 };
+    if (location) {
+      params.location = location;
+    }
+    return await this._get<QueryResponse>(name, params);
   }
 }

--- a/toolbox/mdcode/src/libts/gcp/bigquery.ts
+++ b/toolbox/mdcode/src/libts/gcp/bigquery.ts
@@ -85,9 +85,16 @@ export class BigQueryClient extends api.ApiClient {
   }
 
   // Executes a SQL statement (including DDL) synchronously via jobs.query.
-  async query(project: string, sql: string): Promise<api.ApiResult<QueryResponse>> {
+  // When `location` is set it pins the job's processing location so it agrees
+  // with getQueryResults/getJob; otherwise BigQuery infers it from the
+  // referenced tables.
+  async query(project: string, sql: string, location?: string): Promise<api.ApiResult<QueryResponse>> {
     const name = `projects/${project}/queries`;
-    return await this._post<QueryResponse>(name, { query: sql, useLegacySql: false });
+    const body: Record<string, any> = { query: sql, useLegacySql: false };
+    if (location) {
+      body.location = location;
+    }
+    return await this._post<QueryResponse>(name, body);
   }
 
   // Fetches the status/results of a running query job. Used to poll until the

--- a/toolbox/mdcode/src/libts/gcp/bigquery.ts
+++ b/toolbox/mdcode/src/libts/gcp/bigquery.ts
@@ -37,6 +37,15 @@ export interface QueryResponse {
   [key: string]: any;
 }
 
+export interface Job {
+  status?: {
+    state?: string;
+    errorResult?: { reason?: string; message: string };
+    errors?: { reason?: string; message: string }[];
+  };
+  [key: string]: any;
+}
+
 
 export class BigQueryClient extends api.ApiClient {
 
@@ -91,5 +100,17 @@ export class BigQueryClient extends api.ApiClient {
       params.location = location;
     }
     return await this._get<QueryResponse>(name, params);
+  }
+
+  // Fetches a job's full status. status.errorResult is the definitive fatal
+  // error for a completed job; the query response's errors[] also includes
+  // non-fatal warnings, so it cannot decide success on its own.
+  async getJob(project: string, jobId: string, location?: string): Promise<api.ApiResult<Job>> {
+    const name = `projects/${project}/jobs/${jobId}`;
+    const params: Record<string, any> = {};
+    if (location) {
+      params.location = location;
+    }
+    return await this._get<Job>(name, params);
   }
 }

--- a/toolbox/mdcode/src/libts/layout.ts
+++ b/toolbox/mdcode/src/libts/layout.ts
@@ -4,10 +4,12 @@
 import * as md from './metadata';
 import { StandardLayout } from './layouts/standard';
 import { DocumentsLayout } from './layouts/documents';
+import { SemanticModelLayout } from './layouts/semantic-model';
 
 export enum Layouts {
   STANDARD = 'standard',
-  DOCUMENTS = 'documents'
+  DOCUMENTS = 'documents',
+  SEMANTIC_MODEL = 'SemanticModel'
 }
 
 
@@ -29,6 +31,8 @@ export function createLayout(layout: Layouts,
       return new StandardLayout(catalogPath);
     case Layouts.DOCUMENTS:
       return new DocumentsLayout(catalogPath);
+    case Layouts.SEMANTIC_MODEL:
+      return new SemanticModelLayout(catalogPath);
     default:
       throw new Error(`Unknown layout type: ${layout}`);
   }

--- a/toolbox/mdcode/src/libts/layout.ts
+++ b/toolbox/mdcode/src/libts/layout.ts
@@ -25,14 +25,15 @@ export interface CatalogLayout {
 
 
 export function createLayout(layout: Layouts,
-                             catalogPath: string): CatalogLayout {
+                             catalogPath: string,
+                             entryGroup?: string): CatalogLayout {
   switch (layout) {
     case Layouts.STANDARD:
       return new StandardLayout(catalogPath);
     case Layouts.DOCUMENTS:
       return new DocumentsLayout(catalogPath);
     case Layouts.SEMANTIC_MODEL:
-      return new SemanticModelLayout(catalogPath);
+      return new SemanticModelLayout(catalogPath, entryGroup);
     default:
       throw new Error(`Unknown layout type: ${layout}`);
   }

--- a/toolbox/mdcode/src/libts/layout.ts
+++ b/toolbox/mdcode/src/libts/layout.ts
@@ -9,7 +9,7 @@ import { SemanticModelLayout } from './layouts/semantic-model';
 export enum Layouts {
   STANDARD = 'standard',
   DOCUMENTS = 'documents',
-  SEMANTIC_MODEL = 'SemanticModel'
+  SEMANTIC_MODEL = 'semantic-model'
 }
 
 

--- a/toolbox/mdcode/src/libts/layouts/semantic-model.ts
+++ b/toolbox/mdcode/src/libts/layouts/semantic-model.ts
@@ -19,12 +19,14 @@ const SIDECAR_SUFFIXES = ['.aspects.yaml', '.overview.yaml'];
 
 export class SemanticModelLayout implements CatalogLayout {
   private readonly _catalogPath: string;
+  private readonly _entryGroup?: string;
 
   // Maps a model handle (the document's file basename) to its absolute path.
   private readonly _index = new Map<string, string>();
 
-  constructor(catalogPath: string) {
+  constructor(catalogPath: string, entryGroup?: string) {
     this._catalogPath = catalogPath;
+    this._entryGroup = entryGroup;
   }
 
   async init(): Promise<void> {
@@ -34,9 +36,16 @@ export class SemanticModelLayout implements CatalogLayout {
       return;
     }
 
-    // A model document is a top-level `<model>.yaml` under an EntryGroup dir,
-    // excluding the `.aspects.yaml` / `.overview.yaml` sidecars.
-    const matches = await glob.glob('EntryGroups/*/*.yaml', {
+    // A model document is a top-level `<model>.yaml` under the configured
+    // EntryGroup dir, excluding the `.aspects.yaml` / `.overview.yaml`
+    // sidecars. Scoping to the manifest's entryGroup keeps unrelated group
+    // directories out of the deploy set and avoids the basename collision that
+    // a cross-group `EntryGroups/*/*.yaml` glob would produce (same file name
+    // in two groups). Fall back to all groups only when no scope was provided.
+    const pattern = this._entryGroup ?
+        `EntryGroups/${this._entryGroup}/*.yaml` :
+        'EntryGroups/*/*.yaml';
+    const matches = await glob.glob(pattern, {
       cwd: this._catalogPath,
       absolute: true,
       nodir: true,
@@ -58,8 +67,13 @@ export class SemanticModelLayout implements CatalogLayout {
     return !!p && fs.existsSync(p);
   }
 
+  // This is a push-only layout: it exposes no per-entry Knowledge Catalog
+  // files, so it lists no entries. Returning model handles here would make
+  // callers that pair listEntries() with loadEntry() -- e.g. the MCP server --
+  // list a model and then throw on read. modelDocuments() is the sole accessor
+  // for the authored model documents.
   listEntries(): string[] {
-    return Array.from(this._index.keys());
+    return [];
   }
 
   // Reads the raw Ossie document text for each discovered model. This is the

--- a/toolbox/mdcode/src/libts/layouts/semantic-model.ts
+++ b/toolbox/mdcode/src/libts/layouts/semantic-model.ts
@@ -1,0 +1,94 @@
+// Implements the SemanticModel layout.
+//
+// The whole model definition is a single Apache Ossie document per model,
+// located at `catalog/EntryGroups/<entryGroupId>/<model>.yaml`. Optional
+// `.aspects.yaml` / `.overview.yaml` sidecars and nested entity/metric sidecars
+// are part of this layout's design but are a follow-on; this push-only
+// implementation discovers and reads the model documents and nothing else.
+//
+
+import * as glob from 'glob';
+import * as fs from 'node:fs';
+
+import {CatalogLayout} from '../layout';
+import * as md from '../metadata';
+
+// Sidecar suffixes that are NOT model documents.
+const SIDECAR_SUFFIXES = ['.aspects.yaml', '.overview.yaml'];
+
+
+export class SemanticModelLayout implements CatalogLayout {
+  private readonly _catalogPath: string;
+
+  // Maps a model handle (the document's file basename) to its absolute path.
+  private readonly _index = new Map<string, string>();
+
+  constructor(catalogPath: string) {
+    this._catalogPath = catalogPath;
+  }
+
+  async init(): Promise<void> {
+    this._index.clear();
+
+    if (!fs.existsSync(this._catalogPath)) {
+      return;
+    }
+
+    // A model document is a top-level `<model>.yaml` under an EntryGroup dir,
+    // excluding the `.aspects.yaml` / `.overview.yaml` sidecars.
+    const matches = await glob.glob('EntryGroups/*/*.yaml', {
+      cwd: this._catalogPath,
+      absolute: true,
+      nodir: true,
+    });
+
+    for (const localPath of matches) {
+      if (SIDECAR_SUFFIXES.some(s => localPath.endsWith(s))) {
+        continue;
+      }
+
+      const base = localPath.slice(localPath.lastIndexOf('/') + 1);
+      const name = base.slice(0, base.length - '.yaml'.length);
+      this._index.set(name, localPath);
+    }
+  }
+
+  entryExists(name: string): boolean {
+    const p = this._index.get(name);
+    return !!p && fs.existsSync(p);
+  }
+
+  listEntries(): string[] {
+    return Array.from(this._index.keys());
+  }
+
+  // Reads the raw Ossie document text for each discovered model. This is the
+  // seam the push path consumes; the Ossie text is parsed to the semantic IR by
+  // the loader, not mapped to a Knowledge Catalog entry here.
+  modelDocuments(): {name: string; text: string}[] {
+    const docs: {name: string; text: string}[] = [];
+    for (const [name, localPath] of this._index) {
+      docs.push({name, text: fs.readFileSync(localPath, 'utf8')});
+    }
+    return docs;
+  }
+
+  // The Knowledge Catalog entry-level members are not applicable to this
+  // push-only layout; the model is authored as a single Ossie document, not as
+  // per-entry Knowledge Catalog files. These are wired when KC-resource emit
+  // and semantic-model `pull` land.
+  async loadEntry(_name: string): Promise<md.Entry> {
+    throw new Error(
+        'The SemanticModel layout does not expose per-entry Knowledge Catalog files yet.');
+  }
+
+  async saveEntry(_name: string, _entry: md.Entry): Promise<void> {
+    throw new Error(
+        'The SemanticModel layout does not support writing per-entry files yet.');
+  }
+
+  async deleteEntry(_name: string): Promise<void> {
+    throw new Error(
+        'The SemanticModel layout does not support deleting per-entry files yet.');
+  }
+}

--- a/toolbox/mdcode/src/libts/layouts/semantic-model.ts
+++ b/toolbox/mdcode/src/libts/layouts/semantic-model.ts
@@ -9,6 +9,7 @@
 
 import * as glob from 'glob';
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import {CatalogLayout} from '../layout';
 import * as md from '../metadata';
@@ -56,15 +57,18 @@ export class SemanticModelLayout implements CatalogLayout {
         continue;
       }
 
-      const base = localPath.slice(localPath.lastIndexOf('/') + 1);
-      const name = base.slice(0, base.length - '.yaml'.length);
+      const name = path.basename(localPath, '.yaml');
       this._index.set(name, localPath);
     }
   }
 
-  entryExists(name: string): boolean {
-    const p = this._index.get(name);
-    return !!p && fs.existsSync(p);
+  // Consistent with listEntries(): this push-only layout exposes no per-entry
+  // Knowledge Catalog files, so no entry "exists" at the KC layer. Answering
+  // from _index (which holds model-document handles) would report an entry that
+  // listEntries() won't return and that loadEntry()/saveEntry() reject. The
+  // model documents are surfaced via modelDocuments(), not as entries.
+  entryExists(_name: string): boolean {
+    return false;
   }
 
   // This is a push-only layout: it exposes no per-entry Knowledge Catalog

--- a/toolbox/mdcode/src/libts/manifest.ts
+++ b/toolbox/mdcode/src/libts/manifest.ts
@@ -66,6 +66,11 @@ export class CatalogManifest {
     return new CatalogManifest(source);
   }
 
+  static async initWithSemanticModel(name: string, ctx: gcp.ApiContext): Promise<CatalogManifest> {
+    const source = await createSource(Sources.SEMANTIC_MODEL, name, ctx);
+    return new CatalogManifest(source);
+  }
+
   static async load(path: string, ctx: gcp.ApiContext): Promise<CatalogManifest> {
     const content = fs.readFileSync(path, 'utf8');
     const parsed = yaml.parse(content);

--- a/toolbox/mdcode/src/libts/semantic/deploy.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy.ts
@@ -8,6 +8,10 @@
 // The Knowledge Catalog resource emit (entries + entryLinks) for the semantic
 // model is a follow-on; `push` currently deploys only the BigQuery Graph.
 //
+// This is a library module: it emits no console output. The generated DDL and
+// any loader/generator warnings are returned in `DeployResult` for the CLI
+// (src/tool/commands.ts) to print.
+//
 
 import {ApiResult} from '../gcp/api';
 import {BigQueryClient, QueryResponse} from '../gcp/bigquery';
@@ -23,8 +27,12 @@ const GOOGLE_VENDOR = 'GOOGLE';
 
 // A BigQuery Graph deployment target, e.g.
 // //bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>
+// The capture groups are restricted to valid BigQuery identifier characters:
+// the components are interpolated into DDL unescaped (see qualifyGraph), so a
+// permissive `[^/]+` would let backticks or semicolons through. Malformed URIs
+// fail the match and are reported rather than producing broken DDL downstream.
 const BQ_GRAPH_TARGET =
-    /^\/\/bigquery\.googleapis\.com\/projects\/([^/]+)\/datasets\/([^/]+)\/propertyGraphs\/([^/]+)$/;
+    /^\/\/bigquery\.googleapis\.com\/projects\/([A-Za-z0-9_-]+)\/datasets\/([A-Za-z0-9_-]+)\/propertyGraphs\/([A-Za-z0-9_-]+)$/;
 
 
 export interface BigQueryGraphTarget {
@@ -42,6 +50,14 @@ export interface DeployOptions {
 export interface DeployResult {
   success: boolean;
   details?: string;
+  // Generated DDL, one entry per target (each prefixed with a `-- <uri>`
+  // comment), in deploy order. Populated even for validateOnly, where nothing
+  // is executed, so the caller can print or inspect it.
+  ddl: string[];
+  // Loader and generator warnings collected across all documents.
+  warnings: string[];
+  // Number of graphs actually executed against BigQuery (0 for validateOnly).
+  deployed: number;
 }
 
 
@@ -86,6 +102,15 @@ export function bigQueryGraphTargets(model: SemanticModel):
 // reports completion (each poll long-polls the server for up to 10s).
 const MAX_QUERY_POLLS = 30;
 
+// Pause between polls. getQueryResults long-polls server-side, so this is a
+// backstop for the case where it returns promptly (which would otherwise fire
+// MAX_QUERY_POLLS requests back-to-back with no pause).
+const POLL_BACKOFF_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 
 // Waits for a jobs.query response to reach completion and reports any terminal
 // error. jobs.query can return before a slow DDL statement finishes; in that
@@ -105,6 +130,9 @@ async function awaitQueryDone(
 
   let polls = 0;
   while (result?.jobComplete === false && jobId && polls < MAX_QUERY_POLLS) {
+    if (polls > 0) {
+      await sleep(POLL_BACKOFF_MS);
+    }
     polls++;
     const res = await bigQuery.getQueryResults(project, jobId, location);
     if (res.status !== 200) {
@@ -114,10 +142,14 @@ async function awaitQueryDone(
   }
 
   if (result?.jobComplete === false) {
+    // Distinguish "polled to exhaustion" from "never had a job to poll": with
+    // no jobId the loop above ran zero times, so a "did not complete after N
+    // polls" message would be misleading.
     return {
       ok: false,
-      error: `job ${jobId ?? '(unknown)'} did not complete after ${
-          MAX_QUERY_POLLS} polls`,
+      error: jobId ?
+          `job ${jobId} did not complete after ${MAX_QUERY_POLLS} polls` :
+          'query did not complete and returned no job reference to poll',
     };
   }
 
@@ -142,39 +174,62 @@ async function awaitQueryDone(
 }
 
 
-// Deploys the BigQuery Graph for each authored model document.
+// Best-effort lookup of a dataset's BigQuery location so the query job, its
+// result polls, and the job lookup all agree on a region. jobs.query would
+// otherwise infer the location from the referenced tables, which can pick the
+// wrong region for a non-US dataset. Returns undefined (let BigQuery infer) if
+// the dataset can't be read.
+async function datasetLocation(
+    bigQuery: BigQueryClient,
+    target: BigQueryGraphTarget): Promise<string|undefined> {
+  const res = await bigQuery.getDataset(target.project, target.dataset);
+  return res.status === 200 ? res.result?.location : undefined;
+}
+
+
+// Deploys the BigQuery Graph for each authored model document. Emits no console
+// output; the generated DDL and any warnings are returned for the caller to
+// print.
 export async function deployBigQuery(
     docs: {name: string; text: string}[], ctx: context.ApiContext,
     options: DeployOptions = {}): Promise<DeployResult> {
   const bigQuery = new BigQueryClient(ctx);
+  const ddl: string[] = [];
+  const warnings: string[] = [];
   let deployed = 0;
   let modelsSeen = 0;
 
+  const fail = (details: string): DeployResult =>
+      ({success: false, details, ddl, warnings, deployed});
+
   for (const doc of docs) {
-    const {models, warnings} =
-        loadModels(doc.text, {defaultProject: ctx.project});
-    for (const w of warnings) {
-      console.warn(`Warning [${doc.name}]: ${w}`);
+    // A document that fails to parse (or violates the model schema) is an
+    // authoring error. Report it against the specific document rather than
+    // letting the loader's exception propagate as an uncaught stack trace, and
+    // name the document so a bad file in a multi-document push is identifiable.
+    let loaded;
+    try {
+      loaded = loadModels(doc.text, {defaultProject: ctx.project});
+    } catch (err: any) {
+      return fail(`Model document '${doc.name}': ${err.message || err}`);
+    }
+    for (const w of loaded.warnings) {
+      warnings.push(`[${doc.name}] ${w}`);
     }
 
-    for (const model of models) {
+    for (const model of loaded.models) {
       modelsSeen++;
       let targets: BigQueryGraphTarget[];
       try {
         targets = bigQueryGraphTargets(model);
       } catch (err: any) {
-        return {
-          success: false,
-          details: `Model '${model.name}' (${doc.name}): ${err.message || err}`,
-        };
+        return fail(
+            `Model '${model.name}' (${doc.name}): ${err.message || err}`);
       }
       if (!targets.length) {
-        return {
-          success: false,
-          details: `Model '${model.name}' (${
-                       doc.name}) declares no BigQuery Graph ` +
-              `deploymentTarget in a GOOGLE custom_extension; nothing to deploy.`,
-        };
+        return fail(
+            `Model '${model.name}' (${doc.name}) declares no BigQuery Graph ` +
+            `deploymentTarget in a GOOGLE custom_extension; nothing to deploy.`);
       }
 
       for (const target of targets) {
@@ -184,23 +239,27 @@ export async function deployBigQuery(
           graphName: target.graphName,
         });
         for (const w of gen.warnings) {
-          console.warn(`Warning [${model.name} -> ${target.graphName}]: ${w}`);
+          warnings.push(`[${model.name} -> ${target.graphName}] ${w}`);
         }
+        ddl.push(`-- ${target.uri}\n${gen.ddl}`);
 
         if (options.validateOnly) {
-          console.log(`-- ${target.uri}\n${gen.ddl}\n`);
           continue;
         }
 
-        console.log(`Deploying BigQuery Graph ${target.project}.${
-            target.dataset}.${target.graphName} ...`);
-        const started = await bigQuery.query(target.project, gen.ddl);
+        const location = await datasetLocation(bigQuery, target);
+        const started = await bigQuery.query(target.project, gen.ddl, location);
         const outcome = await awaitQueryDone(bigQuery, target.project, started);
         if (!outcome.ok) {
-          return {
-            success: false,
-            details: `Failed to deploy '${target.graphName}': ${outcome.error}`,
-          };
+          // These are CREATE OR REPLACE statements executed one at a time, so
+          // any graphs already deployed in this run have mutated production and
+          // are not rolled back. Surface that alongside the failing target.
+          const partial = deployed ?
+              ` (${deployed} graph(s) already deployed in this run; ` +
+                  `CREATE OR REPLACE changes are not rolled back)` :
+              '';
+          return fail(`Failed to deploy '${target.graphName}': ${
+              outcome.error}${partial}`);
         }
 
         deployed++;
@@ -208,22 +267,13 @@ export async function deployBigQuery(
     }
   }
 
+  // A parsed document always yields at least one model (the loader enforces
+  // `semantic_model` min 1), so modelsSeen is 0 only when no documents were
+  // found at all.
   if (!modelsSeen) {
-    return {
-      success: false,
-      details: docs.length ?
-          'No semantic models were parsed from the authored document(s); nothing to deploy.' :
-          'No semantic model documents found under catalog/EntryGroups/*/; nothing to deploy.',
-    };
+    return fail(
+        'No semantic model documents found under catalog/EntryGroups/*/; nothing to deploy.');
   }
 
-  if (options.validateOnly) {
-    console.log('Validation complete; no changes applied.');
-  } else {
-    console.log(
-        `Deployed ${deployed} BigQuery Graph(s). ` +
-        `Knowledge Catalog resource emit for the semantic model is not yet implemented.`);
-  }
-
-  return {success: true};
+  return {success: true, ddl, warnings, deployed};
 }

--- a/toolbox/mdcode/src/libts/semantic/deploy.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy.ts
@@ -36,10 +36,15 @@ const GOOGLE_VENDOR = 'GOOGLE';
 const BQ_GRAPH_TARGET =
     /^\/\/bigquery\.googleapis\.com\/projects\/([A-Za-z0-9_-]+)\/datasets\/([A-Za-z0-9_-]+)\/propertyGraphs\/([A-Za-z0-9_-]+)$/;
 
-// Prefix a deployment target must carry to be treated as a (possibly malformed)
-// BigQuery Graph URI rather than an unrelated destination (e.g. a Dataplex
-// URI).
-const BQ_GRAPH_URI_PREFIX = '//bigquery.googleapis.com/';
+// A deployment target that "looks like" a BigQuery Graph URI but fails the
+// strict match above: it carries the bigquery.googleapis host (even under a
+// typo'd scheme such as `https://`, or a truncated host missing `.com`) or the
+// graph-specific `/propertyGraph(s)/` path segment. Such a URI is reported as
+// malformed (see bigQueryGraphTargets) rather than silently dropped, so a
+// host/scheme/segment/identifier typo surfaces instead of being misreported as
+// "no target declared". An unrelated destination (e.g. a Dataplex URI) matches
+// neither this hint nor the strict form and is left alone.
+const BQ_GRAPH_TARGET_HINT = /bigquery\.googleapis|\/propertyGraphs?\//;
 
 
 export interface BigQueryGraphTarget {
@@ -107,9 +112,10 @@ export function bigQueryGraphTargets(model: SemanticModel):
       const m = uri.match(BQ_GRAPH_TARGET);
       if (m) {
         targets.push({project: m[1], dataset: m[2], graphName: m[3], uri});
-      } else if (uri.startsWith(BQ_GRAPH_URI_PREFIX)) {
-        // Looks like a BigQuery Graph target but doesn't parse; a plain
-        // Dataplex/other URI is not our concern and is left alone.
+      } else if (BQ_GRAPH_TARGET_HINT.test(uri)) {
+        // Looks like a BigQuery Graph target but doesn't parse (host, scheme,
+        // path-segment, or identifier-char typo); a plain Dataplex/other URI is
+        // not our concern and is left alone.
         malformed.push(uri);
       }
     }
@@ -147,6 +153,16 @@ async function awaitQueryDone(
   }
 
   let result = started.result;
+  // A 200 with no body is not a verified success: without jobComplete/errors we
+  // cannot confirm the DDL ran, so treat the missing body as a failure rather
+  // than falling through to the `{ok: true}` return below.
+  if (!result) {
+    return {
+      ok: false,
+      error:
+          started.message || 'query returned status 200 with no response body',
+    };
+  }
   const jobId = result?.jobReference?.jobId;
   const location = result?.jobReference?.location;
 
@@ -205,10 +221,12 @@ async function awaitQueryDone(
 // target would otherwise surface later as a murkier DDL error, so we fail fast
 // on it. Other failures (e.g. a 403 when the caller lacks
 // bigquery.datasets.get) are non-fatal: fall back to letting BigQuery infer the
-// location.
+// location, but record a warning so the degraded path is visible -- otherwise a
+// silent fallback can route a non-US CREATE to the wrong region and fail later
+// with an opaque location error.
 async function datasetLocation(
-    bigQuery: BigQueryClient,
-    target: BigQueryGraphTarget): Promise<string|undefined> {
+    bigQuery: BigQueryClient, target: BigQueryGraphTarget,
+    warnings: string[]): Promise<string|undefined> {
   const res = await bigQuery.getDataset(target.project, target.dataset);
   if (res.status === 200) {
     return res.result?.location;
@@ -216,6 +234,10 @@ async function datasetLocation(
   if (res.status === 404) {
     throw new Error(`dataset ${target.project}.${target.dataset} not found`);
   }
+  warnings.push(
+      `could not read location of dataset ${target.project}.${
+          target.dataset} (${res.message || res.status}); ` +
+      `letting BigQuery infer the query location`);
   return undefined;
 }
 
@@ -223,9 +245,17 @@ async function datasetLocation(
 // Deploys the BigQuery Graph for each authored model document. Emits no console
 // output; the generated DDL and any warnings are returned for the caller to
 // print.
+//
+// `defaultProject` qualifies a dataset `source` that omits its project. The
+// caller should pass the scope's declared project (a deterministic,
+// user-authored value) rather than relying on the ambient gcloud project, which
+// can silently drift away from where the model's tables live. It cannot default
+// to each deployment target's own project: a document is parsed once, before
+// its targets are known, and may declare several graphs across projects.
 export async function deployBigQuery(
     docs: {name: string; text: string}[], ctx: context.ApiContext,
-    options: DeployOptions = {}): Promise<DeployResult> {
+    options: DeployOptions = {},
+    defaultProject?: string): Promise<DeployResult> {
   const bigQuery = new BigQueryClient(ctx);
   const ddl: string[] = [];
   const warnings: string[] = [];
@@ -247,7 +277,7 @@ export async function deployBigQuery(
     if (locationCache.has(key)) {
       return locationCache.get(key);
     }
-    const loc = await datasetLocation(bigQuery, target);
+    const loc = await datasetLocation(bigQuery, target, warnings);
     locationCache.set(key, loc);
     return loc;
   };
@@ -259,7 +289,8 @@ export async function deployBigQuery(
     // name the document so a bad file in a multi-document push is identifiable.
     let loaded;
     try {
-      loaded = loadModels(doc.text, {defaultProject: ctx.project});
+      loaded =
+          loadModels(doc.text, {defaultProject: defaultProject ?? ctx.project});
     } catch (err: any) {
       return fail(`Model document '${doc.name}': ${err.message || err}`);
     }
@@ -343,8 +374,14 @@ export async function deployBigQuery(
 
   // A parsed document always yields at least one model (the loader enforces
   // `semantic_model` min 1), so modelsSeen is 0 only when no documents were
-  // found at all.
+  // found at all. validateOnly mutates nothing, so an empty workspace is a
+  // clean no-op there (exit 0); a real push treats "nothing to deploy" as a
+  // configuration error worth flagging.
   if (!modelsSeen) {
+    if (options.validateOnly) {
+      warnings.push('No semantic model documents found; nothing to validate.');
+      return {success: true, ddl, warnings, deployed};
+    }
     return fail('No semantic model documents found; nothing to deploy.');
   }
 

--- a/toolbox/mdcode/src/libts/semantic/deploy.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy.ts
@@ -9,7 +9,8 @@
 // model is a follow-on; `push` currently deploys only the BigQuery Graph.
 //
 
-import {BigQueryClient} from '../gcp/bigquery';
+import {ApiResult} from '../gcp/api';
+import {BigQueryClient, QueryResponse} from '../gcp/bigquery';
 import * as context from '../gcp/context';
 
 import {generatePropertyGraph} from './bigquery';
@@ -81,12 +82,69 @@ export function bigQueryGraphTargets(model: SemanticModel):
 }
 
 
+// Upper bound on getQueryResults polls before we give up on a job that never
+// reports completion (each poll long-polls the server for up to 10s).
+const MAX_QUERY_POLLS = 30;
+
+
+// Waits for a jobs.query response to reach completion and reports any terminal
+// error. jobs.query can return before a slow DDL statement finishes; in that
+// case the response carries `jobComplete: false` and a job reference, and we
+// poll getQueryResults until the job is done. Errors are only judged once the
+// job has actually completed.
+async function awaitQueryDone(
+    bigQuery: BigQueryClient, project: string,
+    started: ApiResult<QueryResponse>): Promise<{ok: boolean; error?: string}> {
+  if (started.status !== 200) {
+    return {ok: false, error: started.message || String(started.status)};
+  }
+
+  let result = started.result;
+  const jobId = result?.jobReference?.jobId;
+  const location = result?.jobReference?.location;
+
+  let polls = 0;
+  while (result?.jobComplete === false && jobId && polls < MAX_QUERY_POLLS) {
+    polls++;
+    const res = await bigQuery.getQueryResults(project, jobId, location);
+    if (res.status !== 200) {
+      return {ok: false, error: res.message || String(res.status)};
+    }
+    result = res.result;
+  }
+
+  if (result?.jobComplete === false) {
+    return {
+      ok: false,
+      error: `job ${jobId ?? '(unknown)'} did not complete after ${
+          MAX_QUERY_POLLS} polls`,
+    };
+  }
+
+  const errors = result?.errors;
+  if (errors && errors.length) {
+    return {ok: false, error: errors.map(e => e.message).join('; ')};
+  }
+
+  return {ok: true};
+}
+
+
 // Deploys the BigQuery Graph for each authored model document.
 export async function deployBigQuery(
     docs: {name: string; text: string}[], ctx: context.ApiContext,
     options: DeployOptions = {}): Promise<DeployResult> {
   const bigQuery = new BigQueryClient(ctx);
   let deployed = 0;
+  let modelsSeen = 0;
+
+  if (!docs.length) {
+    return {
+      success: false,
+      details:
+          'No semantic model documents found under catalog/EntryGroups/*/; nothing to deploy.',
+    };
+  }
 
   for (const doc of docs) {
     const {models, warnings} =
@@ -96,7 +154,16 @@ export async function deployBigQuery(
     }
 
     for (const model of models) {
-      const targets = bigQueryGraphTargets(model);
+      modelsSeen++;
+      let targets: BigQueryGraphTarget[];
+      try {
+        targets = bigQueryGraphTargets(model);
+      } catch (err: any) {
+        return {
+          success: false,
+          details: `Model '${model.name}' (${doc.name}): ${err.message || err}`,
+        };
+      }
       if (!targets.length) {
         return {
           success: false,
@@ -123,27 +190,26 @@ export async function deployBigQuery(
 
         console.log(`Deploying BigQuery Graph ${target.project}.${
             target.dataset}.${target.graphName} ...`);
-        const res = await bigQuery.query(target.project, gen.ddl);
-        if (res.status !== 200) {
+        const started = await bigQuery.query(target.project, gen.ddl);
+        const outcome = await awaitQueryDone(bigQuery, target.project, started);
+        if (!outcome.ok) {
           return {
             success: false,
-            details: `Failed to deploy '${target.graphName}': ${
-                res.message || res.status}`,
-          };
-        }
-
-        const errors = res.result?.errors;
-        if (errors && errors.length) {
-          return {
-            success: false,
-            details: `Failed to deploy '${target.graphName}': ` +
-                errors.map(e => e.message).join('; '),
+            details: `Failed to deploy '${target.graphName}': ${outcome.error}`,
           };
         }
 
         deployed++;
       }
     }
+  }
+
+  if (!modelsSeen) {
+    return {
+      success: false,
+      details:
+          'No semantic models were parsed from the authored document(s); nothing to deploy.',
+    };
   }
 
   if (options.validateOnly) {

--- a/toolbox/mdcode/src/libts/semantic/deploy.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy.ts
@@ -29,10 +29,17 @@ const GOOGLE_VENDOR = 'GOOGLE';
 // //bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>
 // The capture groups are restricted to valid BigQuery identifier characters:
 // the components are interpolated into DDL unescaped (see qualifyGraph), so a
-// permissive `[^/]+` would let backticks or semicolons through. Malformed URIs
-// fail the match and are reported rather than producing broken DDL downstream.
+// permissive `[^/]+` would let backticks or semicolons through. A URI that
+// carries the BigQuery Graph prefix but fails this full match is collected as
+// `malformed` (see bigQueryGraphTargets) and named in the deploy error, rather
+// than being silently skipped and later misreported as "no target declared".
 const BQ_GRAPH_TARGET =
     /^\/\/bigquery\.googleapis\.com\/projects\/([A-Za-z0-9_-]+)\/datasets\/([A-Za-z0-9_-]+)\/propertyGraphs\/([A-Za-z0-9_-]+)$/;
+
+// Prefix a deployment target must carry to be treated as a (possibly malformed)
+// BigQuery Graph URI rather than an unrelated destination (e.g. a Dataplex
+// URI).
+const BQ_GRAPH_URI_PREFIX = '//bigquery.googleapis.com/';
 
 
 export interface BigQueryGraphTarget {
@@ -43,8 +50,12 @@ export interface BigQueryGraphTarget {
 }
 
 export interface DeployOptions {
-  force?: boolean;
   validateOnly?: boolean;
+  // Poll bounds for a slow query job, overridable so tests can exercise the
+  // exhaustion path without burning wall-clock. Default to the module
+  // constants.
+  maxQueryPolls?: number;
+  pollBackoffMs?: number;
 }
 
 export interface DeployResult {
@@ -65,8 +76,11 @@ export interface DeployResult {
 // custom extension. The extension `data` is an opaque, vendor-serialized JSON
 // string (the loader keeps it verbatim); we own its `deploymentTargets` shape.
 export function bigQueryGraphTargets(model: SemanticModel):
-    BigQueryGraphTarget[] {
+    {targets: BigQueryGraphTarget[]; malformed: string[]} {
   const targets: BigQueryGraphTarget[] = [];
+  // BigQuery-prefixed URIs that failed the strict match (typo, bad identifier
+  // char). Kept so the caller can name them instead of silently skipping.
+  const malformed: string[] = [];
 
   for (const ext of model.customExtensions ?? []) {
     if (ext.vendorName !== GOOGLE_VENDOR) {
@@ -87,14 +101,21 @@ export function bigQueryGraphTargets(model: SemanticModel):
     }
 
     for (const uri of uris) {
-      const m = typeof uri === 'string' ? uri.match(BQ_GRAPH_TARGET) : null;
+      if (typeof uri !== 'string') {
+        continue;
+      }
+      const m = uri.match(BQ_GRAPH_TARGET);
       if (m) {
         targets.push({project: m[1], dataset: m[2], graphName: m[3], uri});
+      } else if (uri.startsWith(BQ_GRAPH_URI_PREFIX)) {
+        // Looks like a BigQuery Graph target but doesn't parse; a plain
+        // Dataplex/other URI is not our concern and is left alone.
+        malformed.push(uri);
       }
     }
   }
 
-  return targets;
+  return {targets, malformed};
 }
 
 
@@ -119,7 +140,8 @@ function sleep(ms: number): Promise<void> {
 // job has actually completed.
 async function awaitQueryDone(
     bigQuery: BigQueryClient, project: string,
-    started: ApiResult<QueryResponse>): Promise<{ok: boolean; error?: string}> {
+    started: ApiResult<QueryResponse>, maxPolls: number,
+    backoffMs: number): Promise<{ok: boolean; error?: string}> {
   if (started.status !== 200) {
     return {ok: false, error: started.message || String(started.status)};
   }
@@ -129,9 +151,9 @@ async function awaitQueryDone(
   const location = result?.jobReference?.location;
 
   let polls = 0;
-  while (result?.jobComplete === false && jobId && polls < MAX_QUERY_POLLS) {
+  while (result?.jobComplete === false && jobId && polls < maxPolls) {
     if (polls > 0) {
-      await sleep(POLL_BACKOFF_MS);
+      await sleep(backoffMs);
     }
     polls++;
     const res = await bigQuery.getQueryResults(project, jobId, location);
@@ -148,7 +170,7 @@ async function awaitQueryDone(
     return {
       ok: false,
       error: jobId ?
-          `job ${jobId} did not complete after ${MAX_QUERY_POLLS} polls` :
+          `job ${jobId} did not complete after ${maxPolls} polls` :
           'query did not complete and returned no job reference to poll',
     };
   }
@@ -174,16 +196,27 @@ async function awaitQueryDone(
 }
 
 
-// Best-effort lookup of a dataset's BigQuery location so the query job, its
-// result polls, and the job lookup all agree on a region. jobs.query would
-// otherwise infer the location from the referenced tables, which can pick the
-// wrong region for a non-US dataset. Returns undefined (let BigQuery infer) if
-// the dataset can't be read.
+// Looks up a dataset's BigQuery location so the query job, its result polls,
+// and the job lookup all agree on a region. jobs.query would otherwise infer
+// the location from the referenced tables, which can pick the wrong region for
+// a non-US dataset.
+//
+// A 404 is a precise, free pre-flight: a typo'd dataset in the deployment
+// target would otherwise surface later as a murkier DDL error, so we fail fast
+// on it. Other failures (e.g. a 403 when the caller lacks
+// bigquery.datasets.get) are non-fatal: fall back to letting BigQuery infer the
+// location.
 async function datasetLocation(
     bigQuery: BigQueryClient,
     target: BigQueryGraphTarget): Promise<string|undefined> {
   const res = await bigQuery.getDataset(target.project, target.dataset);
-  return res.status === 200 ? res.result?.location : undefined;
+  if (res.status === 200) {
+    return res.result?.location;
+  }
+  if (res.status === 404) {
+    throw new Error(`dataset ${target.project}.${target.dataset} not found`);
+  }
+  return undefined;
 }
 
 
@@ -201,6 +234,23 @@ export async function deployBigQuery(
 
   const fail = (details: string): DeployResult =>
       ({success: false, details, ddl, warnings, deployed});
+
+  const maxPolls = options.maxQueryPolls ?? MAX_QUERY_POLLS;
+  const backoffMs = options.pollBackoffMs ?? POLL_BACKOFF_MS;
+
+  // A model can declare several graphs in one dataset; cache the location so we
+  // issue one datasets.get per dataset rather than one per target.
+  const locationCache = new Map<string, string|undefined>();
+  const locationFor =
+      async(target: BigQueryGraphTarget): Promise<string|undefined> => {
+    const key = `${target.project}/${target.dataset}`;
+    if (locationCache.has(key)) {
+      return locationCache.get(key);
+    }
+    const loc = await datasetLocation(bigQuery, target);
+    locationCache.set(key, loc);
+    return loc;
+  };
 
   for (const doc of docs) {
     // A document that fails to parse (or violates the model schema) is an
@@ -220,16 +270,33 @@ export async function deployBigQuery(
     for (const model of loaded.models) {
       modelsSeen++;
       let targets: BigQueryGraphTarget[];
+      let malformed: string[];
       try {
-        targets = bigQueryGraphTargets(model);
+        ({targets, malformed} = bigQueryGraphTargets(model));
       } catch (err: any) {
         return fail(
             `Model '${model.name}' (${doc.name}): ${err.message || err}`);
       }
       if (!targets.length) {
+        // A malformed-but-present target must not be reported as "none
+        // declared" -- that sends the author hunting for an extension they
+        // already wrote. Name the URIs that failed to parse.
+        if (malformed.length) {
+          return fail(
+              `Model '${model.name}' (${doc.name}) declares BigQuery Graph ` +
+              `deploymentTarget(s) that could not be parsed: ` +
+              `${malformed.join(', ')}. Expected //bigquery.googleapis.com/` +
+              `projects/<p>/datasets/<d>/propertyGraphs/<g>.`);
+        }
         return fail(
             `Model '${model.name}' (${doc.name}) declares no BigQuery Graph ` +
             `deploymentTarget in a GOOGLE custom_extension; nothing to deploy.`);
+      }
+      // Malformed targets alongside valid ones: surface them so a typo'd URI is
+      // not silently dropped when the deploy otherwise succeeds.
+      for (const bad of malformed) {
+        warnings.push(`[${
+            model.name}] ignoring unparseable BigQuery Graph target: ${bad}`);
       }
 
       for (const target of targets) {
@@ -247,9 +314,16 @@ export async function deployBigQuery(
           continue;
         }
 
-        const location = await datasetLocation(bigQuery, target);
+        let location: string|undefined;
+        try {
+          location = await locationFor(target);
+        } catch (err: any) {
+          return fail(
+              `Failed to deploy '${target.graphName}': ${err.message || err}`);
+        }
         const started = await bigQuery.query(target.project, gen.ddl, location);
-        const outcome = await awaitQueryDone(bigQuery, target.project, started);
+        const outcome = await awaitQueryDone(
+            bigQuery, target.project, started, maxPolls, backoffMs);
         if (!outcome.ok) {
           // These are CREATE OR REPLACE statements executed one at a time, so
           // any graphs already deployed in this run have mutated production and
@@ -271,8 +345,7 @@ export async function deployBigQuery(
   // `semantic_model` min 1), so modelsSeen is 0 only when no documents were
   // found at all.
   if (!modelsSeen) {
-    return fail(
-        'No semantic model documents found under catalog/EntryGroups/*/; nothing to deploy.');
+    return fail('No semantic model documents found; nothing to deploy.');
   }
 
   return {success: true, ddl, warnings, deployed};

--- a/toolbox/mdcode/src/libts/semantic/deploy.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy.ts
@@ -121,8 +121,20 @@ async function awaitQueryDone(
     };
   }
 
+  // errors[] mixes fatal errors and non-fatal warnings. When it is populated,
+  // consult the job's status.errorResult -- the definitive fatal signal -- so a
+  // deploy that only produced warnings is not reported as a failure.
   const errors = result?.errors;
   if (errors && errors.length) {
+    if (jobId) {
+      const job = await bigQuery.getJob(project, jobId, location);
+      if (job.status !== 200) {
+        return {ok: false, error: job.message || String(job.status)};
+      }
+      const fatal = job.result?.status?.errorResult;
+      return fatal ? {ok: false, error: fatal.message} : {ok: true};
+    }
+    // No job reference to disambiguate; treat the errors as fatal.
     return {ok: false, error: errors.map(e => e.message).join('; ')};
   }
 
@@ -137,14 +149,6 @@ export async function deployBigQuery(
   const bigQuery = new BigQueryClient(ctx);
   let deployed = 0;
   let modelsSeen = 0;
-
-  if (!docs.length) {
-    return {
-      success: false,
-      details:
-          'No semantic model documents found under catalog/EntryGroups/*/; nothing to deploy.',
-    };
-  }
 
   for (const doc of docs) {
     const {models, warnings} =
@@ -207,8 +211,9 @@ export async function deployBigQuery(
   if (!modelsSeen) {
     return {
       success: false,
-      details:
-          'No semantic models were parsed from the authored document(s); nothing to deploy.',
+      details: docs.length ?
+          'No semantic models were parsed from the authored document(s); nothing to deploy.' :
+          'No semantic model documents found under catalog/EntryGroups/*/; nothing to deploy.',
     };
   }
 

--- a/toolbox/mdcode/src/libts/semantic/deploy.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy.ts
@@ -1,0 +1,158 @@
+// Deploys a semantic model's BigQuery Graph.
+//
+// This is the BigQuery leg of `kcmd push` for the semantic-model scope: it
+// parses each authored Ossie document into the semantic IR (loader), lowers it
+// to `CREATE OR REPLACE PROPERTY GRAPH` DDL (generator), and executes that DDL
+// against the BigQuery project named by the model's GOOGLE deployment target.
+//
+// The Knowledge Catalog resource emit (entries + entryLinks) for the semantic
+// model is a follow-on; `push` currently deploys only the BigQuery Graph.
+//
+
+import {BigQueryClient} from '../gcp/bigquery';
+import * as context from '../gcp/context';
+
+import {generatePropertyGraph} from './bigquery';
+import {SemanticModel} from './ir';
+import {loadModels} from './loader';
+
+
+// Our own vendor tag in the Ossie `custom_extensions` list.
+const GOOGLE_VENDOR = 'GOOGLE';
+
+// A BigQuery Graph deployment target, e.g.
+// //bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>
+const BQ_GRAPH_TARGET =
+    /^\/\/bigquery\.googleapis\.com\/projects\/([^/]+)\/datasets\/([^/]+)\/propertyGraphs\/([^/]+)$/;
+
+
+export interface BigQueryGraphTarget {
+  project: string;
+  dataset: string;
+  graphName: string;
+  uri: string;
+}
+
+export interface DeployOptions {
+  force?: boolean;
+  validateOnly?: boolean;
+}
+
+export interface DeployResult {
+  success: boolean;
+  details?: string;
+}
+
+
+// Extracts the BigQuery Graph deployment targets from a model's GOOGLE
+// custom extension. The extension `data` is an opaque, vendor-serialized JSON
+// string (the loader keeps it verbatim); we own its `deploymentTargets` shape.
+export function bigQueryGraphTargets(model: SemanticModel):
+    BigQueryGraphTarget[] {
+  const targets: BigQueryGraphTarget[] = [];
+
+  for (const ext of model.customExtensions ?? []) {
+    if (ext.vendorName !== GOOGLE_VENDOR) {
+      continue;
+    }
+
+    let data: any;
+    try {
+      data = JSON.parse(ext.data);
+    } catch {
+      throw new Error(`Model '${
+          model.name}': GOOGLE custom_extension 'data' is not valid JSON.`);
+    }
+
+    const uris = data?.deploymentTargets;
+    if (!Array.isArray(uris)) {
+      continue;
+    }
+
+    for (const uri of uris) {
+      const m = typeof uri === 'string' ? uri.match(BQ_GRAPH_TARGET) : null;
+      if (m) {
+        targets.push({project: m[1], dataset: m[2], graphName: m[3], uri});
+      }
+    }
+  }
+
+  return targets;
+}
+
+
+// Deploys the BigQuery Graph for each authored model document.
+export async function deployBigQuery(
+    docs: {name: string; text: string}[], ctx: context.ApiContext,
+    options: DeployOptions = {}): Promise<DeployResult> {
+  const bigQuery = new BigQueryClient(ctx);
+  let deployed = 0;
+
+  for (const doc of docs) {
+    const {models, warnings} =
+        loadModels(doc.text, {defaultProject: ctx.project});
+    for (const w of warnings) {
+      console.warn(`Warning [${doc.name}]: ${w}`);
+    }
+
+    for (const model of models) {
+      const targets = bigQueryGraphTargets(model);
+      if (!targets.length) {
+        return {
+          success: false,
+          details: `Model '${model.name}' (${
+                       doc.name}) declares no BigQuery Graph ` +
+              `deploymentTarget in a GOOGLE custom_extension; nothing to deploy.`,
+        };
+      }
+
+      for (const target of targets) {
+        const gen = generatePropertyGraph(model, {
+          project: target.project,
+          dataset: target.dataset,
+          graphName: target.graphName,
+        });
+        for (const w of gen.warnings) {
+          console.warn(`Warning [${model.name} -> ${target.graphName}]: ${w}`);
+        }
+
+        if (options.validateOnly) {
+          console.log(`-- ${target.uri}\n${gen.ddl}\n`);
+          continue;
+        }
+
+        console.log(`Deploying BigQuery Graph ${target.project}.${
+            target.dataset}.${target.graphName} ...`);
+        const res = await bigQuery.query(target.project, gen.ddl);
+        if (res.status !== 200) {
+          return {
+            success: false,
+            details: `Failed to deploy '${target.graphName}': ${
+                res.message || res.status}`,
+          };
+        }
+
+        const errors = res.result?.errors;
+        if (errors && errors.length) {
+          return {
+            success: false,
+            details: `Failed to deploy '${target.graphName}': ` +
+                errors.map(e => e.message).join('; '),
+          };
+        }
+
+        deployed++;
+      }
+    }
+  }
+
+  if (options.validateOnly) {
+    console.log('Validation complete; no changes applied.');
+  } else {
+    console.log(
+        `Deployed ${deployed} BigQuery Graph(s). ` +
+        `Knowledge Catalog resource emit for the semantic model is not yet implemented.`);
+  }
+
+  return {success: true};
+}

--- a/toolbox/mdcode/src/libts/snapshot.ts
+++ b/toolbox/mdcode/src/libts/snapshot.ts
@@ -51,6 +51,10 @@ export class CatalogSnapshot {
     return this._aspectTypes;
   }
 
+  get layout(): CatalogLayout {
+    return this._layout;
+  }
+
   // Retrieves the list of locally (pulled and/or created) managed entries
   async listEntries(): Promise<string[]> {
     return this._layout.listEntries();

--- a/toolbox/mdcode/src/libts/snapshot.ts
+++ b/toolbox/mdcode/src/libts/snapshot.ts
@@ -26,7 +26,8 @@ export class CatalogSnapshot {
     this.manifest = manifest;
 
     const catalogPath = path.join(this.basePath, 'catalog');
-    this._layout = createLayout(manifest.source.layout, catalogPath);
+    this._layout = createLayout(
+      manifest.source.layout, catalogPath, manifest.source.entryGroup);
   }
 
   static async fromPath(basePath: string, ctx: gcp.ApiContext): Promise<CatalogSnapshot> {

--- a/toolbox/mdcode/src/libts/source.ts
+++ b/toolbox/mdcode/src/libts/source.ts
@@ -23,6 +23,9 @@ export interface CatalogSource {
   readonly name: string;
   readonly ingestedEntries: boolean;
   readonly layout: Layouts;
+  // Present only for scopes that carry an EntryGroup (e.g. semantic-model);
+  // used to scope the local catalog layout to that group.
+  readonly entryGroup?: string;
 
   entries(ctx: gcp.ApiContext): AsyncGenerator<gcp.Entry, void, unknown>;
   localName(entry: gcp.Entry): string;

--- a/toolbox/mdcode/src/libts/source.ts
+++ b/toolbox/mdcode/src/libts/source.ts
@@ -8,11 +8,13 @@ import { Layouts } from './layout';
 import { EntryGroupSource } from './sources/entrygroup';
 import { BigQueryDatasetSource } from './sources/bq-dataset';
 import { KnowledgeBaseSource } from './sources/kb';
+import { SemanticModelSource } from './sources/semantic-model';
 
 export enum Sources {
   ENTRYGROUP = 'entryGroup',
   BIGQUERY_DATASET = 'bq-dataset',
-  KB = 'kb'
+  KB = 'kb',
+  SEMANTIC_MODEL = 'semantic-model'
 }
 
 
@@ -79,6 +81,8 @@ export async function createSource(type: string, name: string,
     case Sources.KB:
       const knowledgeBase = await getEntryGroup(name, ctx);
       return new KnowledgeBaseSource(Sources.KB, name, knowledgeBase);
+    case Sources.SEMANTIC_MODEL:
+      return new SemanticModelSource(Sources.SEMANTIC_MODEL, name);
     default:
       throw new Error(`Unknown source type: ${type}`);
   }

--- a/toolbox/mdcode/src/libts/sources/semantic-model.ts
+++ b/toolbox/mdcode/src/libts/sources/semantic-model.ts
@@ -1,0 +1,56 @@
+// A locally-authored Semantic Model as a Metadata Source
+//
+// The model is authored on the local filesystem as a single Apache Ossie
+// document per model (the SemanticModel layout); it is not ingested from a
+// remote service. `push` deploys the model's BigQuery Graph.
+//
+// Knowledge Catalog resource emit (entries + entryLinks) for the semantic model
+// is a follow-on; the sync-oriented members below are therefore not yet wired.
+//
+
+import * as gcp from '../gcp';
+import {Layouts} from '../layout';
+import {CatalogSource} from '../source';
+
+
+export class SemanticModelSource implements CatalogSource {
+  readonly type: string;
+  readonly name: string;
+  readonly ingestedEntries = false;
+  readonly layout = Layouts.SEMANTIC_MODEL;
+
+  readonly project: string;
+  readonly location: string;
+  readonly entryGroup: string;
+
+  constructor(type: string, name: string) {
+    const [project, location, entryGroup] = name.split('.');
+    if (!project || !location || !entryGroup) {
+      throw new Error(
+          'Semantic model scope must be in format <projectId>.<locationId>.<entryGroupId>');
+    }
+
+    this.type = type;
+    this.name = name;
+    this.project = project;
+    this.location = location;
+    this.entryGroup = entryGroup;
+  }
+
+  // The model is authored locally; there is nothing to enumerate from a
+  // service.
+  async *
+      entries(_ctx: gcp.ApiContext): AsyncGenerator<gcp.Entry, void, unknown> {
+    return;
+  }
+
+  localName(_entry: gcp.Entry): string {
+    throw new Error(
+        'Knowledge Catalog resource sync is not supported for the semantic-model scope yet.');
+  }
+
+  serviceName(_localName: string): string {
+    throw new Error(
+        'Knowledge Catalog resource sync is not supported for the semantic-model scope yet.');
+  }
+}

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -73,6 +73,13 @@ export async function pull(): Promise<number> {
   const ctx = context.ApiContext.default();
   const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
 
+  if (snapshot.manifest.source.type === Sources.SEMANTIC_MODEL) {
+    console.log(
+      'Semantic-model scope: nothing to pull. Knowledge Catalog resource ' +
+      'pull for the semantic model is not yet implemented.');
+    return 0;
+  }
+
   const catalog = new dataplex.CatalogClient(ctx);
   const sync = new kcmd.CatalogSync(catalog, snapshot);
 
@@ -102,7 +109,25 @@ export async function push(options: PushOptions): Promise<number> {
     }
     console.log('Pushing semantic model (BigQuery Graph)...');
     const result = await deploy.deployBigQuery(layout.modelDocuments(), ctx, options);
+
+    for (const w of result.warnings) {
+      console.warn(`Warning: ${w}`);
+    }
+    if (options.validateOnly) {
+      for (const block of result.ddl) {
+        console.log(`${block}\n`);
+      }
+    }
+
     if (result.success) {
+      if (options.validateOnly) {
+        console.log('Validation complete; no changes applied.');
+      }
+      else {
+        console.log(
+          `Deployed ${result.deployed} BigQuery Graph(s). ` +
+          `Knowledge Catalog resource emit for the semantic model is not yet implemented.`);
+      }
       return 0;
     }
     console.error('Error pushing semantic model:', result.details);

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -9,6 +9,7 @@ import * as dataplex from '../libts/gcp/dataplex';
 import * as context from '../libts/gcp/context';
 import { Sources } from '../libts/source';
 import { SemanticModelLayout } from '../libts/layouts/semantic-model';
+import { SemanticModelSource } from '../libts/sources/semantic-model';
 import * as deploy from '../libts/semantic/deploy';
 
 
@@ -104,8 +105,10 @@ export async function push(options: PushOptions): Promise<number> {
     // The semantic-model source always resolves to the SemanticModel layout
     // (see createLayout), so this cast is safe.
     const layout = snapshot.layout as SemanticModelLayout;
+    const source = snapshot.manifest.source as SemanticModelSource;
     console.log('Pushing semantic model (BigQuery Graph)...');
-    const result = await deploy.deployBigQuery(layout.modelDocuments(), ctx, options);
+    const result = await deploy.deployBigQuery(
+      layout.modelDocuments(), ctx, options, source.project);
 
     for (const w of result.warnings) {
       console.warn(`Warning: ${w}`);

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -49,9 +49,8 @@ export async function init(options: InitOptions): Promise<number> {
   }
   else if (options.semanticModel) {
     manifest = await kcmd.CatalogManifest.initWithSemanticModel(options.semanticModel, ctx);
-    const entryGroup = options.semanticModel.split('.')[2];
+    const entryGroup = manifest.source.entryGroup!;
     fs.mkdirSync(path.join('catalog', 'EntryGroups', entryGroup), { recursive: true });
-    fs.mkdirSync(path.join('catalog', 'EntryLinks', entryGroup), { recursive: true });
   }
   else {
     console.error('Error: Must provide --entry-group, --bigquery-dataset, --kb, or --semantic-model');
@@ -102,11 +101,9 @@ export async function push(options: PushOptions): Promise<number> {
   const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
 
   if (snapshot.manifest.source.type === Sources.SEMANTIC_MODEL) {
-    const layout = snapshot.layout;
-    if (!(layout instanceof SemanticModelLayout)) {
-      console.error('Error: semantic-model scope requires the SemanticModel layout.');
-      return 1;
-    }
+    // The semantic-model source always resolves to the SemanticModel layout
+    // (see createLayout), so this cast is safe.
+    const layout = snapshot.layout as SemanticModelLayout;
     console.log('Pushing semantic model (BigQuery Graph)...');
     const result = await deploy.deployBigQuery(layout.modelDocuments(), ctx, options);
 

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -2,16 +2,21 @@
 //
 
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import * as kcmd from '../libts';
 import * as dataplex from '../libts/gcp/dataplex';
 import * as context from '../libts/gcp/context';
+import { Sources } from '../libts/source';
+import { SemanticModelLayout } from '../libts/layouts/semantic-model';
+import * as deploy from '../libts/semantic/deploy';
 
 
 export interface InitOptions {
   entryGroup?: string;
   bigqueryDataset?: string | string[];
   kb?: string;
+  semanticModel?: string;
   pull?: boolean;
 }
 
@@ -42,13 +47,22 @@ export async function init(options: InitOptions): Promise<number> {
     }
     manifest = await kcmd.CatalogManifest.initWithBigQuery(datasets, ctx);
   }
+  else if (options.semanticModel) {
+    manifest = await kcmd.CatalogManifest.initWithSemanticModel(options.semanticModel, ctx);
+  }
   else {
-    console.error('Error: Must provide either --entry-group or --bigquery-dataset or --kb');
+    console.error('Error: Must provide --entry-group, --bigquery-dataset, --kb, or --semantic-model');
     return 1;
   }
 
   manifest.save('catalog.yaml');
   console.log(fs.readFileSync('catalog.yaml', 'utf8'));
+
+  if (options.semanticModel) {
+    const entryGroup = options.semanticModel.split('.')[2];
+    fs.mkdirSync(path.join('catalog', 'EntryGroups', entryGroup), { recursive: true });
+    fs.mkdirSync(path.join('catalog', 'EntryLinks', entryGroup), { recursive: true });
+  }
 
   if (options.pull) {
     return await pull();
@@ -82,6 +96,21 @@ export async function pull(): Promise<number> {
 export async function push(options: PushOptions): Promise<number> {
   const ctx = context.ApiContext.default();
   const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
+
+  if (snapshot.manifest.source.type === Sources.SEMANTIC_MODEL) {
+    const layout = snapshot.layout;
+    if (!(layout instanceof SemanticModelLayout)) {
+      console.error('Error: semantic-model scope requires the SemanticModel layout.');
+      return 1;
+    }
+    console.log('Pushing semantic model (BigQuery Graph)...');
+    const result = await deploy.deployBigQuery(layout.modelDocuments(), ctx, options);
+    if (result.success) {
+      return 0;
+    }
+    console.error('Error pushing semantic model:', result.details);
+    return 1;
+  }
 
   const catalog = new dataplex.CatalogClient(ctx);
   const sync = new kcmd.CatalogSync(catalog, snapshot);

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -49,6 +49,9 @@ export async function init(options: InitOptions): Promise<number> {
   }
   else if (options.semanticModel) {
     manifest = await kcmd.CatalogManifest.initWithSemanticModel(options.semanticModel, ctx);
+    const entryGroup = options.semanticModel.split('.')[2];
+    fs.mkdirSync(path.join('catalog', 'EntryGroups', entryGroup), { recursive: true });
+    fs.mkdirSync(path.join('catalog', 'EntryLinks', entryGroup), { recursive: true });
   }
   else {
     console.error('Error: Must provide --entry-group, --bigquery-dataset, --kb, or --semantic-model');
@@ -57,12 +60,6 @@ export async function init(options: InitOptions): Promise<number> {
 
   manifest.save('catalog.yaml');
   console.log(fs.readFileSync('catalog.yaml', 'utf8'));
-
-  if (options.semanticModel) {
-    const entryGroup = options.semanticModel.split('.')[2];
-    fs.mkdirSync(path.join('catalog', 'EntryGroups', entryGroup), { recursive: true });
-    fs.mkdirSync(path.join('catalog', 'EntryLinks', entryGroup), { recursive: true });
-  }
 
   if (options.pull) {
     return await pull();

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -11,6 +11,7 @@ cli.command('init', 'Initialize a new catalog snapshot')
    .option('--entry-group <id>', 'Identifier of the EntryGroup (project.location.id)')
    .option('--bigquery-dataset <id...>', 'Identifier of the BigQuery dataset(s) (project.datasetId)')
    .option('--kb <id>', 'Identifier of the Knowledge Base EntryGroup (project.location.id)')
+   .option('--semantic-model <id>', 'Identifier of the semantic model EntryGroup (project.location.id)')
    .option('--pull', 'Optionally pull catalog entries during initialization')
    .action(async (options) => {
       try {

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -11,7 +11,7 @@ cli.command('init', 'Initialize a new catalog snapshot')
    .option('--entry-group <id>', 'Identifier of the EntryGroup (project.location.id)')
    .option('--bigquery-dataset <id...>', 'Identifier of the BigQuery dataset(s) (project.datasetId)')
    .option('--kb <id>', 'Identifier of the Knowledge Base EntryGroup (project.location.id)')
-   .option('--semantic-model <id>', 'Identifier of the semantic model EntryGroup (project.location.id)')
+   .option('--semantic-model <id>', 'Semantic model scope as <projectId>.<locationId>.<entryGroupId>')
    .option('--pull', 'Optionally pull catalog entries during initialization')
    .action(async (options) => {
       try {

--- a/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
@@ -31,6 +31,10 @@ const OSSIE_NO_TARGET =
 // Dataplex URI; exercises the deploy leg's "no BigQuery Graph target" path.
 const OSSIE_DATAPLEX_ONLY =
     fs.readFileSync(path.join(FIXTURES, 'sales_google_ext.yaml'), 'utf8');
+// A model whose only GOOGLE target carries the BigQuery prefix but fails the
+// strict URI match; exercises the "declared but unparseable" report.
+const OSSIE_BAD_TARGET =
+    fs.readFileSync(path.join(FIXTURES, 'sales_bad_target.yaml'), 'utf8');
 
 // A model carrying only a single custom_extension.
 function modelWithExtension(data: string, vendor = 'GOOGLE'): SemanticModel {
@@ -46,7 +50,7 @@ function modelWithExtension(data: string, vendor = 'GOOGLE'): SemanticModel {
 
 describe('bigQueryGraphTargets', () => {
   test('parses a BigQuery Graph deployment target', () => {
-    const targets = bigQueryGraphTargets(
+    const {targets, malformed} = bigQueryGraphTargets(
         modelWithExtension(JSON.stringify({deploymentTargets: [BQ_URI]})));
     expect(targets).toEqual([
       {
@@ -56,24 +60,27 @@ describe('bigQueryGraphTargets', () => {
         uri: BQ_URI
       },
     ]);
+    expect(malformed).toEqual([]);
   });
 
   test('ignores non-GOOGLE vendor extensions', () => {
-    const targets = bigQueryGraphTargets(modelWithExtension(
+    const {targets} = bigQueryGraphTargets(modelWithExtension(
         JSON.stringify({deploymentTargets: [BQ_URI]}), 'DATABRICKS'));
     expect(targets).toEqual([]);
   });
 
   test('ignores deployment targets that are not BigQuery Graphs', () => {
+    // A non-BigQuery URI is not our concern: neither a target nor malformed.
     const dataplexUri =
         'projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph';
-    const targets = bigQueryGraphTargets(
+    const {targets, malformed} = bigQueryGraphTargets(
         modelWithExtension(JSON.stringify({deploymentTargets: [dataplexUri]})));
     expect(targets).toEqual([]);
+    expect(malformed).toEqual([]);
   });
 
   test('returns [] for a model with no custom extensions', () => {
-    const targets = bigQueryGraphTargets(
+    const {targets} = bigQueryGraphTargets(
         {name: 'm', entities: [], relationships: [], metrics: []});
     expect(targets).toEqual([]);
   });
@@ -86,19 +93,22 @@ describe('bigQueryGraphTargets', () => {
   test('collects multiple targets in order', () => {
     const uri2 =
         '//bigquery.googleapis.com/projects/p2/datasets/d2/propertyGraphs/g2';
-    const targets = bigQueryGraphTargets(modelWithExtension(
+    const {targets} = bigQueryGraphTargets(modelWithExtension(
         JSON.stringify({deploymentTargets: [BQ_URI, uri2]})));
     expect(targets.map(t => t.graphName)).toEqual(['sales_graph', 'g2']);
   });
 
-  test('rejects a target whose identifiers contain non-identifier chars', () => {
+  test('collects a prefix-matching URI that fails the strict match', () => {
     // A backtick/semicolon in the graph name would break out of the quoted
     // identifier in the generated DDL; the tightened capture groups reject it.
+    // It carries the BigQuery prefix, so it is surfaced as malformed rather
+    // than silently dropped.
     const evil =
         '//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/g`;DROP';
-    const targets = bigQueryGraphTargets(
+    const {targets, malformed} = bigQueryGraphTargets(
         modelWithExtension(JSON.stringify({deploymentTargets: [evil]})));
     expect(targets).toEqual([]);
+    expect(malformed).toEqual([evil]);
   });
 });
 
@@ -307,6 +317,111 @@ describe('deployBigQuery', () => {
       querySpy.mockRestore();
     }
   });
+
+  test(
+      'fails when the job never completes after the poll budget is exhausted',
+      async () => {
+        // A job that stays jobComplete:false must eventually be given up on.
+        // Small bounds + zero backoff keep this instant (the real defaults
+        // would burn ~29s of sleeps).
+        const dsSpy = mockDataset();
+        const stuck = {
+          status: 200,
+          result: {jobComplete: false, jobReference: {jobId: 'j'}},
+        };
+        const querySpy = spyOn(bq.BigQueryClient.prototype, 'query')
+                             .mockImplementation(async () => stuck);
+        const pollSpy = spyOn(bq.BigQueryClient.prototype, 'getQueryResults')
+                            .mockImplementation(async () => stuck);
+        try {
+          const res = await deployBigQuery(
+              [{name: 'sales', text: OSSIE}], CTX,
+              {maxQueryPolls: 3, pollBackoffMs: 0});
+          expect(res.success).toBe(false);
+          expect(res.details).toContain('did not complete after 3 polls');
+          expect(pollSpy).toHaveBeenCalledTimes(3);
+        } finally {
+          dsSpy.mockRestore();
+          pollSpy.mockRestore();
+          querySpy.mockRestore();
+        }
+      });
+
+  test('fails fast when the target dataset does not exist', async () => {
+    // A 404 on the location pre-flight is a precise error; the DDL job that
+    // would otherwise fail with a murkier message is never submitted.
+    const dsSpy = spyOn(bq.BigQueryClient.prototype, 'getDataset')
+                      .mockImplementation(async () => ({status: 404} as any));
+    const querySpy = spyOn(bq.BigQueryClient.prototype, 'query');
+    try {
+      const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+      expect(res.success).toBe(false);
+      expect(res.details).toContain('demo.sales not found');
+      expect(querySpy).not.toHaveBeenCalled();
+    } finally {
+      dsSpy.mockRestore();
+      querySpy.mockRestore();
+    }
+  });
+
+  test(
+      'proceeds with inferred location when the dataset read is forbidden',
+      async () => {
+        // A 403 (caller lacks bigquery.datasets.get) is non-fatal: the deploy
+        // proceeds and lets BigQuery infer the location (no location arg).
+        const dsSpy =
+            spyOn(bq.BigQueryClient.prototype, 'getDataset')
+                .mockImplementation(async () => ({status: 403} as any));
+        const querySpy =
+            spyOn(bq.BigQueryClient.prototype, 'query')
+                .mockImplementation(
+                    async () => ({status: 200, result: {jobComplete: true}}));
+        try {
+          const res =
+              await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+          expect(res.success).toBe(true);
+          expect(querySpy.mock.calls[0][2]).toBeUndefined();
+        } finally {
+          dsSpy.mockRestore();
+          querySpy.mockRestore();
+        }
+      });
+
+  test(
+      'resolves the dataset location once across targets in one dataset',
+      async () => {
+        // Two documents deploying to demo.sales must trigger a single
+        // datasets.get, not one per graph.
+        const dsSpy = mockDataset();
+        const querySpy =
+            spyOn(bq.BigQueryClient.prototype, 'query')
+                .mockImplementation(
+                    async () => ({status: 200, result: {jobComplete: true}}));
+        try {
+          const res = await deployBigQuery(
+              [{name: 'a', text: OSSIE}, {name: 'b', text: OSSIE}], CTX, {});
+          expect(res.success).toBe(true);
+          expect(res.deployed).toBe(2);
+          expect(dsSpy).toHaveBeenCalledTimes(1);
+        } finally {
+          dsSpy.mockRestore();
+          querySpy.mockRestore();
+        }
+      });
+
+  test(
+      'names an unparseable BigQuery target instead of reporting none',
+      async () => {
+        // A typo'd URI that carries the BigQuery prefix must be reported as
+        // unparseable, not as "declares no deploymentTarget".
+        const res = await deployBigQuery(
+            [{name: 'sales', text: OSSIE_BAD_TARGET}], CTX,
+            {validateOnly: true});
+        expect(res.success).toBe(false);
+        expect(res.details).toContain('could not be parsed');
+        expect(res.details).toContain('propertyGraph/sales_graph');
+        expect(res.details).not.toContain('declares no BigQuery Graph');
+      });
 
   test(
       'reports already-deployed graphs when a later target fails', async () => {

--- a/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
@@ -2,10 +2,12 @@
 // (src/libts/semantic/deploy.ts).
 //
 // `bigQueryGraphTargets` is exercised as a pure function; `deployBigQuery` is
-// exercised end to end over an inline Ossie document (loader -> IR -> generator
-// -> target), with the BigQuery client stubbed so no network call is made.
+// exercised end to end over an Ossie fixture (loader -> IR -> generator ->
+// target), with the BigQuery client stubbed so no network call is made.
 
 import {describe, expect, spyOn, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import * as bq from '../../../src/libts/gcp/bigquery';
 import {ApiContext} from '../../../src/libts/gcp/context';
@@ -14,8 +16,17 @@ import {SemanticModel} from '../../../src/libts/semantic/ir';
 
 const CTX = new ApiContext('test-project', 'us', 'test-token');
 
+const FIXTURES = path.join(__dirname, 'fixtures');
+
 const BQ_URI =
     '//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph';
+
+// A loader-valid model that declares a GOOGLE BigQuery Graph deployment target
+// (resolves to demo.sales.sales_graph), and the same model without one.
+const OSSIE =
+    fs.readFileSync(path.join(FIXTURES, 'sales_bq_graph_target.yaml'), 'utf8');
+const OSSIE_NO_TARGET =
+    fs.readFileSync(path.join(FIXTURES, 'sales_no_target.yaml'), 'utf8');
 
 // A model carrying only a single custom_extension.
 function modelWithExtension(data: string, vendor = 'GOOGLE'): SemanticModel {
@@ -27,55 +38,6 @@ function modelWithExtension(data: string, vendor = 'GOOGLE'): SemanticModel {
     customExtensions: [{vendorName: vendor, data}],
   };
 }
-
-// A minimal, loader-valid Ossie document that declares a GOOGLE BigQuery
-// Graph deployment target.
-const OSSIE = `
-version: "0.2.0.dev0"
-semantic_model:
-  - name: sales
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["${BQ_URI}"]}'
-    datasets:
-      - name: orders
-        source: demo.sales.orders
-        primary_key: [o_orderkey]
-        fields:
-          - name: o_orderkey
-            expression:
-              dialects:
-                - dialect: ANSI_SQL
-                  expression: o_orderkey
-          - name: o_totalprice
-            expression:
-              dialects:
-                - dialect: ANSI_SQL
-                  expression: o_totalprice
-    metrics:
-      - name: total_revenue
-        expression:
-          dialects:
-            - dialect: ANSI_SQL
-              expression: SUM(orders.o_totalprice)
-`;
-
-// The same document without any deployment target.
-const OSSIE_NO_TARGET = `
-version: "0.2.0.dev0"
-semantic_model:
-  - name: sales
-    datasets:
-      - name: orders
-        source: demo.sales.orders
-        primary_key: [o_orderkey]
-        fields:
-          - name: o_orderkey
-            expression:
-              dialects:
-                - dialect: ANSI_SQL
-                  expression: o_orderkey
-`;
 
 
 describe('bigQueryGraphTargets', () => {
@@ -154,7 +116,8 @@ describe('deployBigQuery', () => {
   test('executes the DDL against the target project', async () => {
     const querySpy =
         spyOn(bq.BigQueryClient.prototype, 'query')
-            .mockImplementation(async () => ({status: 200, result: {}}));
+            .mockImplementation(
+                async () => ({status: 200, result: {jobComplete: true}}));
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     try {
       const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
@@ -165,6 +128,53 @@ describe('deployBigQuery', () => {
       expect(project).toBe('demo');
       expect(sql).toContain(
           'CREATE OR REPLACE PROPERTY GRAPH `demo.sales.sales_graph`');
+    } finally {
+      logSpy.mockRestore();
+      querySpy.mockRestore();
+    }
+  });
+
+  test('polls getQueryResults until the job completes', async () => {
+    const querySpy =
+        spyOn(bq.BigQueryClient.prototype, 'query')
+            .mockImplementation(
+                async () => ({
+                  status: 200,
+                  result: {jobComplete: false, jobReference: {jobId: 'job-1'}},
+                }));
+    const pollSpy =
+        spyOn(bq.BigQueryClient.prototype, 'getQueryResults')
+            .mockImplementation(
+                async () => ({status: 200, result: {jobComplete: true}}));
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+      expect(res.success).toBe(true);
+      expect(pollSpy).toHaveBeenCalledTimes(1);
+      // getQueryResults(project, jobId, location) -- jobId is the second arg.
+      expect(pollSpy.mock.calls[0][1]).toBe('job-1');
+    } finally {
+      logSpy.mockRestore();
+      pollSpy.mockRestore();
+      querySpy.mockRestore();
+    }
+  });
+
+  test('fails when the completed job reports errors', async () => {
+    const querySpy =
+        spyOn(bq.BigQueryClient.prototype, 'query')
+            .mockImplementation(async () => ({
+                                  status: 200,
+                                  result: {
+                                    jobComplete: true,
+                                    errors: [{message: 'graph already exists'}],
+                                  },
+                                }));
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+      expect(res.success).toBe(false);
+      expect(res.details).toContain('graph already exists');
     } finally {
       logSpy.mockRestore();
       querySpy.mockRestore();
@@ -194,4 +204,10 @@ describe('deployBigQuery', () => {
         expect(res.success).toBe(false);
         expect(res.details).toContain('no BigQuery Graph');
       });
+
+  test('fails when there are no model documents', async () => {
+    const res = await deployBigQuery([], CTX, {validateOnly: true});
+    expect(res.success).toBe(false);
+    expect(res.details).toContain('No semantic model documents');
+  });
 });

--- a/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
@@ -35,6 +35,10 @@ const OSSIE_DATAPLEX_ONLY =
 // strict URI match; exercises the "declared but unparseable" report.
 const OSSIE_BAD_TARGET =
     fs.readFileSync(path.join(FIXTURES, 'sales_bad_target.yaml'), 'utf8');
+// A model whose dataset `source` omits its project, so the loader must qualify
+// it with the caller-supplied defaultProject.
+const OSSIE_UNQUALIFIED_SOURCE = fs.readFileSync(
+    path.join(FIXTURES, 'sales_unqualified_source.yaml'), 'utf8');
 
 // A model carrying only a single custom_extension.
 function modelWithExtension(data: string, vendor = 'GOOGLE'): SemanticModel {
@@ -109,6 +113,21 @@ describe('bigQueryGraphTargets', () => {
         modelWithExtension(JSON.stringify({deploymentTargets: [evil]})));
     expect(targets).toEqual([]);
     expect(malformed).toEqual([evil]);
+  });
+
+  test('reports a host/scheme-typo target as malformed, not silently dropped', () => {
+    // A truncated host (`.co` not `.com`) and an `https://` scheme both
+    // fail the strict match, yet clearly intend a BigQuery Graph target.
+    // They must be reported (via the /propertyGraphs?/ + host hint) rather
+    // than dropped and later misreported as "no target declared".
+    const hostTypo =
+        '//bigquery.googleapis.co/projects/demo/datasets/sales/propertyGraphs/g';
+    const scheme =
+        'https://bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/g';
+    const {targets, malformed} = bigQueryGraphTargets(modelWithExtension(
+        JSON.stringify({deploymentTargets: [hostTypo, scheme]})));
+    expect(targets).toEqual([]);
+    expect(malformed).toEqual([hostTypo, scheme]);
   });
 });
 
@@ -368,7 +387,8 @@ describe('deployBigQuery', () => {
       'proceeds with inferred location when the dataset read is forbidden',
       async () => {
         // A 403 (caller lacks bigquery.datasets.get) is non-fatal: the deploy
-        // proceeds and lets BigQuery infer the location (no location arg).
+        // proceeds and lets BigQuery infer the location (no location arg), but
+        // records a warning so the degraded path is visible.
         const dsSpy =
             spyOn(bq.BigQueryClient.prototype, 'getDataset')
                 .mockImplementation(async () => ({status: 403} as any));
@@ -381,6 +401,9 @@ describe('deployBigQuery', () => {
               await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
           expect(res.success).toBe(true);
           expect(querySpy.mock.calls[0][2]).toBeUndefined();
+          expect(res.warnings.some(
+                     w => w.includes('could not read location of dataset')))
+              .toBe(true);
         } finally {
           dsSpy.mockRestore();
           querySpy.mockRestore();
@@ -483,9 +506,53 @@ describe('deployBigQuery', () => {
         expect(res.details).toContain('no BigQuery Graph');
       });
 
-  test('fails when there are no model documents', async () => {
+  test(
+      'qualifies an under-qualified source with the given defaultProject',
+      async () => {
+        // The loader qualifies `sales.orders` with the passed defaultProject
+        // ('scope-proj'), not the ambient ctx.project ('test-project'): the
+        // scope's declared project is deterministic where gcloud's is not.
+        const res = await deployBigQuery(
+            [{name: 'sales', text: OSSIE_UNQUALIFIED_SOURCE}], CTX,
+            {validateOnly: true}, 'scope-proj');
+        expect(res.success).toBe(true);
+        const ddl = res.ddl.join('\n');
+        expect(ddl).toContain('`scope-proj.sales.orders`');
+        expect(ddl).not.toContain('test-project.sales.orders');
+      });
+
+  test('validateOnly over an empty workspace is a clean no-op', async () => {
+    // validate-only mutates nothing, so no documents is success (exit 0) with a
+    // warning, not an error.
     const res = await deployBigQuery([], CTX, {validateOnly: true});
+    expect(res.success).toBe(true);
+    expect(res.deployed).toBe(0);
+    expect(res.warnings.some(w => w.includes('nothing to validate')))
+        .toBe(true);
+  });
+
+  test('a real push with no model documents fails', async () => {
+    // Outside validate-only, "nothing to deploy" is a configuration error worth
+    // surfacing rather than silently succeeding.
+    const res = await deployBigQuery([], CTX, {});
     expect(res.success).toBe(false);
     expect(res.details).toContain('No semantic model documents');
+  });
+
+  test('fails a 200 response that carries no body', async () => {
+    // A 200 with no result body cannot confirm the DDL ran; it must fail rather
+    // than fall through to success.
+    const dsSpy = mockDataset();
+    const querySpy =
+        spyOn(bq.BigQueryClient.prototype, 'query')
+            .mockImplementation(async () => ({status: 200} as any));
+    try {
+      const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+      expect(res.success).toBe(false);
+      expect(res.details).toContain('no response body');
+    } finally {
+      dsSpy.mockRestore();
+      querySpy.mockRestore();
+    }
   });
 });

--- a/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
@@ -90,55 +90,76 @@ describe('bigQueryGraphTargets', () => {
         JSON.stringify({deploymentTargets: [BQ_URI, uri2]})));
     expect(targets.map(t => t.graphName)).toEqual(['sales_graph', 'g2']);
   });
+
+  test('rejects a target whose identifiers contain non-identifier chars', () => {
+    // A backtick/semicolon in the graph name would break out of the quoted
+    // identifier in the generated DDL; the tightened capture groups reject it.
+    const evil =
+        '//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/g`;DROP';
+    const targets = bigQueryGraphTargets(
+        modelWithExtension(JSON.stringify({deploymentTargets: [evil]})));
+    expect(targets).toEqual([]);
+  });
 });
 
 
 describe('deployBigQuery', () => {
-  test('validateOnly emits the DDL without calling BigQuery', async () => {
+  // Every execution path resolves the dataset location before submitting the
+  // query job. Stubbed so tests make no network call and the job location is
+  // deterministic.
+  function mockDataset() {
+    return spyOn(bq.BigQueryClient.prototype, 'getDataset')
+        .mockImplementation(
+            async () => ({status: 200, result: {location: 'US'}} as any));
+  }
+
+  test('validateOnly returns the DDL without calling BigQuery', async () => {
     const querySpy = spyOn(bq.BigQueryClient.prototype, 'query');
-    const logs: string[] = [];
-    const logSpy = spyOn(console, 'log').mockImplementation((m?: any) => {
-      logs.push(String(m));
-    });
     try {
       const res = await deployBigQuery(
           [{name: 'sales', text: OSSIE}], CTX, {validateOnly: true});
       expect(res.success).toBe(true);
+      expect(res.deployed).toBe(0);
       expect(querySpy).not.toHaveBeenCalled();
 
-      const out = logs.join('\n');
-      expect(out).toContain('CREATE OR REPLACE PROPERTY GRAPH');
+      // The DDL is returned to the caller, not printed by the library.
+      const ddl = res.ddl.join('\n');
+      expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH');
       // The graph name is qualified from the deployment target, not gcloud
       // defaults.
-      expect(out).toContain('`demo.sales.sales_graph`');
+      expect(ddl).toContain('`demo.sales.sales_graph`');
     } finally {
-      logSpy.mockRestore();
       querySpy.mockRestore();
     }
   });
 
   test('executes the DDL against the target project', async () => {
+    const dsSpy = mockDataset();
     const querySpy =
         spyOn(bq.BigQueryClient.prototype, 'query')
             .mockImplementation(
                 async () => ({status: 200, result: {jobComplete: true}}));
-    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     try {
       const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
       expect(res.success).toBe(true);
+      expect(res.deployed).toBe(1);
       expect(querySpy).toHaveBeenCalledTimes(1);
 
-      const [project, sql] = querySpy.mock.calls[0];
+      // query(project, sql, location) -- the resolved dataset location is
+      // threaded to the job.
+      const [project, sql, location] = querySpy.mock.calls[0];
       expect(project).toBe('demo');
       expect(sql).toContain(
           'CREATE OR REPLACE PROPERTY GRAPH `demo.sales.sales_graph`');
+      expect(location).toBe('US');
     } finally {
-      logSpy.mockRestore();
+      dsSpy.mockRestore();
       querySpy.mockRestore();
     }
   });
 
   test('polls getQueryResults until the job completes', async () => {
+    const dsSpy = mockDataset();
     const querySpy =
         spyOn(bq.BigQueryClient.prototype, 'query')
             .mockImplementation(
@@ -150,7 +171,6 @@ describe('deployBigQuery', () => {
         spyOn(bq.BigQueryClient.prototype, 'getQueryResults')
             .mockImplementation(
                 async () => ({status: 200, result: {jobComplete: true}}));
-    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     try {
       const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
       expect(res.success).toBe(true);
@@ -158,17 +178,39 @@ describe('deployBigQuery', () => {
       // getQueryResults(project, jobId, location) -- jobId is the second arg.
       expect(pollSpy.mock.calls[0][1]).toBe('job-1');
     } finally {
-      logSpy.mockRestore();
+      dsSpy.mockRestore();
       pollSpy.mockRestore();
       querySpy.mockRestore();
     }
   });
 
   test(
+      'fails clearly when the job never completes and has no job reference',
+      async () => {
+        // jobComplete:false with no jobId cannot be polled; the error must say
+        // so rather than claim it polled to exhaustion.
+        const dsSpy = mockDataset();
+        const querySpy =
+            spyOn(bq.BigQueryClient.prototype, 'query')
+                .mockImplementation(
+                    async () => ({status: 200, result: {jobComplete: false}}));
+        try {
+          const res =
+              await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+          expect(res.success).toBe(false);
+          expect(res.details).toContain('no job reference to poll');
+        } finally {
+          dsSpy.mockRestore();
+          querySpy.mockRestore();
+        }
+      });
+
+  test(
       'treats errors[] as warnings when the job has no errorResult',
       async () => {
         // A completed job whose errors[] holds only a warning must not fail the
         // deploy: the definitive fatal signal is status.errorResult.
+        const dsSpy = mockDataset();
         const querySpy =
             spyOn(bq.BigQueryClient.prototype, 'query')
                 .mockImplementation(async () => ({
@@ -183,20 +225,20 @@ describe('deployBigQuery', () => {
             spyOn(bq.BigQueryClient.prototype, 'getJob')
                 .mockImplementation(
                     async () => ({status: 200, result: {status: {}}}));
-        const logSpy = spyOn(console, 'log').mockImplementation(() => {});
         try {
           const res =
               await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
           expect(res.success).toBe(true);
           expect(jobSpy).toHaveBeenCalledTimes(1);
         } finally {
-          logSpy.mockRestore();
+          dsSpy.mockRestore();
           jobSpy.mockRestore();
           querySpy.mockRestore();
         }
       });
 
   test('fails on the job errorResult', async () => {
+    const dsSpy = mockDataset();
     const querySpy = spyOn(bq.BigQueryClient.prototype, 'query')
                          .mockImplementation(async () => ({
                                                status: 200,
@@ -215,13 +257,12 @@ describe('deployBigQuery', () => {
                     status: {errorResult: {message: 'Not found: table'}},
                   },
                 }));
-    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     try {
       const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
       expect(res.success).toBe(false);
       expect(res.details).toContain('Not found: table');
     } finally {
-      logSpy.mockRestore();
+      dsSpy.mockRestore();
       jobSpy.mockRestore();
       querySpy.mockRestore();
     }
@@ -230,6 +271,7 @@ describe('deployBigQuery', () => {
   test(
       'fails on errors[] when there is no job reference to disambiguate',
       async () => {
+        const dsSpy = mockDataset();
         const querySpy =
             spyOn(bq.BigQueryClient.prototype, 'query')
                 .mockImplementation(
@@ -240,32 +282,72 @@ describe('deployBigQuery', () => {
                         errors: [{message: 'graph already exists'}],
                       },
                     }));
-        const logSpy = spyOn(console, 'log').mockImplementation(() => {});
         try {
           const res =
               await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
           expect(res.success).toBe(false);
           expect(res.details).toContain('graph already exists');
         } finally {
-          logSpy.mockRestore();
+          dsSpy.mockRestore();
           querySpy.mockRestore();
         }
       });
 
   test('fails when BigQuery rejects the DDL', async () => {
+    const dsSpy = mockDataset();
     const querySpy = spyOn(bq.BigQueryClient.prototype, 'query')
                          .mockImplementation(
                              async () => ({status: 400, message: 'bad DDL'}));
-    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     try {
       const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
       expect(res.success).toBe(false);
       expect(res.details).toContain('bad DDL');
     } finally {
-      logSpy.mockRestore();
+      dsSpy.mockRestore();
       querySpy.mockRestore();
     }
   });
+
+  test(
+      'reports already-deployed graphs when a later target fails', async () => {
+        // Two documents, each a single-target model: the first deploys, the
+        // second fails. The failure must surface that graph #1 already mutated
+        // production.
+        const dsSpy = mockDataset();
+        let calls = 0;
+        const querySpy = spyOn(bq.BigQueryClient.prototype, 'query')
+                             .mockImplementation(async () => {
+                               calls++;
+                               return calls === 1 ?
+                                   {status: 200, result: {jobComplete: true}} :
+                                   {status: 400, message: 'boom'};
+                             });
+        try {
+          const res = await deployBigQuery(
+              [{name: 'a', text: OSSIE}, {name: 'b', text: OSSIE}], CTX, {});
+          expect(res.success).toBe(false);
+          expect(res.deployed).toBe(1);
+          expect(res.details).toContain('boom');
+          expect(res.details).toContain('already deployed in this run');
+        } finally {
+          dsSpy.mockRestore();
+          querySpy.mockRestore();
+        }
+      });
+
+  test(
+      'fails with the document name when a document cannot be parsed',
+      async () => {
+        // A malformed doc must produce a clean, document-scoped failure rather
+        // than an uncaught loader exception.
+        const res = await deployBigQuery(
+            [
+              {name: 'sales', text: OSSIE}, {name: 'broken', text: 'other: 1\n'}
+            ],
+            CTX, {validateOnly: true});
+        expect(res.success).toBe(false);
+        expect(res.details).toContain('Model document \'broken\'');
+      });
 
   test(
       'fails when a model declares no BigQuery deployment target', async () => {

--- a/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
@@ -27,6 +27,10 @@ const OSSIE =
     fs.readFileSync(path.join(FIXTURES, 'sales_bq_graph_target.yaml'), 'utf8');
 const OSSIE_NO_TARGET =
     fs.readFileSync(path.join(FIXTURES, 'sales_no_target.yaml'), 'utf8');
+// An existing fixture whose only GOOGLE deployment target is a (non-BigQuery)
+// Dataplex URI; exercises the deploy leg's "no BigQuery Graph target" path.
+const OSSIE_DATAPLEX_ONLY =
+    fs.readFileSync(path.join(FIXTURES, 'sales_google_ext.yaml'), 'utf8');
 
 // A model carrying only a single custom_extension.
 function modelWithExtension(data: string, vendor = 'GOOGLE'): SemanticModel {
@@ -160,26 +164,93 @@ describe('deployBigQuery', () => {
     }
   });
 
-  test('fails when the completed job reports errors', async () => {
-    const querySpy =
-        spyOn(bq.BigQueryClient.prototype, 'query')
-            .mockImplementation(async () => ({
-                                  status: 200,
-                                  result: {
-                                    jobComplete: true,
-                                    errors: [{message: 'graph already exists'}],
-                                  },
-                                }));
+  test(
+      'treats errors[] as warnings when the job has no errorResult',
+      async () => {
+        // A completed job whose errors[] holds only a warning must not fail the
+        // deploy: the definitive fatal signal is status.errorResult.
+        const querySpy =
+            spyOn(bq.BigQueryClient.prototype, 'query')
+                .mockImplementation(async () => ({
+                                      status: 200,
+                                      result: {
+                                        jobComplete: true,
+                                        jobReference: {jobId: 'job-1'},
+                                        errors: [{message: 'a warning'}],
+                                      },
+                                    }));
+        const jobSpy =
+            spyOn(bq.BigQueryClient.prototype, 'getJob')
+                .mockImplementation(
+                    async () => ({status: 200, result: {status: {}}}));
+        const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+        try {
+          const res =
+              await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+          expect(res.success).toBe(true);
+          expect(jobSpy).toHaveBeenCalledTimes(1);
+        } finally {
+          logSpy.mockRestore();
+          jobSpy.mockRestore();
+          querySpy.mockRestore();
+        }
+      });
+
+  test('fails on the job errorResult', async () => {
+    const querySpy = spyOn(bq.BigQueryClient.prototype, 'query')
+                         .mockImplementation(async () => ({
+                                               status: 200,
+                                               result: {
+                                                 jobComplete: true,
+                                                 jobReference: {jobId: 'job-1'},
+                                                 errors: [{message: 'summary'}],
+                                               },
+                                             }));
+    const jobSpy =
+        spyOn(bq.BigQueryClient.prototype, 'getJob')
+            .mockImplementation(
+                async () => ({
+                  status: 200,
+                  result: {
+                    status: {errorResult: {message: 'Not found: table'}},
+                  },
+                }));
     const logSpy = spyOn(console, 'log').mockImplementation(() => {});
     try {
       const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
       expect(res.success).toBe(false);
-      expect(res.details).toContain('graph already exists');
+      expect(res.details).toContain('Not found: table');
     } finally {
       logSpy.mockRestore();
+      jobSpy.mockRestore();
       querySpy.mockRestore();
     }
   });
+
+  test(
+      'fails on errors[] when there is no job reference to disambiguate',
+      async () => {
+        const querySpy =
+            spyOn(bq.BigQueryClient.prototype, 'query')
+                .mockImplementation(
+                    async () => ({
+                      status: 200,
+                      result: {
+                        jobComplete: true,
+                        errors: [{message: 'graph already exists'}],
+                      },
+                    }));
+        const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+        try {
+          const res =
+              await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+          expect(res.success).toBe(false);
+          expect(res.details).toContain('graph already exists');
+        } finally {
+          logSpy.mockRestore();
+          querySpy.mockRestore();
+        }
+      });
 
   test('fails when BigQuery rejects the DDL', async () => {
     const querySpy = spyOn(bq.BigQueryClient.prototype, 'query')
@@ -200,6 +271,16 @@ describe('deployBigQuery', () => {
       'fails when a model declares no BigQuery deployment target', async () => {
         const res = await deployBigQuery(
             [{name: 'sales', text: OSSIE_NO_TARGET}], CTX,
+            {validateOnly: true});
+        expect(res.success).toBe(false);
+        expect(res.details).toContain('no BigQuery Graph');
+      });
+
+  test(
+      'fails when the only deployment target is a non-BigQuery destination',
+      async () => {
+        const res = await deployBigQuery(
+            [{name: 'sales', text: OSSIE_DATAPLEX_ONLY}], CTX,
             {validateOnly: true});
         expect(res.success).toBe(false);
         expect(res.details).toContain('no BigQuery Graph');

--- a/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy.test.ts
@@ -1,0 +1,197 @@
+// Tests for the semantic-model BigQuery deploy leg
+// (src/libts/semantic/deploy.ts).
+//
+// `bigQueryGraphTargets` is exercised as a pure function; `deployBigQuery` is
+// exercised end to end over an inline Ossie document (loader -> IR -> generator
+// -> target), with the BigQuery client stubbed so no network call is made.
+
+import {describe, expect, spyOn, test} from 'bun:test';
+
+import * as bq from '../../../src/libts/gcp/bigquery';
+import {ApiContext} from '../../../src/libts/gcp/context';
+import {bigQueryGraphTargets, deployBigQuery} from '../../../src/libts/semantic/deploy';
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+
+const CTX = new ApiContext('test-project', 'us', 'test-token');
+
+const BQ_URI =
+    '//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph';
+
+// A model carrying only a single custom_extension.
+function modelWithExtension(data: string, vendor = 'GOOGLE'): SemanticModel {
+  return {
+    name: 'm',
+    entities: [],
+    relationships: [],
+    metrics: [],
+    customExtensions: [{vendorName: vendor, data}],
+  };
+}
+
+// A minimal, loader-valid Ossie document that declares a GOOGLE BigQuery
+// Graph deployment target.
+const OSSIE = `
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"deploymentTargets": ["${BQ_URI}"]}'
+    datasets:
+      - name: orders
+        source: demo.sales.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_totalprice
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)
+`;
+
+// The same document without any deployment target.
+const OSSIE_NO_TARGET = `
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    datasets:
+      - name: orders
+        source: demo.sales.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+`;
+
+
+describe('bigQueryGraphTargets', () => {
+  test('parses a BigQuery Graph deployment target', () => {
+    const targets = bigQueryGraphTargets(
+        modelWithExtension(JSON.stringify({deploymentTargets: [BQ_URI]})));
+    expect(targets).toEqual([
+      {
+        project: 'demo',
+        dataset: 'sales',
+        graphName: 'sales_graph',
+        uri: BQ_URI
+      },
+    ]);
+  });
+
+  test('ignores non-GOOGLE vendor extensions', () => {
+    const targets = bigQueryGraphTargets(modelWithExtension(
+        JSON.stringify({deploymentTargets: [BQ_URI]}), 'DATABRICKS'));
+    expect(targets).toEqual([]);
+  });
+
+  test('ignores deployment targets that are not BigQuery Graphs', () => {
+    const dataplexUri =
+        'projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph';
+    const targets = bigQueryGraphTargets(
+        modelWithExtension(JSON.stringify({deploymentTargets: [dataplexUri]})));
+    expect(targets).toEqual([]);
+  });
+
+  test('returns [] for a model with no custom extensions', () => {
+    const targets = bigQueryGraphTargets(
+        {name: 'm', entities: [], relationships: [], metrics: []});
+    expect(targets).toEqual([]);
+  });
+
+  test('throws on malformed extension JSON', () => {
+    expect(() => bigQueryGraphTargets(modelWithExtension('{not json')))
+        .toThrow(/not valid JSON/);
+  });
+
+  test('collects multiple targets in order', () => {
+    const uri2 =
+        '//bigquery.googleapis.com/projects/p2/datasets/d2/propertyGraphs/g2';
+    const targets = bigQueryGraphTargets(modelWithExtension(
+        JSON.stringify({deploymentTargets: [BQ_URI, uri2]})));
+    expect(targets.map(t => t.graphName)).toEqual(['sales_graph', 'g2']);
+  });
+});
+
+
+describe('deployBigQuery', () => {
+  test('validateOnly emits the DDL without calling BigQuery', async () => {
+    const querySpy = spyOn(bq.BigQueryClient.prototype, 'query');
+    const logs: string[] = [];
+    const logSpy = spyOn(console, 'log').mockImplementation((m?: any) => {
+      logs.push(String(m));
+    });
+    try {
+      const res = await deployBigQuery(
+          [{name: 'sales', text: OSSIE}], CTX, {validateOnly: true});
+      expect(res.success).toBe(true);
+      expect(querySpy).not.toHaveBeenCalled();
+
+      const out = logs.join('\n');
+      expect(out).toContain('CREATE OR REPLACE PROPERTY GRAPH');
+      // The graph name is qualified from the deployment target, not gcloud
+      // defaults.
+      expect(out).toContain('`demo.sales.sales_graph`');
+    } finally {
+      logSpy.mockRestore();
+      querySpy.mockRestore();
+    }
+  });
+
+  test('executes the DDL against the target project', async () => {
+    const querySpy =
+        spyOn(bq.BigQueryClient.prototype, 'query')
+            .mockImplementation(async () => ({status: 200, result: {}}));
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+      expect(res.success).toBe(true);
+      expect(querySpy).toHaveBeenCalledTimes(1);
+
+      const [project, sql] = querySpy.mock.calls[0];
+      expect(project).toBe('demo');
+      expect(sql).toContain(
+          'CREATE OR REPLACE PROPERTY GRAPH `demo.sales.sales_graph`');
+    } finally {
+      logSpy.mockRestore();
+      querySpy.mockRestore();
+    }
+  });
+
+  test('fails when BigQuery rejects the DDL', async () => {
+    const querySpy = spyOn(bq.BigQueryClient.prototype, 'query')
+                         .mockImplementation(
+                             async () => ({status: 400, message: 'bad DDL'}));
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const res = await deployBigQuery([{name: 'sales', text: OSSIE}], CTX, {});
+      expect(res.success).toBe(false);
+      expect(res.details).toContain('bad DDL');
+    } finally {
+      logSpy.mockRestore();
+      querySpy.mockRestore();
+    }
+  });
+
+  test(
+      'fails when a model declares no BigQuery deployment target', async () => {
+        const res = await deployBigQuery(
+            [{name: 'sales', text: OSSIE_NO_TARGET}], CTX,
+            {validateOnly: true});
+        expect(res.success).toBe(false);
+        expect(res.details).toContain('no BigQuery Graph');
+      });
+});

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bad_target.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bad_target.yaml
@@ -1,0 +1,35 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# A loader-valid model whose only GOOGLE deployment target carries the BigQuery
+# Graph prefix but fails the strict URI match (the `propertyGraphs` segment is
+# misspelled). Exercises the deploy leg's "declared but unparseable" path: the
+# error must name the bad URI rather than claim no target was declared.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: sales
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraph/sales_graph"]}'
+    datasets:
+      - name: orders
+        source: demo.sales.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_totalprice
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.yaml
@@ -1,0 +1,35 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# A minimal, loader-valid model that declares a GOOGLE BigQuery Graph
+# deployment target (a `//bigquery.googleapis.com/.../propertyGraphs/...` URI).
+# This is the happy-path document for the deploy leg: loader -> IR -> generator
+# -> BigQuery Graph. The target resolves to `demo.sales.sales_graph`.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: sales
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph"]}'
+    datasets:
+      - name: orders
+        source: demo.sales.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_totalprice
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_no_target.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_no_target.yaml
@@ -1,0 +1,20 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# The same shape as sales_bq_graph_target.yaml but with no GOOGLE deployment
+# target, so the deploy leg has nothing to push and must fail loudly rather
+# than silently succeed.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: sales
+    datasets:
+      - name: orders
+        source: demo.sales.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_unqualified_source.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_unqualified_source.yaml
@@ -1,0 +1,35 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# A loader-valid model whose dataset `source` omits its project (`sales.orders`,
+# not `<project>.sales.orders`). The loader must qualify it with the caller's
+# `defaultProject`, so this fixture exercises which project the deploy leg feeds
+# the loader -- the scope's declared project, not the ambient gcloud project.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: sales
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph"]}'
+    datasets:
+      - name: orders
+        source: sales.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_totalprice
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)

--- a/toolbox/mdcode/tests/libts/semantic/semantic_model_scope.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/semantic_model_scope.test.ts
@@ -69,14 +69,26 @@ describe('semantic-model scope wiring', () => {
         fs.writeFileSync(
             path.join(modelDir, 'sales.aspects.yaml'), 'name: sales\n');
 
+        // A second, unrelated EntryGroup directory (with a colliding basename)
+        // that the scoped layout must NOT pick up.
+        const otherDir =
+            path.join(dir, 'catalog', 'EntryGroups', 'other-group');
+        fs.mkdirSync(otherDir, {recursive: true});
+        fs.writeFileSync(
+            path.join(otherDir, 'sales.yaml'),
+            'semantic_model:\n  - name: other\n');
+
         // load: scope -> source -> layout resolves to the SemanticModel layout.
         const snapshot = await CatalogSnapshot.fromPath(dir, CTX);
         expect(snapshot.manifest.source.type).toBe('semantic-model');
         expect(snapshot.layout).toBeInstanceOf(SemanticModelLayout);
 
         const layout = snapshot.layout as SemanticModelLayout;
-        expect(layout.listEntries()).toEqual(['sales']);
+        // Push-only layout: it exposes no per-entry Knowledge Catalog files.
+        expect(layout.listEntries()).toEqual([]);
 
+        // Only the document under the scoped EntryGroup is discovered; the
+        // colliding sales.yaml in other-group is ignored.
         const docs = layout.modelDocuments();
         expect(docs).toHaveLength(1);
         expect(docs[0].name).toBe('sales');

--- a/toolbox/mdcode/tests/libts/semantic/semantic_model_scope.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/semantic_model_scope.test.ts
@@ -1,0 +1,85 @@
+// Tests the semantic-model scope + SemanticModel layout wiring: the scope
+// string round-trips through the manifest, and a snapshot over an authored
+// workspace resolves to the SemanticModel layout and reads the Ossie model
+// document (while ignoring sidecar files).
+
+import {afterEach, describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {ApiContext} from '../../../src/libts/gcp/context';
+import {Layouts} from '../../../src/libts/layout';
+import {SemanticModelLayout} from '../../../src/libts/layouts/semantic-model';
+import {CatalogManifest} from '../../../src/libts/manifest';
+import {CatalogSnapshot} from '../../../src/libts/snapshot';
+import {SemanticModelSource} from '../../../src/libts/sources/semantic-model';
+
+const CTX = new ApiContext('test-project', 'us', 'test-token');
+
+
+describe('SemanticModelSource', () => {
+  test('parses a well-formed scope name', () => {
+    const s = new SemanticModelSource('semantic-model', 'proj.us.eg');
+    expect(s.type).toBe('semantic-model');
+    expect(s.project).toBe('proj');
+    expect(s.location).toBe('us');
+    expect(s.entryGroup).toBe('eg');
+    expect(s.layout).toBe(Layouts.SEMANTIC_MODEL);
+    expect(s.ingestedEntries).toBe(false);
+  });
+
+  test('rejects a malformed scope name', () => {
+    expect(() => new SemanticModelSource('semantic-model', 'proj.us'))
+        .toThrow();
+  });
+});
+
+
+describe('semantic-model scope wiring', () => {
+  let dir = '';
+
+  afterEach(() => {
+    if (dir) {
+      fs.rmSync(dir, {recursive: true, force: true});
+      dir = '';
+    }
+  });
+
+  test(
+      'manifest writes the scope; snapshot resolves the layout and reads the model',
+      async () => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kcmd-sm-'));
+
+        // init: manifest carries the semantic-model scope string.
+        const manifest = await CatalogManifest.initWithSemanticModel(
+            'proj.us.sales-group', CTX);
+        manifest.save(path.join(dir, 'catalog.yaml'));
+        expect(fs.readFileSync(path.join(dir, 'catalog.yaml'), 'utf8'))
+            .toContain('scope: semantic-model.proj.us.sales-group');
+
+        // author: a single Ossie model document, plus a sidecar that must be
+        // ignored.
+        const modelDir =
+            path.join(dir, 'catalog', 'EntryGroups', 'sales-group');
+        fs.mkdirSync(modelDir, {recursive: true});
+        fs.writeFileSync(
+            path.join(modelDir, 'sales.yaml'),
+            'semantic_model:\n  - name: sales\n');
+        fs.writeFileSync(
+            path.join(modelDir, 'sales.aspects.yaml'), 'name: sales\n');
+
+        // load: scope -> source -> layout resolves to the SemanticModel layout.
+        const snapshot = await CatalogSnapshot.fromPath(dir, CTX);
+        expect(snapshot.manifest.source.type).toBe('semantic-model');
+        expect(snapshot.layout).toBeInstanceOf(SemanticModelLayout);
+
+        const layout = snapshot.layout as SemanticModelLayout;
+        expect(layout.listEntries()).toEqual(['sales']);
+
+        const docs = layout.modelDocuments();
+        expect(docs).toHaveLength(1);
+        expect(docs[0].name).toBe('sales');
+        expect(docs[0].text).toContain('name: sales');
+      });
+});

--- a/toolbox/mdcode/tests/libts/semantic/semantic_model_scope.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/semantic_model_scope.test.ts
@@ -85,7 +85,10 @@ describe('semantic-model scope wiring', () => {
 
         const layout = snapshot.layout as SemanticModelLayout;
         // Push-only layout: it exposes no per-entry Knowledge Catalog files.
+        // entryExists agrees with listEntries -- neither reports the model
+        // document as a KC entry.
         expect(layout.listEntries()).toEqual([]);
+        expect(layout.entryExists('sales')).toBe(false);
 
         // Only the document under the scoped EntryGroup is discovered; the
         // colliding sales.yaml in other-group is ignored.


### PR DESCRIPTION
Third change in the mdcode Semantic Model series, on top of the now-merged
IR (#258) and BigQuery Graph generator (#269). Targets `main`.

## What this adds

A `semantic-model` scope and a push-only `SemanticModel` layout, so the
existing `init` / `push` verbs manage a locally-authored Apache Ossie model
instead of a bespoke command:

```
kcmd init --semantic-model <project>.<location>.<entryGroup>
kcmd push          # deploys the model's BigQuery Graph
kcmd push --validate-only   # prints the DDL, applies nothing
```

- The scope is recorded in `catalog.yaml` (`scope: semantic-model.<p>.<l>.<eg>`);
  `init` scaffolds `catalog/EntryGroups/<eg>` and `catalog/EntryLinks/<eg>`.
- The model is a single Ossie document per model under
  `catalog/EntryGroups/<eg>/<model>.yaml`.
- `push` parses each document to the semantic IR (PR1 loader), lowers it to
  `CREATE OR REPLACE PROPERTY GRAPH` DDL (PR2 generator), and executes it
  against the project named by the model's `GOOGLE` `custom_extension`
  `deploymentTargets`, e.g.
  `//bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>`.
- `BigQueryClient.query` runs DDL synchronously via `jobs.query`.

## Scope / follow-on

This PR is the BigQuery leg only. Knowledge Catalog resource emit
(entries + entryLinks) for the semantic model is a follow-on; `push`
currently deploys only the BigQuery Graph and logs that the KC emit is not
yet implemented.

## Tests

- `deploymentTargets` parsing (GOOGLE-vendor filter, BigQuery-URI filter,
  malformed JSON, multiple targets).
- The deploy leg over an inline Ossie document with the BigQuery client
  stubbed: `--validate-only` (no query), execute against the target
  project, BigQuery-error failure, and no-target failure.
- Scope/layout wiring: the scope round-trips through the manifest, and a
  snapshot over an authored workspace resolves to `SemanticModelLayout` and
  reads the model document while ignoring sidecars.

`tsc --noEmit` clean; full mdcode suite green.

## Live validation

Validated end-to-end against real BigQuery (`sqlgen-testing`): authored an
Ossie model with a `//bigquery.googleapis.com/.../propertyGraphs/sales_graph`
deploymentTarget, ran `kcmd init --semantic-model` + `kcmd push`, and
confirmed:
- the target project/dataset/graph are resolved from the URI and the
  `CREATE OR REPLACE PROPERTY GRAPH` DDL executes via `jobs.query`;
- a GQL traversal over the deployed edge and the native `MEASURE`
  (`GRAPH_EXPAND`) both reproduce a direct-`SUM` control (per-customer
  revenue correct through the FK edge, no fan-out);
- `push` is idempotent (second run re-deploys cleanly).
