### PR TITLE
okf: write stackoverflow bundle tags as YAML lists

### DIFF
--- a/okf/bundles/stackoverflow/datasets/stackoverflow.md
+++ b/okf/bundles/stackoverflow/datasets/stackoverflow.md
@@ -5,7 +5,7 @@ title: Stack Overflow Public Dataset
 description: This dataset contains a public archive of Stack Overflow data, including
   posts, users, and tags. It was last updated on 2022-11-25 and is no longer actively
   updated.
-tags: Stack Overflow, Q&A, developer, programming, public dataset
+tags: [Stack Overflow, Q&A, developer, programming, public dataset]
 generated:
   by: reference_agent/gemini-2.5-flash
   at: '2026-07-10T22:46:36+00:00'

--- a/okf/bundles/stackoverflow/tables/posts_answers.md
+++ b/okf/bundles/stackoverflow/tables/posts_answers.md
@@ -4,7 +4,7 @@ resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datas
 title: Posts Answers
 description: Contains Stack Overflow answers, including their content, scores, and
   associated metadata.
-tags: stackoverflow, answers, posts, Q&A
+tags: [stackoverflow, answers, posts, Q&A]
 generated:
   by: reference_agent/gemini-2.5-flash
   at: '2026-07-10T22:48:04+00:00'

--- a/okf/bundles/stackoverflow/tables/posts_moderator_nomination.md
+++ b/okf/bundles/stackoverflow/tables/posts_moderator_nomination.md
@@ -4,7 +4,7 @@ resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datas
 title: Posts Moderator Nomination
 description: Contains posts related to moderator nominations on the Stack Overflow
   platform.
-tags: stackoverflow, posts, moderator, nomination
+tags: [stackoverflow, posts, moderator, nomination]
 generated:
   by: reference_agent/gemini-2.5-flash
   at: '2026-07-10T22:48:22+00:00'

--- a/okf/bundles/stackoverflow/tables/posts_questions.md
+++ b/okf/bundles/stackoverflow/tables/posts_questions.md
@@ -3,7 +3,7 @@ type: BigQuery Table
 resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datasets/stackoverflow/tables/posts_questions
 title: Stack Overflow Posts Questions
 description: Contains all question posts from Stack Overflow.
-tags: stackoverflow, posts, questions
+tags: [stackoverflow, posts, questions]
 generated:
   at: '2026-07-10T22:49:19+00:00'
   by: reference_agent/gemini-2.5-flash

--- a/okf/bundles/stackoverflow/tables/posts_wiki_placeholder.md
+++ b/okf/bundles/stackoverflow/tables/posts_wiki_placeholder.md
@@ -4,7 +4,7 @@ resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datas
 title: Stack Overflow Posts Wiki Placeholder
 description: Placeholder table for various Wiki-style posts within the Stack Overflow
   dataset.
-tags: stackoverflow, posts, wiki, placeholder, community
+tags: [stackoverflow, posts, wiki, placeholder, community]
 generated:
   by: reference_agent/gemini-2.5-flash
   at: '2026-07-10T22:59:18+00:00'

--- a/okf/bundles/stackoverflow/tables/stackoverflow_posts.md
+++ b/okf/bundles/stackoverflow/tables/stackoverflow_posts.md
@@ -4,7 +4,7 @@ resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datas
 title: Stack Overflow Posts (Deprecated)
 description: A deprecated table containing Stack Overflow posts. Use the posts_answers
   or posts_questions tables instead.
-tags: stackoverflow, posts, deprecated
+tags: [stackoverflow, posts, deprecated]
 status: deprecated
 generated:
   by: reference_agent/gemini-2.5-flash

--- a/okf/bundles/stackoverflow/tables/users.md
+++ b/okf/bundles/stackoverflow/tables/users.md
@@ -3,7 +3,7 @@ type: BigQuery Table
 resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datasets/stackoverflow/tables/users
 title: Stack Overflow Users
 description: Contains information about registered users on the Stack Overflow platform.
-tags: stackoverflow, users, community, reputation
+tags: [stackoverflow, users, community, reputation]
 generated:
   by: reference_agent/gemini-2.5-flash
   at: '2026-07-10T22:51:02+00:00'

--- a/okf/bundles/stackoverflow/tables/votes.md
+++ b/okf/bundles/stackoverflow/tables/votes.md
@@ -3,7 +3,7 @@ type: BigQuery Table
 resource: https://bigquery.googleapis.com/v2/projects/bigquery-public-data/datasets/stackoverflow/tables/votes
 title: Stack Overflow Votes
 description: Records all votes cast on Stack Overflow posts.
-tags: Stack Overflow, votes, posts, community
+tags: [Stack Overflow, votes, posts, community]
 generated:
   by: reference_agent/gemini-2.5-flash
   at: '2026-07-10T22:51:18+00:00'


### PR DESCRIPTION
## Problem

`tags:` in OKF frontmatter is meant to be a list. Eight files in
`okf/bundles/stackoverflow` write it as a bare comma-separated string instead.

A JavaScript string is iterable, so the Documents Layout iterates it anyway and
each *character* becomes a Dataplex label. Pushing `tables/votes.md`
(`tags: Stack Overflow, votes, posts, community`) to Knowledge Catalog stored:

```
{" ": "true", ",": "true", "O": "true", "S": "true", "a": "true", "c": "true", ...}
```

No error, no warning. Those eight files round-tripped corrupted; the other 24
in the bundle were fine.

## Fix

Rewrite the eight files as YAML flow sequences, matching the style the nine
`acme_retail` files already use:

```yaml
tags: [Stack Overflow, votes, posts, community]
```

The brackets are the whole difference. Without them it is a plain scalar, not a
sequence.

Files changed:

`datasets/stackoverflow.md`, `tables/posts_answers.md`,
`tables/posts_moderator_nomination.md`, `tables/posts_questions.md`,
`tables/posts_wiki_placeholder.md`, `tables/stackoverflow_posts.md`,
`tables/users.md`, `tables/votes.md`

Bundle data only. #294 adds the library-side guard that makes this shape an
error instead of silent corruption; it should land after this PR, since these
are the files that trip it.

## Verification

Against `hormati-bqml` / `us-central1`, using the demo's push/pull path:

* Before: 24 of 32 stackoverflow files round-tripped losslessly.
* After: 32 of 32.
* `tables/votes` now stores four labels (`Stack Overflow`, `votes`, `posts`,
  `community`) instead of fourteen single characters.

Found while round-tripping the sample bundles for #292. #292, #293, and #294
share no files.
