### PR TITLE
okf: publish bundle documents under a custom okf-bundle entry type

### DIFF
--- a/toolbox/mdcode/demo/README.md
+++ b/toolbox/mdcode/demo/README.md
@@ -134,6 +134,15 @@ translate it into a custom typed `okf` Dataplex aspect (created by
 `setup.ts`) and back, keeping the on-disk files clean OKF and
 round-tripping the signal losslessly.
 
+Entries are published under a custom `okf-bundle` entry type rather than
+the built-in `dataplex-types.global.generic`, so a catalog-wide search can
+pick out OKF documents. A document's OKF `type:` is freeform prose, not a
+Dataplex type ref, so it is recorded separately as `okf_type` on the `okf`
+aspect. `okf-bundle` declares no required aspects, because SPEC 8 index
+files carry no signal layer and requiring the `okf` aspect would reject
+them. An entry's type is fixed at creation, so a bundle already published
+under the generic type has to have its entry group deleted and recreated.
+
 The aspect models the full OKF v0.2 signal as typed, searchable fields:
 `type`, `resource`, `generated`, `verified`, `status`, `stale_after`,
 `sources` (with `author`, `usage_count`, `last_modified`), `usage_window`,
@@ -153,8 +162,9 @@ applies elsewhere.
 * Creates an empty Dataplex EntryGroup (`okf_ga4`).
 * Creates the custom `okf` aspect type from `okf-aspect.json`, or updates it
   if a previous run of this demo left an older template behind.
+* Creates the custom `okf-bundle` entry type.
 * Creates a `catalog.yaml` manifest pointing at the EntryGroup and listing
-  the `okf` aspect.
+  the `okf-bundle` entry type and the `okf` aspect.
 * The `catalog/` directory is already populated with the GA4 markdown bundle.
 
 ```bash
@@ -167,9 +177,8 @@ ls -R catalog
 
 * Push the bundled markdown to Knowledge Catalog. Entry names mirror the
   file path (e.g. `references/metrics/purchasers.md` &rarr; entry
-  `references/metrics/purchasers`). Custom `type:` values in frontmatter
-  that aren't valid Dataplex type refs are preserved on the `okf` aspect
-  (the entry itself falls back to `dataplex-types.global.generic`).
+  `references/metrics/purchasers`). Every file lands as an `okf-bundle`
+  entry, index files included, with its OKF `type:` on the `okf` aspect.
 
 ```bash
 bun push.ts
@@ -222,10 +231,11 @@ bun pull.ts --bundle /tmp/acme_pulled
 
 **Cleanup**
 
-* Deletes the Dataplex EntryGroup. The custom `okf` aspect type is left in
-  place: it is scoped to the project and location rather than to this demo, so
-  other OKF bundles in the same project carry their signal layer on it. The
-  command to remove it manually is printed at the end.
+* Deletes the Dataplex EntryGroup. The custom `okf` aspect type and
+  `okf-bundle` entry type are left in place: they are scoped to the project and
+  location rather than to this demo, so other OKF bundles in the same project
+  are typed by them too. The commands to remove them manually are printed at
+  the end.
 
 ```bash
 bun cleanup.ts

--- a/toolbox/mdcode/demo/okf/cleanup.ts
+++ b/toolbox/mdcode/demo/okf/cleanup.ts
@@ -14,11 +14,14 @@ function dataplex(cmd: string, data: string|null=null) {
 dataplex(`entry-groups delete ${entryGroup}`);
 console.log(`Deleted entry group ${entryGroup}`);
 
-// The okf aspect type is scoped to the project and location, not to this demo's
-// entry group, so any other OKF bundle in the project attaches its signal layer
-// to the same type. Deleting it here would strip that signal from bundles this
-// demo does not own.
+// The okf aspect type and the okf-bundle entry type are scoped to the project
+// and location, not to this demo's entry group, so any other OKF bundle in the
+// project is typed by them too. Deleting them here would strip the signal layer
+// from bundles this demo does not own, and Dataplex refuses to delete a type
+// that entries still reference.
 console.log(
-  `Left aspect type ${project}.${location}.okf in place (shared across OKF bundles). ` +
-  `To remove it: gcloud dataplex aspect-types delete okf --project ${project} --location ${location}`
+  `Left aspect type ${project}.${location}.okf and entry type ` +
+  `${project}.${location}.okf-bundle in place (shared across OKF bundles). To remove them:\n` +
+  `  gcloud dataplex aspect-types delete okf --project ${project} --location ${location}\n` +
+  `  gcloud dataplex entry-types delete okf-bundle --project ${project} --location ${location}`
 );

--- a/toolbox/mdcode/demo/okf/okf.ts
+++ b/toolbox/mdcode/demo/okf/okf.ts
@@ -117,10 +117,14 @@ function pick(obj: any, keys: string[]): any {
 }
 
 // clean OKF -> pushable (signal moved into catalogEntry / okf aspect)
-export function toStaging(content: string, okfKey: string): string {
+export function toStaging(content: string, okfKey: string, entryTypeKey: string): string {
   const { meta, body } = splitFrontmatter(content);
   if (!meta) {
-    return content;
+    // SPEC 8 index files carry no frontmatter, so stage the entry type on its
+    // own. Without it the layout falls back to the built-in generic type and
+    // the bundle's navigation nodes end up a different kind of thing from the
+    // concepts they link to. Pull drops it again: there is no signal to restore.
+    return render({ type: entryTypeKey }, body);
   }
 
   // OKF permits producer-defined keys at any depth, so an enumerated template
@@ -168,7 +172,10 @@ export function toStaging(content: string, okfKey: string): string {
     signal.extra = JSON.stringify(extras);
   }
 
-  const staged = pick(meta, LAYOUT_KEYS);
+  // The OKF `type` is freeform prose and never a Dataplex type ref, so the
+  // layout would fall back to generic. It rides on the aspect as `okf_type`
+  // instead, leaving `type` here to name the Dataplex entry type.
+  const staged: any = { type: entryTypeKey, ...pick(meta, LAYOUT_KEYS) };
   staged.catalogEntry = {
     resource: { name: meta.resource },
     aspects: { [okfKey]: signal },

--- a/toolbox/mdcode/demo/okf/push.ts
+++ b/toolbox/mdcode/demo/okf/push.ts
@@ -13,6 +13,7 @@ import { bundleDir, listMarkdown, toStaging } from './okf';
 
 const context = kcmd.gcp.ApiContext.default();
 const okfKey = `${context.project}.${context.location}.okf`;
+const entryTypeKey = `${context.project}.${context.location}.okf-bundle`;
 
 const root = process.cwd();
 const catalogDir = bundleDir(root);
@@ -27,7 +28,7 @@ for (const file of listMarkdown(catalogDir)) {
   const rel = path.relative(catalogDir, file);
   const dest = path.join(stagingDir, 'catalog', rel);
   fs.mkdirSync(path.dirname(dest), { recursive: true });
-  fs.writeFileSync(dest, toStaging(fs.readFileSync(file, 'utf8'), okfKey));
+  fs.writeFileSync(dest, toStaging(fs.readFileSync(file, 'utf8'), okfKey, entryTypeKey));
 }
 
 try {

--- a/toolbox/mdcode/demo/okf/setup.ts
+++ b/toolbox/mdcode/demo/okf/setup.ts
@@ -39,26 +39,47 @@ catch {
   console.log();
 }
 
-const okfAspect = `${project}.${location}.okf`;
+// A custom entry type, so a search can tell an OKF document apart from anything
+// else in the project. It declares no required aspects: SPEC 8 index files
+// carry no signal layer, so requiring the okf aspect would reject them.
+const entryTypeFlags =
+  '--display-name="OKF Document" ' +
+  '--description="A document in an Open Knowledge Format bundle."';
 
+try {
+  dataplex(`entry-types create okf-bundle ${entryTypeFlags}`);
+  console.log('Created custom entry type okf-bundle');
+  console.log();
+}
+catch {
+  dataplex(`entry-types update okf-bundle ${entryTypeFlags}`);
+  console.log('Updated existing entry type okf-bundle');
+  console.log();
+}
+
+const okfAspect = `${project}.${location}.okf`;
+const okfEntryType = `${project}.${location}.okf-bundle`;
+
+// Every markdown file in the bundle is published as okf-bundle, so the built-in
+// generic type is gone from both lists. The list must stay non-empty: it is
+// what keeps the entry group's own root entry, which belongs to no file, from
+// being pulled down as one.
 await Bun.file(path.join(process.cwd(), 'catalog.yaml')).write(YAML.stringify({
   scope: `kb.${project}.${location}.${entryGroup}`,
   snapshot: {
     entries: [
-      'dataplex-types.global.generic'
+      okfEntryType
     ],
     aspects: [
-      'dataplex-types.global.generic',
       'dataplex-types.global.overview',
       okfAspect
     ]
   },
   publishing: {
     entries: [
-      'dataplex-types.global.generic'
+      okfEntryType
     ],
     aspects: [
-      'dataplex-types.global.generic',
       'dataplex-types.global.overview',
       okfAspect
     ]


### PR DESCRIPTION
Every entry the OKF demo published landed as `dataplex-types.global.generic`,
so nothing in the catalog distinguished an OKF document from any other markdown
in the project. This adds a custom `okf-bundle` entry type and publishes under
it.

## Why the layout could not do this on its own

`documents.ts` derives the entry type from frontmatter, but only when the value
looks like a Dataplex type ref:

```ts
entry.type = (typeof metadata.type === 'string' && metadata.type.split('.').length === 3)
  ? metadata.type : DEFAULT_ENTRY_TYPE;
```

An OKF `type:` is freeform prose (`Metric`, `Attested Computation`), so it never
matched and every document fell through to generic. It already rides on the
`okf` aspect as `okf_type`, so the two are not in competition: `toStaging` now
names the Dataplex entry type in staged `type:` and leaves the OKF one where it
was.

`setup.ts` creates the entry type, or updates it when a previous run left one
behind, matching what it already does for the `okf` aspect type.

## Index files

They carry no frontmatter, and SPEC 8 forbids giving them any except a
bundle-root `okf_version`. `toStaging` passed them through untouched, so they
fell back to generic and a bundle's navigation nodes ended up a different kind
of thing from the concepts they link to. They now get a staged `type:` and
nothing else.

That is what rules out `--required-aspects` on the entry type. Requiring the
`okf` aspect would be the natural way to make `okf-bundle` mean something, but
an index has no signal layer to put there, so it would reject seven of the
seventeen files.

Pull needed no change. `toMarkdown` already writes `type:` into every pulled
file, and `fromStaging` already discards it: the `hasSignal` branch exists
precisely because pull was writing `type: dataplex-types.global.generic` onto
index files. Only the discarded value changes.

## The entry group's root entry

`catalog.yaml` no longer lists `dataplex-types.global.generic` under `entries`,
but the list has to stay non-empty. `sync.ts:36` is what keeps the entry group's
own root entry, which belongs to no file, from being pulled down as one:

```ts
if (this._snapshot.entryTypes.size && !this._snapshot.entryTypes.has(entry.entryType)) continue;
```

That entry is `dataplex-types.global.entrygroup`, so listing `okf-bundle`
filters it just as listing generic did. Emptying `entries` would disable the
filter entirely.

The generic aspect also leaves both `aspects` lists. `documents.ts:85` attached
it only as a side effect of the entry type being generic, and nothing produces
or consumes it now.

## Verification

Live against `hormati-bqml` / `us-central1` with the unmodified
`okf/bundles/acme_retail`, plus local checks.

* All 17 entries report `entryType: okf-bundle`, index files included. The root
  entry is still `entrygroup` and is not pulled down as a file: pull produced
  exactly 17 files with no `okf_ga4_entry.md`.
* Round-trip through Dataplex: 17 files, 17 lossless, 0 lossy by semantic diff
  of parsed frontmatter plus body. The 7 index files and `log.md` come back
  byte-identical.
* `metrics/gross-margin` carries overview + okf with `okf_type: Metric`, its
  three labels, and `extra` holding the producer-defined `not:` key.
  `metrics/index` carries overview only.
* Ran `setup.ts` twice to exercise the update path, then re-pushed over the
  existing entries: both clean.
* GA4 (`demo/okf/catalog`, 14 files): still byte-identical through `toStaging`
  then `fromStaging`.
* `bun test ./tests/libts/scenarios.ts`: 17 pass, 0 fail. No library files
  change in this PR.

## Migration

An entry's type is fixed at creation, so a bundle already published under the
generic type needs its entry group deleted and recreated. Noted in the README.
`cleanup.ts` leaves the entry type in place alongside the aspect type, since
both are scoped to the project and location rather than to this demo, and
prints the delete command for each.
