### PR TITLE
okf: update the demo's defaults, flags, and gcloud calls

### DIFF
--- a/toolbox/mdcode/demo/.gitignore
+++ b/toolbox/mdcode/demo/.gitignore
@@ -1,3 +1,4 @@
 catalog/
 catalog.yaml
+pulled/
 !okf/catalog/

--- a/toolbox/mdcode/demo/README.md
+++ b/toolbox/mdcode/demo/README.md
@@ -122,11 +122,16 @@ bun cleanup.ts
 
 This demo demonstrates publishing an [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
 wiki bundle (a directory of markdown files with YAML frontmatter) into a
-Knowledge Catalog EntryGroup via the Documents Layout. The bundle in
-`okf/catalog/` is a GA4 sample with indexes, references, a dataset, and a
-table, 14 markdown files in total. The Documents Layout maps each `.md`
+Knowledge Catalog EntryGroup via the Documents Layout. By default it operates
+on `okf/bundles/acme_retail`, the canonical in-repo bundle: 17 markdown files
+covering metrics, computations, policies, skills, and tables, and the one that
+exercises the full v0.2 signal layer. The Documents Layout maps each `.md`
 file to an entry whose name is derived from the file path, with the
 markdown body stored on the `dataplex-types.global.overview` aspect.
+
+A second bundle in `okf/catalog/` is a GA4 sample with indexes, references, a
+dataset, and a table, 14 markdown files in total. It is kept for anyone who was
+using the old default, and is reachable with `--bundle catalog`.
 
 The generic Documents Layout only carries `title`/`description`/`tags` +
 body. OKF's signal layer has no generic home, so `push.ts`/`pull.ts`
@@ -159,26 +164,31 @@ applies elsewhere.
 
 **Setup**
 
-* Creates an empty Dataplex EntryGroup (`okf_ga4`).
+* Creates an empty Dataplex EntryGroup (`okf_demo`). `--entry-group <name>`
+  names a different one; the name must match Dataplex's own rule
+  (`/^[a-z][a-z0-9_-]{0,61}[a-z0-9]$/`) or setup stops before calling gcloud.
 * Creates the custom `okf` aspect type from `okf-aspect.json`, or updates it
   if a previous run of this demo left an older template behind.
 * Creates the custom `okf-bundle` entry type.
 * Creates a `catalog.yaml` manifest pointing at the EntryGroup and listing
   the `okf-bundle` entry type and the `okf` aspect.
-* The `catalog/` directory is already populated with the GA4 markdown bundle.
+
+`setup.ts` is the only script that takes `--entry-group`. The rest read the
+EntryGroup back out of the `catalog.yaml` it writes, so they cannot be aimed at
+an EntryGroup this demo never created.
 
 ```bash
 bun setup.ts
 cat catalog.yaml
-ls -R catalog
 ```
 
 **Publish Metadata Snapshot**
 
-* Push the bundled markdown to Knowledge Catalog. Entry names mirror the
-  file path (e.g. `references/metrics/purchasers.md` &rarr; entry
-  `references/metrics/purchasers`). Every file lands as an `okf-bundle`
-  entry, index files included, with its OKF `type:` on the `okf` aspect.
+* Push the bundled markdown to Knowledge Catalog. Without `--bundle` this
+  pushes `okf/bundles/acme_retail`. Entry names mirror the file path
+  (e.g. `metrics/revenue.md` &rarr; entry `metrics/revenue`). Every file
+  lands as an `okf-bundle` entry, index files included, with its OKF
+  `type:` on the `okf` aspect.
 
 ```bash
 bun push.ts
@@ -186,17 +196,19 @@ bun push.ts
 
 **Pull Metadata Snapshot**
 
-* Pull the snapshot back down into `catalog/` as clean OKF. The signal
-  layer is restored from the `okf` aspect, so a pull right after a push
-  leaves `catalog/` unchanged.
+* Pull the snapshot back down as clean OKF. The signal layer is restored
+  from the `okf` aspect. Pull writes to `./pulled/`, a gitignored scratch
+  directory, so it never overwrites the bundle push reads from; compare the
+  two to confirm the round trip.
 
 ```bash
 bun pull.ts
+diff -r ../../../../okf/bundles/acme_retail pulled
 ```
 
 **Modify Metadata Snapshot**
 
-* Edit any markdown file under `catalog/` directly. Any frontmatter key and
+* Edit any markdown file in the bundle directly. Any frontmatter key and
   the markdown body can be changed, then push again.
 
 ```bash
@@ -206,22 +218,22 @@ bun push.ts
 **Run Against Another Bundle**
 
 * `push.ts` and `pull.ts` both take `--bundle <dir>`, so the demo can run
-  against a bundle elsewhere in the repo without copying it in.
-  `okf/bundles/acme_retail` is the bundle that exercises the full v0.2
-  signal layer, including an Attested Computation and a producer-defined
-  key.
+  against a bundle elsewhere in the repo without copying it in, and pull can
+  be aimed somewhere other than `./pulled/`. `--bundle catalog` selects the
+  GA4 sample that used to be the default.
 
 ```bash
-bun push.ts --bundle ../../../../okf/bundles/acme_retail
+bun push.ts --bundle catalog
 bun pull.ts --bundle /tmp/acme_pulled
 ```
 
 * Pull re-emits frontmatter in a canonical key order and block style, so
-  pulling a bundle that was hand-authored with flow mappings back over
-  itself shows presentation churn in `git diff` even though nothing was
-  lost. Compare parsed frontmatter and body rather than bytes. The GA4
-  bundle in `catalog/` is already in canonical form, so for it a pull after
-  a push leaves the tree byte-identical.
+  pulling a hand-authored bundle back shows presentation churn in a `diff`
+  even though nothing was lost. The Acme Retail bundle uses flow mappings, so
+  expect churn there; compare parsed frontmatter and body rather than bytes.
+  The GA4 bundle in `catalog/` is already in canonical form, so
+  `bun push.ts --bundle catalog` followed by `bun pull.ts --bundle catalog`
+  leaves that tree byte-identical.
 
 * Two things do not make the trip. Only `.md` files are pushed, so bundle
   attachments such as `acme_retail/attesters/sql_equality.py` stay local
@@ -231,7 +243,9 @@ bun pull.ts --bundle /tmp/acme_pulled
 
 **Cleanup**
 
-* Deletes the Dataplex EntryGroup. The custom `okf` aspect type and
+* Deletes the Dataplex EntryGroup named in `catalog.yaml`, printing which one
+  and in which project first. It takes no flags, so the only EntryGroup it can
+  delete is the one `setup.ts` created. The custom `okf` aspect type and
   `okf-bundle` entry type are left in place: they are scoped to the project and
   location rather than to this demo, so other OKF bundles in the same project
   are typed by them too. The commands to remove them manually are printed at

--- a/toolbox/mdcode/demo/okf/cleanup.ts
+++ b/toolbox/mdcode/demo/okf/cleanup.ts
@@ -1,17 +1,31 @@
 import * as cp from 'child_process';
 import * as kcmd from 'kcmd';
+import { manifestEntryGroup, rejectArgs } from './okf';
 
 const context = kcmd.gcp.ApiContext.default();
 const project = context.project;
 const location = context.location;
-const entryGroup = 'okf_ga4';
 
-function dataplex(cmd: string, data: string|null=null) {
-  cmd = 'gcloud -q dataplex ' + cmd + ` --project ${project} --location ${location}`;
-  cp.execSync(cmd, { encoding: 'utf8', input: data ?? undefined, stdio: 'inherit'});
+// The entry group to delete comes from the manifest setup.ts wrote, so cleanup
+// can only ever undo this demo's own setup.
+rejectArgs();
+const entryGroup = manifestEntryGroup(process.cwd());
+
+// Arguments go to gcloud as an argv array rather than a shell string, so a name
+// read out of the manifest is never word-split or interpreted by a shell.
+function dataplex(args: string[], data: string|null=null) {
+  const argv = [...args, '--project', project, '--location', location];
+  cp.execFileSync('gcloud', argv, { encoding: 'utf8', input: data ?? undefined, stdio: 'inherit'});
 }
 
-dataplex(`entry-groups delete ${entryGroup}`);
+// `-q` skips the confirmation prompt, so this is the only chance to notice that
+// the deletion is aimed at the wrong entry group.
+console.log(
+  `About to delete entry group ${entryGroup} in ${project}/${location}. ` +
+  `If this is not the entry group you meant, abort now.`
+);
+
+dataplex(['-q', 'dataplex', 'entry-groups', 'delete', entryGroup]);
 console.log(`Deleted entry group ${entryGroup}`);
 
 // The okf aspect type and the okf-bundle entry type are scoped to the project

--- a/toolbox/mdcode/demo/okf/okf.ts
+++ b/toolbox/mdcode/demo/okf/okf.ts
@@ -8,7 +8,79 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { parseArgs as nodeParseArgs } from 'node:util';
 import * as yaml from 'yaml';
+
+export const DEFAULT_ENTRY_GROUP = 'okf_demo';
+
+// Relative to the repo root. The demo runs from toolbox/mdcode/demo/okf, so the
+// root is four levels up.
+export const DEFAULT_BUNDLE = 'okf/bundles/acme_retail';
+const REPO_ROOT_FROM_DEMO = '../../../..';
+
+// Parse argv against an exact set of accepted flags. Handles both
+// `--flag value` and `--flag=value`. An unknown flag, a missing value, or a
+// bare positional stops the run rather than being ignored, so a mistyped flag
+// can never be dropped in silence.
+function parseFlags(argv: string[], accepted: string[]): Record<string, string | undefined> {
+  const options: Record<string, { type: 'string' }> = {};
+  for (const name of accepted) {
+    options[name] = { type: 'string' };
+  }
+  try {
+    const parsed = nodeParseArgs({ args: argv, options, strict: true, allowPositionals: false });
+    return parsed.values as Record<string, string | undefined>;
+  } catch (e) {
+    throw new Error(`Invalid arguments: ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Parse setup.ts's argv into { entryGroup }. `--entry-group` names the entry
+ * group to create; setup.ts is the only script that takes it, because every
+ * other script reads the entry group back out of the manifest it writes.
+ * Validates the name against Dataplex's own naming rule.
+ */
+export function parseDemoArgs(argv: string[] = process.argv.slice(2)): { entryGroup: string } {
+  const values = parseFlags(argv, ['entry-group']);
+  const entryGroup = values['entry-group'] ?? DEFAULT_ENTRY_GROUP;
+  if (!/^[a-z][a-z0-9_-]{0,61}[a-z0-9]$/.test(entryGroup)) {
+    throw new Error(`Invalid entry-group name: '${entryGroup}'. Must match /^[a-z][a-z0-9_-]{0,61}[a-z0-9]$/`);
+  }
+  return { entryGroup };
+}
+
+/** Stop if argv carries any flag at all. For the scripts that take none. */
+export function rejectArgs(argv: string[] = process.argv.slice(2)): void {
+  parseFlags(argv, []);
+}
+
+// The manifest setup.ts writes. Every later script addresses the entry group it
+// names, so without it there is nothing to act on.
+function manifestPath(root: string): string {
+  const file = path.join(root, 'catalog.yaml');
+  if (!fs.existsSync(file)) {
+    throw new Error('catalog.yaml not found; run setup.ts first.');
+  }
+  return file;
+}
+
+/** Stop unless setup.ts has written a manifest for this demo to act on. */
+export function requireManifest(root: string): void {
+  manifestPath(root);
+}
+
+// cleanup deletes an entry group outright, so the name comes from the manifest
+// that setup.ts wrote rather than from a flag a caller could mistype.
+export function manifestEntryGroup(root: string): string {
+  const file = manifestPath(root);
+  const scope = yaml.parse(fs.readFileSync(file, 'utf8'))?.scope;
+  const entryGroup = String(scope ?? '').split('.').pop() ?? '';
+  if (!entryGroup) {
+    throw new Error(`catalog.yaml has no usable scope to read an entry group from: ${JSON.stringify(scope)}`);
+  }
+  return entryGroup;
+}
 
 export interface Split { meta: any | null; body: string; }
 
@@ -18,16 +90,28 @@ export interface Split { meta: any | null; body: string; }
 type Path = (string | number)[];
 type Extra = [Path, any];
 
-// `--bundle <dir>` selects which OKF bundle to operate on, so the demo can run
-// against a bundle elsewhere in the repo instead of only its own catalog/.
+// `--bundle <dir>` selects which OKF bundle push and pull operate on, so the
+// demo can run against a bundle elsewhere in the repo. Without it they operate
+// on the in-repo Acme Retail bundle, which exercises the full v0.2 signal
+// layer. It is the only flag these two scripts take: the entry group comes from
+// the manifest, not from the command line.
 export function bundleDir(root: string, argv: string[] = process.argv.slice(2)): string {
-  const i = argv.indexOf('--bundle');
-  if (i === -1) {
-    return path.join(root, 'catalog');
+  const value = parseFlags(argv, ['bundle'])['bundle'];
+  if (value === undefined) {
+    return path.resolve(root, REPO_ROOT_FROM_DEMO, DEFAULT_BUNDLE);
   }
-  const value = argv[i + 1];
-  if (!value) {
-    throw new Error('--bundle requires a directory path');
+  return path.resolve(root, value);
+}
+
+// Pull writes files, so it defaults to a gitignored scratch directory instead of
+// the bundle push reads. Defaulting both to the same place would let a stray
+// `bun pull.ts` overwrite the canonical Acme Retail source in the repo.
+export const DEFAULT_PULL_TARGET = 'pulled';
+
+export function pullTargetDir(root: string, argv: string[] = process.argv.slice(2)): string {
+  const value = parseFlags(argv, ['bundle'])['bundle'];
+  if (value === undefined) {
+    return path.join(root, DEFAULT_PULL_TARGET);
   }
   return path.resolve(root, value);
 }

--- a/toolbox/mdcode/demo/okf/pull.ts
+++ b/toolbox/mdcode/demo/okf/pull.ts
@@ -2,19 +2,20 @@
 //
 // kcmd pulls into a throwaway .staging/ tree in the "pushable" form (signal
 // carried in the custom `okf` aspect via the catalogEntry passthrough); we then
-// translate each file back to clean OKF and write it to catalog/. Inverse of push.ts.
+// translate each file back to clean OKF and write it to pulled/. Inverse of push.ts.
 
 import * as cp from 'child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as kcmd from 'kcmd';
-import { bundleDir, listMarkdown, fromStaging } from './okf';
+import { pullTargetDir, listMarkdown, fromStaging, requireManifest } from './okf';
 
 const context = kcmd.gcp.ApiContext.default();
 const okfKey = `${context.project}.${context.location}.okf`;
 
 const root = process.cwd();
-const catalogDir = bundleDir(root);
+requireManifest(root);
+const catalogDir = pullTargetDir(root);
 const stagingDir = path.join(root, '.staging');
 const stagingCatalog = path.join(stagingDir, 'catalog');
 const binary = path.resolve(root, '../../dist/kcmd');

--- a/toolbox/mdcode/demo/okf/push.ts
+++ b/toolbox/mdcode/demo/okf/push.ts
@@ -1,6 +1,6 @@
 // Push clean OKF -> Dataplex, preserving the OKF signal layer.
 //
-// The on-disk catalog/ is clean OKF. kcmd's generic Documents Layout only maps
+// The on-disk bundle is clean OKF. kcmd's generic Documents Layout only maps
 // title/description/tags + body, so we translate each file into the "pushable"
 // form (signal moved into a custom `okf` aspect via the catalogEntry passthrough)
 // in a throwaway .staging/ tree, then delegate to the real kcmd binary.
@@ -9,13 +9,14 @@ import * as cp from 'child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as kcmd from 'kcmd';
-import { bundleDir, listMarkdown, toStaging } from './okf';
+import { bundleDir, listMarkdown, requireManifest, toStaging } from './okf';
 
 const context = kcmd.gcp.ApiContext.default();
 const okfKey = `${context.project}.${context.location}.okf`;
 const entryTypeKey = `${context.project}.${context.location}.okf-bundle`;
 
 const root = process.cwd();
+requireManifest(root);
 const catalogDir = bundleDir(root);
 const stagingDir = path.join(root, '.staging');
 const binary = path.resolve(root, '../../dist/kcmd');

--- a/toolbox/mdcode/demo/okf/setup.ts
+++ b/toolbox/mdcode/demo/okf/setup.ts
@@ -2,19 +2,23 @@ import * as cp from 'child_process';
 import * as path from 'node:path';
 import * as kcmd from 'kcmd';
 import { YAML } from 'bun';
+import { parseDemoArgs } from './okf';
 
 const context = kcmd.gcp.ApiContext.default();
 const project = context.project;
 const location = context.location;
-const entryGroup = 'okf_ga4';
+const { entryGroup } = parseDemoArgs();
 
-function dataplex(cmd: string, data: string|null=null) {
-  cmd = 'gcloud dataplex ' + cmd + ` --project ${project} --location ${location}`;
-  cp.execSync(cmd, { encoding: 'utf8', input: data ?? undefined, stdio: 'inherit'});
+// Arguments go to gcloud as an argv array rather than a shell string, so an
+// entry group name from the command line is never word-split or interpreted by
+// a shell.
+function dataplex(args: string[], data: string|null=null) {
+  const argv = [...args, '--project', project, '--location', location];
+  cp.execFileSync('gcloud', argv, { encoding: 'utf8', input: data ?? undefined, stdio: 'inherit'});
 }
 
 try {
-  dataplex(`entry-groups create ${entryGroup}`);
+  dataplex(['dataplex', 'entry-groups', 'create', entryGroup]);
   console.log(`Created empty entry group ${entryGroup}`);
   console.log();
 }
@@ -23,7 +27,7 @@ catch {
 }
 
 try {
-  dataplex(`aspect-types create okf --metadata-template-file-name=okf-aspect.json`);
+  dataplex(['dataplex', 'aspect-types', 'create', 'okf', '--metadata-template-file-name=okf-aspect.json']);
   console.log('Created custom aspect type okf');
   console.log();
 }
@@ -34,7 +38,7 @@ catch {
   // backwards-incompatible template changes, so new fields in okf-aspect.json
   // must be appended with fresh indices; renumbering an existing field breaks
   // this update for everyone who already ran the demo.
-  dataplex(`aspect-types update okf --metadata-template-file-name=okf-aspect.json`);
+  dataplex(['dataplex', 'aspect-types', 'update', 'okf', '--metadata-template-file-name=okf-aspect.json']);
   console.log('Updated existing aspect type okf to the current template');
   console.log();
 }
@@ -42,17 +46,18 @@ catch {
 // A custom entry type, so a search can tell an OKF document apart from anything
 // else in the project. It declares no required aspects: SPEC 8 index files
 // carry no signal layer, so requiring the okf aspect would reject them.
-const entryTypeFlags =
-  '--display-name="OKF Document" ' +
-  '--description="A document in an Open Knowledge Format bundle."';
+const entryTypeFlags = [
+  '--display-name=OKF Document',
+  '--description=A document in an Open Knowledge Format bundle.',
+];
 
 try {
-  dataplex(`entry-types create okf-bundle ${entryTypeFlags}`);
+  dataplex(['dataplex', 'entry-types', 'create', 'okf-bundle', ...entryTypeFlags]);
   console.log('Created custom entry type okf-bundle');
   console.log();
 }
 catch {
-  dataplex(`entry-types update okf-bundle ${entryTypeFlags}`);
+  dataplex(['dataplex', 'entry-types', 'update', 'okf-bundle', ...entryTypeFlags]);
   console.log('Updated existing entry type okf-bundle');
   console.log();
 }


### PR DESCRIPTION
The demo pushed a GA4 sample into a hardcoded okf_ga4 entry group, built gcloud command lines by string concatenation, and pulled back over the same directory it pushed from. Each of those is a way to lose work or hit the wrong project resource.

Default to okf/bundles/acme_retail, the in-repo bundle that exercises the full v0.2 signal layer. The GA4 sample stays reachable as --bundle catalog.

Parse argv with node:util parseArgs instead of scanning for a flag by index, so --flag=value works, an unknown or mistyped flag stops the run, and a missing value is reported rather than silently read as the next flag. Validate an entry group name against Dataplex's rule before calling out.

Give --entry-group to setup.ts alone. push, pull, and cleanup read the entry group back out of the catalog.yaml setup writes, so they cannot be aimed at an entry group this demo never created, and they stop with a clear message when that manifest is missing. cleanup names the entry group and project it is about to delete, since -q skips the prompt.

Pass gcloud an argv array via execFileSync rather than a shell string, so no value reaches a shell.

Pull writes to ./pulled/, gitignored, instead of over the bundle push reads from.