### PR TITLE
mdcode: reject non-list frontmatter tags

### DIFF
--- a/toolbox/mdcode/src/libts/layouts/documents.ts
+++ b/toolbox/mdcode/src/libts/layouts/documents.ts
@@ -64,7 +64,7 @@ export class DocumentsLayout implements CatalogLayout {
     let body = '';
     if (entryPath) {
       const content = await fs.promises.readFile(entryPath, 'utf8');
-      const result = parseMarkdown(content);
+      const result = parseMarkdown(content, entryPath);
       parsed = result.entry;
       body = result.body;
     }
@@ -182,7 +182,7 @@ function deriveParentLocalName(name: string): string | undefined {
   return [...parentDir, INDEX_NAME].join('/');
 }
 
-export function parseMarkdown(content: string): { entry: md.Entry|null; body: string } {
+export function parseMarkdown(content: string, source?: string): { entry: md.Entry|null; body: string } {
   const lines = content.split(/\r?\n/);
   if (lines[0] !== '---') {
     return { entry: null, body: content };
@@ -203,7 +203,14 @@ export function parseMarkdown(content: string): { entry: md.Entry|null; body: st
   entry.resource = entry.resource ?? {}
   entry.resource.displayName = metadata.title;
   entry.resource.description = metadata.description;
-  if (metadata.tags) {
+  if (metadata.tags !== undefined && metadata.tags !== null) {
+    if (!Array.isArray(metadata.tags)) {
+      // A bare string is iterable, so without this the tags would silently
+      // become one label per character.
+      throw new Error(
+        `${source ?? 'frontmatter'}: "tags" must be a list, got ${JSON.stringify(metadata.tags)}`,
+      );
+    }
     entry.resource.labels = entry.resource.labels ?? {};
     for (const tag of metadata.tags) {
       entry.resource.labels[tag] = 'true';


### PR DESCRIPTION
## Problem

`tags:` in OKF frontmatter is meant to be a list. The Documents Layout does not
check that, and a JavaScript string is iterable, so a bare comma-separated
value is expanded into one Dataplex label per *character*.

`tags: Stack Overflow, votes, posts, community` in a real bundle file stored
this in Knowledge Catalog:

```
{" ": "true", ",": "true", "O": "true", "S": "true", "a": "true", "c": "true", ...}
```

No error, no warning. The entry looks fine locally and is corrupt in the
catalog.

## Fix

`parseMarkdown` throws when `tags` is present and is not an array:

```
okf/bundles/stackoverflow/tables/votes.md: "tags" must be a list, got "Stack Overflow, votes, posts, community"
```

Coercing the string by splitting on commas is the other option. I did not take
it: a comma can legitimately appear inside a tag, so coercion silently invents
a different tag set than the author wrote. An error at parse time is cheap and
points at the file.

Two supporting details:

* `parseMarkdown` gained an optional `source` parameter so the message can name
  the file. Its only caller, `loadEntry`, passes the entry path.
* The outer condition moved from truthy to an explicit `undefined`/`null` check,
  so an empty-string `tags` is reported rather than skipped.

## Verification

* `tags: a, b, c` throws with the file name and the offending value.
* A proper YAML list and frontmatter with no `tags` at all behave exactly as
  before.
* `bun test ./tests/libts/scenarios.ts`: 17 pass, 0 fail.

## Ordering

Land after #293. The eight stackoverflow bundle files fixed there are the ones
that trip this guard, so merging this first makes that bundle fail to push.
