### PR TITLE
mdcode: run list-form scenario filesystem assertions

### DIFF
--- a/toolbox/mdcode/tests/libts/scenarios.ts
+++ b/toolbox/mdcode/tests/libts/scenarios.ts
@@ -131,13 +131,25 @@ function runScenario(scenario: any) {
           }
           else {
             expect(fs.existsSync(absolutePath)).toBe(true);
-            if (typeof condition === 'string') {
-              const actualContent = fs.readFileSync(absolutePath, 'utf8') as string;
-              expect(actualContent.trim()).toBe(condition.trim());
-            }
-            else if (condition && typeof condition === 'object' && 'contains' in condition) {
-              const actualContent = fs.readFileSync(absolutePath, 'utf8') as string;
-              expect(actualContent).toContain(condition.contains);
+            const actualContent = fs.readFileSync(absolutePath, 'utf8') as string;
+            // A condition is one of: a bare string (exact match), a `{contains}`
+            // mapping, an empty `{}` mapping (existence only, already asserted
+            // above), or a list of such conditions.
+            const conditions = Array.isArray(condition) ? condition : [condition];
+            for (const c of conditions) {
+              if (typeof c === 'string') {
+                expect(actualContent.trim()).toBe(c.trim());
+              }
+              else if (c && typeof c === 'object' && 'contains' in c) {
+                expect(actualContent).toContain(c.contains);
+              }
+              else if (c && typeof c === 'object' && Object.keys(c).length === 0) {
+                // Existence-only assertion; nothing more to check.
+              }
+              else {
+                throw new Error(
+                  `Unsupported fileSystem assertion for ${fpath}: ${JSON.stringify(c)}`);
+              }
             }
           }
         }

--- a/toolbox/mdcode/tests/scenarios/pull_bq.yaml
+++ b/toolbox/mdcode/tests/scenarios/pull_bq.yaml
@@ -37,5 +37,5 @@ assert:
       - contains: "name: p.d"
       - contains: "type: dataplex-types.global.bigquery-dataset"
     catalog/p.d/t1.yaml:
-      - contains: "name: p.d.t1"
+      - contains: "name: p.d/t1"
       - contains: "type: dataplex-types.global.bigquery-table"


### PR DESCRIPTION
Fixes #306.

## Problem

`tests/libts/scenarios.ts` only handled two condition shapes for a filesystem assertion — a bare string or a single `{contains}` mapping. But every scenario writes them as a YAML **list**:

```yaml
catalog/e1.yaml:
  - contains: "name: e1"
```

which parses to `[{contains: "..."}]`. `'contains' in [...]` is `false` for an array, so neither branch ran and only `fs.existsSync` was checked. **34 assertions across 11 scenario files silently never executed.**

## Fix

- Normalize the condition to a list and evaluate each element, keeping the bare-string (exact match) and `{contains}` forms.
- Treat an empty `{}` mapping as existence-only (several `pull_kb` assertions rely on this).
- Unknown shapes now `throw` instead of passing silently.

Scenario `expect()` calls go from 45 → 79 (the 34 dormant assertions now run). Verified the reproduce case from the issue: changing an expectation to something impossible now fails.

## Stale expectation surfaced

Enabling the assertions surfaced exactly what the issue predicted — `pull_bq.yaml` expected `name: p.d.t1`, but `BigQueryDatasetSource` produces `p.d/t1` (the form `pull_bq_multiple` already asserts). Corrected it. No other scenarios had wrong expectations.

## Testing

`npm run test:libts` → 17 pass, 0 fail, 79 expect() calls. The unrelated `transpile.ts` compile/test failures pre-exist on `main` (airlock-blocked `@polyglot-sql/sdk`).