### PR TITLE
mdcode: emit synonyms as a structured BigQuery graph option

### DIFF
--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -131,18 +131,50 @@ becomes one part of that graph:
 | Model | `PROPERTY GRAPH` | named by the deployment-target URI |
 | Entity | `NODE TABLE` | backed by the entity's `source` table, keyed by its primary key |
 | Relationship | `EDGE TABLE` | connects the two entities' node tables |
-| Metric | `MEASURE` on a node table | must reduce to one aggregate over one entity, or it is skipped with a warning |
+| Metric | `MEASURE` on a node table | must resolve to a single entity (otherwise the push is rejected — see [Validation](#validation)) and reduce to one supported aggregate over one operand (otherwise that metric is skipped with a warning) |
 
 `push` reads the target dataset's location (`bigquery.datasets.get`) so the
 statement runs in the right region; without that permission it falls back to
-BigQuery's own location inference and warns. Nothing runs under
-`--validate-only`; add `--print` to see the DDL.
+BigQuery's own location inference and warns. Under `--validate-only` no graph
+DDL is executed and nothing is written (the live source-table checks still run —
+see [Validation](#validation)); add `--print` to see the generated DDL.
 
-Push to BigQuery is **lossy**: the graph captures the queryable structure —
-node tables, edge tables, and measures — but not descriptive metadata
-(descriptions, `ai_context`, synonyms, labels), and a metric that does not
-reduce to a single MEASURE is dropped with a warning. It is a query surface,
-not a copy of your model.
+#### What carries over, and what doesn't
+
+Push preserves both the queryable structure and the descriptive metadata
+attached to it. The structure becomes the node tables, edge tables, and
+measures; the descriptive metadata is written into each element's `OPTIONS(...)`
+in the graph (visible with `--print`). BigQuery's graph `OPTIONS` give an element
+a `description` string and a `synonyms` array, so synonyms are carried across
+structurally, as their own array — not flattened into the description text.
+
+**Carried over** — for every entity, relationship, metric, and field:
+
+| Authored metadata | Where it lands in the generated DDL |
+|---|---|
+| `ai_context.synonyms` | the element's `OPTIONS(synonyms=[...])`, a structured array |
+| `description` | the element's `OPTIONS(description=...)` |
+| `ai_context.instructions` | added to the same `OPTIONS(description=...)` |
+| `ai_context.examples` | added to it, as an `Examples: …` line |
+| A field's `label` | added to the field's `OPTIONS(description=...)` |
+| A field's time-dimension role | noted in the field's `OPTIONS(description=...)` |
+
+**Not carried over:**
+
+| Authored metadata | Why |
+|---|---|
+| The model's own `description` / `ai_context` | BigQuery silently drops statement-level graph `OPTIONS`, so model-level metadata has no home in the graph; it is carried into [Knowledge Catalog](#what-gets-created-in-knowledge-catalog) instead |
+| A field's `datatype` | BigQuery uses the source column's own type |
+| Unique keys beyond the primary key | only the primary key is emitted |
+| The imported vendor SQL and its dialect | only the canonical GoogleSQL expression is used |
+| `custom_extensions` | not part of the graph (the model-level `GOOGLE` block only supplies the [deployment target](#deployment-targets-required)) |
+| A metric that isn't a single aggregate (`SUM`/`AVG`/`COUNT`/`MIN`/`MAX`) over one column | it can't become a `MEASURE`, so it is skipped with a warning |
+
+One caveat on the metadata that carries over: `synonyms` is the only part with a
+dedicated BigQuery option. The rest — `description`, `instructions`, `examples`,
+and a field's `label` — share the single `description` string, so they are
+combined into it (examples as an `Examples: …` line). Their content is
+preserved; their separate structure is not.
 
 ### What gets created in Knowledge Catalog
 
@@ -155,7 +187,7 @@ them, it never creates them.
 | Model | `semantic-model` | entry — anchor / parent of the rest | `<model>` |
 | Entity | `semantic-entity` (+ built-in `schema` aspect) | entry | `<model>.entities.<entity>` |
 | Metric | `semantic-metric` | entry | `<model>.metrics.<metric>` |
-| Relationship | `schema-join` | entry link between the two entity entries | derived from the relationship name |
+| Relationship | `schema-join` | entry link between the two entity entries | derived from the model and relationship names |
 
 An entity entry carries its columns in the `schema` aspect (name, data type, and
 description per field); a `schema-join` link carries the relationship detail — the
@@ -226,11 +258,14 @@ Relationships owned by other models that share the entry group are left
 untouched.
 
 **When you remove a whole model** — deleting its document does *not* remove it
-from the catalog on the next push. Instead, push stops and names the model the
-catalog still has that you no longer push, so you can't wipe out a model by
-accident or by pushing from the wrong directory. When you do mean to remove it,
-run push again with `--force-remove` and its entries and links are deleted
-first.
+from the catalog. As long as you still push at least one other model in the same
+entry group, push stops and names the model the catalog still has that you no
+longer push, so you can't wipe one out by accident or by pushing from the wrong
+directory; run push again with `--force-remove` to delete its entries and links.
+Deleting *every* document is the exception: with no models left to push, the run
+reports `No semantic model documents found; nothing to deploy` and touches
+nothing — so remove a model while other models in its group remain, or delete
+its catalog entries directly.
 
 Every push prints one line per destination summarizing what it did. For a
 `--target all` push:

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -163,12 +163,12 @@ structurally, as their own array — not flattened into the description text.
 
 | Authored metadata | Why |
 |---|---|
-| The model's own `description` / `ai_context` | BigQuery silently drops statement-level graph `OPTIONS`, so model-level metadata has no home in the graph; it is carried into [Knowledge Catalog](#what-gets-created-in-knowledge-catalog) instead |
+| The model's own `description` / `ai_context` | BigQuery silently drops statement-level graph `OPTIONS`, so model-level metadata has no home in the graph. The model's `description` is carried into [Knowledge Catalog](#what-gets-created-in-knowledge-catalog) instead; its `ai_context` (instructions, synonyms, examples) is not preserved in either destination |
 | A field's `datatype` | BigQuery uses the source column's own type |
 | Unique keys beyond the primary key | only the primary key is emitted |
 | The imported vendor SQL and its dialect | only the canonical GoogleSQL expression is used |
 | `custom_extensions` | not part of the graph (the model-level `GOOGLE` block only supplies the [deployment target](#deployment-targets-required)) |
-| A metric that isn't a single aggregate (`SUM`/`AVG`/`COUNT`/`MIN`/`MAX`) over one column | it can't become a `MEASURE`, so it is skipped with a warning |
+| A metric that isn't a single aggregate (`SUM`/`AVG`/`COUNT`/`MIN`/`MAX`) over one operand | it can't become a `MEASURE`, so it is skipped with a warning |
 
 One caveat on the metadata that carries over: `synonyms` is the only part with a
 dedicated BigQuery option. The rest — `description`, `instructions`, `examples`,

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -140,12 +140,12 @@ export function generatePropertyGraph(
     blocks.push(`EDGE TABLES (\n${edgeTables.join(',\n')}\n)`);
   }
 
-  // Graph-level metadata: the trailing OPTIONS after the EDGE TABLES clause
-  // (grammar: create_property_graph_statement). The model's AI-first
-  // annotations are folded into the description here (see elementDescription).
-  const graphOpts =
-      optionsClause(elementDescription(model.description, model.aiContext));
-  if (graphOpts) blocks.push(graphOpts);
+  // Model-level description / ai_context has no home in the BigQuery graph:
+  // statement-level `OPTIONS` after EDGE TABLES parses but BigQuery silently
+  // drops it (verified live; create_property_graph_options is off for
+  // BigQuery), so we do not emit it. The model's description is carried into
+  // Knowledge Catalog's model entry instead (see knowledge_catalog.ts);
+  // element-level metadata rides on labels, properties, and measures here.
 
   return {ddl: blocks.join('\n') + ';\n', warnings: dedupe(warnings)};
 }
@@ -309,8 +309,9 @@ function placeMetric(
   const propName = exposeOperand(lowering, operandExpr, metric.name);
   const aggregate = `${agg.fn}(${agg.distinct ? 'DISTINCT ' : ''}${propName})`;
 
-  const opts =
-      optionsClause(elementDescription(metric.description, metric.aiContext));
+  const opts = optionsClause(
+      elementDescription(metric.description, metric.aiContext),
+      metric.aiContext?.synonyms);
   const measure = `MEASURE(${aggregate}) AS ${metric.name}`;
   const lines = metricsByEntity.get(entityName) ?? [];
   lines.push(opts ? `${measure} ${opts}` : measure);
@@ -475,10 +476,11 @@ function renderNodeTable(
     line(1, `${table} AS ${entity.name}`),
     line(2, `KEY(${entity.keys.join(', ')})`),
   ];
-  // Element-table description attaches to the DEFAULT LABEL: after the key
-  // clause, before PROPERTIES (grammar: element_table_definition).
-  const labelOpts =
-      optionsClause(elementDescription(entity.description, entity.aiContext));
+  // Element-table description and synonyms attach to the DEFAULT LABEL: after
+  // the key clause, before PROPERTIES (grammar: element_table_definition).
+  const labelOpts = optionsClause(
+      elementDescription(entity.description, entity.aiContext),
+      entity.aiContext?.synonyms);
   if (labelOpts) lines.push(line(2, labelOpts));
   // Omit the PROPERTIES block when there is nothing to list, rather than emit
   // an empty `PROPERTIES()` (a node table may declare just its KEY).
@@ -495,7 +497,8 @@ function renderFieldProperty(field: Field, entity: string): string {
   const expr = fieldExpression(field);
   const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
   const prop = local === field.name ? field.name : `${local} AS ${field.name}`;
-  const opts = optionsClause(fieldDescription(field));
+  const opts =
+      optionsClause(fieldDescription(field), field.aiContext?.synonyms);
   return opts ? `${prop} ${opts}` : prop;
 }
 
@@ -540,10 +543,11 @@ function renderEdgeTable(
             rel.destination.entity}(${rel.destination.columns.join(', ')})`),
   ];
 
-  // Edge description attaches to the DEFAULT LABEL: after the
+  // Edge description and synonyms attach to the DEFAULT LABEL: after the
   // SOURCE/DESTINATION clauses (grammar: element_table_definition).
-  const labelOpts =
-      optionsClause(elementDescription(rel.description, rel.aiContext));
+  const labelOpts = optionsClause(
+      elementDescription(rel.description, rel.aiContext),
+      rel.aiContext?.synonyms);
   if (labelOpts) lines.push(line(2, labelOpts));
 
   return lines.join('\n');
@@ -590,11 +594,12 @@ function renderAssociationEdge(
             rel.destination.entity}(${refColumns(rel.destination)})`),
   ];
 
-  // Edge description attaches to the DEFAULT LABEL: after the
+  // Edge description and synonyms attach to the DEFAULT LABEL: after the
   // SOURCE/DESTINATION clauses, before PROPERTIES (grammar:
   // element_table_definition).
-  const labelOpts =
-      optionsClause(elementDescription(rel.description, rel.aiContext));
+  const labelOpts = optionsClause(
+      elementDescription(rel.description, rel.aiContext),
+      rel.aiContext?.synonyms);
   if (labelOpts) lines.push(line(2, labelOpts));
 
   // The junction's own non-key fields are the edge's properties.
@@ -694,37 +699,33 @@ function propertiesBlock(properties: string[]): string {
 }
 
 
-// Composes the `OPTIONS(description=...)` text for a graph element from its
-// base description and AI-first annotations. BigQuery graph DDL exposes only a
-// single description slot, so instructions, synonyms, and examples are folded
-// into that one text (the only metadata sink the graph DDL provides).
+// Composes the folded `description` text for a graph element from its base
+// description and the AI-first annotations that have no dedicated BigQuery
+// option: instructions and examples. Synonyms are NOT folded in here --
+// BigQuery's PropertyGraph{Label,Property}Options carry a structured `synonyms`
+// array, so they are emitted as their own option (see optionsClause and the
+// call sites).
 function elementDescription(description?: string, ai?: AiContext): string|
     undefined {
   return composeText([
     description,
     ai?.instructions,
-    synonymsLine(ai?.synonyms),
     examplesLine(ai?.examples),
   ]);
 }
 
 // A field additionally carries a human `label` and a temporal-dimension role,
 // which lead the composed text (matching the authored order) ahead of its
-// description and AI-first annotations.
+// description and instructions/examples. Synonyms are emitted structurally, as
+// for elementDescription.
 function fieldDescription(field: Field): string|undefined {
   return composeText([
     field.label,
     isTimeDimension(field) ? 'Time dimension.' : undefined,
     field.description,
     field.aiContext?.instructions,
-    synonymsLine(field.aiContext?.synonyms),
     examplesLine(field.aiContext?.examples),
   ]);
-}
-
-function synonymsLine(synonyms?: string[]): string|undefined {
-  return synonyms && synonyms.length ? `Synonyms: ${synonyms.join(', ')}` :
-                                       undefined;
 }
 
 function examplesLine(examples?: string[]): string|undefined {
@@ -740,14 +741,22 @@ function composeText(parts: (string|undefined)[]): string|undefined {
   return kept.length ? kept.join('\n\n') : undefined;
 }
 
-// Renders the trailing `OPTIONS(description=...)` clause, or undefined when
-// there is nothing to say. The grammar allows this clause on graph properties
-// and measures (after the alias), on element tables (as DEFAULT LABEL options,
-// before PROPERTIES), and on the graph itself (after the EDGE TABLES clause).
-// See storage/googlesql/parser: `derived_property`, `element_table_definition`,
-// `create_property_graph_statement`.
-function optionsClause(text?: string): string|undefined {
-  return text ? `OPTIONS(description=${quote(text)})` : undefined;
+// Renders the trailing `OPTIONS(...)` clause for a graph element -- a folded
+// `description` string and/or a structured `synonyms` array -- or undefined
+// when there is nothing to emit. Both map to BigQuery's
+// PropertyGraph{Label,Property}Options (`description` singular, `synonyms`
+// repeated), honored on element-table labels (DEFAULT LABEL, before PROPERTIES)
+// and on derived properties and measures (after the alias). Statement-level
+// graph OPTIONS is intentionally not emitted: it parses but BigQuery silently
+// drops it (verified live; create_property_graph_options is off for BigQuery).
+function optionsClause(description?: string, synonyms?: string[]): string|
+    undefined {
+  const parts: string[] = [];
+  if (description) parts.push(`description=${quote(description)}`);
+  if (synonyms && synonyms.length) {
+    parts.push(`synonyms=[${synonyms.map(quote).join(', ')}]`);
+  }
+  return parts.length ? `OPTIONS(${parts.join(', ')})` : undefined;
 }
 
 // Renders a value as a BigQuery double-quoted string literal. Backslash and the

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -351,6 +351,92 @@ describe('degenerate inputs and GenerateOptions behavior', () => {
 });
 
 
+describe('descriptive metadata: structured synonyms vs folded description', () => {
+  // A two-entity model with an FK edge, exercising ai_context on every element
+  // kind (entity label, field property, measure, edge label) plus the model.
+  // BigQuery's PropertyGraph{Label,Property}Options carry a structured
+  // `synonyms` array (verified live), so synonyms are emitted as their own
+  // option; instructions and examples (which have no dedicated option) still
+  // fold into `description`.
+  const model = (): SemanticModel => ({
+    name: 'm',
+    description: 'MODEL_LEVEL_DESC',
+    aiContext: {instructions: 'model help', synonyms: ['modelsyn']},
+    entities: [
+      {
+        name: 'orders',
+        dataSource: 'orders',
+        keys: ['o_orderkey'],
+        description: 'the orders',
+        aiContext: {
+          instructions: 'one row per order',
+          synonyms: ['ord', 'purchase'],
+          examples: ['how many orders?'],
+        },
+        fields: [
+          {name: 'o_orderkey', expression: 'orders.o_orderkey'},
+          {
+            name: 'amount',
+            expression: 'orders.amount',
+            label: 'Order amount',
+            aiContext: {synonyms: ['total', 'value']},
+          },
+        ],
+      },
+      {
+        name: 'customers',
+        dataSource: 'customers',
+        keys: ['c_custkey'],
+        fields: [{name: 'c_custkey', expression: 'customers.c_custkey'}],
+      },
+    ],
+    relationships: [{
+      name: 'placed_by',
+      source: {entity: 'orders', columns: ['o_custkey']},
+      destination: {entity: 'customers', columns: ['c_custkey']},
+      aiContext: {synonyms: ['belongs to']},
+    }],
+    metrics: [{
+      name: 'total_amount',
+      expression: 'SUM(orders.amount)',
+      entity: 'orders',
+      aiContext: {synonyms: ['revenue', 'sales']},
+    }],
+  });
+
+  test(
+      'synonyms are a structured array on every element, not folded into description',
+      () => {
+        const {ddl} = generatePropertyGraph(model(), GEN_OPTS);
+        // Entity label, field property, measure, and edge label each carry a
+        // structured `synonyms=[...]` array.
+        expect(ddl).toContain('synonyms=["ord", "purchase"]');
+        expect(ddl).toContain('synonyms=["total", "value"]');
+        expect(ddl).toContain('synonyms=["revenue", "sales"]');
+        expect(ddl).toContain('synonyms=["belongs to"]');
+        // The legacy folded "Synonyms: ..." text is gone entirely.
+        expect(ddl).not.toContain('Synonyms:');
+      });
+
+  test(
+      'instructions and examples still fold into the description option',
+      () => {
+        const {ddl} = generatePropertyGraph(model(), GEN_OPTS);
+        expect(ddl).toContain('one row per order');  // entity instructions
+        expect(ddl).toContain('Examples: how many orders?');
+        expect(ddl).toContain('Order amount');  // field label leads
+      });
+
+  test(
+      'model-level metadata is not emitted (BigQuery drops statement-level graph OPTIONS)',
+      () => {
+        const {ddl} = generatePropertyGraph(model(), GEN_OPTS);
+        expect(ddl).not.toContain('MODEL_LEVEL_DESC');
+        expect(ddl).not.toContain('modelsyn');
+      });
+});
+
+
 // The BigQuery restrictions recorded at
 // go/x20 -> bei/bigquery-property-graph-limits.html (section A): a graph
 // MEASURE may only aggregate a SINGLE EXPOSED PROPERTY of its node — never a

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.bigquery.golden.sql
@@ -6,9 +6,9 @@ NODE TABLES (
     PROPERTIES(
       o_orderkey OPTIONS(description="Order identifier"),
       o_custkey,
-      o_orderdate OPTIONS(description="Order Date\n\nTime dimension.\n\nSynonyms: order date, date"),
+      o_orderdate OPTIONS(description="Order Date\n\nTime dimension.", synonyms=["order date", "date"]),
       o_totalprice,
-      MEASURE(SUM(o_totalprice)) AS total_revenue OPTIONS(description="Total order revenue\n\nSynonyms: revenue, sales"),
+      MEASURE(SUM(o_totalprice)) AS total_revenue OPTIONS(description="Total order revenue", synonyms=["revenue", "sales"]),
       MEASURE(COUNT(o_orderkey)) AS order_count OPTIONS(description="Number of orders")
     ),
   `samples.tpch.customer` AS customer
@@ -23,8 +23,7 @@ EDGE TABLES (
     KEY(o_orderkey)
     SOURCE KEY(o_orderkey) REFERENCES orders(o_orderkey)
     DESTINATION KEY(o_custkey) REFERENCES customer(c_custkey)
-)
-OPTIONS(description="Sales orders with customer attributes\n\nUse this model for order analysis.");
+);
 
 -- warnings --
 -- note: no 'BIGQUERY' dialect for one or more expressions; using the portable 'ANSI_SQL' dialect verbatim ('BIGQUERY' accepts the ANSI core subset — supply 'BIGQUERY' variants only for BIGQUERY-specific SQL)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.bigquery.golden.sql
@@ -54,8 +54,7 @@ EDGE TABLES (
     KEY(ss_item_sk, ss_ticket_number)
     SOURCE KEY(ss_item_sk, ss_ticket_number) REFERENCES store_sales(ss_item_sk, ss_ticket_number)
     DESTINATION KEY(ss_store_sk) REFERENCES store(s_store_sk)
-)
-OPTIONS(description="TPC-DS retail model");
+);
 
 -- warnings --
 -- note: no 'BIGQUERY' dialect for one or more expressions; using the portable 'ANSI_SQL' dialect verbatim ('BIGQUERY' accepts the ANSI core subset — supply 'BIGQUERY' variants only for BIGQUERY-specific SQL)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_retail.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_retail.bigquery.golden.sql
@@ -2,62 +2,62 @@ CREATE OR REPLACE PROPERTY GRAPH `sqlgen-testing.demo.tpcds_retail_model`
 NODE TABLES (
   `tpcds.public.store_sales` AS store_sales
     KEY(ss_item_sk, ss_ticket_number)
-    OPTIONS(description="Fact table containing all store sales transactions\n\nSynonyms: sales transactions, store purchases, retail sales, POS data")
+    OPTIONS(description="Fact table containing all store sales transactions", synonyms=["sales transactions", "store purchases", "retail sales", "POS data"])
     PROPERTIES(
-      ss_sold_date_sk OPTIONS(description="Foreign key to date dimension\n\nSynonyms: sale date, transaction date"),
-      ss_item_sk OPTIONS(description="Foreign key to item dimension\n\nSynonyms: product, item"),
-      ss_customer_sk OPTIONS(description="Foreign key to customer dimension\n\nSynonyms: customer, buyer"),
-      ss_store_sk OPTIONS(description="Foreign key to store dimension\n\nSynonyms: store, location"),
-      ss_quantity OPTIONS(description="Quantity of items sold\n\nSynonyms: units sold, quantity"),
-      ss_sales_price OPTIONS(description="Sales price per unit\n\nSynonyms: unit price, price"),
-      ss_ext_sales_price OPTIONS(description="Extended sales price (quantity * price)\n\nSynonyms: total price, line total"),
-      ss_net_profit OPTIONS(description="Net profit from the sale\n\nSynonyms: profit, margin"),
-      MEASURE(SUM(ss_ext_sales_price)) AS total_sales OPTIONS(description="Total sales revenue across all transactions\n\nSynonyms: total revenue, gross sales, sales amount"),
-      MEASURE(SUM(ss_net_profit)) AS total_profit OPTIONS(description="Total net profit from store sales\n\nSynonyms: net profit, total earnings, profit"),
-      MEASURE(SUM(ss_ext_sales_price)) AS sales_by_brand OPTIONS(description="Total sales by brand (requires grouping by item.i_brand)\n\nSynonyms: brand sales, brand performance, brand revenue")
+      ss_sold_date_sk OPTIONS(description="Foreign key to date dimension", synonyms=["sale date", "transaction date"]),
+      ss_item_sk OPTIONS(description="Foreign key to item dimension", synonyms=["product", "item"]),
+      ss_customer_sk OPTIONS(description="Foreign key to customer dimension", synonyms=["customer", "buyer"]),
+      ss_store_sk OPTIONS(description="Foreign key to store dimension", synonyms=["store", "location"]),
+      ss_quantity OPTIONS(description="Quantity of items sold", synonyms=["units sold", "quantity"]),
+      ss_sales_price OPTIONS(description="Sales price per unit", synonyms=["unit price", "price"]),
+      ss_ext_sales_price OPTIONS(description="Extended sales price (quantity * price)", synonyms=["total price", "line total"]),
+      ss_net_profit OPTIONS(description="Net profit from the sale", synonyms=["profit", "margin"]),
+      MEASURE(SUM(ss_ext_sales_price)) AS total_sales OPTIONS(description="Total sales revenue across all transactions", synonyms=["total revenue", "gross sales", "sales amount"]),
+      MEASURE(SUM(ss_net_profit)) AS total_profit OPTIONS(description="Total net profit from store sales", synonyms=["net profit", "total earnings", "profit"]),
+      MEASURE(SUM(ss_ext_sales_price)) AS sales_by_brand OPTIONS(description="Total sales by brand (requires grouping by item.i_brand)", synonyms=["brand sales", "brand performance", "brand revenue"])
     ),
   `tpcds.public.date_dim` AS date_dim
     KEY(d_date_sk)
-    OPTIONS(description="Date dimension with calendar attributes\n\nSynonyms: calendar, dates, time periods")
+    OPTIONS(description="Date dimension with calendar attributes", synonyms=["calendar", "dates", "time periods"])
     PROPERTIES(
       d_date_sk OPTIONS(description="Surrogate key for date"),
-      d_date OPTIONS(description="Time dimension.\n\nActual date value\n\nSynonyms: date, calendar date"),
-      d_year OPTIONS(description="Time dimension.\n\nYear\n\nSynonyms: year"),
-      d_quarter_name OPTIONS(description="Time dimension.\n\nQuarter name (e.g., 2024Q1)\n\nSynonyms: quarter, fiscal quarter"),
-      d_month_name OPTIONS(description="Time dimension.\n\nMonth name\n\nSynonyms: month")
+      d_date OPTIONS(description="Time dimension.\n\nActual date value", synonyms=["date", "calendar date"]),
+      d_year OPTIONS(description="Time dimension.\n\nYear", synonyms=["year"]),
+      d_quarter_name OPTIONS(description="Time dimension.\n\nQuarter name (e.g., 2024Q1)", synonyms=["quarter", "fiscal quarter"]),
+      d_month_name OPTIONS(description="Time dimension.\n\nMonth name", synonyms=["month"])
     ),
   `tpcds.public.customer` AS customer
     KEY(c_customer_sk)
-    OPTIONS(description="Customer dimension with demographic information\n\nSynonyms: customers, shoppers, buyers")
+    OPTIONS(description="Customer dimension with demographic information", synonyms=["customers", "shoppers", "buyers"])
     PROPERTIES(
       c_customer_sk OPTIONS(description="Surrogate key for customer"),
-      c_customer_id OPTIONS(description="Business key for customer\n\nSynonyms: customer ID, customer number"),
+      c_customer_id OPTIONS(description="Business key for customer", synonyms=["customer ID", "customer number"]),
       c_first_name OPTIONS(description="Customer first name"),
       c_last_name OPTIONS(description="Customer last name"),
-      c_first_name || ' ' || c_last_name AS customer_full_name OPTIONS(description="Customer full name (computed field)\n\nSynonyms: full name, customer name"),
-      c_email_address OPTIONS(description="Customer email address\n\nSynonyms: email, contact")
+      c_first_name || ' ' || c_last_name AS customer_full_name OPTIONS(description="Customer full name (computed field)", synonyms=["full name", "customer name"]),
+      c_email_address OPTIONS(description="Customer email address", synonyms=["email", "contact"])
     ),
   `tpcds.public.item` AS item
     KEY(i_item_sk)
-    OPTIONS(description="Item/Product dimension with product attributes\n\nSynonyms: products, items, merchandise")
+    OPTIONS(description="Item/Product dimension with product attributes", synonyms=["products", "items", "merchandise"])
     PROPERTIES(
       i_item_sk OPTIONS(description="Surrogate key for item"),
-      i_item_id OPTIONS(description="Business key for item\n\nSynonyms: item ID, product ID, SKU"),
-      i_item_desc OPTIONS(description="Item description\n\nSynonyms: product description, item name"),
-      i_brand OPTIONS(description="Brand name\n\nSynonyms: brand, manufacturer"),
-      i_category OPTIONS(description="Item category\n\nSynonyms: product category, department"),
-      i_current_price OPTIONS(description="Current price of the item\n\nSynonyms: price, list price")
+      i_item_id OPTIONS(description="Business key for item", synonyms=["item ID", "product ID", "SKU"]),
+      i_item_desc OPTIONS(description="Item description", synonyms=["product description", "item name"]),
+      i_brand OPTIONS(description="Brand name", synonyms=["brand", "manufacturer"]),
+      i_category OPTIONS(description="Item category", synonyms=["product category", "department"]),
+      i_current_price OPTIONS(description="Current price of the item", synonyms=["price", "list price"])
     ),
   `tpcds.public.store` AS store
     KEY(s_store_sk)
-    OPTIONS(description="Store dimension with location and store attributes\n\nSynonyms: stores, retail locations, branches")
+    OPTIONS(description="Store dimension with location and store attributes", synonyms=["stores", "retail locations", "branches"])
     PROPERTIES(
       s_store_sk OPTIONS(description="Surrogate key for store"),
-      s_store_id OPTIONS(description="Business key for store\n\nSynonyms: store ID, store number"),
-      s_store_name OPTIONS(description="Store name\n\nSynonyms: store name, location name"),
-      s_city OPTIONS(description="City where store is located\n\nSynonyms: city, location"),
-      s_state OPTIONS(description="State where store is located\n\nSynonyms: state, region"),
-      s_number_employees OPTIONS(description="Number of employees at the store\n\nSynonyms: employee count, staff size")
+      s_store_id OPTIONS(description="Business key for store", synonyms=["store ID", "store number"]),
+      s_store_name OPTIONS(description="Store name", synonyms=["store name", "location name"]),
+      s_city OPTIONS(description="City where store is located", synonyms=["city", "location"]),
+      s_state OPTIONS(description="State where store is located", synonyms=["state", "region"]),
+      s_number_employees OPTIONS(description="Number of employees at the store", synonyms=["employee count", "staff size"])
     )
 )
 EDGE TABLES (
@@ -65,24 +65,23 @@ EDGE TABLES (
     KEY(ss_item_sk, ss_ticket_number)
     SOURCE KEY(ss_item_sk, ss_ticket_number) REFERENCES store_sales(ss_item_sk, ss_ticket_number)
     DESTINATION KEY(ss_sold_date_sk) REFERENCES date_dim(d_date_sk)
-    OPTIONS(description="Synonyms: sales date relationship, when sale occurred"),
+    OPTIONS(synonyms=["sales date relationship", "when sale occurred"]),
   `tpcds.public.store_sales` AS store_sales_to_customer
     KEY(ss_item_sk, ss_ticket_number)
     SOURCE KEY(ss_item_sk, ss_ticket_number) REFERENCES store_sales(ss_item_sk, ss_ticket_number)
     DESTINATION KEY(ss_customer_sk) REFERENCES customer(c_customer_sk)
-    OPTIONS(description="Synonyms: customer purchase relationship, who bought"),
+    OPTIONS(synonyms=["customer purchase relationship", "who bought"]),
   `tpcds.public.store_sales` AS store_sales_to_item
     KEY(ss_item_sk, ss_ticket_number)
     SOURCE KEY(ss_item_sk, ss_ticket_number) REFERENCES store_sales(ss_item_sk, ss_ticket_number)
     DESTINATION KEY(ss_item_sk) REFERENCES item(i_item_sk)
-    OPTIONS(description="Synonyms: product sold relationship, what was sold"),
+    OPTIONS(synonyms=["product sold relationship", "what was sold"]),
   `tpcds.public.store_sales` AS store_sales_to_store
     KEY(ss_item_sk, ss_ticket_number)
     SOURCE KEY(ss_item_sk, ss_ticket_number) REFERENCES store_sales(ss_item_sk, ss_ticket_number)
     DESTINATION KEY(ss_store_sk) REFERENCES store(s_store_sk)
-    OPTIONS(description="Synonyms: store location relationship, where sale occurred")
-)
-OPTIONS(description="TPC-DS retail semantic model for sales and customer analytics\n\nUse this semantic model for retail analytics. It provides comprehensive sales, customer, product, and store data. The model supports time-based analysis, customer segmentation, product performance, and store operations metrics.");
+    OPTIONS(synonyms=["store location relationship", "where sale occurred"])
+);
 
 -- warnings --
 -- note: no 'BIGQUERY' dialect for one or more expressions; using the portable 'ANSI_SQL' dialect verbatim ('BIGQUERY' accepts the ANSI core subset — supply 'BIGQUERY' variants only for BIGQUERY-specific SQL)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/vendor_dialects.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/vendor_dialects.bigquery.golden.sql
@@ -32,8 +32,7 @@ EDGE TABLES (
     KEY(o_orderkey)
     SOURCE KEY(o_orderkey) REFERENCES orders(o_orderkey)
     DESTINATION KEY(o_custkey) REFERENCES customer(c_custkey)
-)
-OPTIONS(description="Orders and customers with vendor-dialect expressions");
+);
 
 -- warnings --
 -- note: no 'BIGQUERY' dialect for one or more expressions; using the portable 'ANSI_SQL' dialect verbatim ('BIGQUERY' accepts the ANSI core subset — supply 'BIGQUERY' variants only for BIGQUERY-specific SQL)


### PR DESCRIPTION
## What

BigQuery property-graph `OPTIONS` carry a structured `synonyms` array (plus a `description` string) on labels, properties, and measures — see `PropertyGraph{Label,Property}Options` in `analysis/dremel/core/ddl/bigquery-ddl-options.proto`; the `graph_property_options` feature is on for BigQuery. The converter was folding `ai_context.synonyms` into the description text as a `Synonyms: …` line instead of using that option.

This PR makes the push carry synonyms **structurally**:

- Emit `OPTIONS(synonyms=[...])` on entity/relationship labels, field properties, and measures.
- `description`, `ai_context.instructions`, `ai_context.examples`, and a field's `label` still fold into the single `description` string (BigQuery gives them no dedicated option).
- Stop emitting the **statement-level** graph `OPTIONS`: BigQuery parses but silently discards it (`create_property_graph_options` is off for BigQuery), so model-level metadata never landed in the graph. The model's description is carried into Knowledge Catalog instead.
- Correct the semantic-model guide's lossiness section (the earlier draft wrongly claimed BigQuery had no `synonyms` option) and add converter test coverage.

## Verification

- `bun test tests/libts/semantic/bigquery.test.ts` — 17 pass (3 new).
- **Live against BigQuery** (`sqlgen-testing`): the generated DDL deploys clean and the `synonyms` array persists on labels, properties, and measures (confirmed via `INFORMATION_SCHEMA.PROPERTY_GRAPHS`). Statement-level graph `OPTIONS` confirmed silently dropped.