### PR TITLE
mdcode: persist entity keys, field labels, and ai_context instructions through KC push/pull

### DIFF
--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -401,6 +401,9 @@ local model and replace it with the catalog's. Pull never touches BigQuery.
 * `dataplex.entryGroups.useSemanticModelAspect`,
   `dataplex.entryGroups.useSemanticEntityAspect`, and
   `dataplex.entryGroups.useSemanticMetricAspect` on the destination entry group
+* `dataplex.entryGroups.useSchemaAspect` on the destination entry group — every
+  entity carries the built-in `schema` aspect (its fields, keys, unique keys,
+  and labels)
 * `dataplex.entryGroups.useGuidelinesAspect` when any element carries
   `ai_context.instructions` (the model, an entity, or a metric)
 * `dataplex.entryGroups.useSchemaJoinEntryLink` and

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -163,7 +163,7 @@ structurally, as their own array — not flattened into the description text.
 
 | Authored metadata | Why |
 |---|---|
-| The model's own `description` / `ai_context` | BigQuery silently drops statement-level graph `OPTIONS`, so model-level metadata has no home in the graph. The model's `description` is carried into [Knowledge Catalog](#what-gets-created-in-knowledge-catalog) instead; its `ai_context` (instructions, synonyms, examples) is not preserved in either destination |
+| The model's own `description` / `ai_context` | BigQuery silently drops statement-level graph `OPTIONS`, so model-level metadata has no home in the graph. The model's `description` and its `ai_context.instructions` are carried into [Knowledge Catalog](#what-gets-created-in-knowledge-catalog) instead (the model's `ai_context.synonyms`/`examples` are preserved in neither destination) |
 | A field's `datatype` | BigQuery uses the source column's own type |
 | Unique keys beyond the primary key | only the primary key is emitted |
 | The imported vendor SQL and its dialect | only the canonical GoogleSQL expression is used |
@@ -189,22 +189,30 @@ them, it never creates them.
 | Metric | `semantic-metric` | entry | `<model>.metrics.<metric>` |
 | Relationship | `schema-join` | entry link between the two entity entries | derived from the model and relationship names |
 
-An entity entry carries its columns in the `schema` aspect (name, data type, and
-description per field); a `schema-join` link carries the relationship detail — the
-paired columns and foreign-key direction — in its aspect.
+An entity entry carries its columns in the `schema` aspect (name, data type,
+description, and any `label` per field), plus the entity's keys and unique keys
+(`primaryKey` / `uniqueConstraints`); a `schema-join` link carries the
+relationship detail — the paired columns and foreign-key direction — in its
+aspect. Any element with `ai_context.instructions` (the model, an entity, or a
+metric) also gets a built-in `guidelines` aspect holding that text.
 
 > **Note — push to Knowledge Catalog is lossy.** The catalog holds metadata,
 > not a full copy of your model. It **stores** names, descriptions, data
 > sources, field datatypes and roles, and 1:1 / 1:N relationships (as
-> `schema-join` links). By default it does **not** store the SQL expressions:
-> the published system-type templates do not yet carry a per-field `semantics`
-> block or a `semantic-metric.expression` field, so the default push omits them
-> (pass `--emit-expressions` to write the canonical GoogleSQL/ANSI expression
-> once the templates gain the fields). It never stores entity keys, `ai_context`,
-> field labels, or the original vendor SQL (`importedExpression` — e.g. the MAQL
-> or Snowflake form a metric was imported from). Those stay in your authored
-> document; the vendor SQL and expressions are still used when generating
-> BigQuery SQL. Keep your model document as the source of truth.
+> `schema-join` links). It also stores entity keys and unique keys (the built-in
+> `schema` aspect's `primaryKey` / `uniqueConstraints`), field labels (the
+> `schema` aspect's per-field `annotations`), and `ai_context.instructions` on
+> the model, entities, and metrics (the built-in `guidelines` aspect). By
+> default it does **not** store the SQL expressions: the published system-type
+> templates do not yet carry a per-field `semantics` block or a
+> `semantic-metric.expression` field, so the default push omits them (pass
+> `--emit-expressions` to write the canonical GoogleSQL/ANSI expression once the
+> templates gain the fields). It never stores `ai_context.synonyms`/`examples`,
+> field-level `ai_context` (only model/entity/metric instructions have a home),
+> or the original vendor SQL (`importedExpression` — e.g. the MAQL or Snowflake
+> form a metric was imported from). Those stay in your authored document; the
+> vendor SQL and expressions are still used when generating BigQuery SQL. Keep
+> your model document as the source of truth.
 
 ## Validation
 
@@ -314,6 +322,11 @@ local model and replace it with the catalog's. Pull never touches BigQuery.
 > - Model structure: the model, its entities, and each entity's fields.
 > - Each field's data source (its data type round-trips with the two collapses
 >   noted below).
+> - Entity keys and unique keys (from the `schema` aspect's `primaryKey` /
+>   `uniqueConstraints`).
+> - Field labels (from the `schema` aspect's per-field `annotations`).
+> - `ai_context.instructions` on the model, entities, and metrics (from the
+>   `guidelines` aspect).
 > - Metrics: name and attach entity (a concrete data type round-trips; see below).
 > - 1:1 / 1:N relationships: endpoints, foreign-key direction, and join columns
 >   (from the `schema-join` links).
@@ -342,10 +355,12 @@ local model and replace it with the catalog's. Pull never touches BigQuery.
 >   the authored one. Comments in the original YAML are not preserved.
 >
 > **Not recovered** — push never wrote these, so pull cannot return them:
-> - Entity keys / unique keys.
-> - `ai_context`.
-> - Field labels.
-> - The original vendor SQL (`importedExpression`).
+> - `ai_context.synonyms` and `ai_context.examples` (only `instructions` has a
+>   home, in the `guidelines` aspect).
+> - Field-level `ai_context` (only the model, entities, and metrics get a
+>   `guidelines` aspect).
+> - The original vendor SQL (`importedExpression` / `importedDialect`).
+> - M:N (`association`) relationships.
 >
 > **So: a push followed by a pull does not return your original file.** Treat a
 > pulled document as a faithful copy of the catalog metadata, not of the authored
@@ -386,6 +401,8 @@ local model and replace it with the catalog's. Pull never touches BigQuery.
 * `dataplex.entryGroups.useSemanticModelAspect`,
   `dataplex.entryGroups.useSemanticEntityAspect`, and
   `dataplex.entryGroups.useSemanticMetricAspect` on the destination entry group
+* `dataplex.entryGroups.useGuidelinesAspect` when any element carries
+  `ai_context.instructions` (the model, an entity, or a metric)
 * `dataplex.entryGroups.useSchemaJoinEntryLink` and
   `dataplex.entryGroups.useSchemaJoinAspect` when the model has relationships
 

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -195,10 +195,15 @@ function readEntity(entry: Entry, warnings: string[]): Entity {
 
 // Recovers ai_context from an entry's `guidelines` aspect. The emitter routes
 // only `ai_context.instructions` to that aspect (see guidelinesAspectData), so
-// synonyms and examples stay absent. Returns undefined when the entry carries
-// no guidelines instructions.
+// synonyms and examples stay absent. Author-declared guidelines are stamped
+// userManaged:true; Dataplex may also attach machine-generated guidelines
+// (userManaged:false), which are not authored model content, so those are
+// skipped. Returns undefined when the entry carries no author guidelines
+// instructions.
 function readAiContext(entry: Entry): AiContext|undefined {
-  const instructions = aspectData(entry, 'guidelines').instructions;
+  const guidelines = aspectData(entry, 'guidelines');
+  if (guidelines.userManaged === false) return undefined;
+  const instructions = guidelines.instructions;
   if (typeof instructions !== 'string' || instructions === '') return undefined;
   return {instructions};
 }

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -26,19 +26,23 @@
 //
 // Fidelity is bounded by what the emitter persisted, so this read is the
 // inverse of the WRITE, not of the authored document. It recovers names,
-// descriptions, data sources, field datatypes (via the schema aspect), each
-// metric's attach entity (re-derived from its expression, as the loader does,
-// when the catalog holds one, else the value the emitter persisted), the
-// model's deployment targets (from the semantic-model aspect, back into the
-// GOOGLE `custom_extensions` block), and 1:1 / 1:N relationships (from the
-// `schema-join` entry links a pull fetched -- see
-// `modelsFromCatalogResources`'s `entryLinks` argument). The per-field
-// `semantics` block -- field/metric expressions and the DIMENSION role -- is
-// gated off the catalog by default: the emitter writes it only under
+// descriptions, data sources, field datatypes and labels (via the schema
+// aspect), entity keys and unique keys (the schema aspect's primaryKey /
+// uniqueConstraints), each object's `ai_context.instructions` (from its
+// `guidelines` aspect, on the model/entity/metric), each metric's attach entity
+// (re-derived from its expression, as the loader does, when the catalog holds
+// one, else the value the emitter persisted), the model's deployment targets
+// (from the semantic-model aspect, back into the GOOGLE `custom_extensions`
+// block), and 1:1 / 1:N relationships (from the `schema-join` entry links a
+// pull fetched -- see `modelsFromCatalogResources`'s `entryLinks` argument).
+// The per-field `semantics` block -- field/metric expressions and the DIMENSION
+// role
+// -- is gated off the catalog by default: the emitter writes it only under
 // `--emit-expressions` (see `KcGenerateOptions.emitExpressions`), so those
 // three recover only when the push that wrote them enabled it, and a default
 // push -> pull drops them. It cannot recover what the emitter never writes:
-// entity keys/unique keys, `ai_context`, field labels,
+// `ai_context.synonyms`/`examples` and field-level `ai_context` (only
+// model/entity/metric `instructions` are persisted, via `guidelines`),
 // `importedExpression`/`importedDialect` (the vendor-dialect SQL), and
 // many-to-many (association) relationships (whose edge lives only in the
 // BigQuery property graph). A `String`- or `Opaque`-typed METRIC also reads
@@ -50,7 +54,7 @@
 
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
-import {CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
+import {AiContext, CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface ReadResult {
@@ -127,6 +131,8 @@ export function modelsFromCatalogResources(
     // the author wrote them in (the inverse of the emitter's modelAspectData).
     const targets = readDeploymentTargets(anchor);
     if (targets) model.customExtensions = [targets];
+    const ai = readAiContext(anchor);
+    if (ai) model.aiContext = ai;
     return model;
   });
 
@@ -145,9 +151,9 @@ export function modelsFromCatalogResources(
 }
 
 
-// Reconstructs an entity from its `semantic-entity` aspect (the backing source)
-// and the built-in `schema` aspect (its fields). Keys are not persisted by the
-// emitter and so come back empty.
+// Reconstructs an entity from its `semantic-entity` aspect (the backing
+// source), the built-in `schema` aspect (its fields, primary key, and unique
+// constraints), and the built-in `guidelines` aspect (ai_context instructions).
 function readEntity(entry: Entry, warnings: string[]): Entity {
   const name = entry.entrySource?.displayName ?? idOf(entry.name);
   const semantic = aspectData(entry, 'semantic-entity');
@@ -166,14 +172,35 @@ function readEntity(entry: Entry, warnings: string[]): Entity {
   const entity: Entity = {
     name,
     dataSource,
-    keys: [],  // not persisted by the emitter; unrecoverable on read
+    // The grain / primary key, from the schema aspect's primaryKey.fields
+    // (ordered, so a composite key's ordinal positions round-trip).
+    keys: stringList(schema.primaryKey?.fields),
     fields: asArray(schema.fields)
                 .map(fd => readField(fd, name, warnings))
                 .filter((f): f is Field => f !== undefined),
   };
+  // Additional unique column sets, from the schema aspect's uniqueConstraints
+  // (each constraint's `fields` is one set); dropped when empty.
+  const uniqueKeys = asArray(schema.uniqueConstraints)
+                         .map(uc => stringList(uc?.fields))
+                         .filter(fields => fields.length);
+  if (uniqueKeys.length) entity.uniqueKeys = uniqueKeys;
   const description = entry.entrySource?.description;
   if (description !== undefined) entity.description = description;
+  const ai = readAiContext(entry);
+  if (ai) entity.aiContext = ai;
   return entity;
+}
+
+
+// Recovers ai_context from an entry's `guidelines` aspect. The emitter routes
+// only `ai_context.instructions` to that aspect (see guidelinesAspectData), so
+// synonyms and examples stay absent. Returns undefined when the entry carries
+// no guidelines instructions.
+function readAiContext(entry: Entry): AiContext|undefined {
+  const instructions = aspectData(entry, 'guidelines').instructions;
+  if (typeof instructions !== 'string' || instructions === '') return undefined;
+  return {instructions};
 }
 
 
@@ -197,6 +224,10 @@ function readField(fd: any, entityName: string, warnings: string[]): Field|
   if (type !== undefined) field.type = type;
   if (sem.role === 'DIMENSION') field.dimension = {};
   if (fd?.description !== undefined) field.description = fd.description;
+  // The display label rides in the schema field's `annotations` map (the
+  // inverse of the emitter's `annotations: {label}`).
+  const label = fd?.annotations?.label;
+  if (typeof label === 'string' && label !== '') field.label = label;
   return field;
 }
 
@@ -244,6 +275,8 @@ function readMetric(
   if (type !== undefined) metric.type = type;
   const description = entry.entrySource?.description;
   if (description !== undefined) metric.description = description;
+  const ai = readAiContext(entry);
+  if (ai) metric.aiContext = ai;
   return metric;
 }
 
@@ -481,4 +514,12 @@ export function idOf(name: string): string {
 
 function asArray(value: any): any[] {
   return Array.isArray(value) ? value : [];
+}
+
+
+// The non-empty strings of an array value, dropping non-string and empty
+// entries. Used for key / unique-constraint field lists from the schema aspect.
+function stringList(value: any): string[] {
+  return asArray(value).filter(
+      (s): s is string => typeof s === 'string' && s !== '');
 }

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -308,6 +308,16 @@ function entityAspectData(entity: Entity): Record<string, any> {
 // column.
 function schemaAspectData(
     entity: Entity, emitExpressions: boolean): Record<string, any> {
+  // Key column lists ride the schema aspect verbatim -- they need NOT be
+  // declared fields (the closed template accepts and round-trips columns absent
+  // from fields[], live-verified). Keep only non-empty strings, matching the
+  // reader's stringList, so a degenerate '' member does not round-trip
+  // asymmetrically; a set that is empty after filtering is then dropped.
+  const keyFields = (cols: readonly string[]|undefined): string[] =>
+      (cols ?? []).filter(c => typeof c === 'string' && c !== '');
+  const primaryKey = keyFields(entity.keys);
+  const uniqueConstraints =
+      (entity.uniqueKeys ?? []).map(keyFields).filter(set => set.length);
   return compact({
     fields: (entity.fields ??
              []).map(f => compact({
@@ -339,14 +349,13 @@ function schemaAspectData(
                      })),
     // The entity's grain / primary key -> the schema aspect's primaryKey.fields
     // (ordered, so a composite key's ordinal positions round-trip). Omitted
-    // when the entity declares no keys.
-    primaryKey: entity.keys && entity.keys.length ? {fields: entity.keys} :
-                                                    undefined,
+    // when the entity declares no (non-empty) keys.
+    primaryKey: primaryKey.length ? {fields: primaryKey} : undefined,
     // Additional uniqueness constraints beyond the primary key -> one
-    // uniqueConstraints entry per unique column set. Omitted when there are
-    // none.
-    uniqueConstraints: entity.uniqueKeys && entity.uniqueKeys.length ?
-        entity.uniqueKeys.map(fields => ({fields})) :
+    // uniqueConstraints entry per non-empty unique column set. Omitted when
+    // there are none.
+    uniqueConstraints: uniqueConstraints.length ?
+        uniqueConstraints.map(fields => ({fields})) :
         undefined,
   });
 }

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -10,12 +10,14 @@
 //
 // Target schema: the `semantic-model`, `semantic-entity`, and `semantic-metric`
 // entry/aspect types are built-in system types under `dataplex-types/global`,
-// alongside the built-in `schema` aspect. This emitter references them; it never
-// provisions them. Each entry type declares `required_aspects`, so the emitted aspect set
-// per entry is a hard contract:
-//   * semantic-model entry -> { semantic-model }
-//   * semantic-entity entry -> { semantic-entity, schema }
-//   * semantic-metric entry -> { semantic-metric }
+// alongside the built-in `schema` and `guidelines` aspects. This emitter
+// references them; it never provisions them. Each entry type declares
+// `required_aspects`; the emitted aspect set per entry is those plus the
+// optional `guidelines` aspect (attached only when the object carries
+// `ai_context.instructions`):
+//   * semantic-model entry -> { semantic-model, guidelines? }
+//   * semantic-entity entry -> { semantic-entity, schema, guidelines? }
+//   * semantic-metric entry -> { semantic-metric, guidelines? }
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):
@@ -24,7 +26,9 @@
 //                                    importedResource? } }
 //   * semantic-metric = { entity?, dataType (required) }
 //   * schema          = { fields: [{ name, dataType, metadataType,
-//                                    description? }] }
+//                                    description?, annotations? }],
+//                         primaryKey?: { fields }, uniqueConstraints?: [...] }
+//   * guidelines      = { instructions, userManaged (required) }
 //
 // The SQL-expression fields -- `semantic-metric.expression` and the per-field
 // `schema.semantics` { expression, role } block -- are NOT in the published
@@ -45,7 +49,7 @@
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
 import {bigQueryGraphTargets} from './deploy_bigquery';
-import {DataType, Entity, Metric, Relationship, SemanticModel} from './ir';
+import {AiContext, DataType, Entity, Metric, Relationship, SemanticModel} from './ir';
 
 // Where the `semantic-*` and `schema` system types live: built-in types in
 // project `dataplex-types`, location `global`. Callers may override to reference
@@ -115,9 +119,8 @@ export function generateCatalogResources(
     name: modelEntryName,
     entryType: names.typeName('entry', 'semantic-model'),
     entrySource: source(model.name, model.description),
-    aspects: aspectMap(names, {
-      'semantic-model': modelAspectData(model),
-    }),
+    aspects: aspectsFor(
+        names, {'semantic-model': modelAspectData(model)}, model.aiContext),
   }];
 
   // Maps an entity's model name to its published entry name, so a relationship
@@ -138,11 +141,15 @@ export function generateCatalogResources(
       entryType: names.typeName('entry', 'semantic-entity'),
       parentEntry: modelEntryName,
       entrySource: source(entity.name, entity.description),
-      // required_aspects: semantic-entity AND the built-in schema.
-      aspects: aspectMap(names, {
-        'semantic-entity': entityAspectData(entity),
-        'schema': schemaAspectData(entity, emitExpr),
-      }),
+      // required_aspects: semantic-entity AND the built-in schema; plus the
+      // built-in guidelines aspect when the entity carries ai_context
+      // instructions.
+      aspects: aspectsFor(
+          names, {
+            'semantic-entity': entityAspectData(entity),
+            'schema': schemaAspectData(entity, emitExpr),
+          },
+          entity.aiContext),
     });
   }
 
@@ -155,9 +162,9 @@ export function generateCatalogResources(
       entryType: names.typeName('entry', 'semantic-metric'),
       parentEntry: modelEntryName,
       entrySource: source(metric.name, metric.description),
-      aspects: aspectMap(names, {
-        'semantic-metric': metricAspectData(metric, emitExpr),
-      }),
+      aspects: aspectsFor(
+          names, {'semantic-metric': metricAspectData(metric, emitExpr)},
+          metric.aiContext),
     });
   }
 
@@ -295,12 +302,13 @@ function entityAspectData(entity: Entity): Record<string, any> {
   };
 }
 
-// The built-in schema aspect, carrying each field's column type plus the new
-// per-field `semantics` block (expression / role). name,
-// dataType, and metadataType are required per column.
+// The built-in schema aspect, carrying each field's column type and display
+// label, the entity's primary/unique keys, plus the gated per-field `semantics`
+// block (expression / role). name, dataType, and metadataType are required per
+// column.
 function schemaAspectData(
     entity: Entity, emitExpressions: boolean): Record<string, any> {
-  return {
+  return compact({
     fields: (entity.fields ??
              []).map(f => compact({
                        name: f.name,
@@ -311,6 +319,12 @@ function schemaAspectData(
                        dataType: columnDataType(f.type ?? 'Opaque'),
                        metadataType: columnMetadataType(f.type ?? 'Opaque'),
                        description: f.description,
+                       // A field's display label rides in the schema field's
+                       // `annotations` map (the template's free-form
+                       // string->string map) -- the one slot for metadata the
+                       // template has no dedicated column for. Omitted when the
+                       // field has no label.
+                       annotations: f.label ? {label: f.label} : undefined,
                        // The per-field `semantics` block (expression + role) is
                        // not in the published `schema` aspect template yet, so
                        // it is gated off by default (see
@@ -323,7 +337,31 @@ function schemaAspectData(
                          role: f.dimension ? 'DIMENSION' : 'DEFAULT',
                        }) : undefined,
                      })),
-  };
+    // The entity's grain / primary key -> the schema aspect's primaryKey.fields
+    // (ordered, so a composite key's ordinal positions round-trip). Omitted
+    // when the entity declares no keys.
+    primaryKey: entity.keys && entity.keys.length ? {fields: entity.keys} :
+                                                    undefined,
+    // Additional uniqueness constraints beyond the primary key -> one
+    // uniqueConstraints entry per unique column set. Omitted when there are
+    // none.
+    uniqueConstraints: entity.uniqueKeys && entity.uniqueKeys.length ?
+        entity.uniqueKeys.map(fields => ({fields})) :
+        undefined,
+  });
+}
+
+// The built-in guidelines aspect: routes an object's `ai_context.instructions`
+// -- free-form guidance for AI consumers -- to the aspect's `instructions`
+// richText field. `userManaged` is required and always true: these guidelines
+// are author-declared, so Dataplex must not overwrite them. Only `instructions`
+// is routed here; `ai_context.synonyms`/`examples` have no home in this aspect.
+// Returns undefined (attach no aspect) when there are no instructions.
+function guidelinesAspectData(ai: AiContext|undefined): Record<string, any>|
+    undefined {
+  const instructions = ai?.instructions;
+  if (instructions === undefined || instructions === '') return undefined;
+  return {instructions, userManaged: true};
 }
 
 // semantic-metric: the model-level aggregate. `dataType` is required by the
@@ -487,6 +525,18 @@ function aspectMap(names: Namer, byType: Record<string, Record<string, any>>):
     };
   }
   return out;
+}
+
+// An entry's aspect map: its required `base` aspects, plus the optional
+// built-in `guidelines` aspect when the object carries
+// `ai_context.instructions`. Kept in one place so every entry kind
+// (model/entity/metric) routes instructions the same way and an object without
+// instructions carries no empty guidelines aspect.
+function aspectsFor(
+    names: Namer, base: Record<string, Record<string, any>>,
+    ai: AiContext|undefined): Record<string, Aspect> {
+  const guidelines = guidelinesAspectData(ai);
+  return aspectMap(names, guidelines ? {...base, guidelines} : base);
 }
 
 // The native catalog entry source (display name + description), separate from

--- a/toolbox/mdcode/src/libts/semantic/pull_kc.ts
+++ b/toolbox/mdcode/src/libts/semantic/pull_kc.ts
@@ -136,8 +136,9 @@ export async function pullKnowledgeCatalog(
 
 // The aspect type resource names to hydrate for a semantic entry, derived from
 // its entryType (the aspect types are the parallel resources in the same
-// project/location). An entity carries two aspects: its `semantic-entity`
-// aspect and the built-in `schema` aspect that holds its fields. Returns
+// project/location). Every entry also carries the built-in `guidelines` aspect
+// (ai_context instructions); an entity additionally carries the built-in
+// `schema` aspect that holds its fields, keys, and unique constraints. Returns
 // undefined for entries that are not part of a semantic model.
 function semanticAspectTypes(entryType: string): string[]|undefined {
   const marker = '/entryTypes/';
@@ -148,11 +149,14 @@ function semanticAspectTypes(entryType: string): string[]|undefined {
   const aspectType = (name: string) => `${typeBase}/aspectTypes/${name}`;
   switch (t) {
     case 'semantic-model':
-      return [aspectType('semantic-model')];
+      return [aspectType('semantic-model'), aspectType('guidelines')];
     case 'semantic-entity':
-      return [aspectType('semantic-entity'), aspectType('schema')];
+      return [
+        aspectType('semantic-entity'), aspectType('schema'),
+        aspectType('guidelines')
+      ];
     case 'semantic-metric':
-      return [aspectType('semantic-metric')];
+      return [aspectType('semantic-metric'), aspectType('guidelines')];
     default:
       return undefined;
   }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.knowledge_catalog.golden.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.knowledge_catalog.golden.json
@@ -49,7 +49,12 @@
                 "dataType": "STRING",
                 "metadataType": "OTHER"
               }
-            ]
+            ],
+            "primaryKey": {
+              "fields": [
+                "o_orderkey"
+              ]
+            }
           }
         }
       }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.pull.golden.yaml
@@ -8,6 +8,8 @@ semantic_model:
     datasets:
       - name: orders
         source: demo.sales.orders
+        primary_key:
+          - o_orderkey
         fields:
           - name: o_orderkey
             datatype: Opaque

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.knowledge_catalog.golden.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.knowledge_catalog.golden.json
@@ -15,6 +15,13 @@
               "//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales"
             ]
           }
+        },
+        "dataplex-types.global.guidelines": {
+          "aspectType": "projects/dataplex-types/locations/global/aspectTypes/guidelines",
+          "data": {
+            "instructions": "Use this model for order analysis.",
+            "userManaged": true
+          }
         }
       }
     },
@@ -55,14 +62,22 @@
               {
                 "name": "o_orderdate",
                 "dataType": "STRING",
-                "metadataType": "OTHER"
+                "metadataType": "OTHER",
+                "annotations": {
+                  "label": "Order Date"
+                }
               },
               {
                 "name": "o_totalprice",
                 "dataType": "STRING",
                 "metadataType": "OTHER"
               }
-            ]
+            ],
+            "primaryKey": {
+              "fields": [
+                "o_orderkey"
+              ]
+            }
           }
         }
       }
@@ -100,7 +115,12 @@
                 "metadataType": "OTHER",
                 "description": "Customer name"
               }
-            ]
+            ],
+            "primaryKey": {
+              "fields": [
+                "c_custkey"
+              ]
+            }
           }
         }
       }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.pull.golden.yaml
@@ -3,12 +3,16 @@ version: 0.2.0.dev0
 semantic_model:
   - name: sales
     description: Sales orders with customer attributes
+    ai_context:
+      instructions: Use this model for order analysis.
     custom_extensions:
       - vendor_name: GOOGLE
         data: '{"deploymentTargets":["//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales"]}'
     datasets:
       - name: orders
         source: samples.tpch.orders
+        primary_key:
+          - o_orderkey
         description: One row per order
         fields:
           - name: o_orderkey
@@ -18,10 +22,13 @@ semantic_model:
             datatype: Opaque
           - name: o_orderdate
             datatype: Opaque
+            label: Order Date
           - name: o_totalprice
             datatype: Opaque
       - name: customer
         source: samples.tpch.customer
+        primary_key:
+          - c_custkey
         fields:
           - name: c_custkey
             datatype: Opaque

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.knowledge_catalog.golden.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.knowledge_catalog.golden.json
@@ -81,7 +81,13 @@
                 "metadataType": "OTHER",
                 "description": "Net profit from the sale"
               }
-            ]
+            ],
+            "primaryKey": {
+              "fields": [
+                "ss_item_sk",
+                "ss_ticket_number"
+              ]
+            }
           }
         }
       }
@@ -126,7 +132,12 @@
                 "metadataType": "OTHER",
                 "description": "Customer last name"
               }
-            ]
+            ],
+            "primaryKey": {
+              "fields": [
+                "c_customer_sk"
+              ]
+            }
           }
         }
       }
@@ -175,7 +186,12 @@
                 "metadataType": "OTHER",
                 "description": "Current price of the item"
               }
-            ]
+            ],
+            "primaryKey": {
+              "fields": [
+                "i_item_sk"
+              ]
+            }
           }
         }
       }
@@ -229,7 +245,12 @@
                 "metadataType": "OTHER",
                 "description": "Number of employees at the store"
               }
-            ]
+            ],
+            "primaryKey": {
+              "fields": [
+                "s_store_sk"
+              ]
+            }
           }
         }
       }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.pull.golden.yaml
@@ -6,6 +6,9 @@ semantic_model:
     datasets:
       - name: store_sales
         source: tpcds.public.store_sales
+        primary_key:
+          - ss_item_sk
+          - ss_ticket_number
         description: Fact table containing all store sales transactions
         fields:
           - name: ss_item_sk
@@ -30,6 +33,8 @@ semantic_model:
             description: Net profit from the sale
       - name: customer
         source: tpcds.public.customer
+        primary_key:
+          - c_customer_sk
         description: Customer dimension with demographic information
         fields:
           - name: c_customer_sk
@@ -42,6 +47,8 @@ semantic_model:
             description: Customer last name
       - name: item
         source: tpcds.public.item
+        primary_key:
+          - i_item_sk
         description: Item/Product dimension
         fields:
           - name: i_item_sk
@@ -55,6 +62,8 @@ semantic_model:
             description: Current price of the item
       - name: store
         source: tpcds.public.store
+        primary_key:
+          - s_store_sk
         description: Store dimension with location attributes
         fields:
           - name: s_store_sk

--- a/toolbox/mdcode/tests/libts/semantic/kc_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/kc_converter.test.ts
@@ -177,6 +177,54 @@ describe('schema + guidelines recovery (keys / labels / instructions)', () => {
 });
 
 
+describe('a guidelines aspect is recovered only when author-managed', () => {
+  // A minimal one-entity model with no ai_context, so the emitter attaches no
+  // guidelines aspect. Tests inject one directly to exercise the userManaged
+  // gate the reader applies (see readAiContext).
+  const model: SemanticModel = {
+    name: 'sales',
+    entities: [{name: 'orders', dataSource: 'demo.sales.orders', keys: [],
+                fields: [{name: 'o_orderkey', expression: 'orders.o_orderkey'}]}],
+    relationships: [],
+    metrics: [],
+  };
+  const GUIDELINES = 'dataplex-types.global.guidelines';
+
+  // Emits the model and stamps a guidelines aspect (with the given userManaged)
+  // onto the entity entry, then reads it back and returns the entity's
+  // recovered ai_context.
+  function withGuidelines(userManaged: boolean|undefined) {
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const entity = entries.find(e => e.entryType.endsWith('/semantic-entity'))!;
+    const data: Record<string, unknown> = {instructions: 'One row per order.'};
+    if (userManaged !== undefined) data.userManaged = userManaged;
+    entity.aspects = {
+      ...entity.aspects,
+      [GUIDELINES]: {
+        aspectType:
+            'projects/dataplex-types/locations/global/aspectTypes/guidelines',
+        data,
+      },
+    };
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    return models[0].entities[0].aiContext;
+  }
+
+  test('userManaged:true guidelines are recovered', () => {
+    expect(withGuidelines(true)).toEqual({instructions: 'One row per order.'});
+  });
+  test('guidelines with no userManaged flag are still recovered', () => {
+    expect(withGuidelines(undefined))
+        .toEqual({instructions: 'One row per order.'});
+  });
+  test('userManaged:false (machine-generated) guidelines are skipped', () => {
+    // Dataplex may attach auto-generated guidelines; those are not authored
+    // model content, so pull must not fold them into ai_context.
+    expect(withGuidelines(false)).toBeUndefined();
+  });
+});
+
+
 describe('relationship recovery (schema-join links -> IR)', () => {
   // orders.o_custkey (the foreign-key side) references customer.c_custkey.
   const twoEntities: Entity[] = [

--- a/toolbox/mdcode/tests/libts/semantic/kc_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/kc_converter.test.ts
@@ -4,9 +4,12 @@
 // The reader is the inverse of the emitter (generateCatalogResources). The
 // central guarantee is an emitter -> reader round trip: emit a model's entries
 // AND entry links, read them back, and get an IR equal to the source WHERE the
-// emitter is lossless. The write drops content by design (entity keys,
-// ai_context, field labels, importedDialect, and many-to-many relationships --
-// see the emitter header), so the expected read-back is the source model with
+// emitter is lossless. The write persists entity keys / unique keys (schema
+// aspect primaryKey / uniqueConstraints), field labels (schema aspect per-field
+// annotations), and ai_context.instructions (guidelines aspect) on
+// model/entity/metric. It still drops by design ai_context.synonyms/examples,
+// field-level ai_context, importedDialect, and many-to-many relationships (see
+// the emitter header), so the expected read-back is the source model with
 // exactly those fields cleared. It ALSO drops the per-field `semantics` block
 // (field/metric expressions and the DIMENSION role) unless the push enabled
 // `emitExpressions`, so a DEFAULT round trip (roundTrip) loses those too, while
@@ -57,10 +60,10 @@ function roundTripFull(model: SemanticModel):
 
 
 describe('emitter -> reader round trip (lossless slice)', () => {
-  // A model using only round-trippable content: no keys/ai_context/labels/
-  // relationships (all dropped by the write), and datatypes that invert
-  // cleanly. Its fields and metric carry expressions and a DIMENSION role, so
-  // it round-trips losslessly only through a `--emit-expressions` push
+  // A model using only round-trippable content: no relationships (dropped when
+  // M:N, else name-normalized) and no still-lossy ai_context; datatypes that
+  // invert cleanly. Its fields and metric carry expressions and a DIMENSION
+  // role, so it round-trips losslessly only through a `--emit-expressions` push
   // (roundTripFull); a default push omits the per-field `semantics` block.
   const source: SemanticModel = {
     name: 'sales',
@@ -68,7 +71,7 @@ describe('emitter -> reader round trip (lossless slice)', () => {
     entities: [{
       name: 'orders',
       dataSource: 'demo.sales.orders',
-      keys: [],  // keys are not persisted; keep empty so the round trip matches
+      keys: [],  // no keys: an entity with none writes no primaryKey
       fields: [
         {name: 'o_orderkey', expression: 'orders.o_orderkey', type: 'Integer'},
         {
@@ -93,6 +96,83 @@ describe('emitter -> reader round trip (lossless slice)', () => {
     const {models} = roundTripFull(source);
     expect(models).toHaveLength(1);
     expect(models[0]).toEqual(source);
+  });
+});
+
+
+describe('schema + guidelines recovery (keys / labels / instructions)', () => {
+  // A model exercising every field now persisted through a built-in aspect:
+  // entity keys (schema primaryKey), unique keys (schema uniqueConstraints),
+  // field labels (schema per-field annotations), and ai_context.instructions
+  // (guidelines aspect) on the model, an entity, and a metric. It also carries
+  // the still-lossy pieces -- ai_context.synonyms/examples and field-level
+  // ai_context -- so the round trip pins that those still drop. Keys/labels are
+  // persisted by a default push, so a plain roundTrip (no --emit-expressions)
+  // suffices.
+  const source: SemanticModel = {
+    name: 'sales',
+    description: 'the sales model',
+    aiContext: {instructions: 'Use for order analysis.', synonyms: ['selling']},
+    entities: [{
+      name: 'orders',
+      dataSource: 'demo.sales.orders',
+      keys: ['o_orderkey'],
+      uniqueKeys: [['o_orderkey'], ['o_custkey', 'o_orderdate']],
+      aiContext: {instructions: 'One row per order.', examples: ['SELECT 1']},
+      fields: [
+        {name: 'o_orderkey', expression: 'orders.o_orderkey'},
+        {
+          name: 'o_orderdate',
+          expression: 'orders.o_orderdate',
+          label: 'Order Date',
+          aiContext: {synonyms: ['order date', 'date']},
+        },
+      ],
+    }],
+    relationships: [],
+    metrics: [{
+      name: 'total_revenue',
+      expression: 'SUM(orders.o_totalprice)',
+      entity: 'orders',
+      aiContext: {instructions: 'Sum of order totals.', synonyms: ['revenue']},
+    }],
+  };
+
+  test('keys, unique keys, and field labels round-trip', () => {
+    const {models} = roundTrip(source);
+    expect(models).toHaveLength(1);
+    const [entity] = models[0].entities;
+    expect(entity.keys).toEqual(['o_orderkey']);
+    expect(entity.uniqueKeys).toEqual([
+      ['o_orderkey'], ['o_custkey', 'o_orderdate']
+    ]);
+    const orderdate = entity.fields.find(f => f.name === 'o_orderdate')!;
+    expect(orderdate.label).toBe('Order Date');
+  });
+
+  test('ai_context.instructions round-trips on model / entity / metric', () => {
+    const {models} = roundTrip(source);
+    const model = models[0];
+    expect(model.aiContext).toEqual({instructions: 'Use for order analysis.'});
+    expect(model.entities[0].aiContext).toEqual({
+      instructions: 'One row per order.'
+    });
+    expect(model.metrics[0].aiContext).toEqual({
+      instructions: 'Sum of order totals.'
+    });
+  });
+
+  test('synonyms/examples and field-level ai_context still drop', () => {
+    const {models} = roundTrip(source);
+    const model = models[0];
+    // instructions survive but synonyms/examples ride nothing back.
+    expect(model.aiContext?.synonyms).toBeUndefined();
+    expect(model.entities[0].aiContext?.examples).toBeUndefined();
+    expect(model.metrics[0].aiContext?.synonyms).toBeUndefined();
+    // Fields get no guidelines aspect, so a field-only ai_context vanishes.
+    const orderdate =
+        model.entities[0].fields.find(f => f.name === 'o_orderdate')!;
+    expect(orderdate.aiContext).toBeUndefined();
   });
 });
 
@@ -705,9 +785,12 @@ describe(
 function stripToKcFloor(model: SemanticModel): SemanticModel {
   const m = structuredClone(model);
 
-  // Model ai_context is not persisted; only a GOOGLE deployment-targets block
-  // rides back, re-serialized to the reader's canonical JSON form.
-  delete m.aiContext;
+  // ai_context rides back through the built-in `guidelines` aspect, but only
+  // `instructions` -- synonyms/examples are not persisted. Reduce every
+  // entry-backed object's ai_context to instructions-only (dropping the block
+  // when it carried nothing else). A GOOGLE deployment-targets block also rides
+  // back, re-serialized to the reader's canonical JSON form.
+  floorAiContext(m);
   const ext = canonicalGoogleExt(m.customExtensions);
   if (ext) {
     m.customExtensions = ext;
@@ -716,12 +799,16 @@ function stripToKcFloor(model: SemanticModel): SemanticModel {
   }
 
   for (const e of m.entities) {
-    e.keys = [];  // keys / unique keys are never persisted
-    delete e.uniqueKeys;
-    delete e.aiContext;
+    // keys (primaryKey) and unique keys (uniqueConstraints) now persist through
+    // the built-in `schema` aspect. An empty uniqueKeys array is written as
+    // nothing and reads back absent, so normalize it away.
+    floorAiContext(e);
+    if (e.uniqueKeys && !e.uniqueKeys.length) delete e.uniqueKeys;
     delete e.customExtensions;
     for (const f of e.fields) {
-      delete f.label;  // display label is not persisted
+      // Field label now persists via the schema aspect's per-field annotations;
+      // field-level ai_context does not (only entry-backed objects get a
+      // guidelines aspect).
       delete f.aiContext;
       delete f.importedExpression;  // vendor SQL is not persisted
       delete f.importedDialect;
@@ -744,7 +831,7 @@ function stripToKcFloor(model: SemanticModel): SemanticModel {
   }
 
   for (const metric of m.metrics) {
-    delete metric.aiContext;
+    floorAiContext(metric);
     delete metric.importedExpression;
     delete metric.importedDialect;
     delete metric.customExtensions;
@@ -769,6 +856,20 @@ function stripToKcFloor(model: SemanticModel): SemanticModel {
   });
 
   return m;
+}
+
+
+// Reduces an object's `aiContext` to what a push -> pull round trip preserves:
+// only `instructions` survives (via the `guidelines` aspect), so synonyms and
+// examples are dropped, and an ai_context that carried nothing but those is
+// removed entirely. Mutates in place.
+function floorAiContext(obj: {aiContext?: {instructions?: string}}): void {
+  const instructions = obj.aiContext?.instructions;
+  if (typeof instructions === 'string' && instructions !== '') {
+    obj.aiContext = {instructions};
+  } else {
+    delete obj.aiContext;
+  }
 }
 
 

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
@@ -148,6 +148,131 @@ describe('the schema semantics block is gated behind emitExpressions', () => {
 });
 
 
+describe(
+    'the schema aspect carries keys, unique constraints, and labels', () => {
+      // Entity keys / unique keys and a field label ride the built-in `schema`
+      // aspect (primaryKey / uniqueConstraints / per-field annotations); all
+      // three are in the CLOSED schema template, so they emit on a default push
+      // (no
+      // --emit-expressions gating).
+      const model: SemanticModel = {
+        name: 'm',
+        relationships: [],
+        metrics: [],
+        entities: [{
+          name: 'e',
+          dataSource: 'p.d.t',
+          keys: ['a', 'b'],
+          uniqueKeys: [['a'], ['b', 'c']],
+          fields: [
+            {name: 'a', expression: 'e.a'},
+            {name: 'b', expression: 'e.b', label: 'Bee'},
+          ],
+        }],
+      };
+      const {entries} = generateCatalogResources(model, OPTS);
+      const schema =
+          entries.find(e => e.entryType.endsWith('/semantic-entity'))!
+              .aspects!['dataplex-types.global.schema']
+              .data!;
+
+      test('entity keys emit as an ordered primaryKey', () => {
+        expect(schema.primaryKey).toEqual({fields: ['a', 'b']});
+      });
+      test('unique keys emit as uniqueConstraints, one per key', () => {
+        expect(schema.uniqueConstraints).toEqual([
+          {fields: ['a']}, {fields: ['b', 'c']}
+        ]);
+      });
+      test(
+          'a field label emits as an annotations map; unlabeled fields omit it',
+          () => {
+            const [a, b] = schema.fields;
+            expect(a.annotations).toBeUndefined();
+            expect(b.annotations).toEqual({label: 'Bee'});
+          });
+
+      test(
+          'an entity with no keys / unique keys / labels omits all three',
+          () => {
+            const bare: SemanticModel = {
+              name: 'm',
+              relationships: [],
+              metrics: [],
+              entities: [{
+                name: 'e',
+                dataSource: 'p.d.t',
+                keys: [],
+                fields: [
+                  {name: 'a', expression: 'e.a'},
+                ]
+              }],
+            };
+            const s = generateCatalogResources(bare, OPTS)
+                          .entries
+                          .find(e => e.entryType.endsWith('/semantic-entity'))!
+                          .aspects!['dataplex-types.global.schema']
+                          .data!;
+            expect(s.primaryKey).toBeUndefined();
+            expect(s.uniqueConstraints).toBeUndefined();
+            expect(s.fields[0].annotations).toBeUndefined();
+          });
+    });
+
+
+describe('ai_context.instructions emits a guidelines aspect', () => {
+  const GUIDELINES = 'dataplex-types.global.guidelines';
+  const model: SemanticModel = {
+    name: 'm',
+    aiContext: {instructions: 'Model doc.', synonyms: ['syn']},
+    relationships: [],
+    entities: [{
+      name: 'e',
+      dataSource: 'p.d.t',
+      keys: ['k'],
+      aiContext: {instructions: 'Entity doc.'},
+      fields: [
+        // A field-level ai_context has no entry to attach a guidelines aspect
+        // to, so it must not surface anywhere.
+        {name: 'k', expression: 'e.k', aiContext: {synonyms: ['field syn']}},
+      ],
+    }],
+    metrics: [{
+      name: 'rev',
+      expression: 'SUM(e.k)',
+      entity: 'e',
+      type: 'Integer',
+      aiContext: {instructions: 'Metric doc.'},
+    }],
+  };
+  const {entries} = generateCatalogResources(model, OPTS);
+  const byType = (suffix: string) =>
+      entries.find(e => e.entryType.endsWith(suffix))!;
+
+  test('the model anchor carries a userManaged guidelines aspect', () => {
+    expect(byType('/semantic-model').aspects![GUIDELINES].data)
+        .toEqual({instructions: 'Model doc.', userManaged: true});
+  });
+  test('the entity carries its instructions in a guidelines aspect', () => {
+    expect(byType('/semantic-entity').aspects![GUIDELINES].data)
+        .toEqual({instructions: 'Entity doc.', userManaged: true});
+  });
+  test('the metric carries its instructions in a guidelines aspect', () => {
+    expect(byType('/semantic-metric').aspects![GUIDELINES].data)
+        .toEqual({instructions: 'Metric doc.', userManaged: true});
+  });
+
+  test('an object with no instructions gets no guidelines aspect', () => {
+    // The field's synonym-only ai_context routes nothing; and a model without
+    // instructions omits the aspect entirely.
+    const plain: SemanticModel =
+        {name: 'm', entities: [], relationships: [], metrics: []};
+    const anchor = generateCatalogResources(plain, OPTS).entries[0];
+    expect(anchor.aspects![GUIDELINES]).toBeUndefined();
+  });
+});
+
+
 describe('entity dataSource maps to a resource path', () => {
   function resources(dataSource: string): string[] {
     const model: SemanticModel = {

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
@@ -217,6 +217,33 @@ describe(
             expect(s.uniqueConstraints).toBeUndefined();
             expect(s.fields[0].annotations).toBeUndefined();
           });
+
+      test(
+          'empty-string key members and empty unique-key sets are dropped',
+          () => {
+            // Degenerate key input: the reader's stringList drops '' members,
+            // so the emitter must too or the round trip is asymmetric. A unique
+            // key that is empty after filtering is omitted entirely.
+            const degenerate: SemanticModel = {
+              name: 'm',
+              relationships: [],
+              metrics: [],
+              entities: [{
+                name: 'e',
+                dataSource: 'p.d.t',
+                keys: ['a', ''],
+                uniqueKeys: [[''], ['b', '']],
+                fields: [{name: 'a', expression: 'e.a'}],
+              }],
+            };
+            const s = generateCatalogResources(degenerate, OPTS)
+                          .entries
+                          .find(e => e.entryType.endsWith('/semantic-entity'))!
+                          .aspects!['dataplex-types.global.schema']
+                          .data!;
+            expect(s.primaryKey).toEqual({fields: ['a']});
+            expect(s.uniqueConstraints).toEqual([{fields: ['b']}]);
+          });
     });
 
 

--- a/toolbox/mdcode/tests/libts/semantic/pull_kc.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/pull_kc.test.ts
@@ -29,12 +29,24 @@ const OPTS = {
 
 const SALES: SemanticModel = {
   name: 'sales',
+  // ai_context.instructions rides back through the guidelines aspect; keys,
+  // unique keys, and the field label ride back through the schema aspect -- all
+  // persisted by a default push, so the full model reconstructs exactly.
+  aiContext: {instructions: 'Use for order analysis.'},
   entities: [{
     name: 'orders',
     dataSource: 'demo.sales.orders',
-    keys: [],
+    keys: ['o_orderkey'],
+    uniqueKeys: [['o_totalprice']],
+    aiContext: {instructions: 'One row per order.'},
     fields: [
-      {name: 'o_totalprice', expression: 'orders.o_totalprice', type: 'Decimal'}
+      {name: 'o_orderkey', expression: 'orders.o_orderkey', type: 'Integer'},
+      {
+        name: 'o_totalprice',
+        expression: 'orders.o_totalprice',
+        type: 'Decimal',
+        label: 'Total Price',
+      },
     ],
   }],
   relationships: [],
@@ -42,6 +54,7 @@ const SALES: SemanticModel = {
     name: 'total_revenue',
     expression: 'SUM(orders.o_totalprice)',
     entity: 'orders',
+    aiContext: {instructions: 'Sum of order totals.'},
     // Metrics carry a datatype through KC (semantic-metric.dataType is
     // required); Decimal -> NUMERIC on emit, NUMERIC -> Decimal on read.
     type: 'Decimal'
@@ -117,7 +130,8 @@ describe('pullKnowledgeCatalog: happy path', () => {
   });
 
   test(
-      'an entity is hydrated with BOTH its semantic-entity and schema aspects',
+      'an entity is hydrated with its semantic-entity, schema, and ' +
+          'guidelines aspects',
       async () => {
         const entries = entriesFor(SALES);
         const {lookup} = stubClient(entries, entries);
@@ -136,6 +150,10 @@ describe('pullKnowledgeCatalog: happy path', () => {
             aspectTypes.some(t => t.endsWith('/aspectTypes/semantic-entity')))
             .toBe(true);
         expect(aspectTypes.some(t => t.endsWith('/aspectTypes/schema')))
+            .toBe(true);
+        // The guidelines aspect carries ai_context.instructions, so pull must
+        // request it too (for every semantic entry, not just entities).
+        expect(aspectTypes.some(t => t.endsWith('/aspectTypes/guidelines')))
             .toBe(true);
       });
 });


### PR DESCRIPTION
## What

Push previously dropped four IR fields the catalog already has natural homes for, so `pull` could never return them. This routes each onto an **existing built-in aspect** — no new entry/aspect types, no template changes:

| IR field | Where it now lives |
|---|---|
| `Entity.keys` | `schema` aspect `primaryKey.fields` (ordered → composite keys round-trip) |
| `Entity.uniqueKeys` | `schema` aspect `uniqueConstraints[].fields` |
| `Field.label` | `schema` field `annotations` map (`{label}`) |
| `ai_context.instructions` (model / entity / metric) | built-in `guidelines` aspect (`{instructions, userManaged: true}`), attached only when present |

The reader inverts each mapping; pull now also hydrates the `guidelines` aspect for the model, entity, and metric entry kinds.

## Still lossy (documented)

`ai_context.synonyms`/`examples`, field-level `ai_context`, vendor SQL (`importedExpression`/`importedDialect` — deferred to the sql-expressions companion), and M:N (`association`) relationships.

## Validation

- **Live-validated against Dataplex** (`sqlgen-testing`): a `generic` entry carrying the new `schema` fields (`primaryKey`, `uniqueConstraints`, per-field `annotations.label`) and a `guidelines` aspect (`instructions`) is accepted by the closed templates and round-trips every field — confirming no push regresses and the `guidelines` aspect attaches.
- `tsc --noEmit` clean; hermetic emitter/reader/pull suites green; golden fixtures regenerated (composite primary keys now visible in the tpcds fixture).

Adds the `dataplex.entryGroups.useGuidelinesAspect` permission to the docs.