### PR TITLE
mdcode: honor --validate-only in CatalogSync.push on non-semantic scopes

### DIFF
--- a/toolbox/mdcode/src/libts/sync.ts
+++ b/toolbox/mdcode/src/libts/sync.ts
@@ -60,8 +60,12 @@ export class CatalogSync {
     }
   }
 
-  // Pushes local metadata to the Catalog service to publish/deploy it.
+  // Pushes local metadata to the Catalog service to publish/deploy it. Under
+  // `validateOnly` the entries are still walked and the pre-flight lookups run,
+  // but no create or update is issued -- mirroring the dry-run contract the
+  // semantic-model legs honor, so the flag behaves the same on every scope.
   async push(options?: { force?: boolean, validateOnly?: boolean; }): Promise<SyncResult> {
+    const validateOnly = !!options?.validateOnly;
     const entries = await this._snapshot.listEntries();
 
     for (const name of entries) {
@@ -81,6 +85,10 @@ export class CatalogSync {
 
       const exist = await this._catalog.lookupEntry(project, location, entry.name);
       if (exist.status != 200 || !exist.result) {
+        if (validateOnly) {
+          // Would create; write nothing under --validate-only.
+          continue;
+        }
         const entryGroup = nameParts[5];
         const entryId = nameParts.slice(7).join('/');
         const createEntryRes = await this._catalog.createEntry(project, location, entryGroup, entryId, entry);
@@ -106,6 +114,11 @@ export class CatalogSync {
       }
 
       if (!updateMask.length) {
+        continue;
+      }
+
+      if (validateOnly) {
+        // Would update; write nothing under --validate-only.
         continue;
       }
 

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -316,11 +316,15 @@ export async function push(options: PushOptions): Promise<number> {
   const catalog = new dataplex.CatalogClient(ctx);
   const sync = new kcmd.CatalogSync(catalog, snapshot);
 
-  console.log('Pushing catalog entries...');
+  console.log(options.validateOnly
+    ? 'Validating catalog entries...'
+    : 'Pushing catalog entries...');
   const result = await sync.push(options);
 
   if (result.success) {
-    console.log('Successfully pushed catalog entries.');
+    console.log(options.validateOnly
+      ? 'Validation complete; no changes applied.'
+      : 'Successfully pushed catalog entries.');
     return 0;
   }
   else {

--- a/toolbox/mdcode/tests/scenarios/push_validate_only_create.yaml
+++ b/toolbox/mdcode/tests/scenarios/push_validate_only_create.yaml
@@ -1,0 +1,49 @@
+name: push_validate_only_create
+description: >
+  A --validate-only push that would create a new entry writes nothing to the
+  catalog (regression for the ignored validateOnly flag on non-semantic scopes).
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/p/locations/us/entryGroups/custom-group
+    entryTypes:
+      - name: projects/p/locations/global/entryTypes/custom-type
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/existing-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.p.us.custom-group
+      snapshot:
+        entries:
+          - p.global.custom-type
+
+actions:
+  - action: pull
+  - action: createEntry
+    name: custom-entry
+    entry:
+      name: custom-entry
+      type: p.global.custom-type
+      resource:
+        description: Hello world
+  - action: push
+    options:
+      validateOnly: true
+
+assert:
+  # The local snapshot still holds the staged entry ...
+  fileSystem:
+    catalog/custom-entry.yaml:
+      - contains: "name: custom-entry"
+      - contains: "description: Hello world"
+  # ... but the catalog is untouched: no new entry was created.
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/existing-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description

--- a/toolbox/mdcode/tests/scenarios/push_validate_only_update.yaml
+++ b/toolbox/mdcode/tests/scenarios/push_validate_only_update.yaml
@@ -1,0 +1,51 @@
+name: push_validate_only_update
+description: >
+  A --validate-only push that would update an existing entry writes nothing to
+  the catalog (regression for the ignored validateOnly flag on non-semantic
+  scopes).
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/p/locations/us/entryGroups/custom-group
+    entryTypes:
+      - name: projects/p/locations/global/entryTypes/custom-type
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/custom-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.p.us.custom-group
+      snapshot:
+        entries:
+          - p.global.custom-type
+
+actions:
+  - action: pull
+  - action: updateEntry
+    entry:
+      name: custom-entry
+      type: p.global.custom-type
+      resource:
+        description: New custom description
+    fields:
+      - resource
+  - action: push
+    options:
+      validateOnly: true
+
+assert:
+  # The local snapshot holds the edited description ...
+  fileSystem:
+    catalog/custom-entry.yaml:
+      - contains: "name: custom-entry"
+      - contains: "description: New custom description"
+  # ... but the catalog still shows the old description: nothing was modified.
+  catalog:
+    entries:
+      - name: projects/p/locations/us/entryGroups/custom-group/entries/custom-entry
+        entryType: projects/p/locations/global/entryTypes/custom-type
+        entrySource:
+          description: Old custom description


### PR DESCRIPTION
## Summary

Fixes #309.

`CatalogSync.push` accepted `{ force, validateOnly }` but read neither. On the
non-semantic-model scopes (`entryGroup`, `bq-dataset`, `kb`), `kcmd push
--validate-only` therefore still created and updated catalog entries and exited
0. The flag only behaved correctly on the semantic-model legs, so its effect
depended on the scope.

## Changes

- `sync.ts`: short-circuit the create and update writes when `validateOnly` is
  set. Entries are still walked and the pre-flight lookups still run, but no
  `createEntry` / `modifyEntry` is issued.
- `commands.ts`: the catalog push command prints the validate-only banner and a
  "no changes applied" summary, matching the semantic-model legs.
- Two scenario regressions (create + update paths) asserting the catalog is
  untouched under `--validate-only`. Both fail on `main` and pass with the fix.

`force` is left as-is: the generic catalog push has no conflict/overwrite gate
for it to control yet (see the existing `TODO: Handle conflicts`).

## Testing

`bun test ./tests/libts/scenarios.ts` — 19 pass (17 existing + 2 new).