### PR TITLE
okf: point readers at the dedicated OKF repository

### DIFF
--- a/okf/README.md
+++ b/okf/README.md
@@ -1,8 +1,20 @@
+> [!IMPORTANT]
+> **OKF now lives in its own repository:
+> [GoogleCloudPlatform/open-knowledge-format](https://github.com/GoogleCloudPlatform/open-knowledge-format).**
+>
+> That repository is the canonical home of the specification, the reference
+> agent, and the sample bundles. Please read the spec, file issues, and open
+> pull requests there.
+>
+> **Stop using the copy under `okf/` in this repository.** It is a frozen
+> snapshot, no longer maintained, and anything built against it will drift out
+> of date.
+
 # Open Knowledge Format (OKF)
 
 ### 📖 [Read the Open Knowledge Format v0.2 specification → SPEC.md](SPEC.md)
 
-> **This repository is primarily about the [Open Knowledge Format
+> **This directory is primarily about the [Open Knowledge Format
 > (OKF)](SPEC.md).**
 >
 > OKF is a **universal, vendor-neutral format** for representing knowledge


### PR DESCRIPTION
## Summary

OKF now has its own repository, [GoogleCloudPlatform/open-knowledge-format](https://github.com/GoogleCloudPlatform/open-knowledge-format). Nothing in `okf/README.md` distinguished this copy from the real thing, so a reader landing here had no way to know their issue or pull request belonged somewhere else.

- Adds an `[!IMPORTANT]` notice **above** the title, so it is the first thing rendered: where OKF lives now, and that this copy is a frozen snapshot nobody should build against.
- Reworded one adjacent line. The blockquote below the title said *"This repository is primarily about OKF"*, which reads as a contradiction sitting directly under a move notice; it now says *"This directory"*.

No other content changed.

## Test plan

- [x] Rendered the markdown to confirm the `[!IMPORTANT]` callout displays correctly and precedes the `# Open Knowledge Format (OKF)` heading

## Note for the reviewer

`knowledge-catalog` is public but `open-knowledge-format` is currently **private**, so the link in this notice will 404 for anyone outside the org. Worth making the OKF repo public before merging — otherwise the notice points readers at a door they cannot open.
