### PR TITLE
okf: carry nested producer-defined keys, and stop leaking .staging

### DIFF
--- a/toolbox/mdcode/demo/README.md
+++ b/toolbox/mdcode/demo/README.md
@@ -139,9 +139,14 @@ The aspect models the full OKF v0.2 signal as typed, searchable fields:
 `sources` (with `author`, `usage_count`, `last_modified`), `usage_window`,
 and the Attested Computation contract (`runtime`, `parameters`,
 `computation`, `executor`, `attester`). OKF also permits producer-defined
-frontmatter keys, so no enumerated template can ever be complete. Anything
-the template does not model is carried as JSON on a single `extra` field,
-which keeps the round-trip lossless for any conformant bundle.
+frontmatter keys at any depth, so no enumerated template can ever be
+complete. Anything the template does not model, whether a top-level key like
+`not:` or a subfield inside a modeled record like `sources[].license`, is
+diverted onto a single `extra` field as a JSON list of `[path, value]` pairs
+and restored on pull. That keeps the round-trip lossless for any conformant
+bundle. A diverted subfield returns at the end of its record rather than its
+original position, which is the same presentation normalization pull already
+applies elsewhere.
 
 **Setup**
 

--- a/toolbox/mdcode/demo/okf/okf-aspect.json
+++ b/toolbox/mdcode/demo/okf/okf-aspect.json
@@ -320,7 +320,7 @@
       "type": "string",
       "annotations": {
         "displayName": "Extra Frontmatter",
-        "description": "JSON of producer-defined frontmatter keys this template does not model. OKF allows arbitrary extra keys, so no enumerated template can be complete; keeping them here makes the round-trip lossless."
+        "description": "Producer-defined frontmatter this template does not model, as a JSON list of [path, value] pairs where a path is a list of record field names and list indices. OKF allows arbitrary extra keys at any depth, so no enumerated template can be complete; keeping them here makes the round-trip lossless."
       }
     }
   ],

--- a/toolbox/mdcode/demo/okf/okf.ts
+++ b/toolbox/mdcode/demo/okf/okf.ts
@@ -12,6 +12,12 @@ import * as yaml from 'yaml';
 
 export interface Split { meta: any | null; body: string; }
 
+// Where an unmodeled key sits in the frontmatter: record fields are strings,
+// list positions are numbers. `['sources', 0, 'license']` is a producer-defined
+// subfield on the first source.
+type Path = (string | number)[];
+type Extra = [Path, any];
+
 // `--bundle <dir>` selects which OKF bundle to operate on, so the demo can run
 // against a bundle elsewhere in the repo instead of only its own catalog/.
 export function bundleDir(root: string, argv: string[] = process.argv.slice(2)): string {
@@ -87,6 +93,18 @@ function render(meta: any, body: string): string {
   return `---\n${fm}\n---\n\n${body.trim()}\n`;
 }
 
+function setAtPath(root: any, path: Path, value: any): void {
+  let node = root;
+  for (let i = 0; i < path.length - 1; i++) {
+    const segment = path[i];
+    if (node[segment] === undefined) {
+      node[segment] = typeof path[i + 1] === 'number' ? [] : {};
+    }
+    node = node[segment];
+  }
+  node[path[path.length - 1]] = value;
+}
+
 // Keep only present keys, in a stable order, so round-trips are deterministic.
 function pick(obj: any, keys: string[]): any {
   const out: any = {};
@@ -105,27 +123,49 @@ export function toStaging(content: string, okfKey: string): string {
     return content;
   }
 
+  // OKF permits producer-defined keys at any depth, so an enumerated template
+  // can never be complete. Anything unmodeled is diverted here and rides along
+  // in `extra` as a [path, value] pair to keep the round-trip lossless.
+  const extras: Extra[] = [];
+  const divert = (value: any, fields: string[], path: Path): any => {
+    const kept: any = {};
+    for (const [key, item] of Object.entries(value)) {
+      if (item === undefined || item === null) {
+        continue;
+      }
+      if (fields.includes(key)) {
+        kept[key] = item;
+      } else {
+        extras.push([[...path, key], item]);
+      }
+    }
+    return pick(kept, fields);
+  };
+
   const signal: any = {};
   if (meta.type !== undefined) {
     signal.okf_type = meta.type;
   }
-  Object.assign(signal, pick(meta, SIGNAL_KEYS));
-  // SPEC 5.2 allows a lone verifier as a bare mapping; the aspect field is a list.
-  if (signal.verified !== undefined && !Array.isArray(signal.verified)) {
-    signal.verified = [signal.verified];
-  }
-
-  // OKF permits producer-defined keys, so an enumerated template can never be
-  // complete. Anything unmodeled rides along as JSON to keep the round-trip
-  // lossless.
-  const extra: any = {};
-  for (const key of Object.keys(meta)) {
-    if (!MODELED_KEYS.has(key)) {
-      extra[key] = meta[key];
+  for (const [key, value] of Object.entries(pick(meta, SIGNAL_KEYS))) {
+    const fields = RECORD_KEYS[key];
+    if (!fields) {
+      signal[key] = value;
+    } else if (LIST_KEYS.has(key)) {
+      // SPEC 5.2 allows a lone verifier as a bare mapping; the field is a list.
+      const list = Array.isArray(value) ? value : [value];
+      signal[key] = list.map((item, i) => divert(item, fields, [key, i]));
+    } else {
+      signal[key] = divert(value, fields, [key]);
     }
   }
-  if (Object.keys(extra).length > 0) {
-    signal.extra = JSON.stringify(extra);
+
+  for (const key of Object.keys(meta)) {
+    if (!MODELED_KEYS.has(key)) {
+      extras.push([[key], meta[key]]);
+    }
+  }
+  if (extras.length > 0) {
+    signal.extra = JSON.stringify(extras);
   }
 
   const staged = pick(meta, LAYOUT_KEYS);
@@ -166,8 +206,13 @@ export function fromStaging(content: string, okfKey: string): string {
       clean[key] = pick(value, fields);
     }
   }
+  // Last, so the records the nested paths point into already exist. A diverted
+  // subfield returns at the end of its record rather than its original
+  // position, which pull already normalizes anyway.
   if (okf.extra !== undefined) {
-    Object.assign(clean, JSON.parse(okf.extra));
+    for (const [path, value] of JSON.parse(okf.extra) as Extra[]) {
+      setAtPath(clean, path, value);
+    }
   }
   return render(clean, body);
 }

--- a/toolbox/mdcode/demo/okf/pull.ts
+++ b/toolbox/mdcode/demo/okf/pull.ts
@@ -23,13 +23,15 @@ fs.rmSync(stagingDir, { recursive: true, force: true });
 fs.mkdirSync(stagingCatalog, { recursive: true });
 fs.copyFileSync(path.join(root, 'catalog.yaml'), path.join(stagingDir, 'catalog.yaml'));
 
-cp.execFileSync(binary, ['pull'], { cwd: stagingDir, stdio: 'inherit' });
+try {
+  cp.execFileSync(binary, ['pull'], { cwd: stagingDir, stdio: 'inherit' });
 
-for (const file of listMarkdown(stagingCatalog)) {
-  const rel = path.relative(stagingCatalog, file);
-  const dest = path.join(catalogDir, rel);
-  fs.mkdirSync(path.dirname(dest), { recursive: true });
-  fs.writeFileSync(dest, fromStaging(fs.readFileSync(file, 'utf8'), okfKey));
+  for (const file of listMarkdown(stagingCatalog)) {
+    const rel = path.relative(stagingCatalog, file);
+    const dest = path.join(catalogDir, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, fromStaging(fs.readFileSync(file, 'utf8'), okfKey));
+  }
+} finally {
+  fs.rmSync(stagingDir, { recursive: true, force: true });
 }
-
-fs.rmSync(stagingDir, { recursive: true, force: true });

--- a/toolbox/mdcode/demo/okf/push.ts
+++ b/toolbox/mdcode/demo/okf/push.ts
@@ -30,6 +30,8 @@ for (const file of listMarkdown(catalogDir)) {
   fs.writeFileSync(dest, toStaging(fs.readFileSync(file, 'utf8'), okfKey));
 }
 
-cp.execFileSync(binary, ['push'], { cwd: stagingDir, stdio: 'inherit' });
-
-fs.rmSync(stagingDir, { recursive: true, force: true });
+try {
+  cp.execFileSync(binary, ['push'], { cwd: stagingDir, stdio: 'inherit' });
+} finally {
+  fs.rmSync(stagingDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
Two defects found while round-tripping `acme_retail` after #292.

## 1. The `extra` escape hatch was top-level only

#292 added `extra` because OKF permits producer-defined frontmatter keys, so no
enumerated aspect template can ever be complete. But it only collected keys at
the top level. A producer-defined subfield *inside* a modeled record was still
forwarded to Dataplex verbatim:

```yaml
sources:
  - id: margin-standard
    license: CC-BY-4.0      # not in the template
    resource: policies/margin-standard.md
```

```
400 ... ASPECT_SCHEMA_PARSING_FAILURE
```

So the failure class `extra` was introduced to close was still wide open one
level down.

`RECORD_KEYS` in `okf.ts` already declares the legal subfields of every record,
but it was only consulted on the pull side. `toStaging` now applies it on push
too and diverts anything it does not name.

Top-level and nested extras now share one encoding, a JSON list of
`[path, value]` pairs, where a path segment is a record field name or a list
index:

```json
[[["sources", 0, "license"], "CC-BY-4.0"], [["not"], [{"term": "..."}]]]
```

`fromStaging` restores them by walking the path, after the signal records are
rebuilt so the containers exist. This replaces the previous
`Object.assign(clean, JSON.parse(okf.extra))`.

Folding the list case into the same loop also absorbed the standalone SPEC 5.2
normalization that turned a bare `verified: {by, at}` mapping into a
one-element list.

One behavior note, now in the README: a diverted subfield comes back at the end
of its record rather than its original position. Semantically identical, and the
same presentation normalization pull already applies to key order and block
style.

## 2. `.staging/` leaked on failure

`push.ts` and `pull.ts` removed the throwaway staging tree on the line *after*
the `execFileSync` call, which is skipped when that call throws. Any failed push
left `.staging/` on disk. Both now clean up in a `finally`. In `pull.ts` the
block also has to cover the write-back loop, which sits between the kcmd call
and the old cleanup line.

## Verification

Live against `hormati-bqml` / `us-central1`, plus local checks.

* `sources[].license` added to a scratch copy of `acme_retail`: pushes cleanly
  where it previously returned `ASPECT_SCHEMA_PARSING_FAILURE`, and comes back
  on pull. Confirmed the stored aspect holds
  `[["sources",0,"license"],"CC-BY-4.0"]` in `extra` with `sources[0]` carrying
  only modeled fields.
* Full `acme_retail` round-trip through Dataplex: 17 files, 17 lossless, 0 lossy
  by semantic diff of parsed frontmatter plus body.
* GA4 (`demo/okf/catalog`, 14 files): still byte-identical through
  `toStaging` then `fromStaging`.
* Forced a push failure with an invalid typed value (`usage_count: not-an-integer`)
  and confirmed the command errors and `.staging/` is gone.
* `bun test ./tests/libts/scenarios.ts`: 17 pass, 0 fail. No library files change
  in this PR.

## Not addressed

A related review point was to publish these entries under a custom `okf-bundle`
EntryType instead of `dataplex-types.global.generic`. Deliberately skipped: the
document's OKF type is already recorded as `okf_type` on the `okf` aspect, and
keeping the entry type generic also keeps the three-aspect shape stable, since
`documents.ts` auto-attaches the generic aspect only for generic-typed entries.
