### PR TITLE
mdcode: don't let an ambiguous 403 masquerade as "absent" in sync

### DIFF
--- a/toolbox/mdcode/src/libts/sync.ts
+++ b/toolbox/mdcode/src/libts/sync.ts
@@ -7,6 +7,10 @@ import { CatalogSnapshot } from './snapshot';
 export interface SyncResult {
   success: boolean;
   details?: string;
+  // Number of entries the pull could not read because the service returned a
+  // non-success status. The Catalog API answers 403 for both "does not exist"
+  // and "permission denied", so a skip is ambiguous rather than a clean miss.
+  skipped?: number;
 }
 
 export interface ValidationResult {
@@ -31,7 +35,16 @@ export class CatalogSync {
   async pull(): Promise<SyncResult> {
     try {
       const entries = this._snapshot.manifest.source.entries(this._catalog.context);
-      
+
+      // The Catalog API responds with 403 for both "resource does not exist" and
+      // "insufficient permission", so a non-200 lookup below is ambiguous: we
+      // cannot tell an absent entry from a forbidden one. Rather than silently
+      // skip and still report success (which would present an empty or partial
+      // snapshot under "Successfully updated"), count the skips and surface them
+      // so the outcome is not mistaken for a complete pull.
+      let skipped = 0;
+      let firstSkipped: string | undefined;
+
       for await (const entry of entries) {
         if (this._snapshot.entryTypes.size && !this._snapshot.entryTypes.has(entry.entryType)) {
           continue;
@@ -44,16 +57,27 @@ export class CatalogSync {
         const nameParts = entry.name.split('/');
         const res = await this._catalog.lookupEntry(nameParts[1], nameParts[3], entry.name,
                                                     [...this._snapshot.aspectTypes.keys()]);
-        // The server will respond with 403 permission denied for both resource not exist or 
-        // insufficient permission. We cannot tell if a resource not exist or user does not 
-        // have the access. Thus using 200 for an ensured result.
         if (res.status != 200 || !res.result) {
+          skipped++;
+          firstSkipped ??= entry.name;
           continue;
         }
 
         await this._snapshot._storeEntry(res.result);
       }
-      return { success: true };
+
+      if (skipped) {
+        return {
+          success: false,
+          skipped,
+          details: `${skipped} ${skipped === 1 ? 'entry was' : 'entries were'} skipped: `
+            + `the Catalog service returned a non-success status (typically 403, which `
+            + `it uses for both "not found" and "permission denied"). The local snapshot `
+            + `may be incomplete; check your read permission on these entries. `
+            + `First skipped: ${firstSkipped}.`,
+        };
+      }
+      return { success: true, skipped: 0 };
     }
     catch (e: any) {
       return { success: false, details: e.message };
@@ -81,9 +105,18 @@ export class CatalogSync {
 
       const exist = await this._catalog.lookupEntry(project, location, entry.name);
       if (exist.status != 200 || !exist.result) {
+        // The lookup is ambiguous: the Catalog API returns 403 for both "does not
+        // exist" and "permission denied", so a non-200 here does not confirm the
+        // entry is absent. Attempt the create (the common case is a genuinely new
+        // entry), but treat a 409 as proof the entry already exists — which means
+        // the lookup's status was a permission problem, not a missing entry.
+        // Reporting that as "Failed to create" would point at the wrong problem.
         const entryGroup = nameParts[5];
         const entryId = nameParts.slice(7).join('/');
         const createEntryRes = await this._catalog.createEntry(project, location, entryGroup, entryId, entry);
+        if (createEntryRes.status === 409) {
+          return { success: false, details: `Entry ${entry.name} already exists but the lookup did not return it (status ${exist.status}${exist.message ? `: ${exist.message}` : ''}); the Catalog API returns 403 for both "not found" and "permission denied", so this usually means you lack read/update permission on the existing entry.` };
+        }
         if (createEntryRes.status != 200 || !createEntryRes.result) {
           return { success: false, details: `Failed to create entry ${entry.name}: ${createEntryRes.message || createEntryRes.status}` };
         }

--- a/toolbox/mdcode/tests/libts/sync.test.ts
+++ b/toolbox/mdcode/tests/libts/sync.test.ts
@@ -1,0 +1,167 @@
+// Behavior spec for CatalogSync's handling of the Catalog API's ambiguous 403:
+// the service returns 403 for both "entry does not exist" and "permission
+// denied", so neither pull nor push can treat a non-200 lookup as a clean
+// "absent". These tests pin the two failure modes from issue #308 — pull must
+// not report success over a snapshot it did not fully take, and push must not
+// mislabel an already-exists (409) as a create failure.
+
+import {describe, expect, test} from 'bun:test';
+
+import {CatalogSync} from '../../src/libts/sync';
+
+// Minimal fakes: CatalogSync only touches a handful of members on the catalog
+// client and the snapshot, so we stub exactly those rather than stand up a real
+// client/snapshot. Cast through `any` at the constructor boundary.
+function makeSnapshotForPull(names: string[]) {
+  const stored: any[] = [];
+  const snapshot = {
+    entryTypes: new Map(),
+    aspectTypes: new Map(),
+    manifest: {
+      source: {
+        // Async generator over the listed entries, mirroring the real source.
+        async *
+            entries() {
+              for (const name of names) {
+                yield {name, entryType: 'x'};
+              }
+            },
+      },
+    },
+    async _storeEntry(entry: any) {
+      stored.push(entry);
+    },
+  };
+  return {snapshot, stored};
+}
+
+describe('CatalogSync.pull', () => {
+  test('reports success when every entry is readable', async () => {
+    const {snapshot, stored} = makeSnapshotForPull(
+        ['projects/p/locations/us/entryGroups/g/entries/a']);
+    const catalog = {
+      context: {},
+      async lookupEntry() {
+        return {status: 200, result: {name: 'a'}};
+      },
+    };
+
+    const res = await new CatalogSync(catalog as any, snapshot as any).pull();
+
+    expect(res.success).toBe(true);
+    expect(res.skipped).toBe(0);
+    expect(stored.length).toBe(1);
+  });
+
+  test(
+      'does not report success when an entry 403s; counts the skip',
+      async () => {
+        const {snapshot, stored} = makeSnapshotForPull([
+          'projects/p/locations/us/entryGroups/g/entries/a',
+          'projects/p/locations/us/entryGroups/g/entries/b',
+        ]);
+        const catalog = {
+          context: {},
+          async lookupEntry(_project: string, _location: string, name: string) {
+            // 'a' readable, 'b' forbidden/absent (403).
+            return name.endsWith('/a') ?
+                {status: 200, result: {name: 'a'}} :
+                {status: 403, message: 'permission denied'};
+          },
+        };
+
+        const res =
+            await new CatalogSync(catalog as any, snapshot as any).pull();
+
+        expect(res.success).toBe(false);
+        expect(res.skipped).toBe(1);
+        expect(res.details).toContain('403');
+        // The readable entry is still stored — the pull is partial, not
+        // aborted.
+        expect(stored.length).toBe(1);
+      });
+
+  test(
+      'fails when every entry 403s rather than claiming a clean snapshot',
+      async () => {
+        const {snapshot, stored} = makeSnapshotForPull([
+          'projects/p/locations/us/entryGroups/g/entries/a',
+          'projects/p/locations/us/entryGroups/g/entries/b',
+        ]);
+        const catalog = {
+          context: {},
+          async lookupEntry() {
+            return {status: 403, message: 'permission denied'};
+          },
+        };
+
+        const res =
+            await new CatalogSync(catalog as any, snapshot as any).pull();
+
+        expect(res.success).toBe(false);
+        expect(res.skipped).toBe(2);
+        expect(stored.length).toBe(0);
+      });
+});
+
+function makeSnapshotForPush(entry: any) {
+  return {
+    manifest: {source: {ingestedEntries: false}},
+    async listEntries() {
+      return [entry.name];
+    },
+    async _fetchEntry() {
+      return entry;
+    },
+  };
+}
+
+const PUSH_ENTRY = {
+  name: 'projects/p/locations/us/entryGroups/g/entries/a',
+  aspects: {foo: {}},
+};
+
+describe('CatalogSync.push', () => {
+  test(
+      'creates when the lookup is non-200 and the create succeeds',
+      async () => {
+        const snapshot = makeSnapshotForPush(PUSH_ENTRY);
+        let created = false;
+        const catalog = {
+          async lookupEntry() {
+            return {status: 403, message: 'not found or forbidden'};
+          },
+          async createEntry() {
+            created = true;
+            return {status: 200, result: PUSH_ENTRY};
+          },
+        };
+
+        const res =
+            await new CatalogSync(catalog as any, snapshot as any).push();
+
+        expect(res.success).toBe(true);
+        expect(created).toBe(true);
+      });
+
+  test(
+      'a 409 on create is reported as already-exists, not "Failed to create"',
+      async () => {
+        const snapshot = makeSnapshotForPush(PUSH_ENTRY);
+        const catalog = {
+          async lookupEntry() {
+            return {status: 403, message: 'permission denied'};
+          },
+          async createEntry() {
+            return {status: 409, message: 'entry already exists'};
+          },
+        };
+
+        const res =
+            await new CatalogSync(catalog as any, snapshot as any).push();
+
+        expect(res.success).toBe(false);
+        expect(res.details).toContain('already exists');
+        expect(res.details).not.toContain('Failed to create');
+      });
+});


### PR DESCRIPTION
Fixes #308.

The Catalog API returns 403 for both "entry does not exist" and "caller lacks permission" (noted at `src/libts/sync.ts`). Both sync paths treated any non-200 lookup as "absent", producing a wrong outcome in each direction.

## pull — reported success over a snapshot it did not take
A pull in which every entry 403'd skipped every entry and still returned `{success: true}` → the user saw *Successfully updated local snapshot* over an empty/partial snapshot.

Now pull **counts the skips** and, when any occur, returns `success: false` (surfaced by the CLI, exit 1) with a message that names the 403 ambiguity and the first skipped entry. Readable entries are still stored, so the pull is partial rather than aborted, and `SyncResult` gains a `skipped` count.

## push — attempted a create on an entry that exists
A 403 on the lookup read as "not there", so push called `createEntry`, the service returned 409, and the whole push aborted reporting *Failed to create entry* — the wrong problem.

Now a **409 on create is reported as already-exists**, i.e. the lookup's 403 was a permission problem on an existing entry, not a missing one. The genuine-new-entry create path is unchanged (new entries also lookup-403, then create succeeds).

## Test
Adds `tests/libts/sync.test.ts` covering both failure modes (pull skip-counting incl. all-403, push 409→already-exists vs. create-success) with lightweight fakes. Typechecks clean; full existing suite unaffected (pre-existing polyglot-wasm failures are environmental).