### PR TITLE
okf: stop demo cleanup from deleting the shared okf aspect type

### DIFF
--- a/toolbox/mdcode/demo/README.md
+++ b/toolbox/mdcode/demo/README.md
@@ -183,7 +183,10 @@ bun push.ts
 
 **Cleanup**
 
-* Deletes the Dataplex EntryGroup and the custom `okf` aspect type.
+* Deletes the Dataplex EntryGroup. The custom `okf` aspect type is left in
+  place: it is scoped to the project and location rather than to this demo, so
+  other OKF bundles in the same project carry their signal layer on it. The
+  command to remove it manually is printed at the end.
 
 ```bash
 bun cleanup.ts

--- a/toolbox/mdcode/demo/okf/cleanup.ts
+++ b/toolbox/mdcode/demo/okf/cleanup.ts
@@ -14,10 +14,11 @@ function dataplex(cmd: string, data: string|null=null) {
 dataplex(`entry-groups delete ${entryGroup}`);
 console.log(`Deleted entry group ${entryGroup}`);
 
-try {
-  dataplex(`aspect-types delete okf`);
-  console.log('Deleted custom aspect type okf');
-}
-catch {
-  // Might not exist, or still referenced
-}
+// The okf aspect type is scoped to the project and location, not to this demo's
+// entry group, so any other OKF bundle in the project attaches its signal layer
+// to the same type. Deleting it here would strip that signal from bundles this
+// demo does not own.
+console.log(
+  `Left aspect type ${project}.${location}.okf in place (shared across OKF bundles). ` +
+  `To remove it: gcloud dataplex aspect-types delete okf --project ${project} --location ${location}`
+);


### PR DESCRIPTION
## Summary

`toolbox/mdcode/demo/okf/cleanup.ts` deletes the custom `okf` aspect type as part
of tearing down the demo. That aspect type is scoped to the **project and
location** (`{project}.{location}.okf`), while the entry group the demo creates
(`okf_ga4`) is not. Every OKF bundle in the same project therefore attaches its
signal layer to that one shared type, so running the demo's cleanup strips
`type` / `generated` / `sources` from bundles the demo does not own.

Two things made it worse:

- The delete was wrapped in a bare `catch {}`, so the damage (or the failure to
  do it) was silent either way.
- `setup.ts` already tolerates the aspect type pre-existing, so the demo happily
  reuses a type it did not create, then deletes it on the way out.

This was not hypothetical. In the project used to verify the OKF demo there is a
second, unrelated entry group (`okf_e2e`) owned by another user; every cleanup
run would have deleted the aspect type out from under it.

## Change

Cleanup now deletes only the entry group it created and leaves the aspect type
in place, printing the command to remove it by hand:

```
Deleted entry group okf_ga4
Left aspect type <project>.<location>.okf in place (shared across OKF bundles).
To remove it: gcloud dataplex aspect-types delete okf --project <p> --location <l>
```

An aspect type is a schema definition, so leaving it costs nothing, and a single
shared `okf` type per project is the desirable end state rather than residue.
README updated to match.

## Test plan

- [x] `bun cleanup.ts` against a live demo deployment: entry group `okf_ga4`
      deleted, aspect type `okf` still present afterwards
- [x] Confirmed via `gcloud dataplex entry-groups list` / `aspect-types list`
- [ ] Reviewer sanity check on the wording of the printed hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
