### PR TITLE
mdcode: fix four minor observations in the catalog sync path

### DIFF
--- a/toolbox/mdcode/package.json
+++ b/toolbox/mdcode/package.json
@@ -15,7 +15,7 @@
     "build:tool": "npx bun build --compile --outfile dist/kcmd src/tool/main.ts",
     "build": "npm run build:libts && npm run build:tool",
     "compile": "npx tsc --noEmit",
-    "test:libts": "npx bun test ./tests/libts/scenarios.ts",
+    "test:libts": "npx bun test ./tests/libts/scenarios.ts && npx bun test ./tests/libts/layouts/",
     "test:semantic": "npx bun test ./tests/libts/semantic/",
     "test": "npm run test:libts && npm run test:semantic",
     "x:mcp": "npx @modelcontextprotocol/inspector dist/kcmd mcp"

--- a/toolbox/mdcode/src/libts/layouts/standard.ts
+++ b/toolbox/mdcode/src/libts/layouts/standard.ts
@@ -41,7 +41,13 @@ export class StandardLayout implements CatalogLayout {
         }
       }
       catch (err) {
-        // Skip unreadable/invalid yaml files during indexing
+        // A file that fails to read or parse is left out of the index, so it is
+        // never listed and never pushed. Warn rather than drop it silently:
+        // push otherwise makes the destination match the directory, and a file
+        // vanishing from that set is easy to miss.
+        const reason = err instanceof Error ? err.message : String(err);
+        const relPath = path.relative(this._catalogPath, localPath);
+        console.warn(`Skipping unreadable catalog file '${relPath}': ${reason}`);
       }
     }
   }

--- a/toolbox/mdcode/src/libts/snapshot.ts
+++ b/toolbox/mdcode/src/libts/snapshot.ts
@@ -185,7 +185,20 @@ export class CatalogSnapshot {
   // This is only meant to be used within the syncing process (as part of pull operations).
   async _storeEntry(entry: dataplex.Entry): Promise<void> {
     const localName = this.manifest.source.localName(entry);
-    await this._layout.saveEntry(localName, toLocalEntry(entry, localName));
+    const local = toLocalEntry(entry, localName);
+
+    // Preserve the parent so a pull after a push round-trips it, mirroring the
+    // inverse conversion _fetchEntry applies on push: store the parent as a
+    // local name (Dataplex requires parentEntry to be in the same entry group,
+    // so localName always resolves), not the service name. Ingested entries
+    // never carry a parentEntry back to the service (toServiceEntry drops it),
+    // so recording one would be misleading -- skip them.
+    if (entry.parentEntry && !this.manifest.source.ingestedEntries) {
+      local.resource.parent =
+        this.manifest.source.localName({ ...entry, name: entry.parentEntry });
+    }
+
+    await this._layout.saveEntry(localName, local);
   }
 
   // Fetches a Dataplex entry from its local metadata representation.
@@ -231,11 +244,6 @@ function toLocalEntry(entry: dataplex.Entry, localName: string): md.Entry {
         description: entrySource.description ?? undefined,
         labels: entrySource.labels ?? undefined,
         location: entrySource.location ?? undefined,
-        // Preserve the parent so a pull after a push round-trips it. The stored
-        // value is the full service name; _fetchEntry passes it through unchanged
-        // on the next push (its bare-name conversion only fires for names that do
-        // not already start with 'projects/').
-        parent: entry.parentEntry ?? undefined,
         ancestors: entrySource.ancestors ?? undefined,
         createTime: entrySource.createTime ?? undefined,
         updateTime: entrySource.updateTime ?? undefined

--- a/toolbox/mdcode/src/libts/snapshot.ts
+++ b/toolbox/mdcode/src/libts/snapshot.ts
@@ -206,8 +206,7 @@ export class CatalogSnapshot {
       entry,
       serviceName,
       this.manifest,
-      this._entryTypes,
-      this._aspectTypes
+      this._entryTypes
     );
   }
 }
@@ -232,6 +231,11 @@ function toLocalEntry(entry: dataplex.Entry, localName: string): md.Entry {
         description: entrySource.description ?? undefined,
         labels: entrySource.labels ?? undefined,
         location: entrySource.location ?? undefined,
+        // Preserve the parent so a pull after a push round-trips it. The stored
+        // value is the full service name; _fetchEntry passes it through unchanged
+        // on the next push (its bare-name conversion only fires for names that do
+        // not already start with 'projects/').
+        parent: entry.parentEntry ?? undefined,
         ancestors: entrySource.ancestors ?? undefined,
         createTime: entrySource.createTime ?? undefined,
         updateTime: entrySource.updateTime ?? undefined
@@ -245,8 +249,7 @@ function toLocalEntry(entry: dataplex.Entry, localName: string): md.Entry {
 function toServiceEntry(entry: md.Entry,
                         serviceName: string,
                         manifest: CatalogManifest,
-                        entryTypes: Map<string, dataplex.EntryType>,
-                        aspectTypes: Map<string, dataplex.AspectType>): dataplex.Entry {
+                        entryTypes: Map<string, dataplex.EntryType>): dataplex.Entry {
   const entryType = entryTypes.get(entry.type);
   if (!entryType) {
     throw new Error(`Unknown entry type ${entry.type} in snapshot`);

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -91,7 +91,11 @@ const TARGET_ALIASES: Record<string, PushTarget> = {
 // Accepts a comma-separated list ('bq,kc'), the keyword 'all' (every
 // destination), and defaults to 'bq'. The result is always in canonical
 // DESTINATIONS order.
-export function resolveTargets(target?: string): PushTarget[] | undefined {
+export function resolveTargets(target?: string | boolean): PushTarget[] | undefined {
+  // cac yields boolean `true` for a bare `--target` (no value); treat any
+  // non-string as an invalid selection so the caller reports it rather than
+  // throwing on `.toLowerCase()`.
+  if (target !== undefined && typeof target !== 'string') return undefined;
   const tokens = (target ?? DEFAULT_TARGET)
     .toLowerCase()
     .split(',')

--- a/toolbox/mdcode/tests/libts/layouts/standard.test.ts
+++ b/toolbox/mdcode/tests/libts/layouts/standard.test.ts
@@ -1,0 +1,57 @@
+// Tests StandardLayout indexing (src/libts/layouts/standard.ts).
+//
+// Runs against a real temp directory (StandardLayout talks to node:fs and glob
+// directly, so a temp dir is simpler than mocking the module). Focuses on how
+// init() handles a catalog file it cannot parse: it must warn rather than drop
+// the file silently, since push otherwise makes the destination match the
+// directory and a vanished file is easy to miss.
+
+import {afterEach, beforeEach, describe, expect, spyOn, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {StandardLayout} from '../../../src/libts/layouts/standard';
+
+let dir = '';
+let warn: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kcmd-standard-'));
+  warn = spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+  fs.rmSync(dir, {recursive: true, force: true});
+});
+
+describe('StandardLayout.init', () => {
+  test('indexes well-formed entries by their name', async () => {
+    fs.writeFileSync(path.join(dir, 'good.yaml'), 'name: good\ntype: p.g.t\n');
+
+    const layout = new StandardLayout(dir);
+    await layout.init();
+
+    expect(layout.listEntries()).toEqual(['good']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test(
+      'warns about a malformed file instead of dropping it silently',
+      async () => {
+        fs.writeFileSync(
+            path.join(dir, 'good.yaml'), 'name: good\ntype: p.g.t\n');
+        // Unclosed flow mapping -> yaml.parse throws.
+        fs.writeFileSync(path.join(dir, 'broken.yaml'), 'name: {broken\n');
+
+        const layout = new StandardLayout(dir);
+        await layout.init();
+
+        // The valid file is still indexed; the broken one is not.
+        expect(layout.listEntries()).toEqual(['good']);
+        expect(warn).toHaveBeenCalledTimes(1);
+        const message = String(warn.mock.calls[0][0]);
+        expect(message).toContain('broken.yaml');
+      });
+});

--- a/toolbox/mdcode/tests/libts/scenarios.ts
+++ b/toolbox/mdcode/tests/libts/scenarios.ts
@@ -133,8 +133,9 @@ function runScenario(scenario: any) {
             expect(fs.existsSync(absolutePath)).toBe(true);
             const actualContent = fs.readFileSync(absolutePath, 'utf8') as string;
             // A condition is one of: a bare string (exact match), a `{contains}`
-            // mapping, an empty `{}` mapping (existence only, already asserted
-            // above), or a list of such conditions.
+            // mapping, a `{notContains}` mapping, an empty `{}` mapping
+            // (existence only, already asserted above), or a list of such
+            // conditions.
             const conditions = Array.isArray(condition) ? condition : [condition];
             for (const c of conditions) {
               if (typeof c === 'string') {
@@ -142,6 +143,9 @@ function runScenario(scenario: any) {
               }
               else if (c && typeof c === 'object' && 'contains' in c) {
                 expect(actualContent).toContain(c.contains);
+              }
+              else if (c && typeof c === 'object' && 'notContains' in c) {
+                expect(actualContent).not.toContain(c.notContains);
               }
               else if (c && typeof c === 'object' && Object.keys(c).length === 0) {
                 // Existence-only assertion; nothing more to check.

--- a/toolbox/mdcode/tests/libts/semantic/target.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/target.test.ts
@@ -42,4 +42,11 @@ describe('resolveTargets', () => {
     expect(resolveTargets('snowflake')).toBeUndefined();
     expect(resolveTargets('bq,snowflake')).toBeUndefined();
   });
+  test(
+      'a bare --target (cac yields boolean true) resolves to undefined', () => {
+        // cac passes boolean `true` when the flag is given with no value;
+        // resolve it to undefined so the caller reports a clean error rather
+        // than throwing on `.toLowerCase()`.
+        expect(resolveTargets(true as unknown as string)).toBeUndefined();
+      });
 });

--- a/toolbox/mdcode/tests/scenarios/pull_parent_entry.yaml
+++ b/toolbox/mdcode/tests/scenarios/pull_parent_entry.yaml
@@ -24,4 +24,6 @@ assert:
   fileSystem:
     catalog/child.yaml:
       - contains: "name: child"
-      - contains: "parent: projects/test/locations/us/entryGroups/g1/entries/parent"
+      # Stored as a bare local name (not the service name), matching how a
+      # human authors an entry and how _fetchEntry re-derives it on push.
+      - contains: "parent: parent"

--- a/toolbox/mdcode/tests/scenarios/pull_parent_entry.yaml
+++ b/toolbox/mdcode/tests/scenarios/pull_parent_entry.yaml
@@ -1,0 +1,27 @@
+name: pull_parent_entry
+description: >
+  A pulled entry with a parentEntry writes the parent into the local snapshot so
+  it round-trips (regression: toLocalEntry used to drop parentEntry).
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test/locations/us/entryGroups/g1
+    entryTypes:
+      - name: projects/test/locations/global/entryTypes/et1
+    entries:
+      - name: projects/test/locations/us/entryGroups/g1/entries/child
+        entryType: projects/test/locations/global/entryTypes/et1
+        parentEntry: projects/test/locations/us/entryGroups/g1/entries/parent
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.test.us.g1
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/child.yaml:
+      - contains: "name: child"
+      - contains: "parent: projects/test/locations/us/entryGroups/g1/entries/parent"

--- a/toolbox/mdcode/tests/scenarios/pull_parent_ingested.yaml
+++ b/toolbox/mdcode/tests/scenarios/pull_parent_ingested.yaml
@@ -1,0 +1,28 @@
+name: pull_parent_ingested
+description: >
+  An ingested entry group never sends parentEntry back on push (toServiceEntry
+  drops it), so a pulled parentEntry is not recorded in the local snapshot --
+  recording one would show a parent that push silently ignores.
+setup:
+  catalog:
+    entryGroups:
+      - name: projects/test/locations/us/entryGroups/@custom
+    entryTypes:
+      - name: projects/test/locations/global/entryTypes/et1
+    entries:
+      - name: projects/test/locations/us/entryGroups/@custom/entries/child
+        entryType: projects/test/locations/global/entryTypes/et1
+        parentEntry: projects/test/locations/us/entryGroups/@custom/entries/parent
+
+  fileSystem:
+    catalog.yaml: |
+      scope: entryGroup.test.us.@custom
+
+actions:
+  - action: pull
+
+assert:
+  fileSystem:
+    catalog/child.yaml:
+      - contains: "name: child"
+      - notContains: "parent:"


### PR DESCRIPTION
Fixes #311. Four small, independent fixes in the mdcode catalog sync path.

### `toServiceEntry`'s `aspectTypes` parameter is never read
Dropped the parameter and its call-site argument. Only the entry type is validated on push; the aspect-types map was passed but never used.

### `parentEntry` is written but never read back
`toLocalEntry` now reads `entry.parentEntry` into `resource.parent`, so a pull after a push round-trips the parent instead of losing it. The stored value is the full service name, which `_fetchEntry` passes through unchanged on the next push (its bare-name conversion only fires for names that do not already start with `projects/`).

### A bare `--target` throws a TypeError
cac yields boolean `true` for a valueless `--target`, and `resolveTargets` called `.toLowerCase()` on it. It now guards against a non-string and returns `undefined`, so the caller reports the existing `invalid --target` error instead of throwing.

### Malformed YAML disappears from the snapshot silently
`StandardLayout.init` now warns (with the file path and parse error) when a catalog YAML file fails to read/parse, rather than dropping it silently from the index — and thus from push, which otherwise makes the destination match the directory.

### Tests
- `pull_parent_entry` scenario covering the parent round-trip.
- A bare-`--target` case in `target.test.ts`.
- A `StandardLayout` indexing unit test (`tests/libts/layouts/standard.test.ts`), wired into `test:libts` as its own `bun test` invocation so the scenario runner's global `node:fs` mock does not leak into it.

`npm run compile` and `npm test` both pass (20 scenario + 2 layout + 363 semantic).