### PR TITLE
mdcode: exit non-zero when kcmd init fails

### DIFF
--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -14,13 +14,16 @@ cli.command('init', 'Initialize a new catalog snapshot')
    .option('--semantic-model <id>', 'Semantic model scope as <projectId>.<locationId>.<entryGroupId>')
    .option('--pull', 'Optionally pull catalog entries during initialization')
    .action(async (options) => {
+      let exitCode = 1;
       try {
-        await commands.init(options);
+        exitCode = await commands.init(options);
       }
       catch (err: any) {
         console.error('Error:', err.message || err);
-        process.exit(1);
+        exitCode = 1;
       }
+
+      process.exit(exitCode);
    });
 
 


### PR DESCRIPTION
## Summary

`kcmd init` computes an exit code (1 on failure, 0 on success) but `main.ts`
discarded the return value of `commands.init`, so a failed init still exited 0.
The `pull` and `push` actions already capture their code and `process.exit` with
it; `init` did not.

The practical consequence is CI: `kcmd init && kcmd push` continues to the push
even when init failed (e.g. entry-group creation returned 403), then fails
against a scope whose entry group was never created.

## Change

Capture `init`'s return value into `exitCode` and `process.exit(exitCode)`,
mirroring the existing `pull`/`push` action handlers. Failure branches in
`commands.init` already `return 1`, so no changes there are needed.

Fixes #310