### PR TITLE
mdcode: one-way OWL ontology -> OSI import (kcmd owl import)

### DIFF
--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -384,6 +384,200 @@ local model and replace it with the catalog's. Pull never touches BigQuery.
 > validation gate before any leg runs, so it is never written — see
 > [Validation](#validation).)
 
+## Importing an OWL ontology
+
+An OWL ontology and a semantic model share a backbone: **classes ≈ entities**,
+**object properties ≈ relationships**, **datatype properties ≈ fields**. `kcmd`
+does not learn a second format — it **converts OWL into a semantic model** once,
+then the ontology rides the normal `kcmd push` / `kcmd pull` above. The semantic
+model stays the single canonical form.
+
+This first cut converts only the OWL constructs that have a clean BigQuery Graph
+shape (class → node, object property → edge, datatype property → property).
+Richer OWL (`subClassOf`, `inverseOf`, SHACL, cardinality, individuals) is not
+read yet — see [What is not covered yet](#what-is-not-covered-yet).
+
+### 1. The OWL file
+
+A small sales ontology, `sales.owl.ttl` — two classes, four datatype properties,
+one object property. Nothing here needs an OWL reasoner:
+
+```turtle
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <http://example.com/sales#> .
+
+ex:Customer a owl:Class ;
+    rdfs:label   "Customer" ;
+    rdfs:comment "A person or organization that places orders." .
+
+ex:Order a owl:Class ;
+    rdfs:label   "Order" ;
+    rdfs:comment "A purchase placed by a customer." .
+
+ex:customerName a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:string ; rdfs:label "name" .
+
+ex:signupDate a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:date .
+
+ex:orderAmount a owl:DatatypeProperty ;
+    rdfs:domain ex:Order ; rdfs:range xsd:decimal .
+
+ex:orderDate a owl:DatatypeProperty ;
+    rdfs:domain ex:Order ; rdfs:range xsd:date .
+
+ex:placedBy a owl:ObjectProperty ;
+    rdfs:domain  ex:Order ; rdfs:range ex:Customer ;
+    rdfs:label   "placed by" ;
+    rdfs:comment "Links an order to the customer who placed it." .
+```
+
+### 2. The command
+
+```console
+$ kcmd owl import sales.owl.ttl
+converted 2 classes, 1 object property, 4 datatype properties
+wrote catalog/EntryGroups/<entryGroup>/sales.yaml
+note: this model is UNBOUND (no backing tables yet).
+      -> `kcmd push --target kc` works now (publishes ontology metadata).
+      -> `kcmd push --target bq` is skipped until you bind sources.
+```
+
+The model name comes from the file (`sales.owl.ttl` → `sales`). By default the
+document is written into the semantic-model layout dir so the next `kcmd push`
+picks it up; pass `--out <path>` to write it elsewhere.
+
+### 3. The semantic model it produces — `sales.yaml`
+
+Note what is **not** here: no IRIs, no `custom_extensions`. Every OWL term has an
+IRI (`ex:Customer` = `http://example.com/sales#Customer`), but for the
+constructs that map cleanly, the IRI carries nothing the model doesn't already
+have — the term's identity is its name, and the source namespace is recorded once
+in the model `description` as provenance.
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: sales
+    description: Imported from OWL ontology http://example.com/sales#
+    datasets:
+      - name: Customer
+        source: unbound:Customer        # placeholder — bind to a table for BigQuery Graph
+        description: A person or organization that places orders.
+        fields:
+          - name: customerName
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: customerName
+            datatype: String
+            label: name
+          - name: signupDate
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: signupDate
+            datatype: Date
+      - name: Order
+        source: unbound:Order
+        description: A purchase placed by a customer.
+        fields:
+          - name: orderAmount
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: orderAmount
+            datatype: Decimal
+          - name: orderDate
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: orderDate
+            datatype: Date
+    relationships:
+      - name: placedBy
+        from: Order
+        to: Customer
+        # UNBOUND: real FK/key columns are unknown until sources are bound.
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - TODO_BIND
+        ai_context:
+          instructions: Links an order to the customer who placed it.
+```
+
+#### How each OWL construct landed
+
+| OWL | Semantic model | Notes |
+|---|---|---|
+| `owl:Class` | `datasets[]` entry | `source` = `unbound:<Name>` placeholder until bound |
+| `owl:DatatypeProperty` | `fields[]` on the domain's dataset | `expression` defaults to the property's local name (a valid column ref once bound) |
+| `rdfs:range xsd:*` | field `datatype` | `xsd:string→String`, `xsd:date→Date`, `xsd:decimal→Decimal`, else `Opaque` |
+| `owl:ObjectProperty` | `relationships[]` | `from`=domain, `to`=range; join columns unbound (`TODO_BIND`) |
+| `rdfs:label` on a datatype property | field `label` | the field's display name (a `label` slot exists only on fields); dropped when it only respaces/recases the name |
+| `rdfs:label` on a class / object property | `ai_context.synonyms` | no `label` slot there, so a distinct label becomes an alternate name; dropped when it only respaces/recases the name |
+| extra `rdfs:label` / `skos:altLabel` / `skos:prefLabel` | `ai_context.synonyms` | genuinely alternate names; feed NL search |
+| `rdfs:comment` on a class / datatype property | `description` | |
+| `rdfs:comment` on an object property | `ai_context.instructions` | a relationship has no `description` slot, so its comment rides in `ai_context` |
+| term IRIs, `@prefix` | dropped (provenance kept in model `description`) | reconstructable as `<base><name>`; re-carried only if reverse export or `subClassOf` needs them |
+
+A datatype property whose domain is not a class in the ontology, or an object
+property missing an endpoint, cannot be placed; it is **skipped with a warning**
+rather than failing the whole import.
+
+### 4. Going from ontology to a running graph (binding)
+
+The import gets you a **KC-ready, BQ-pending** model. Publish the ontology as
+catalog metadata immediately:
+
+```console
+$ kcmd push --target kc      # Customer/Order entries + placedBy link appear in Knowledge Catalog
+```
+
+To make it queryable in **BigQuery Graph**, bind each class to a real table by
+editing the `unbound:` / `TODO_BIND` spots — `source` (+ `primary_key`) per
+dataset, and the relationship's join columns:
+
+```yaml
+  - name: Customer
+    source: myproj.sales.customers
+    primary_key:
+      - customer_id
+    fields:
+      - name: customerName
+        expression:
+          dialects:
+            - dialect: BIGQUERY
+              expression: name
+        datatype: String
+  # ...Order bound to myproj.sales.orders, primary_key [order_id]...
+  relationships:
+    - name: placedBy
+      from: Order
+      to: Customer
+      from_columns:
+        - customer_id
+      to_columns:
+        - customer_id
+```
+
+You also need a [deployment target](#deployment-targets-required) on the model
+before a BigQuery push. Binding is a manual edit in this first cut.
+
+### What is not covered yet
+
+- `rdfs:subClassOf`, `owl:inverseOf`, `rdfs:subPropertyOf` — not read yet. When
+  added, they will land in a GOOGLE `custom_extensions` block (under a
+  `data.ontology` key), which is also where the base IRI + prefixes come back
+  (needed to expand parent-class/property references).
+- SHACL shapes, cardinality, `owl:unionOf` domains, symmetric/transitive
+  properties, `equivalentClass`, individuals — not read.
+- Semantic model → OWL export (reverse) — not built; import is one-way.
+- OWL serializations other than Turtle (`.ttl`) — not read.
+
 ## Permissions
 
 `push` needs access to whichever destinations you deploy to.

--- a/toolbox/mdcode/package-lock.json
+++ b/toolbox/mdcode/package-lock.json
@@ -11,8 +11,10 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@polyglot-sql/sdk": "^0.9.1",
+        "@types/n3": "^1.26.1",
         "cac": "^7.0.0",
         "glob": "^13.0.6",
+        "n3": "^2.2.5",
         "yaml": "^2.8.4",
         "zod": "^4.4.2"
       },
@@ -2043,6 +2045,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2088,14 +2099,35 @@
         "bun-types": "1.3.14"
       }
     },
+    "node_modules/@types/n3": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.26.1.tgz",
+      "integrity": "sha512-TilYHzpU6ecXVJAbV+6o17Z8ZkWLWx6ZJD3IluaU4RiGHxqjU2or9fopxFHS6iXS6qcl5Mg1K3wSx9L8xxJaJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.8.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
       "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -2225,6 +2257,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -2259,6 +2311,30 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bun": {
@@ -2787,6 +2863,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -3182,6 +3276,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3509,6 +3623,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/n3": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-2.2.5.tgz",
+      "integrity": "sha512-lR/0N7zVayC6N0uWqrMkPpJn8Up4+qBsjWiBnoOWWEi/ldTcygs2Dw1iAgozzDXLW/fcxXFfbMzpGHlc/1MBLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -3707,6 +3834,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3879,6 +4015,22 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -3970,6 +4122,26 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4359,6 +4531,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4580,7 +4761,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/toolbox/mdcode/package.json
+++ b/toolbox/mdcode/package.json
@@ -29,12 +29,14 @@
     "@polyglot-sql/sdk": "^0.9.1",
     "cac": "^7.0.0",
     "glob": "^13.0.6",
+    "n3": "^2.2.5",
     "yaml": "^2.8.4",
     "zod": "^4.4.2"
   },
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.21.2",
     "@types/bun": "^1.3.14",
+    "@types/n3": "^1.26.1",
     "@types/node": "^25.6.0",
     "ajv": "^8.17.1",
     "bun": "^1.3.14",

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/convert.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/convert.ts
@@ -1,0 +1,48 @@
+// OWL -> OSI conversion orchestrator.
+//
+// The public entry point of the OWL converter: it wires the three steps --
+// parse Turtle (parse.ts) -> map to the IR (to_ir.ts) -> serialize to OSI YAML
+// (../../osi_converter, reused unchanged) -- and returns the YAML plus a small
+// summary the CLI reports. It adds no mapping policy of its own.
+
+import {serializeModel} from '../../osi_converter';
+
+import {parseOwl} from './parse';
+import {owlToIr} from './to_ir';
+
+export interface ConvertResult {
+  // The OSI document text, ready to write as `<model>.yaml`.
+  yaml: string;
+  // Counts for the CLI's one-line summary.
+  stats:
+      {classes: number; datatypeProperties: number; objectProperties: number};
+  // Notes about OWL content that could not be mapped (from the mapper) and IR
+  // content with no loadable representation (from the serializer). Non-fatal.
+  warnings: string[];
+}
+
+/**
+ * Converts a Turtle (.ttl) OWL ontology to an OSI YAML document.
+ *
+ * `modelName` names the resulting semantic model (the CLI derives it from the
+ * source filename). The output is UNBOUND -- see to_ir.ts and the user guide --
+ * but loads and pushes to Knowledge Catalog as-is.
+ *
+ * Throws only on malformed Turtle (the parser's error); mapping gaps are
+ * reported as warnings, not failures.
+ */
+export function convertOwlToOsi(
+    turtle: string, modelName: string): ConvertResult {
+  const owl = parseOwl(turtle);
+  const {model, warnings: mapWarnings} = owlToIr(owl, modelName);
+  const {yaml, warnings: serializeWarnings} = serializeModel(model);
+  return {
+    yaml,
+    stats: {
+      classes: owl.classes.length,
+      datatypeProperties: owl.datatypeProperties.length,
+      objectProperties: owl.objectProperties.length,
+    },
+    warnings: [...mapWarnings, ...serializeWarnings],
+  };
+}

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -1,0 +1,78 @@
+// The OWL intermediate model: a thin, parser-facing view of an ontology.
+//
+// This is deliberately NOT the semantic-model IR (see ../../ir.ts). It is a
+// small staging shape that the Turtle parser (parse.ts) fills from RDF triples
+// and the mapper (to_ir.ts) reads to produce the IR. Keeping the two apart lets
+// the parser stay a mechanical triples-to-structs step while all of the OWL ->
+// OSI mapping policy lives in one place (to_ir.ts).
+//
+// Scope: only the constructs the first cut converts -- classes, datatype
+// properties, object properties, and the handful of annotations on them
+// (rdfs:label / rdfs:comment / alternate labels). Richer OWL (subClassOf,
+// inverseOf, SHACL, cardinality, individuals) is intentionally absent; see the
+// "What is not covered yet" note in the user guide.
+
+/** An `owl:Class` -- becomes an OSI dataset (entity). */
+export interface OwlClass {
+  // The term's local name (the part after the namespace `#`/`/`), used as the
+  // OSI entity name, e.g. `Customer`.
+  localName: string;
+  // rdfs:label, if present. A display name; carried to the entity only when it
+  // adds information over `localName` (see to_ir.ts).
+  label?: string;
+  // rdfs:comment, if present -> entity description.
+  comment?: string;
+  // Additional human names (extra rdfs:label / skos:altLabel|prefLabel) ->
+  // ai_context.synonyms.
+  synonyms: string[];
+}
+
+/**
+ * An `owl:DatatypeProperty` -- becomes a field on its domain class's dataset.
+ */
+export interface OwlDatatypeProperty {
+  localName: string;
+  // Local name of the rdfs:domain class this property hangs off; the field is
+  // added to that entity. Undefined when no domain is declared (skipped with a
+  // warning -- an unattached field has nowhere to live).
+  domain?: string;
+  // The rdfs:range IRI (e.g. the xsd:string IRI), mapped to an OSI datatype by
+  // the mapper. Undefined when no range is declared (-> Opaque).
+  rangeIri?: string;
+  label?: string;
+  comment?: string;
+  synonyms: string[];
+}
+
+/**
+ * An `owl:ObjectProperty` -- becomes a relationship (edge) between two
+ * classes.
+ */
+export interface OwlObjectProperty {
+  localName: string;
+  // Local names of the rdfs:domain (edge source) and rdfs:range (edge
+  // destination) classes. Undefined when not declared (skipped with a warning:
+  // an edge needs both endpoints).
+  domain?: string;
+  range?: string;
+  label?: string;
+  comment?: string;
+  synonyms: string[];
+}
+
+/**
+ * A parsed OWL ontology, in declaration order.
+ *
+ * Order is preserved from the source document so the generated OSI (and its
+ * golden) is stable: entities appear in class-declaration order and each
+ * entity's fields in datatype-property-declaration order.
+ */
+export interface OwlModel {
+  // The ontology's base namespace IRI (from the default `@prefix` or the first
+  // term's namespace), kept only as provenance for the model description. Term
+  // IRIs themselves are dropped -- see the user guide.
+  baseIri?: string;
+  classes: OwlClass[];
+  datatypeProperties: OwlDatatypeProperty[];
+  objectProperties: OwlObjectProperty[];
+}

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -1,0 +1,182 @@
+// Turtle (.ttl) -> OwlModel parser.
+//
+// A mechanical triples-to-structs step: it reads RDF with `n3`, recognizes the
+// handful of OWL/RDFS terms the first cut supports, and fills the staging
+// OwlModel (model.ts). All OWL -> OSI mapping policy lives in to_ir.ts, not
+// here; this file only decides "which triples matter and where do their values
+// go".
+//
+// Declaration order is preserved: classes and properties appear in the order
+// their `rdf:type` triple is first seen in the document, so the generated OSI
+// is stable across runs (and matches its golden).
+
+import {Parser} from 'n3';
+
+import {OwlClass, OwlDatatypeProperty, OwlModel, OwlObjectProperty,} from './model';
+
+// RDF/RDFS/OWL/SKOS term IRIs we recognize. Only these; anything else is
+// carried by neither the parser nor the model (see the user guide's
+// "not covered yet").
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const OWL_CLASS = 'http://www.w3.org/2002/07/owl#Class';
+const OWL_DATATYPE_PROPERTY = 'http://www.w3.org/2002/07/owl#DatatypeProperty';
+const OWL_OBJECT_PROPERTY = 'http://www.w3.org/2002/07/owl#ObjectProperty';
+const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
+const RDFS_COMMENT = 'http://www.w3.org/2000/01/rdf-schema#comment';
+const RDFS_DOMAIN = 'http://www.w3.org/2000/01/rdf-schema#domain';
+const RDFS_RANGE = 'http://www.w3.org/2000/01/rdf-schema#range';
+const SKOS_ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
+const SKOS_PREF_LABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel';
+
+// One of the three OWL kinds we route a typed subject to.
+type OwlKind = 'class'|'datatypeProperty'|'objectProperty';
+
+const KIND_BY_TYPE: Record<string, OwlKind> = {
+  [OWL_CLASS]: 'class',
+  [OWL_DATATYPE_PROPERTY]: 'datatypeProperty',
+  [OWL_OBJECT_PROPERTY]: 'objectProperty',
+};
+
+// The namespace-stripped local name of a term IRI: the part after the last `#`
+// or `/`. This is the OSI-facing identity (see the user guide -- the full IRI
+// is reconstructable as `<base><localName>` and is not carried).
+function localName(iri: string): string {
+  const hash = iri.lastIndexOf('#');
+  const slash = iri.lastIndexOf('/');
+  const cut = Math.max(hash, slash);
+  return cut >= 0 ? iri.slice(cut + 1) : iri;
+}
+
+// The namespace portion of a term IRI (everything up to and including the last
+// `#`/`/`); used as the ontology's base IRI for provenance.
+function namespace(iri: string): string|undefined {
+  const cut = Math.max(iri.lastIndexOf('#'), iri.lastIndexOf('/'));
+  return cut >= 0 ? iri.slice(0, cut + 1) : undefined;
+}
+
+// Per-subject accumulator, filled in a single ordered pass so the first
+// rdfs:label wins the `label` slot and later labels / SKOS alt labels become
+// synonyms.
+interface Annotations {
+  label?: string;
+  comment?: string;
+  domain?: string;
+  range?: string;
+  synonyms: string[];
+}
+
+function emptyAnnotations(): Annotations {
+  return {synonyms: []};
+}
+
+/**
+ * Parses a Turtle document into an OwlModel.
+ *
+ * Synchronous: `n3`'s Parser returns the full quad array when called without a
+ * callback, which suits a one-shot file import. Throws on malformed Turtle (the
+ * parser's own error), which the CLI surfaces.
+ */
+export function parseOwl(turtle: string): OwlModel {
+  const quads = new Parser().parse(turtle);
+
+  // Pass 1: ordered list of typed subjects (first `rdf:type` occurrence wins
+  // the position), plus a kind index. Scanning `quads` directly (not the Store)
+  // keeps document order.
+  const order: string[] = [];
+  const kind = new Map<string, OwlKind>();
+  for (const q of quads) {
+    if (q.predicate.value !== RDF_TYPE) continue;
+    const k = KIND_BY_TYPE[q.object.value];
+    if (!k) continue;
+    const iri = q.subject.value;
+    if (!kind.has(iri)) {
+      kind.set(iri, k);
+      order.push(iri);
+    }
+  }
+
+  // Pass 2: accumulate annotations for each typed subject in document order, so
+  // the first label is the primary and the rest are synonyms.
+  const annotations = new Map<string, Annotations>();
+  const annotationsFor = (iri: string): Annotations => {
+    let a = annotations.get(iri);
+    if (!a) {
+      a = emptyAnnotations();
+      annotations.set(iri, a);
+    }
+    return a;
+  };
+  for (const q of quads) {
+    const subject = q.subject.value;
+    if (!kind.has(subject)) continue;
+    const a = annotationsFor(subject);
+    switch (q.predicate.value) {
+      case RDFS_LABEL:
+        // First label -> the display label; any further label -> a synonym.
+        if (a.label === undefined)
+          a.label = q.object.value;
+        else
+          a.synonyms.push(q.object.value);
+        break;
+      case SKOS_ALT_LABEL:
+      case SKOS_PREF_LABEL:
+        a.synonyms.push(q.object.value);
+        break;
+      case RDFS_COMMENT:
+        a.comment = q.object.value;
+        break;
+      case RDFS_DOMAIN:
+        a.domain = localName(q.object.value);
+        break;
+      case RDFS_RANGE:
+        a.range = q.object.value;  // kept as IRI; mapper maps xsd:* -> datatype
+        break;
+      default:
+        break;
+    }
+  }
+
+  const classes: OwlClass[] = [];
+  const datatypeProperties: OwlDatatypeProperty[] = [];
+  const objectProperties: OwlObjectProperty[] = [];
+  let baseIri: string|undefined;
+
+  for (const iri of order) {
+    if (baseIri === undefined) baseIri = namespace(iri);
+    const a = annotations.get(iri) ?? emptyAnnotations();
+    switch (kind.get(iri)) {
+      case 'class':
+        classes.push({
+          localName: localName(iri),
+          label: a.label,
+          comment: a.comment,
+          synonyms: a.synonyms,
+        });
+        break;
+      case 'datatypeProperty':
+        datatypeProperties.push({
+          localName: localName(iri),
+          domain: a.domain,
+          rangeIri: a.range,
+          label: a.label,
+          comment: a.comment,
+          synonyms: a.synonyms,
+        });
+        break;
+      case 'objectProperty':
+        objectProperties.push({
+          localName: localName(iri),
+          domain: a.domain,
+          range: a.range !== undefined ? localName(a.range) : undefined,
+          label: a.label,
+          comment: a.comment,
+          synonyms: a.synonyms,
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {baseIri, classes, datatypeProperties, objectProperties};
+}

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -1,0 +1,250 @@
+// OwlModel -> Semantic Model IR mapping.
+//
+// This is the whole OWL -> OSI policy layer. The parser (parse.ts) is
+// mechanical; every decision about how an ontology becomes a semantic model
+// lives here, in one place, so the mapping is easy to read and to evolve.
+//
+// The mapping (see the user guide's table):
+//   owl:Class            -> dataset (entity), unbound source placeholder
+//   owl:DatatypeProperty -> field on its domain class's dataset
+//   owl:ObjectProperty   -> relationship (edge) between domain and range
+//   rdfs:range xsd:*      -> field datatype (string/date/decimal; else Opaque)
+//   rdfs:label           -> field label, or a synonym where there is no label
+//                           slot (classes/relationships)
+//   rdfs:comment         -> description
+//
+// The result is UNBOUND: entities carry an `unbound:<Name>` source placeholder
+// and relationships carry `TODO_BIND` join columns, because an ontology has no
+// physical tables. The model still loads and pushes to Knowledge Catalog as-is;
+// binding real sources/columns is a manual follow-up before a BigQuery push
+// (see the user guide, "Going from ontology to a running graph").
+
+import {AiContext, CustomExtension, Entity, Field, Relationship, SemanticModel,} from '../../ir';
+
+import {OwlModel} from './model';
+
+export interface ToIrResult {
+  model: SemanticModel;
+  // Human-readable notes about OWL content that could not be mapped (e.g. a
+  // property with no domain). The caller prints these; they do not fail the
+  // conversion.
+  warnings: string[];
+}
+
+// --- Seams: the isolated change-points for later work. ----------------------
+
+// The GOOGLE custom-extensions vendor name. Ontology data that OSI can't yet
+// express natively (subClassOf, inverseOf, base IRI, ...) will ride in this
+// vendor's block under a `data.ontology` key -- Google's choice to support OWL,
+// so it sits in the GOOGLE block alongside deployment targets, not a new "OWL"
+// vendor. See deploy_bigquery.googleDeploymentTargets, which safely ignores a
+// GOOGLE block that carries no deploymentTargets.
+const GOOGLE_VENDOR = 'GOOGLE';
+
+/**
+ * Builds the GOOGLE custom-extension block that carries OWL constructs OSI
+ * cannot express natively, under `data.ontology`.
+ *
+ * This is the promotion seam: when subClassOf / inverseOf / base-IRI carriage
+ * lands, it is emitted here (and, later, promoted to native OSI fields by
+ * changing only this function and its callers). The minimal first cut maps
+ * everything to native OSI, so nothing calls this yet -- it is defined, tested
+ * for shape, and left unused until the richer constructs arrive.
+ */
+export function googleOntologyExtension(ontology: Record<string, unknown>):
+    CustomExtension {
+  return {
+    vendorName: GOOGLE_VENDOR,
+    data: JSON.stringify({data: {ontology}}),
+  };
+}
+
+// The placeholder source for an unbound entity: an ontology class has no
+// backing table, so the entity is emitted with this sentinel until a real
+// source is bound. Chosen so it is obviously not a real table reference.
+function unboundSource(name: string): string {
+  return `unbound:${name}`;
+}
+
+// The placeholder join column for an unbound relationship: the real foreign-key
+// / key columns are unknown until sources are bound. The loader requires at
+// least one column per endpoint, so a sentinel stands in until binding.
+const TODO_BIND = 'TODO_BIND';
+
+// --- Datatype mapping. ------------------------------------------------------
+
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+
+// The xsd:* ranges the first cut maps to an OSI datatype. Everything else falls
+// back to Opaque (a valid, lossless "unknown logical type" per the IR). Kept as
+// a table so adding ranges later is a one-line change; the user guide documents
+// exactly this set.
+const XSD_DATATYPES: Record<string, Field['type']> = {
+  [`${XSD}string`]: 'String',
+  [`${XSD}date`]: 'Date',
+  [`${XSD}decimal`]: 'Decimal',
+};
+
+function datatypeFor(rangeIri: string|undefined): Field['type'] {
+  if (rangeIri && XSD_DATATYPES[rangeIri]) return XSD_DATATYPES[rangeIri];
+  return 'Opaque';
+}
+
+// --- Label / synonym policy. ------------------------------------------------
+
+// True when an rdfs:label carries nothing over the term's own name -- e.g. a
+// class named `Customer` labeled "Customer", or an object property `placedBy`
+// labeled "placed by". Compared case-insensitively with non-alphanumerics
+// stripped, so a spaced/cased human rendering of the same name is treated as
+// redundant and dropped rather than duplicated as a label or synonym.
+function isRedundantLabel(label: string, name: string): boolean {
+  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return norm(label) === norm(name);
+}
+
+// The display label for a FIELD: the OSI `label` slot exists only on fields, so
+// a datatype property's rdfs:label lands here -- unless it is redundant with
+// the field name, in which case it is dropped.
+function fieldLabel(label: string|undefined, name: string): string|undefined {
+  if (label && !isRedundantLabel(label, name)) return label;
+  return undefined;
+}
+
+// The ai_context for a term that has NO label slot (classes, relationships): a
+// non-redundant rdfs:label becomes an alternate name, joined with any explicit
+// synonyms (extra labels / skos alt labels). Returns undefined when there are
+// none, so no empty ai_context is emitted.
+function synonymAiContext(
+    label: string|undefined, name: string, synonyms: string[]): AiContext|
+    undefined {
+  const all: string[] = [];
+  if (label && !isRedundantLabel(label, name)) all.push(label);
+  all.push(...synonyms);
+  return all.length ? {synonyms: dedupe(all)} : undefined;
+}
+
+// The ai_context for a FIELD (which already consumed its primary label into the
+// `label` slot): only the explicit synonyms remain. Undefined when empty.
+function fieldAiContext(synonyms: string[]): AiContext|undefined {
+  return synonyms.length ? {synonyms: dedupe(synonyms)} : undefined;
+}
+
+// The ai_context for a RELATIONSHIP. Unlike datasets/fields, the OSI
+// relationship has no `description` slot (see the Apache OSI schema), so an
+// object property's rdfs:comment is carried as ai_context `instructions`, and
+// its non-redundant label/synonyms as `synonyms`. Undefined when both are
+// empty.
+function relationshipAiContext(
+    label: string|undefined, name: string, synonyms: string[],
+    comment: string|undefined): AiContext|undefined {
+  const names: string[] = [];
+  if (label && !isRedundantLabel(label, name)) names.push(label);
+  names.push(...synonyms);
+  const ai: AiContext = {};
+  if (comment) ai.instructions = comment;
+  if (names.length) ai.synonyms = dedupe(names);
+  return ai.instructions || ai.synonyms ? ai : undefined;
+}
+
+function dedupe(items: string[]): string[] {
+  return [...new Set(items)];
+}
+
+// --- Mapping. ---------------------------------------------------------------
+
+/**
+ * Maps a parsed OwlModel to a Semantic Model IR (see ../../ir.ts).
+ *
+ * `modelName` names the resulting semantic model (the CLI derives it from the
+ * source filename). The IR it returns serializes, via osi_converter, to the
+ * OSI YAML shown in the user guide.
+ */
+export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
+  const warnings: string[] = [];
+  const classNames = new Set(owl.classes.map(c => c.localName));
+
+  // Entities, one per class, in class-declaration order. Fields are attached in
+  // datatype-property-declaration order below.
+  const entitiesByName = new Map<string, Entity>();
+  const entities: Entity[] = owl.classes.map(c => {
+    const entity: Entity = {
+      name: c.localName,
+      dataSource: unboundSource(c.localName),
+      keys: [],
+      description: c.comment,
+      aiContext: synonymAiContext(c.label, c.localName, c.synonyms),
+      fields: [],
+    };
+    entitiesByName.set(c.localName, entity);
+    return entity;
+  });
+
+  // Datatype properties -> fields on their domain's entity.
+  for (const p of owl.datatypeProperties) {
+    if (!p.domain) {
+      warnings.push(
+          `datatype property '${p.localName}' has no rdfs:domain; skipped ` +
+          `(a field must belong to a class).`);
+      continue;
+    }
+    const entity = entitiesByName.get(p.domain);
+    if (!entity) {
+      warnings.push(
+          `datatype property '${p.localName}' has domain '${p.domain}', ` +
+          `which is not an owl:Class in this ontology; skipped.`);
+      continue;
+    }
+    const field: Field = {
+      name: p.localName,
+      // The property's local name is a valid column reference once the entity
+      // is bound to a real table; it is the default binding target.
+      expression: p.localName,
+      type: datatypeFor(p.rangeIri),
+      label: fieldLabel(p.label, p.localName),
+      description: p.comment,
+      aiContext: fieldAiContext(p.synonyms),
+    };
+    entity.fields.push(field);
+  }
+
+  // Object properties -> relationships (edges). Both endpoints must be known
+  // classes; the join columns are unbound placeholders.
+  const relationships: Relationship[] = [];
+  for (const p of owl.objectProperties) {
+    if (!p.domain || !p.range) {
+      warnings.push(
+          `object property '${p.localName}' is missing an rdfs:domain or ` +
+          `rdfs:range; skipped (a relationship needs both endpoints).`);
+      continue;
+    }
+    if (!classNames.has(p.domain) || !classNames.has(p.range)) {
+      warnings.push(
+          `object property '${p.localName}' references a non-class endpoint ` +
+          `(domain '${p.domain}', range '${p.range}'); skipped.`);
+      continue;
+    }
+    relationships.push({
+      name: p.localName,
+      source: {entity: p.domain, columns: [TODO_BIND]},
+      destination: {entity: p.range, columns: [TODO_BIND]},
+      // No `description`: the OSI relationship has no such slot, so the comment
+      // rides in ai_context.instructions (see relationshipAiContext).
+      aiContext:
+          relationshipAiContext(p.label, p.localName, p.synonyms, p.comment),
+    });
+  }
+
+  const description = owl.baseIri ?
+      `Imported from OWL ontology ${owl.baseIri}` :
+      'Imported from OWL ontology';
+
+  const model: SemanticModel = {
+    name: modelName,
+    description,
+    entities,
+    relationships,
+    metrics: [],
+  };
+
+  return {model, warnings};
+}

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -102,6 +102,13 @@ function isRedundantLabel(label: string, name: string): boolean {
   return norm(label) === norm(name);
 }
 
+// Drops synonyms that merely respace/recase the term's own name -- the same
+// redundancy rule the primary label gets -- so an alternate label identical to
+// the name is not emitted as a synonym.
+function nonRedundant(names: string[], name: string): string[] {
+  return names.filter(s => !isRedundantLabel(s, name));
+}
+
 // The display label for a FIELD: the OSI `label` slot exists only on fields, so
 // a datatype property's rdfs:label lands here -- unless it is redundant with
 // the field name, in which case it is dropped.
@@ -119,14 +126,16 @@ function synonymAiContext(
     undefined {
   const all: string[] = [];
   if (label && !isRedundantLabel(label, name)) all.push(label);
-  all.push(...synonyms);
+  all.push(...nonRedundant(synonyms, name));
   return all.length ? {synonyms: dedupe(all)} : undefined;
 }
 
 // The ai_context for a FIELD (which already consumed its primary label into the
 // `label` slot): only the explicit synonyms remain. Undefined when empty.
-function fieldAiContext(synonyms: string[]): AiContext|undefined {
-  return synonyms.length ? {synonyms: dedupe(synonyms)} : undefined;
+function fieldAiContext(
+    synonyms: string[], name: string): AiContext|undefined {
+  const names = nonRedundant(synonyms, name);
+  return names.length ? {synonyms: dedupe(names)} : undefined;
 }
 
 // The ai_context for a RELATIONSHIP. Unlike datasets/fields, the OSI
@@ -139,7 +148,7 @@ function relationshipAiContext(
     comment: string|undefined): AiContext|undefined {
   const names: string[] = [];
   if (label && !isRedundantLabel(label, name)) names.push(label);
-  names.push(...synonyms);
+  names.push(...nonRedundant(synonyms, name));
   const ai: AiContext = {};
   if (comment) ai.instructions = comment;
   if (names.length) ai.synonyms = dedupe(names);
@@ -164,9 +173,19 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
   const classNames = new Set(owl.classes.map(c => c.localName));
 
   // Entities, one per class, in class-declaration order. Fields are attached in
-  // datatype-property-declaration order below.
+  // datatype-property-declaration order below. Two classes can share a local
+  // name (e.g. same name in different namespaces); OSI dataset names must be
+  // unique, so the first wins and the rest are warned and skipped rather than
+  // silently emitting a duplicate the loader would reject.
   const entitiesByName = new Map<string, Entity>();
-  const entities: Entity[] = owl.classes.map(c => {
+  const entities: Entity[] = [];
+  for (const c of owl.classes) {
+    if (entitiesByName.has(c.localName)) {
+      warnings.push(
+          `class '${c.localName}' is declared more than once (same local name, ` +
+          `possibly across namespaces); keeping the first and skipping the rest.`);
+      continue;
+    }
     const entity: Entity = {
       name: c.localName,
       dataSource: unboundSource(c.localName),
@@ -176,8 +195,8 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       fields: [],
     };
     entitiesByName.set(c.localName, entity);
-    return entity;
-  });
+    entities.push(entity);
+  }
 
   // Datatype properties -> fields on their domain's entity.
   for (const p of owl.datatypeProperties) {
@@ -194,6 +213,12 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `which is not an owl:Class in this ontology; skipped.`);
       continue;
     }
+    if (entity.fields.some(f => f.name === p.localName)) {
+      warnings.push(
+          `datatype property '${p.localName}' on '${p.domain}' duplicates an ` +
+          `existing field name; skipped (field names must be unique).`);
+      continue;
+    }
     const field: Field = {
       name: p.localName,
       // The property's local name is a valid column reference once the entity
@@ -202,7 +227,7 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       type: datatypeFor(p.rangeIri),
       label: fieldLabel(p.label, p.localName),
       description: p.comment,
-      aiContext: fieldAiContext(p.synonyms),
+      aiContext: fieldAiContext(p.synonyms, p.localName),
     };
     entity.fields.push(field);
   }
@@ -221,6 +246,12 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       warnings.push(
           `object property '${p.localName}' references a non-class endpoint ` +
           `(domain '${p.domain}', range '${p.range}'); skipped.`);
+      continue;
+    }
+    if (relationships.some(r => r.name === p.localName)) {
+      warnings.push(
+          `object property '${p.localName}' duplicates an existing relationship ` +
+          `name; skipped (relationship names must be unique).`);
       continue;
     }
     relationships.push({

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -17,6 +17,7 @@ import {LoadedModel, loadSemanticModels} from '../libts/semantic/loader';
 import {transpileModels} from '../libts/semantic/transpile';
 import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
 import {serializeModel} from '../libts/semantic/osi_converter';
+import {convertOwlToOsi} from '../libts/semantic/converters/owl/convert';
 import {validateBigQueryDataSources, validatePushRequirements} from '../libts/semantic/validate';
 
 
@@ -532,4 +533,94 @@ async function pullSemanticModel(
     ? `Dry run: would write ${created} new and ${updated} updated model document(s).`
     : `Wrote ${created} new and ${updated} updated model document(s).`);
   return 0;
+}
+
+
+export interface OwlImportOptions {
+  // Write the generated OSI document to this path instead of the semantic-model
+  // layout dir. When omitted, the model lands in the scope's model layout so the
+  // next `kcmd push` picks it up.
+  out?: string;
+}
+
+// Recognized OWL source extensions, stripped to derive the model name from the
+// filename: `sales.owl.ttl` -> `sales`.
+const OWL_EXTENSIONS = /\.owl\.ttl$|\.ttl$|\.owl$/i;
+
+// Handles `kcmd owl <action> <file>`. The only action is `import`: convert a
+// Turtle OWL ontology into an OSI model document that then rides the normal
+// `kcmd push` / `kcmd pull`. The converted model is UNBOUND (see the OWL
+// converter): it publishes to Knowledge Catalog as-is, but its sources / join
+// columns must be bound before a BigQuery push. Returns a process exit code.
+export async function owl(
+  action: string, file: string, options: OwlImportOptions): Promise<number> {
+  if (action !== 'import') {
+    console.error(
+      `Error: unknown owl action '${action}'; the only action is 'import' `
+      + `(usage: kcmd owl import <file.ttl>).`);
+    return 1;
+  }
+
+  if (!fs.existsSync(file)) {
+    console.error(`Error: file not found: ${file}`);
+    return 1;
+  }
+
+  const turtle = fs.readFileSync(file, 'utf8');
+  const modelName = path.basename(file).replace(OWL_EXTENSIONS, '');
+  if (!modelName) {
+    console.error(`Error: could not derive a model name from '${file}'.`);
+    return 1;
+  }
+
+  // convertOwlToOsi throws only on malformed Turtle; main.ts's try/catch
+  // reports it.
+  const result = convertOwlToOsi(turtle, modelName);
+  for (const w of result.warnings) {
+    console.warn(`Warning: ${w}`);
+  }
+
+  const { classes, datatypeProperties, objectProperties } = result.stats;
+  console.log(
+    `converted ${classes} ${plural(classes, 'class', 'classes')}, `
+    + `${objectProperties} `
+    + `${plural(objectProperties, 'object property', 'object properties')}, `
+    + `${datatypeProperties} `
+    + `${plural(datatypeProperties, 'datatype property', 'datatype properties')}`);
+
+  // Sink: an explicit --out path writes directly; otherwise the semantic-model
+  // layout places the document under the scope's entry group so `kcmd push`
+  // finds it.
+  let writtenPath: string;
+  if (options.out) {
+    fs.mkdirSync(path.dirname(path.resolve(options.out)), { recursive: true });
+    fs.writeFileSync(options.out, result.yaml);
+    writtenPath = options.out;
+  }
+  else {
+    const ctx = context.ApiContext.default();
+    const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
+    if (snapshot.manifest.source.type !== Sources.SEMANTIC_MODEL) {
+      console.error(
+        `Error: this catalog is not a semantic-model scope, so there is no `
+        + `model layout to write into. Run \`kcmd init --semantic-model ...\` `
+        + `first, or pass --out <path> to write the OSI document directly.`);
+      return 1;
+    }
+    const layout = snapshot.layout as SemanticModelLayout;
+    layout.writeModelDocument(modelName, result.yaml);
+    writtenPath = layout.modelPath(modelName);
+  }
+
+  console.log(`wrote ${writtenPath}`);
+  console.log(
+    `note: this model is UNBOUND (no backing tables yet).\n`
+    + `      -> \`kcmd push --target kc\` works now (publishes ontology metadata).\n`
+    + `      -> \`kcmd push --target bq\` is skipped until you bind sources.`);
+  return 0;
+}
+
+// Selects the singular or plural form based on `n` (English count agreement).
+function plural(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
 }

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -588,6 +588,15 @@ export async function owl(
     + `${datatypeProperties} `
     + `${plural(datatypeProperties, 'datatype property', 'datatype properties')}`);
 
+  // Guard: an ontology with no owl:Class yields a model with no datasets, which
+  // is not a loadable OSI model. Fail clearly rather than writing an empty
+  // artifact that only errors on a later push/pull.
+  if (classes === 0) {
+    console.error(
+      `Error: no owl:Class declarations found in '${file}'; nothing to import.`);
+    return 1;
+  }
+
   // Sink: an explicit --out path writes directly; otherwise the semantic-model
   // layout places the document under the scope's entry group so `kcmd push`
   // finds it.

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -65,6 +65,22 @@ cli.command('push', 'Push catalog entries')
    });
 
 
+cli.command('owl <action> <file>', 'OWL ontology tools (action: import a .ttl ontology into an OSI model)')
+   .option('--out <path>', 'Write the generated OSI document to this path instead of the semantic-model layout dir')
+   .action(async (action, file, options) => {
+      let exitCode = 1;
+      try {
+        exitCode = await commands.owl(action, file, options);
+      }
+      catch (err: any) {
+        console.error('Error:', err.message || err);
+        exitCode = 1;
+      }
+
+      process.exit(exitCode);
+   });
+
+
 cli.command('mcp', 'Run the Model Context Protocol (MCP) server')
    .option('--path <path>', 'Path to the catalog snapshot root directory')
    .action(async (options) => {

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -94,7 +94,13 @@ cli.command('mcp', 'Run the Model Context Protocol (MCP) server')
    });
 
 
-cli.parse();
+try {
+  cli.parse();
+}
+catch (err: any) {
+  console.error('Error:', err.message || err);
+  process.exit(1);
+}
 
 if (!cli.matchedCommand) {
   if (cli.args.length > 0) {

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.osi.golden.yaml
@@ -1,0 +1,106 @@
+version: 0.2.0.dev0
+semantic_model:
+  - name: org
+    description: Imported from OWL ontology http://example.com/org#
+    datasets:
+      - name: Employee
+        source: unbound:Employee
+        description: A person employed by the organization.
+        ai_context:
+          synonyms:
+            - Staff member
+            - Worker
+        fields:
+          - name: fullName
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: fullName
+            datatype: String
+            label: name
+          - name: hireDate
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: hireDate
+            datatype: Date
+          - name: salary
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: salary
+            datatype: Decimal
+          - name: employeeId
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: employeeId
+            datatype: Opaque
+          - name: isActive
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: isActive
+            datatype: Opaque
+      - name: Department
+        source: unbound:Department
+        description: A functional unit that employees belong to.
+        ai_context:
+          synonyms:
+            - Org unit
+        fields:
+          - name: budget
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: budget
+            datatype: Decimal
+      - name: Project
+        source: unbound:Project
+        fields:
+          - name: startDate
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: startDate
+            datatype: Date
+          - name: code
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: code
+            datatype: String
+          - name: notes
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: notes
+            datatype: Opaque
+    relationships:
+      - name: worksIn
+        from: Employee
+        to: Department
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - TODO_BIND
+        ai_context:
+          instructions: The department an employee belongs to.
+          synonyms:
+            - member of
+      - name: reportsTo
+        from: Employee
+        to: Employee
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - TODO_BIND
+        ai_context:
+          instructions: The manager an employee reports to.
+      - name: worksOn
+        from: Employee
+        to: Project
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - TODO_BIND

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.owl.ttl
@@ -1,0 +1,76 @@
+# A broader ontology than sales.owl.ttl, exercising the full range of OWL
+# constructs the converter maps today (see the user guide's mapping table):
+#   - a class whose label is redundant with its name (dropped), one whose label
+#     is a genuine alternate name (-> synonym), and a bare class with no
+#     annotations at all;
+#   - skos:altLabel / skos:prefLabel and extra labels collected as synonyms;
+#   - every mapped xsd datatype (string/date/decimal) plus ranges outside the
+#     mapped set (xsd:integer, xsd:boolean) and a property with no range at all,
+#     all of which fall back to Opaque;
+#   - a field label that adds a name (kept) vs. one that only recases (dropped);
+#   - multiple object properties, including a self-referential one, with
+#     comments (-> ai_context.instructions) and synonyms.
+# Everything here maps cleanly to native OSI (no warnings) and stays UNBOUND.
+
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <http://example.com/org#> .
+
+# Redundant label ("Employee" == name) dropped; comment + skos synonyms kept.
+ex:Employee a owl:Class ;
+    rdfs:label    "Employee" ;
+    rdfs:comment  "A person employed by the organization." ;
+    skos:altLabel "Staff member" ;
+    skos:prefLabel "Worker" .
+
+# Non-redundant label -> synonym; comment -> description.
+ex:Department a owl:Class ;
+    rdfs:label   "Org unit" ;
+    rdfs:comment "A functional unit that employees belong to." .
+
+# Bare class: no annotations at all.
+ex:Project a owl:Class .
+
+# The three mapped xsd types; "name" adds a display name over the field name.
+ex:fullName a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:string ; rdfs:label "name" .
+ex:hireDate a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:date .
+ex:salary a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:decimal .
+# Outside today's mapped set -> Opaque.
+ex:employeeId a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:integer .
+ex:isActive a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:boolean .
+
+ex:budget a owl:DatatypeProperty ;
+    rdfs:domain ex:Department ; rdfs:range xsd:decimal .
+
+ex:startDate a owl:DatatypeProperty ;
+    rdfs:domain ex:Project ; rdfs:range xsd:date .
+# Label "code" only recases the field name -> dropped.
+ex:code a owl:DatatypeProperty ;
+    rdfs:domain ex:Project ; rdfs:range xsd:string ; rdfs:label "code" .
+# No range declared -> Opaque.
+ex:notes a owl:DatatypeProperty ;
+    rdfs:domain ex:Project .
+
+# Relationship with a redundant label (dropped), a skos synonym (kept), and a
+# comment (-> ai_context.instructions).
+ex:worksIn a owl:ObjectProperty ;
+    rdfs:domain ex:Employee ; rdfs:range ex:Department ;
+    rdfs:label    "works in" ;
+    skos:altLabel "member of" ;
+    rdfs:comment  "The department an employee belongs to." .
+
+# Self-referential relationship: Employee -> Employee.
+ex:reportsTo a owl:ObjectProperty ;
+    rdfs:domain ex:Employee ; rdfs:range ex:Employee ;
+    rdfs:comment "The manager an employee reports to." .
+
+ex:worksOn a owl:ObjectProperty ;
+    rdfs:domain ex:Employee ; rdfs:range ex:Project ;
+    rdfs:label "works on" .

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.osi.golden.yaml
@@ -1,0 +1,48 @@
+version: 0.2.0.dev0
+semantic_model:
+  - name: sales
+    description: Imported from OWL ontology http://example.com/sales#
+    datasets:
+      - name: Customer
+        source: unbound:Customer
+        description: A person or organization that places orders.
+        fields:
+          - name: customerName
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: customerName
+            datatype: String
+            label: name
+          - name: signupDate
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: signupDate
+            datatype: Date
+      - name: Order
+        source: unbound:Order
+        description: A purchase placed by a customer.
+        fields:
+          - name: orderAmount
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: orderAmount
+            datatype: Decimal
+          - name: orderDate
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: orderDate
+            datatype: Date
+    relationships:
+      - name: placedBy
+        from: Order
+        to: Customer
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - TODO_BIND
+        ai_context:
+          instructions: Links an order to the customer who placed it.

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.owl.ttl
@@ -1,0 +1,29 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <http://example.com/sales#> .
+
+ex:Customer a owl:Class ;
+    rdfs:label   "Customer" ;
+    rdfs:comment "A person or organization that places orders." .
+
+ex:Order a owl:Class ;
+    rdfs:label   "Order" ;
+    rdfs:comment "A purchase placed by a customer." .
+
+ex:customerName a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:string ; rdfs:label "name" .
+
+ex:signupDate a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:date .
+
+ex:orderAmount a owl:DatatypeProperty ;
+    rdfs:domain ex:Order ; rdfs:range xsd:decimal .
+
+ex:orderDate a owl:DatatypeProperty ;
+    rdfs:domain ex:Order ; rdfs:range xsd:date .
+
+ex:placedBy a owl:ObjectProperty ;
+    rdfs:domain  ex:Order ; rdfs:range ex:Customer ;
+    rdfs:label   "placed by" ;
+    rdfs:comment "Links an order to the customer who placed it." .

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -57,6 +57,66 @@ describe('sales ontology matches the user-guide CUJ', () => {
 });
 
 
+describe('org ontology exercises the full range of mapped constructs', () => {
+  const ttl = readFixture('org.owl.ttl');
+
+  test('produces exactly the documented OSI (golden)', () => {
+    const {yaml} = convertOwlToOsi(ttl, 'org');
+    expect(yaml).toEqual(readFixture('org.osi.golden.yaml'));
+  });
+
+  test('maps cleanly with no warnings', () => {
+    // Every construct here is supported, so nothing is dropped.
+    expect(convertOwlToOsi(ttl, 'org').warnings).toEqual([]);
+  });
+
+  test('the generated OSI loads and covers the mapping table', () => {
+    const model = loadModels(convertOwlToOsi(ttl, 'org').yaml).models[0];
+
+    // Classes in declaration order; a bare class carries no metadata.
+    expect(model.entities.map(e => e.name))
+        .toEqual(['Employee', 'Department', 'Project']);
+    const [employee, department, project] = model.entities;
+
+    // Redundant class label dropped; skos alt/pref labels -> synonyms.
+    expect(employee.aiContext?.synonyms).toEqual(['Staff member', 'Worker']);
+    // Non-redundant class label -> synonym.
+    expect(department.aiContext?.synonyms).toEqual(['Org unit']);
+    // Bare class: no description, no ai_context.
+    expect(project.description).toBeUndefined();
+    expect(project.aiContext).toBeUndefined();
+
+    // Datatypes: the three mapped xsd types, and Opaque for everything else
+    // (xsd:integer, xsd:boolean, and a property with no range).
+    const empTypes = Object.fromEntries(
+        employee.fields.map(f => [f.name, f.type]));
+    expect(empTypes).toEqual({
+      fullName: 'String',
+      hireDate: 'Date',
+      salary: 'Decimal',
+      employeeId: 'Opaque',
+      isActive: 'Opaque',
+    });
+    expect(project.fields.find(f => f.name === 'notes')!.type).toBe('Opaque');
+
+    // Field label kept when it adds a name, dropped when it only recases.
+    expect(employee.fields.find(f => f.name === 'fullName')!.label).toBe('name');
+    expect(project.fields.find(f => f.name === 'code')!.label).toBeUndefined();
+
+    // Relationships, including a self-referential one; comments -> instructions.
+    const byName = Object.fromEntries(model.relationships.map(r => [r.name, r]));
+    expect(Object.keys(byName)).toEqual(['worksIn', 'reportsTo', 'worksOn']);
+    // Redundant edge label dropped, skos synonym kept, comment -> instructions.
+    expect(byName['worksIn'].aiContext)
+        .toEqual({instructions: 'The department an employee belongs to.',
+                  synonyms: ['member of']});
+    // Self-referential edge: both endpoints are the same entity.
+    expect(byName['reportsTo'].source.entity).toBe('Employee');
+    expect(byName['reportsTo'].destination.entity).toBe('Employee');
+  });
+});
+
+
 describe('mapping table rules', () => {
   // A datatype property's rdfs:label is a display name -> the field `label`
   // slot; a class/object-property label has no slot, so a *non-redundant* one

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -15,6 +15,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import {convertOwlToOsi} from '../../../src/libts/semantic/converters/owl/convert';
+import {googleOntologyExtension} from '../../../src/libts/semantic/converters/owl/to_ir';
 import {loadModels} from '../../../src/libts/semantic/loader';
 
 const FIXTURES = path.join(__dirname, 'fixtures', 'owl');
@@ -132,4 +133,141 @@ describe('mapping table rules', () => {
     expect(model.entities[0].fields).toHaveLength(0);
     expect(model.relationships).toHaveLength(0);
   });
+
+  // rdfs:comment is a description everywhere it has a slot; the OSI
+  // relationship has none, so an object property's comment rides in
+  // ai_context.instructions.
+  test(
+      'rdfs:comment routes to description, or relationship instructions',
+      () => {
+        const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+      @prefix ex:   <http://example.com/x#> .
+
+      ex:Order a owl:Class ; rdfs:comment "A purchase." .
+      ex:Customer a owl:Class .
+      ex:amount a owl:DatatypeProperty ;
+          rdfs:domain ex:Order ; rdfs:range xsd:decimal ; rdfs:comment "Total charged." .
+      ex:placedBy a owl:ObjectProperty ;
+          rdfs:domain ex:Order ; rdfs:range ex:Customer ;
+          rdfs:comment "Who placed the order." .
+    `;
+        const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+        const order = model.entities.find(e => e.name === 'Order')!;
+        // Class comment -> entity description.
+        expect(order.description).toBe('A purchase.');
+        // Datatype-property comment -> field description.
+        expect(order.fields.find(f => f.name === 'amount')!.description)
+            .toBe('Total charged.');
+        // Object-property comment -> relationship ai_context.instructions.
+        const placedBy = model.relationships.find(r => r.name === 'placedBy')!;
+        expect(placedBy.aiContext?.instructions).toBe('Who placed the order.');
+      });
+
+  // An object property is an edge between its domain and range; the real join
+  // columns are unknown until sources are bound, so both ends carry TODO_BIND.
+  test('an object property becomes an edge with UNBOUND join columns', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix ex:   <http://example.com/x#> .
+
+      ex:Order a owl:Class .
+      ex:Customer a owl:Class .
+      ex:placedBy a owl:ObjectProperty ;
+          rdfs:domain ex:Order ; rdfs:range ex:Customer .
+    `;
+    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+    const edge = model.relationships.find(r => r.name === 'placedBy')!;
+    expect(edge.source.entity).toBe('Order');
+    expect(edge.destination.entity).toBe('Customer');
+    expect(edge.source.columns).toEqual(['TODO_BIND']);
+    expect(edge.destination.columns).toEqual(['TODO_BIND']);
+  });
+
+  // A class has no label slot, so its first (non-redundant) label and every
+  // further rdfs:label / skos label all collect as synonyms, in document order.
+  test('skos and extra rdfs:label values collect as synonyms', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+      @prefix ex:   <http://example.com/x#> .
+
+      ex:Client a owl:Class ;
+          rdfs:label "Customer account" ;
+          rdfs:label "Buyer" ;
+          skos:altLabel "Account holder" ;
+          skos:prefLabel "Patron" .
+    `;
+    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+    const client = model.entities.find(e => e.name === 'Client')!;
+    expect(client.aiContext?.synonyms).toEqual([
+      'Customer account', 'Buyer', 'Account holder', 'Patron'
+    ]);
+  });
+
+  // A domain that names something not declared as an owl:Class cannot host a
+  // field; it is skipped with a warning naming the property and the domain.
+  test('a datatype property whose domain is not a class is skipped', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+      @prefix ex:   <http://example.com/x#> .
+
+      ex:Thing a owl:Class .
+      ex:stray a owl:DatatypeProperty ;
+          rdfs:domain ex:NotAClass ; rdfs:range xsd:string .
+    `;
+    const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
+    expect(warnings.some(w => w.includes('stray') && w.includes('NotAClass')))
+        .toBe(true);
+    const model = loadModels(yaml).models[0];
+    expect(model.entities.find(e => e.name === 'Thing')!.fields)
+        .toHaveLength(0);
+  });
+
+  // The source ontology's base IRI is not carried on terms, but is preserved
+  // once as provenance in the model description.
+  test('the model description records the source ontology base IRI', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix ex:   <http://example.com/sales#> .
+      ex:Customer a owl:Class .
+    `;
+    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+    expect(model.description)
+        .toBe('Imported from OWL ontology http://example.com/sales#');
+  });
+});
+
+
+// The GOOGLE data.ontology extension is the promotion seam for OWL constructs
+// OSI cannot yet express natively (subClassOf, inverseOf, ...). It is defined
+// and shape-tested but unused by the minimal example, which maps entirely to
+// native OSI -- see to_ir.ts.
+describe('the GOOGLE ontology extension seam (defined-but-unused)', () => {
+  test(
+      'wraps its payload as a GOOGLE custom extension under data.ontology',
+      () => {
+        const ext =
+            googleOntologyExtension({subClassOf: {Manager: 'Employee'}});
+        expect(ext.vendorName).toBe('GOOGLE');
+        expect(JSON.parse(ext.data)).toEqual({
+          data: {ontology: {subClassOf: {Manager: 'Employee'}}}
+        });
+      });
+
+  test(
+      'is not exercised by the minimal example (nothing to promote yet)',
+      () => {
+        const {yaml} = convertOwlToOsi(readFixture('sales.owl.ttl'), 'sales');
+        // Everything maps natively, so no custom_extensions / GOOGLE block
+        // appears.
+        expect(yaml).not.toContain('custom_extensions');
+        expect(yaml).not.toContain('GOOGLE');
+      });
 });

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -1,0 +1,135 @@
+// Behavior specification for the OWL -> OSI converter
+// (convertOwlToOsi in src/libts/semantic/converters/owl/convert.ts).
+//
+// The converter is one-way: a Turtle OWL ontology becomes an OSI YAML document
+// that then rides the normal kcmd push/pull. The guarantees pinned here mirror
+// the user-guide section "Importing an OWL ontology":
+//   1. the sales example produces exactly the documented OSI (golden), and
+//   2. that OSI loads through the OSI loader (the UNBOUND placeholders satisfy
+//      the schema, so `kcmd push --target kc` works on the result), and
+//   3. each row of the mapping table behaves as documented.
+// The scope is exactly the user guide; richer OWL is out of scope by design.
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {convertOwlToOsi} from '../../../src/libts/semantic/converters/owl/convert';
+import {loadModels} from '../../../src/libts/semantic/loader';
+
+const FIXTURES = path.join(__dirname, 'fixtures', 'owl');
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(FIXTURES, name), 'utf8');
+}
+
+
+describe('sales ontology matches the user-guide CUJ', () => {
+  const ttl = readFixture('sales.owl.ttl');
+
+  test('produces exactly the documented OSI (golden)', () => {
+    const {yaml} = convertOwlToOsi(ttl, 'sales');
+    const golden = readFixture('sales.osi.golden.yaml');
+    expect(yaml).toEqual(golden);
+  });
+
+  test('reports the documented conversion counts', () => {
+    const {stats, warnings} = convertOwlToOsi(ttl, 'sales');
+    expect(stats).toEqual(
+        {classes: 2, datatypeProperties: 4, objectProperties: 1});
+    // The minimal example maps entirely to native OSI, so nothing is dropped.
+    expect(warnings).toEqual([]);
+  });
+
+  test(
+      'the generated OSI loads (UNBOUND placeholders are schema-valid)', () => {
+        const {yaml} = convertOwlToOsi(ttl, 'sales');
+        // loadModels throws on a schema violation; a clean return proves the
+        // model is loadable and thus KC-pushable as-is.
+        const loaded = loadModels(yaml);
+        expect(loaded.models).toHaveLength(1);
+        const model = loaded.models[0];
+        expect(model.name).toBe('sales');
+        expect(model.entities.map(e => e.name)).toEqual(['Customer', 'Order']);
+        expect(model.relationships.map(r => r.name)).toEqual(['placedBy']);
+      });
+});
+
+
+describe('mapping table rules', () => {
+  // A datatype property's rdfs:label is a display name -> the field `label`
+  // slot; a class/object-property label has no slot, so a *non-redundant* one
+  // becomes a synonym; a label that only respaces/recases the name is dropped.
+  test('labels route to field label vs. synonyms vs. dropped', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+      @prefix ex:   <http://example.com/x#> .
+
+      ex:Client a owl:Class ; rdfs:label "Customer account" .
+      ex:Widget a owl:Class ; rdfs:label "Widget" .
+      ex:fullName a owl:DatatypeProperty ;
+          rdfs:domain ex:Client ; rdfs:range xsd:string ; rdfs:label "Legal name" .
+      ex:code a owl:DatatypeProperty ;
+          rdfs:domain ex:Widget ; rdfs:range xsd:string ; rdfs:label "code" .
+    `;
+    const {yaml} = convertOwlToOsi(ttl, 'x');
+    const model = loadModels(yaml).models[0];
+    const client = model.entities.find(e => e.name === 'Client')!;
+    const widget = model.entities.find(e => e.name === 'Widget')!;
+    // Non-redundant class label -> synonym.
+    expect(client.aiContext?.synonyms).toEqual(['Customer account']);
+    // Redundant class label ("Widget" == name) -> dropped, no ai_context.
+    expect(widget.aiContext).toBeUndefined();
+    // A datatype-property label that adds a name -> field label slot.
+    const fullName = client.fields.find(f => f.name === 'fullName')!;
+    expect(fullName.label).toBe('Legal name');
+    // A datatype-property label that only recases the field name -> dropped.
+    const code = widget.fields.find(f => f.name === 'code')!;
+    expect(code.label).toBeUndefined();
+  });
+
+  // rdfs:range xsd:* maps string/date/decimal to the OSI datatype; every other
+  // range falls back to Opaque (the documented set).
+  test('xsd ranges map to datatypes, else Opaque', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+      @prefix ex:   <http://example.com/x#> .
+
+      ex:Thing a owl:Class .
+      ex:s a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:string .
+      ex:d a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:date .
+      ex:m a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:decimal .
+      ex:i a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:integer .
+    `;
+    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+    const types =
+        Object.fromEntries(model.entities[0].fields.map(f => [f.name, f.type]));
+    expect(types).toEqual({s: 'String', d: 'Date', m: 'Decimal', i: 'Opaque'});
+  });
+
+  // A property with no usable endpoint can't be placed; it is skipped with a
+  // warning rather than failing the conversion.
+  test('unmappable properties are warned and skipped', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+      @prefix ex:   <http://example.com/x#> .
+
+      ex:Thing a owl:Class .
+      ex:orphan a owl:DatatypeProperty ; rdfs:range xsd:string .
+      ex:danglingEdge a owl:ObjectProperty ; rdfs:domain ex:Thing .
+    `;
+    const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
+    expect(warnings).toHaveLength(2);
+    expect(warnings.some(w => w.includes('orphan'))).toBe(true);
+    expect(warnings.some(w => w.includes('danglingEdge'))).toBe(true);
+    const model = loadModels(yaml).models[0];
+    expect(model.entities[0].fields).toHaveLength(0);
+    expect(model.relationships).toHaveLength(0);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -230,6 +230,51 @@ describe('mapping table rules', () => {
         .toHaveLength(0);
   });
 
+  // A synonym (skos alt label or extra rdfs:label) that only respaces/recases
+  // the term's own name is redundant with the name and dropped -- the same rule
+  // the primary label gets.
+  test('synonyms redundant with the term name are dropped', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+      @prefix ex:   <http://example.com/x#> .
+
+      ex:Customer a owl:Class ;
+          rdfs:label "Customer" ;
+          skos:altLabel "customer" ;
+          skos:altLabel "Buyer" .
+    `;
+    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+    const customer = model.entities.find(e => e.name === 'Customer')!;
+    // Both "Customer" and "customer" collapse to the name; only "Buyer" survives.
+    expect(customer.aiContext?.synonyms).toEqual(['Buyer']);
+  });
+
+  // Terms are named by their namespace-stripped local name, so two terms that
+  // share a local name (e.g. across namespaces) would collapse to one OSI name.
+  // OSI names must be unique, so the first wins and the rest are warned and
+  // skipped -- the output stays valid and loadable rather than emitting a
+  // duplicate.
+  test('local-name collisions are warned and deduped (first wins)', () => {
+    const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix a:    <http://example.com/a#> .
+      @prefix b:    <http://example.com/b#> .
+
+      a:Customer a owl:Class ; rdfs:comment "from a" .
+      b:Customer a owl:Class ; rdfs:comment "from b" .
+    `;
+    const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
+    expect(warnings.some(w => w.includes('Customer') && w.includes('more than once')))
+        .toBe(true);
+    // The result still loads: a single Customer entity, the first declaration.
+    const model = loadModels(yaml).models[0];
+    expect(model.entities.map(e => e.name)).toEqual(['Customer']);
+    expect(model.entities[0].description).toBe('from a');
+  });
+
   // The source ontology's base IRI is not carried on terms, but is preserved
   // once as provenance in the model description.
   test('the model description records the source ontology base IRI', () => {


### PR DESCRIPTION
## What

Adds one-way **OWL ontology → OSI** import to `kcmd`:

```
kcmd owl import sales.owl.ttl
```

A Turtle OWL ontology is converted once into an OSI semantic-model document that then rides the **existing** `kcmd push` / `kcmd pull` rails. No new push/pull verbs, no new `--target`, no new IR concepts — OSI stays the single canonical model.

## Mapping

| OWL | OSI |
|---|---|
| `owl:Class` | entity (dataset), `source: unbound:<Name>` |
| `owl:DatatypeProperty` | field on its domain entity |
| `owl:ObjectProperty` | relationship (`TODO_BIND` join columns) |
| `rdfs:range xsd:*` | datatype (string/date/decimal, else `Opaque`) |
| `rdfs:label` | field `label`, or `ai_context.synonyms` where there is no label slot |
| `rdfs:comment` | `description` (or relationship `ai_context.instructions`) |

## Binding

The output is **UNBOUND** — entities carry an `unbound:<Name>` source placeholder and relationships carry `TODO_BIND` join columns, because an ontology has no physical tables. It therefore:
- publishes to **Knowledge Catalog** as-is (`kcmd push --target kc`), and
- is skipped for **BigQuery Graph** until sources/columns are bound (a manual edit in this first cut).

A defined-but-unused GOOGLE `data.ontology` custom-extension seam is left in place for future `subClassOf` / `inverseOf` carriage.

## Layout

Converter is bounded under `src/libts/semantic/converters/owl/` (`parse` → `model` → `to_ir` → `convert`), reusing `serializeModel` unchanged. Turtle is parsed with the `n3` library.

## Testing

- `npx tsc --noEmit` clean
- Full suite green (406 tests)
- Golden test (`sales.owl.ttl` → `sales.osi.golden.yaml`) that also asserts the output reloads through `loadModels` (placeholders are schema-valid)
- Behavior tests for label routing, xsd datatype mapping, and warn-and-skip of unmappable properties
- Live CLI smoke test: `kcmd owl import ... --out` produces output identical to the golden
- User-guide section added to `docs/semantic-model.md`

## Not covered yet

`subClassOf` / `inverseOf` / `subPropertyOf`, SHACL / cardinality / individuals, and OSI → OWL export (import is one-way).