### PR TITLE
mdcode: enrich OWL import with datatypes, keys, and metadata

### DIFF
--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -395,38 +395,63 @@ model stays the single canonical form.
 This first cut converts the OWL constructs that have a clean BigQuery Graph
 shape (class → node, object property → edge, datatype property → property), plus
 **class hierarchies** (`rdfs:subClassOf` → entity `extends`, see
-[Class hierarchies](#class-hierarchies-rdfssubclassof)). Richer OWL
-(`inverseOf`, `rdfs:subPropertyOf`, SHACL, cardinality, individuals) is not read
-yet — see [What is not covered yet](#what-is-not-covered-yet).
+[Class hierarchies](#class-hierarchies-rdfssubclassof)). Everything the converter
+reads maps to a **native** semantic-model field — no custom extensions, no IRIs
+to carry. Richer OWL that has no native home yet (`inverseOf`,
+`rdfs:subPropertyOf`, SHACL, cardinality, individuals) is not read yet — see
+[What is not covered yet](#what-is-not-covered-yet).
 
 ### 1. The OWL file
 
-A small sales ontology, `sales.owl.ttl` — two classes, four datatype properties,
-one object property. Nothing here needs an OWL reasoner:
+`sales.owl.ttl` — an ontology header, two classes with keys, datatype
+properties across several `xsd` types, and one object property. Nothing here
+needs an OWL reasoner:
 
 ```turtle
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix ex:   <http://example.com/sales#> .
 
+<http://example.com/sales> a owl:Ontology ;
+    rdfs:label      "Sales domain" ;
+    rdfs:comment    "A minimal sales domain: customers and the orders they place." ;
+    skos:example    "How many orders did each customer place last month?" ;
+    owl:versionInfo "1.0" .
+
 ex:Customer a owl:Class ;
-    rdfs:label   "Customer" ;
-    rdfs:comment "A person or organization that places orders." .
+    rdfs:label    "Customer" ;
+    rdfs:comment  "A person or organization that places orders." ;
+    skos:altLabel "Buyer" ;
+    owl:hasKey ( ex:customerId ) .
 
 ex:Order a owl:Class ;
     rdfs:label   "Order" ;
-    rdfs:comment "A purchase placed by a customer." .
+    rdfs:comment "A purchase placed by a customer." ;
+    owl:hasKey ( ex:orderId ) .
 
+# customerId is the key; email uniquely identifies a customer
+# (inverse-functional) so it becomes a unique-key constraint.
+ex:customerId a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:string .
+ex:email a owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:string ;
+    rdfs:comment "The customer's unique email address." .
 ex:customerName a owl:DatatypeProperty ;
     rdfs:domain ex:Customer ; rdfs:range xsd:string ; rdfs:label "name" .
-
 ex:signupDate a owl:DatatypeProperty ;
     rdfs:domain ex:Customer ; rdfs:range xsd:date .
+ex:isVip a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:boolean ;
+    rdfs:comment "Whether the customer is in the loyalty program." .
 
+ex:orderId a owl:DatatypeProperty ;
+    rdfs:domain ex:Order ; rdfs:range xsd:string .
 ex:orderAmount a owl:DatatypeProperty ;
-    rdfs:domain ex:Order ; rdfs:range xsd:decimal .
-
+    rdfs:domain ex:Order ; rdfs:range xsd:decimal ; skos:example "19.99" .
+ex:quantity a owl:DatatypeProperty ;
+    rdfs:domain ex:Order ; rdfs:range xsd:integer .
 ex:orderDate a owl:DatatypeProperty ;
     rdfs:domain ex:Order ; rdfs:range xsd:date .
 
@@ -440,7 +465,7 @@ ex:placedBy a owl:ObjectProperty ;
 
 ```console
 $ kcmd owl import sales.owl.ttl
-converted 2 classes, 1 object property, 4 datatype properties
+converted 2 classes, 1 object property, 9 datatype properties
 wrote catalog/EntryGroups/<entryGroup>/sales.yaml
 note: this model is UNBOUND (no backing tables yet).
       -> `kcmd push --target kc` works now (publishes ontology metadata).
@@ -453,22 +478,45 @@ picks it up; pass `--out <path>` to write it elsewhere.
 
 ### 3. The semantic model it produces — `sales.yaml`
 
-Note what is **not** here: no IRIs, no `custom_extensions`. Every OWL term has an
-IRI (`ex:Customer` = `http://example.com/sales#Customer`), but for the
-constructs that map cleanly, the IRI carries nothing the model doesn't already
-have — the term's identity is its name, and the source namespace is recorded once
-in the model `description` as provenance.
+The `Customer` dataset and the `placedBy` edge, verbatim (the `Order` dataset
+follows the same shape):
 
 ```yaml
 version: 0.2.0.dev0
 semantic_model:
   - name: sales
-    description: Imported from OWL ontology http://example.com/sales#
+    description: "A minimal sales domain: customers and the orders they place.
+      (ontology version 1.0)"
+    ai_context:
+      synonyms:
+        - Sales domain
+      examples:
+        - How many orders did each customer place last month?
     datasets:
       - name: Customer
         source: unbound:Customer        # placeholder — bind to a table for BigQuery Graph
+        primary_key:
+          - customerId                   # from owl:hasKey
+        unique_keys:
+          - - email                      # from the inverse-functional property
         description: A person or organization that places orders.
+        ai_context:
+          synonyms:
+            - Buyer
         fields:
+          - name: customerId
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: customerId
+            datatype: String
+          - name: email
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: email
+            datatype: String
+            description: The customer's unique email address.
           - name: customerName
             expression:
               dialects:
@@ -482,54 +530,89 @@ semantic_model:
                 - dialect: BIGQUERY
                   expression: signupDate
             datatype: Date
-      - name: Order
-        source: unbound:Order
-        description: A purchase placed by a customer.
-        fields:
-          - name: orderAmount
+            dimension:
+              is_time: true              # a temporal field is a time dimension
+          - name: isVip
             expression:
               dialects:
                 - dialect: BIGQUERY
-                  expression: orderAmount
-            datatype: Decimal
-          - name: orderDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: orderDate
-            datatype: Date
+                  expression: isVip
+            datatype: Boolean
+            description: Whether the customer is in the loyalty program.
+      # ... Order dataset: orderId, orderAmount, quantity, orderDate ...
     relationships:
       - name: placedBy
         from: Order
         to: Customer
-        # UNBOUND: real FK/key columns are unknown until sources are bound.
         from_columns:
-          - TODO_BIND
+          - TODO_BIND                    # source FK — fill in when you bind sources
         to_columns:
-          - TODO_BIND
+          - customerId                   # already bound to Customer's key
         ai_context:
           instructions: Links an order to the customer who placed it.
 ```
 
-#### How each OWL construct landed
+Note what is **not** here: no IRIs and no `custom_extensions`. Every OWL term has
+an IRI (`ex:Customer` = `http://example.com/sales#Customer`), but for the
+constructs that map cleanly the IRI carries nothing the model doesn't already
+have — the term's identity is its name, and the source namespace is recorded once
+in the model `description` as provenance.
+
+#### How each OWL construct maps
 
 | OWL | Semantic model | Notes |
 |---|---|---|
+| `owl:Ontology` header | model `description`, `ai_context`, version | comment → `description`; labels → `ai_context.synonyms`; `skos:example` → `ai_context.examples`; `owl:versionInfo` → appended to `description` |
 | `owl:Class` | `datasets[]` entry | `source` = `unbound:<Name>` placeholder until bound |
-| `owl:DatatypeProperty` | `fields[]` on the domain's dataset | `expression` defaults to the property's local name (a valid column ref once bound) |
-| `rdfs:range xsd:*` | field `datatype` | `xsd:string→String`, `xsd:date→Date`, `xsd:decimal→Decimal`, else `Opaque` |
-| `owl:ObjectProperty` | `relationships[]` | `from`=domain, `to`=range; join columns unbound (`TODO_BIND`) |
+| `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; `expression` defaults to the property's local name (a valid column ref once bound) |
+| `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; join columns bound to the destination key when it has one, else `TODO_BIND` (see [binding](#4-going-from-ontology-to-a-running-graph-binding)) |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
+| `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
+| `owl:hasKey ( ... )` | dataset `primary_key` | single or composite, in list order |
+| `owl:InverseFunctionalProperty` | dataset `unique_keys` | a uniquely-identifying property; omitted when it is already the `primary_key` |
 | `rdfs:label` on a datatype property | field `label` | the field's display name (a `label` slot exists only on fields); dropped when it only respaces/recases the name |
-| `rdfs:label` on a class / object property | `ai_context.synonyms` | no `label` slot there, so a distinct label becomes an alternate name; dropped when it only respaces/recases the name |
-| extra `rdfs:label` / `skos:altLabel` / `skos:prefLabel` | `ai_context.synonyms` | genuinely alternate names; feed NL search |
-| `rdfs:comment` on a class / datatype property | `description` | |
-| `rdfs:comment` on an object property | `ai_context.instructions` | a relationship has no `description` slot, so its comment rides in `ai_context` |
-| term IRIs, `@prefix` | dropped (provenance kept in model `description`) | reconstructable as `<base><name>`; re-carried only if reverse export needs them |
+| `rdfs:label` on a class / object property | `ai_context.synonyms` | no `label` slot there, so a distinct label becomes an alternate name; dropped when redundant with the name |
+| extra `rdfs:label` / `skos:altLabel` / `prefLabel` / `hiddenLabel` | `ai_context.synonyms` | genuinely alternate names; feed NL search |
+| `skos:example` | `ai_context.examples` | sample questions / values |
+| `rdfs:comment`, `skos:definition`, `dcterms:`/`dc:description` | `description` | first present wins, in that order; on an object property (which has no `description` slot) the comment rides in `ai_context.instructions` |
+| term IRIs, `@prefix` | dropped (base IRI kept as provenance in model `description`) | reconstructable as `<base><name>`; re-carried only if reverse export or `subClassOf` needs them |
 
-A datatype property whose domain is not a class in the ontology, or an object
-property missing an endpoint, cannot be placed; it is **skipped with a warning**
-rather than failing the whole import.
+A datatype property whose domain is not a class, or an object property missing an
+endpoint, cannot be placed; it is **skipped with a warning** rather than failing
+the whole import.
+
+#### Datatypes (`rdfs:range`)
+
+`rdfs:range` sets a field's logical `datatype`. Physical width is not carried (it
+belongs to the bound table, not the ontology), so several `xsd` types collapse
+onto one logical type:
+
+| `xsd` range | `datatype` |
+|---|---|
+| `string`, `normalizedString`, `token`, `anyURI`, `language`, `Name`, `NCName` | `String` |
+| `integer`, `int`, `long`, `short`, `byte`, `nonNegativeInteger`, `positiveInteger`, `unsignedInt`, … (any width/sign) | `Integer` |
+| `decimal` | `Decimal` |
+| `float`, `double` | `Float` |
+| `boolean` | `Boolean` |
+| `date` | `Date` |
+| `time` | `Time` |
+| `dateTime` | `DateTime` |
+| `dateTimeStamp` | `DateTimeTz` |
+| anything else, or no `rdfs:range` | `Opaque` |
+
+A temporal field (`Date` / `Time` / `DateTime` / `DateTimeTz`) is additionally
+marked a **time dimension** (`dimension: { is_time: true }`), so downstream
+BigQuery Graph / BI treats it as one.
+
+#### Keys (`owl:hasKey`, `owl:InverseFunctionalProperty`)
+
+- **`owl:hasKey ( ... )`** on a class becomes the dataset's `primary_key` (its
+  grain), in list order — single or composite.
+- An **`owl:InverseFunctionalProperty`** (a datatype property that uniquely
+  identifies its subject) becomes a `unique_keys` constraint — unless it is
+  already the `primary_key`, in which case it is not repeated.
+
+Keys also make relationships half-bindable — see the next section.
 
 #### Class hierarchies (`rdfs:subClassOf`)
 
@@ -594,35 +677,38 @@ catalog metadata immediately:
 $ kcmd push --target kc      # Customer/Order entries + placedBy link appear in Knowledge Catalog
 ```
 
-To make it queryable in **BigQuery Graph**, bind each class to a real table by
-editing the `unbound:` / `TODO_BIND` spots — `source` (+ `primary_key`) per
-dataset, and the relationship's join columns:
+To make it queryable in **BigQuery Graph**, bind each class to a real table. A
+declared key does half of this for you: an edge into a class that has a key
+already has its **destination** columns bound to that key, so you only fill each
+dataset's `source` table and the relationship's **source** foreign-key columns
+(the `TODO_BIND` placeholders):
 
 ```yaml
   - name: Customer
-    source: myproj.sales.customers
+    source: myproj.sales.customers       # was unbound:Customer
     primary_key:
-      - customer_id
-    fields:
-      - name: customerName
-        expression:
-          dialects:
-            - dialect: BIGQUERY
-              expression: name
-        datatype: String
-  # ...Order bound to myproj.sales.orders, primary_key [order_id]...
+      - customerId                        # already set from owl:hasKey
+    # ... fields, with each expression bound to its real column ...
+  # ... Order bound to myproj.sales.orders ...
   relationships:
     - name: placedBy
       from: Order
       to: Customer
       from_columns:
-        - customer_id
+        - customer_id                     # fill in the source FK (was TODO_BIND)
       to_columns:
-        - customer_id
+        - customerId                      # already bound to Customer's key
 ```
 
 You also need a [deployment target](#deployment-targets-required) on the model
-before a BigQuery push. Binding is a manual edit in this first cut.
+before a BigQuery push. Then:
+
+```console
+$ kcmd push                  # CREATE PROPERTY GRAPH sales (Customers, Orders, placedBy), then KC
+```
+
+Binding the `source` tables and the source foreign-key columns is a manual edit
+in this first cut.
 
 ### What is not covered yet
 
@@ -631,15 +717,18 @@ before a BigQuery push. Binding is a manual edit in this first cut.
   *Resolving* that inheritance into Knowledge Catalog entries / BigQuery Graph
   node tables (copying inherited fields down) is a follow-on; this cut only
   records the hierarchy.
-- `owl:inverseOf`, `rdfs:subPropertyOf` (property / relationship inheritance) —
-  not supported. A `subPropertyOf` link is dropped with a warning (the field or
-  relationship itself is still imported); only entity-level inheritance exists.
-  When richer constructs are added, they will land in a GOOGLE
-  `custom_extensions` block (under a `data.ontology` key), which is also where the
-  base IRI + prefixes would come back (needed to expand parent-property
+- `owl:inverseOf`, `rdfs:subPropertyOf` (property / relationship inheritance),
+  `owl:equivalentClass` — not supported. A `subPropertyOf` link is dropped with a
+  warning (the field or relationship itself is still imported); only entity-level
+  inheritance exists. When richer constructs are added, they will land in a
+  GOOGLE `custom_extensions` block (under a `data.ontology` key), which is also
+  where the base IRI + prefixes would come back (needed to expand parent-property
   references).
-- SHACL shapes, cardinality, `owl:unionOf` domains, symmetric/transitive
-  properties, `equivalentClass`, individuals — not read.
+- Cardinality / required (`owl:FunctionalProperty`, `owl:minCardinality`,
+  restrictions), enumerations (`owl:oneOf`), and property characteristics
+  (symmetric / transitive) — to be carried later via `custom_extensions`.
+- SHACL shapes, class expressions (`owl:unionOf` / `intersectionOf`), and
+  individuals (A-box instances) — not read.
 - Semantic model → OWL export (reverse) — not built; import is one-way.
 - OWL serializations other than Turtle (`.ttl`) — not read.
 

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -565,7 +565,7 @@ in the model `description` as provenance.
 | `owl:Ontology` header | model `description`, `ai_context`, version | comment → `description`; labels → `ai_context.synonyms`; `skos:example` → `ai_context.examples`; `owl:versionInfo` → appended to `description` |
 | `owl:Class` | `datasets[]` entry | `source` = `unbound:<Name>` placeholder until bound |
 | `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; `expression` defaults to the property's local name (a valid column ref once bound) |
-| `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; join columns bound to the destination key when it has one, else `TODO_BIND` (see [binding](#4-going-from-ontology-to-a-running-graph-binding)) |
+| `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; join columns bound to the destination key when it has one, else `TODO_BIND` (see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
 | `owl:hasKey ( ... )` | dataset `primary_key` | single or composite, in list order |
@@ -579,7 +579,10 @@ in the model `description` as provenance.
 
 A datatype property whose domain is not a class, or an object property missing an
 endpoint, cannot be placed; it is **skipped with a warning** rather than failing
-the whole import.
+the whole import. An object property that declares *more than one* `rdfs:domain`
+or `rdfs:range` is kept — a relationship maps one source to one destination, so
+the first of each is used and the extra endpoints are dropped with a warning
+(unlike a multi-domain *datatype* property, which lands on every domain).
 
 #### Datatypes (`rdfs:range`)
 
@@ -607,10 +610,12 @@ BigQuery Graph / BI treats it as one.
 #### Keys (`owl:hasKey`, `owl:InverseFunctionalProperty`)
 
 - **`owl:hasKey ( ... )`** on a class becomes the dataset's `primary_key` (its
-  grain), in list order — single or composite. A key column that names no
+  grain), in list order — single or composite. If any key column names no
   datatype property on the class (undeclared, or declared only on another class)
-  has no field to back it, so it is dropped from the `primary_key` with a
-  warning rather than left to fail later at graph generation.
+  it has no field to back it; because keeping only the columns that do exist
+  would silently narrow a composite key to a possibly non-unique one, the
+  **entire `primary_key` is dropped** with a warning rather than left to fail
+  later at graph generation.
 - An **`owl:InverseFunctionalProperty`** (a datatype property that uniquely
   identifies its subject) becomes a `unique_keys` constraint — unless it is
   already the `primary_key`, in which case it is not repeated. If a class

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -569,7 +569,7 @@ in the model `description` as provenance.
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
 | `owl:hasKey ( ... )` | dataset `primary_key` | single or composite, in list order |
-| `owl:InverseFunctionalProperty` | dataset `unique_keys` | a uniquely-identifying property; omitted when it is already the `primary_key` |
+| `owl:InverseFunctionalProperty` | dataset `unique_keys` | a uniquely-identifying property; omitted when it is already the `primary_key`; a lone one on a keyless class is promoted to `primary_key` instead |
 | `rdfs:label` on a datatype property | field `label` | the field's display name (a `label` slot exists only on fields); dropped when it only respaces/recases the name |
 | `rdfs:label` on a class / object property | `ai_context.synonyms` | no `label` slot there, so a distinct label becomes an alternate name; dropped when redundant with the name |
 | extra `rdfs:label` / `skos:altLabel` / `prefLabel` / `hiddenLabel` | `ai_context.synonyms` | genuinely alternate names; feed NL search |
@@ -607,10 +607,17 @@ BigQuery Graph / BI treats it as one.
 #### Keys (`owl:hasKey`, `owl:InverseFunctionalProperty`)
 
 - **`owl:hasKey ( ... )`** on a class becomes the dataset's `primary_key` (its
-  grain), in list order — single or composite.
+  grain), in list order — single or composite. A key column that names no
+  datatype property on the class (undeclared, or declared only on another class)
+  has no field to back it, so it is dropped from the `primary_key` with a
+  warning rather than left to fail later at graph generation.
 - An **`owl:InverseFunctionalProperty`** (a datatype property that uniquely
   identifies its subject) becomes a `unique_keys` constraint — unless it is
-  already the `primary_key`, in which case it is not repeated.
+  already the `primary_key`, in which case it is not repeated. If a class
+  declares **no `owl:hasKey`** but has exactly **one** single-column
+  inverse-functional property, that property is promoted to the `primary_key`
+  (with a warning) so the dataset has a grain; ambiguous cases (several unique
+  keys, or a composite one) are left without a `primary_key`.
 
 Keys also make relationships half-bindable — see the next section.
 

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/convert.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/convert.ts
@@ -13,7 +13,9 @@ import {owlToIr} from './to_ir';
 export interface ConvertResult {
   // The OSI document text, ready to write as `<model>.yaml`.
   yaml: string;
-  // Counts for the CLI's one-line summary.
+  // Counts for the CLI's one-line summary -- what was actually converted, not
+  // the source-triple counts (see ToIrResult.stats), so a skipped element is
+  // not reported as "converted".
   stats:
       {classes: number; datatypeProperties: number; objectProperties: number};
   // Notes about OWL content that could not be mapped (from the mapper) and IR
@@ -34,15 +36,11 @@ export interface ConvertResult {
 export function convertOwlToOsi(
     turtle: string, modelName: string): ConvertResult {
   const owl = parseOwl(turtle);
-  const {model, warnings: mapWarnings} = owlToIr(owl, modelName);
+  const {model, warnings: mapWarnings, stats} = owlToIr(owl, modelName);
   const {yaml, warnings: serializeWarnings} = serializeModel(model);
   return {
     yaml,
-    stats: {
-      classes: owl.classes.length,
-      datatypeProperties: owl.datatypeProperties.length,
-      objectProperties: owl.objectProperties.length,
-    },
+    stats,
     warnings: [...mapWarnings, ...serializeWarnings],
   };
 }

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -6,11 +6,12 @@
 // the parser stay a mechanical triples-to-structs step while all of the OWL ->
 // OSI mapping policy lives in one place (to_ir.ts).
 //
-// Scope: only the constructs the first cut converts -- classes, datatype
-// properties, object properties, and the handful of annotations on them
-// (rdfs:label / rdfs:comment / alternate labels). Richer OWL (subClassOf,
-// inverseOf, SHACL, cardinality, individuals) is intentionally absent; see the
-// "What is not covered yet" note in the user guide.
+// Scope: the OWL constructs the converter maps to native OSI today -- classes,
+// datatype/object properties, their human annotations (rdfs:label / comment,
+// skos labels / definition / example, dcterms/dc description), datatype ranges,
+// keys (owl:hasKey, owl:InverseFunctionalProperty), and ontology-header
+// metadata. Richer OWL (subClassOf, inverseOf, SHACL, cardinality, individuals)
+// is intentionally absent; see the "What is not covered yet" note in the guide.
 
 /** An `owl:Class` -- becomes an OSI dataset (entity). */
 export interface OwlClass {
@@ -20,11 +21,17 @@ export interface OwlClass {
   // rdfs:label, if present. A display name; carried to the entity only when it
   // adds information over `localName` (see to_ir.ts).
   label?: string;
-  // rdfs:comment, if present -> entity description.
+  // A description (rdfs:comment, or skos:definition / dcterms:/dc:description
+  // when there is no rdfs:comment) -> entity description.
   comment?: string;
-  // Additional human names (extra rdfs:label / skos:altLabel|prefLabel) ->
-  // ai_context.synonyms.
+  // Additional human names (extra rdfs:label / skos:altLabel|prefLabel|
+  // hiddenLabel) -> ai_context.synonyms.
   synonyms: string[];
+  // skos:example values -> ai_context.examples.
+  examples: string[];
+  // Local names of the properties named by owl:hasKey -> the entity's
+  // primary_key (grain). Empty when the class declares no key.
+  keys: string[];
   // Local names of `rdfs:subClassOf` superclasses, in document order -> the
   // entity's `extends` (entity-level inheritance). Named superclasses only;
   // blank-node axioms (owl:Restriction, ...) are not recorded. Empty when none.
@@ -36,16 +43,22 @@ export interface OwlClass {
  */
 export interface OwlDatatypeProperty {
   localName: string;
-  // Local name of the rdfs:domain class this property hangs off; the field is
-  // added to that entity. Undefined when no domain is declared (skipped with a
+  // Local names of every rdfs:domain class this property hangs off; the field
+  // is added to each. A property may declare more than one domain (it then
+  // appears on each entity). Empty when no domain is declared (skipped with a
   // warning -- an unattached field has nowhere to live).
-  domain?: string;
+  domains: string[];
   // The rdfs:range IRI (e.g. the xsd:string IRI), mapped to an OSI datatype by
   // the mapper. Undefined when no range is declared (-> Opaque).
   rangeIri?: string;
   label?: string;
   comment?: string;
   synonyms: string[];
+  examples: string[];
+  // True when the property is also an owl:InverseFunctionalProperty -- it
+  // uniquely identifies its subject, so it maps to a unique_keys constraint on
+  // each domain entity.
+  inverseFunctional: boolean;
   // Local names of `rdfs:subPropertyOf` superproperties, if any. Property
   // inheritance is NOT supported (only entity-level `rdfs:subClassOf`); this is
   // recorded solely so the mapper can warn and drop it. Empty when none.
@@ -66,10 +79,26 @@ export interface OwlObjectProperty {
   label?: string;
   comment?: string;
   synonyms: string[];
+  examples: string[];
   // Local names of `rdfs:subPropertyOf` superproperties, if any. Relationship
   // inheritance is NOT supported (only entity-level `rdfs:subClassOf`); this is
   // recorded solely so the mapper can warn and drop it. Empty when none.
   subPropertyOf: string[];
+}
+
+/**
+ * The ontology header (an `owl:Ontology` node) -- becomes model-level metadata.
+ *
+ * A description (rdfs:comment / skos:definition / dcterms:/dc:description) ->
+ * the model `description`; labels -> `ai_context.synonyms`; skos:example ->
+ * `ai_context.examples`; owl:versionInfo -> appended to the description as
+ * provenance.
+ */
+export interface OwlOntology {
+  comment?: string;
+  synonyms: string[];
+  examples: string[];
+  version?: string;
 }
 
 /**
@@ -84,6 +113,8 @@ export interface OwlModel {
   // term's namespace), kept only as provenance for the model description. Term
   // IRIs themselves are dropped -- see the user guide.
   baseIri?: string;
+  // The ontology-header metadata (owl:Ontology node), if the document has one.
+  ontology?: OwlOntology;
   classes: OwlClass[];
   datatypeProperties: OwlDatatypeProperty[];
   objectProperties: OwlObjectProperty[];

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -72,10 +72,13 @@ export interface OwlDatatypeProperty {
 export interface OwlObjectProperty {
   localName: string;
   // Local names of the rdfs:domain (edge source) and rdfs:range (edge
-  // destination) classes. Undefined when not declared (skipped with a warning:
-  // an edge needs both endpoints).
-  domain?: string;
-  range?: string;
+  // destination) classes. A relationship maps a single source to a single
+  // destination, so the mapper uses the first of each and warns when more are
+  // declared (multiple domains/ranges mean an intersection in OWL, which has no
+  // clean single-edge shape). Empty when none is declared (skipped with a
+  // warning: an edge needs both endpoints).
+  domains: string[];
+  ranges: string[];
   label?: string;
   comment?: string;
   synonyms: string[];

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -309,8 +309,11 @@ export function parseOwl(turtle: string): OwlModel {
       case 'objectProperty':
         objectProperties.push({
           localName: localName(iri),
-          domain: a.domains[0],
-          range: a.ranges[0] !== undefined ? localName(a.ranges[0]) : undefined,
+          // a.domains are already local names; a.ranges are raw IRIs. Carry all
+          // of each so the mapper can warn about (and drop) the extras rather
+          // than silently keeping only the first.
+          domains: a.domains,
+          ranges: a.ranges.map(localName),
           label: a.label,
           comment: descriptionOf(a),
           synonyms: a.synonyms,

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -1,7 +1,7 @@
 // Turtle (.ttl) -> OwlModel parser.
 //
 // A mechanical triples-to-structs step: it reads RDF with `n3`, recognizes the
-// handful of OWL/RDFS terms the first cut supports, and fills the staging
+// OWL/RDFS/SKOS/Dublin-Core terms the converter supports, and fills the staging
 // OwlModel (model.ts). All OWL -> OSI mapping policy lives in to_ir.ts, not
 // here; this file only decides "which triples matter and where do their values
 // go".
@@ -12,30 +12,54 @@
 
 import {Parser} from 'n3';
 
-import {OwlClass, OwlDatatypeProperty, OwlModel, OwlObjectProperty,} from './model';
+import {OwlClass, OwlDatatypeProperty, OwlModel, OwlObjectProperty, OwlOntology,} from './model';
 
-// RDF/RDFS/OWL/SKOS term IRIs we recognize. Only these; anything else is
-// carried by neither the parser nor the model (see the user guide's
+// RDF/RDFS/OWL/SKOS/Dublin-Core term IRIs we recognize. Only these; anything
+// else is carried by neither the parser nor the model (see the user guide's
 // "not covered yet").
-const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-const OWL_CLASS = 'http://www.w3.org/2002/07/owl#Class';
-const OWL_DATATYPE_PROPERTY = 'http://www.w3.org/2002/07/owl#DatatypeProperty';
-const OWL_OBJECT_PROPERTY = 'http://www.w3.org/2002/07/owl#ObjectProperty';
-const OWL_THING = 'http://www.w3.org/2002/07/owl#Thing';
-const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
-const RDFS_COMMENT = 'http://www.w3.org/2000/01/rdf-schema#comment';
-const RDFS_DOMAIN = 'http://www.w3.org/2000/01/rdf-schema#domain';
-const RDFS_RANGE = 'http://www.w3.org/2000/01/rdf-schema#range';
-const RDFS_SUBCLASS_OF = 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
-const RDFS_SUBPROPERTY_OF =
-    'http://www.w3.org/2000/01/rdf-schema#subPropertyOf';
-const RDFS_RESOURCE = 'http://www.w3.org/2000/01/rdf-schema#Resource';
+const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+const RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
+const OWL = 'http://www.w3.org/2002/07/owl#';
+const SKOS = 'http://www.w3.org/2004/02/skos/core#';
+const DCTERMS = 'http://purl.org/dc/terms/';
+const DC = 'http://purl.org/dc/elements/1.1/';
+
+const RDF_TYPE = `${RDF}type`;
+// RDF collection (list) terms, used to walk an owl:hasKey list.
+const RDF_FIRST = `${RDF}first`;
+const RDF_REST = `${RDF}rest`;
+const RDF_NIL = `${RDF}nil`;
+
+const OWL_CLASS = `${OWL}Class`;
+const OWL_DATATYPE_PROPERTY = `${OWL}DatatypeProperty`;
+const OWL_OBJECT_PROPERTY = `${OWL}ObjectProperty`;
+const OWL_INVERSE_FUNCTIONAL_PROPERTY = `${OWL}InverseFunctionalProperty`;
+const OWL_ONTOLOGY = `${OWL}Ontology`;
+const OWL_HAS_KEY = `${OWL}hasKey`;
+const OWL_VERSION_INFO = `${OWL}versionInfo`;
+const OWL_THING = `${OWL}Thing`;
+
+const RDFS_LABEL = `${RDFS}label`;
+const RDFS_COMMENT = `${RDFS}comment`;
+const RDFS_DOMAIN = `${RDFS}domain`;
+const RDFS_RANGE = `${RDFS}range`;
+const RDFS_SUBCLASS_OF = `${RDFS}subClassOf`;
+const RDFS_SUBPROPERTY_OF = `${RDFS}subPropertyOf`;
+const RDFS_RESOURCE = `${RDFS}Resource`;
 // The implicit universal superclasses: every class is trivially a subclass of
-// owl:Thing / rdfs:Resource, so an explicit `rdfs:subClassOf` naming one carries
-// no inheritance information and is not recorded as `extends` (nor warned about).
+// owl:Thing / rdfs:Resource, so an explicit `rdfs:subClassOf` naming one
+// carries no inheritance information and is not recorded as `extends` (nor
+// warned about).
 const TOP_CLASS_IRIS = new Set([OWL_THING, RDFS_RESOURCE]);
-const SKOS_ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
-const SKOS_PREF_LABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel';
+
+const SKOS_ALT_LABEL = `${SKOS}altLabel`;
+const SKOS_PREF_LABEL = `${SKOS}prefLabel`;
+const SKOS_HIDDEN_LABEL = `${SKOS}hiddenLabel`;
+const SKOS_DEFINITION = `${SKOS}definition`;
+const SKOS_EXAMPLE = `${SKOS}example`;
+
+const DCTERMS_DESCRIPTION = `${DCTERMS}description`;
+const DC_DESCRIPTION = `${DC}description`;
 
 // One of the three OWL kinds we route a typed subject to.
 type OwlKind = 'class'|'datatypeProperty'|'objectProperty';
@@ -50,9 +74,7 @@ const KIND_BY_TYPE: Record<string, OwlKind> = {
 // or `/`. This is the OSI-facing identity (see the user guide -- the full IRI
 // is reconstructable as `<base><localName>` and is not carried).
 function localName(iri: string): string {
-  const hash = iri.lastIndexOf('#');
-  const slash = iri.lastIndexOf('/');
-  const cut = Math.max(hash, slash);
+  const cut = Math.max(iri.lastIndexOf('#'), iri.lastIndexOf('/'));
   return cut >= 0 ? iri.slice(cut + 1) : iri;
 }
 
@@ -65,19 +87,43 @@ function namespace(iri: string): string|undefined {
 
 // Per-subject accumulator, filled in a single ordered pass so the first
 // rdfs:label wins the `label` slot and later labels / SKOS alt labels become
-// synonyms.
+// synonyms. Descriptions are kept per source predicate so a fixed precedence
+// (rdfs:comment > skos:definition > dcterms: > dc:) can be applied at build
+// time regardless of the order the triples appear in the document.
 interface Annotations {
   label?: string;
-  comment?: string;
-  domain?: string;
-  range?: string;
   synonyms: string[];
+  examples: string[];
+  rdfsComment?: string;
+  skosDefinition?: string;
+  dctermsDescription?: string;
+  dcDescription?: string;
+  domains: string[];
+  ranges: string[];  // raw range IRIs; the mapper maps xsd:* -> datatype
+  versionInfo?: string;
+  keyListHeads: string[];  // owl:hasKey list heads (blank nodes)
   subClassOf: string[];
   subPropertyOf: string[];
 }
 
 function emptyAnnotations(): Annotations {
-  return {synonyms: [], subClassOf: [], subPropertyOf: []};
+  return {
+    synonyms: [],
+    examples: [],
+    domains: [],
+    ranges: [],
+    keyListHeads: [],
+    subClassOf: [],
+    subPropertyOf: []
+  };
+}
+
+// The effective description: the first present of rdfs:comment,
+// skos:definition, dcterms:description, dc:description -- a fixed precedence so
+// a term with more than one carries the most specific.
+function descriptionOf(a: Annotations): string|undefined {
+  return a.rdfsComment ?? a.skosDefinition ?? a.dctermsDescription ??
+      a.dcDescription;
 }
 
 /**
@@ -90,24 +136,65 @@ function emptyAnnotations(): Annotations {
 export function parseOwl(turtle: string): OwlModel {
   const quads = new Parser().parse(turtle);
 
-  // Pass 1: ordered list of typed subjects (first `rdf:type` occurrence wins
-  // the position), plus a kind index. Scanning `quads` directly (not the Store)
-  // keeps document order.
+  // Pass 1: types. An ordered list of typed subjects (first `rdf:type`
+  // occurrence wins the position) plus a kind index; the set of
+  // inverse-functional subjects and the ontology-header subject, which are
+  // recognized by their type but are not themselves classes/properties.
+  // Scanning `quads` directly (not the Store) keeps document order.
   const order: string[] = [];
   const kind = new Map<string, OwlKind>();
+  const inverseFunctional = new Set<string>();
+  let ontologyIri: string|undefined;
   for (const q of quads) {
     if (q.predicate.value !== RDF_TYPE) continue;
-    const k = KIND_BY_TYPE[q.object.value];
+    const type = q.object.value;
+    const subject = q.subject.value;
+    if (type === OWL_INVERSE_FUNCTIONAL_PROPERTY) {
+      inverseFunctional.add(subject);
+      continue;
+    }
+    if (type === OWL_ONTOLOGY) {
+      if (ontologyIri === undefined) ontologyIri = subject;
+      continue;
+    }
+    const k = KIND_BY_TYPE[type];
     if (!k) continue;
-    const iri = q.subject.value;
-    if (!kind.has(iri)) {
-      kind.set(iri, k);
-      order.push(iri);
+    if (!kind.has(subject)) {
+      kind.set(subject, k);
+      order.push(subject);
     }
   }
 
-  // Pass 2: accumulate annotations for each typed subject in document order, so
-  // the first label is the primary and the rest are synonyms.
+  // Pass 2: RDF list structure (rdf:first / rdf:rest), so an owl:hasKey list
+  // can be resolved to its member properties. List nodes are blank nodes
+  // unrelated to the typed subjects, so they are collected separately.
+  const listFirst = new Map<string, string>();
+  const listRest = new Map<string, string>();
+  for (const q of quads) {
+    if (q.predicate.value === RDF_FIRST)
+      listFirst.set(q.subject.value, q.object.value);
+    else if (q.predicate.value === RDF_REST)
+      listRest.set(q.subject.value, q.object.value);
+  }
+  // Resolves an RDF collection to its member IRIs, following rdf:rest to nil.
+  // Defensive against a cycle or a missing link (stops at the first gap).
+  const resolveList = (head: string): string[] => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    let node: string|undefined = head;
+    while (node && node !== RDF_NIL && !seen.has(node)) {
+      seen.add(node);
+      const value = listFirst.get(node);
+      if (value === undefined) break;
+      out.push(value);
+      node = listRest.get(node);
+    }
+    return out;
+  };
+
+  // Pass 3: accumulate annotations for each typed subject (and the ontology
+  // header) in document order, so the first label is the primary and the rest
+  // are synonyms.
   const annotations = new Map<string, Annotations>();
   const annotationsFor = (iri: string): Annotations => {
     let a = annotations.get(iri);
@@ -117,9 +204,11 @@ export function parseOwl(turtle: string): OwlModel {
     }
     return a;
   };
+  const annotated = (iri: string): boolean =>
+      kind.has(iri) || iri === ontologyIri;
   for (const q of quads) {
     const subject = q.subject.value;
-    if (!kind.has(subject)) continue;
+    if (!annotated(subject)) continue;
     const a = annotationsFor(subject);
     switch (q.predicate.value) {
       case RDFS_LABEL:
@@ -131,23 +220,43 @@ export function parseOwl(turtle: string): OwlModel {
         break;
       case SKOS_ALT_LABEL:
       case SKOS_PREF_LABEL:
+      case SKOS_HIDDEN_LABEL:
         a.synonyms.push(q.object.value);
         break;
+      case SKOS_EXAMPLE:
+        a.examples.push(q.object.value);
+        break;
       case RDFS_COMMENT:
-        a.comment = q.object.value;
+        a.rdfsComment = q.object.value;
+        break;
+      case SKOS_DEFINITION:
+        a.skosDefinition = q.object.value;
+        break;
+      case DCTERMS_DESCRIPTION:
+        a.dctermsDescription = q.object.value;
+        break;
+      case DC_DESCRIPTION:
+        a.dcDescription = q.object.value;
         break;
       case RDFS_DOMAIN:
-        a.domain = localName(q.object.value);
+        a.domains.push(localName(q.object.value));
         break;
       case RDFS_RANGE:
-        a.range = q.object.value;  // kept as IRI; mapper maps xsd:* -> datatype
+        a.ranges.push(q.object.value);  // kept as IRI; mapper maps xsd:*
+        break;
+      case OWL_VERSION_INFO:
+        a.versionInfo = q.object.value;
+        break;
+      case OWL_HAS_KEY:
+        a.keyListHeads.push(q.object.value);
         break;
       case RDFS_SUBCLASS_OF:
         // Class hierarchy -> the entity's `extends`. Named superclasses only:
         // a blank-node object (an owl:Restriction and similar axioms) is not a
         // named class, so it is ignored here (out of scope). The implicit
         // universal superclasses (owl:Thing / rdfs:Resource) are ignored too --
-        // every class subclasses them, so they carry no inheritance information.
+        // every class subclasses them, so they carry no inheritance
+        // information.
         if (q.object.termType === 'NamedNode' &&
             !TOP_CLASS_IRIS.has(q.object.value))
           a.subClassOf.push(localName(q.object.value));
@@ -177,30 +286,35 @@ export function parseOwl(turtle: string): OwlModel {
         classes.push({
           localName: localName(iri),
           label: a.label,
-          comment: a.comment,
+          comment: descriptionOf(a),
           synonyms: a.synonyms,
+          examples: a.examples,
+          keys: a.keyListHeads.flatMap(resolveList).map(localName),
           subClassOf: a.subClassOf,
         });
         break;
       case 'datatypeProperty':
         datatypeProperties.push({
           localName: localName(iri),
-          domain: a.domain,
-          rangeIri: a.range,
+          domains: a.domains,
+          rangeIri: a.ranges[0],
           label: a.label,
-          comment: a.comment,
+          comment: descriptionOf(a),
           synonyms: a.synonyms,
+          examples: a.examples,
+          inverseFunctional: inverseFunctional.has(iri),
           subPropertyOf: a.subPropertyOf,
         });
         break;
       case 'objectProperty':
         objectProperties.push({
           localName: localName(iri),
-          domain: a.domain,
-          range: a.range !== undefined ? localName(a.range) : undefined,
+          domain: a.domains[0],
+          range: a.ranges[0] !== undefined ? localName(a.ranges[0]) : undefined,
           label: a.label,
-          comment: a.comment,
+          comment: descriptionOf(a),
           synonyms: a.synonyms,
+          examples: a.examples,
           subPropertyOf: a.subPropertyOf,
         });
         break;
@@ -209,5 +323,33 @@ export function parseOwl(turtle: string): OwlModel {
     }
   }
 
-  return {baseIri, classes, datatypeProperties, objectProperties};
+  // The ontology header, if present, becomes model-level metadata. Its own IRI
+  // (a namespace URI without a term fragment) makes a better base-IRI
+  // provenance than the first term's namespace, so prefer it when available.
+  let ontology: OwlOntology|undefined;
+  if (ontologyIri !== undefined) {
+    const a = annotations.get(ontologyIri) ?? emptyAnnotations();
+    const labels =
+        a.label !== undefined ? [a.label, ...a.synonyms] : a.synonyms;
+    ontology = {
+      comment: descriptionOf(a),
+      synonyms: labels,
+      examples: a.examples,
+      version: a.versionInfo,
+    };
+    baseIri = ontologyBaseIri(ontologyIri) ?? baseIri;
+  }
+
+  return {baseIri, ontology, classes, datatypeProperties, objectProperties};
+}
+
+// The base namespace an ontology IRI stands for. An owl:Ontology is commonly
+// named by the namespace root without the trailing `#`/`/` (e.g.
+// `http://example.com/sales`), so append `#` when the IRI has no delimiter of
+// its own; otherwise keep it as given.
+function ontologyBaseIri(iri: string): string|undefined {
+  if (!iri) return undefined;
+  const last = iri[iri.length - 1];
+  if (last === '#' || last === '/') return iri;
+  return `${iri}#`;
 }

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -323,9 +323,10 @@ export function parseOwl(turtle: string): OwlModel {
     }
   }
 
-  // The ontology header, if present, becomes model-level metadata. Its own IRI
-  // (a namespace URI without a term fragment) makes a better base-IRI
-  // provenance than the first term's namespace, so prefer it when available.
+  // The ontology header, if present, becomes model-level metadata. The base IRI
+  // is best derived from an actual term's namespace (exact, delimiter and all);
+  // the ontology IRI is only a heuristic fallback (its own IRI often omits the
+  // trailing `#`/`/`), so use it only when no term supplied a namespace.
   let ontology: OwlOntology|undefined;
   if (ontologyIri !== undefined) {
     const a = annotations.get(ontologyIri) ?? emptyAnnotations();
@@ -337,7 +338,7 @@ export function parseOwl(turtle: string): OwlModel {
       examples: a.examples,
       version: a.versionInfo,
     };
-    baseIri = ontologyBaseIri(ontologyIri) ?? baseIri;
+    baseIri = baseIri ?? ontologyBaseIri(ontologyIri);
   }
 
   return {baseIri, ontology, classes, datatypeProperties, objectProperties};

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -5,23 +5,29 @@
 // lives here, in one place, so the mapping is easy to read and to evolve.
 //
 // The mapping (see the user guide's table):
-//   owl:Class            -> dataset (entity), unbound source placeholder
-//   owl:DatatypeProperty -> field on its domain class's dataset
-//   owl:ObjectProperty   -> relationship (edge) between domain and range
-//   rdfs:range xsd:*      -> field datatype (string/date/decimal; else Opaque)
-//   rdfs:label           -> field label, or a synonym where there is no label
-//                           slot (classes/relationships)
-//   rdfs:comment         -> description
+//   owl:Class                     -> dataset (entity), unbound source
+//   placeholder owl:DatatypeProperty          -> field on each domain class's
+//   dataset owl:ObjectProperty            -> relationship (edge) between domain
+//   and range rdfs:range xsd:*              -> field datatype (see
+//   XSD_DATATYPES; else Opaque) owl:hasKey                    -> dataset
+//   primary_key owl:InverseFunctionalProperty -> dataset unique_keys rdfs:label
+//   -> field label, or a synonym where there is no
+//                                    label slot (classes/relationships)
+//   rdfs:comment / skos:definition / dcterms:/dc:description -> description
+//   skos:example                  -> ai_context.examples
+//   owl:Ontology header           -> model description / ai_context
 //
 // The result is UNBOUND: entities carry an `unbound:<Name>` source placeholder
 // and relationships carry `TODO_BIND` join columns, because an ontology has no
-// physical tables. The model still loads and pushes to Knowledge Catalog as-is;
-// binding real sources/columns is a manual follow-up before a BigQuery push
-// (see the user guide, "Going from ontology to a running graph").
+// physical tables. A declared key sharpens this -- an edge into a class with a
+// key binds its destination columns to that key, leaving only the source
+// foreign-key columns to fill. The model loads and pushes to Knowledge Catalog
+// as-is; binding real sources/columns is a manual follow-up before a BigQuery
+// push (see the user guide, "Going from ontology to a running graph").
 
 import {AiContext, CustomExtension, Entity, Field, Relationship, SemanticModel,} from '../../ir';
 
-import {OwlModel} from './model';
+import {OwlModel, OwlOntology} from './model';
 
 export interface ToIrResult {
   model: SemanticModel;
@@ -47,8 +53,8 @@ const GOOGLE_VENDOR = 'GOOGLE';
  *
  * This is the promotion seam: when subClassOf / inverseOf / base-IRI carriage
  * lands, it is emitted here (and, later, promoted to native OSI fields by
- * changing only this function and its callers). The minimal first cut maps
- * everything to native OSI, so nothing calls this yet -- it is defined, tested
+ * changing only this function and its callers). The current cut maps everything
+ * it reads to native OSI, so nothing calls this yet -- it is defined, tested
  * for shape, and left unused until the richer constructs arrive.
  */
 export function googleOntologyExtension(ontology: Record<string, unknown>):
@@ -75,20 +81,61 @@ const TODO_BIND = 'TODO_BIND';
 
 const XSD = 'http://www.w3.org/2001/XMLSchema#';
 
-// The xsd:* ranges the first cut maps to an OSI datatype. Everything else falls
-// back to Opaque (a valid, lossless "unknown logical type" per the IR). Kept as
-// a table so adding ranges later is a one-line change; the user guide documents
-// exactly this set.
+// The xsd:* ranges we map to an OSI datatype. Everything else falls back to
+// Opaque (a valid, lossless "unknown logical type" per the IR). Kept as a table
+// so adding ranges is a one-line change; the user guide documents this set.
+//
+// The OSI DataType vocabulary is closed (String / Integer / Decimal / Float /
+// Boolean / Date / Time / DateTime / DateTimeTz / Opaque), so several xsd types
+// collapse onto one OSI type (e.g. every bounded/unsigned integer -> Integer,
+// float and double -> Float): the logical type is preserved, physical width is
+// not (it belongs to the bound source, not the ontology).
 const XSD_DATATYPES: Record<string, Field['type']> = {
+  // Text.
   [`${XSD}string`]: 'String',
-  [`${XSD}date`]: 'Date',
+  [`${XSD}normalizedString`]: 'String',
+  [`${XSD}token`]: 'String',
+  [`${XSD}language`]: 'String',
+  [`${XSD}Name`]: 'String',
+  [`${XSD}NCName`]: 'String',
+  [`${XSD}anyURI`]: 'String',
+  // Integers (all widths / signednesses collapse to Integer).
+  [`${XSD}integer`]: 'Integer',
+  [`${XSD}int`]: 'Integer',
+  [`${XSD}long`]: 'Integer',
+  [`${XSD}short`]: 'Integer',
+  [`${XSD}byte`]: 'Integer',
+  [`${XSD}nonNegativeInteger`]: 'Integer',
+  [`${XSD}nonPositiveInteger`]: 'Integer',
+  [`${XSD}positiveInteger`]: 'Integer',
+  [`${XSD}negativeInteger`]: 'Integer',
+  [`${XSD}unsignedLong`]: 'Integer',
+  [`${XSD}unsignedInt`]: 'Integer',
+  [`${XSD}unsignedShort`]: 'Integer',
+  [`${XSD}unsignedByte`]: 'Integer',
+  // Exact and approximate numerics.
   [`${XSD}decimal`]: 'Decimal',
+  [`${XSD}float`]: 'Float',
+  [`${XSD}double`]: 'Float',
+  // Boolean.
+  [`${XSD}boolean`]: 'Boolean',
+  // Temporal.
+  [`${XSD}date`]: 'Date',
+  [`${XSD}time`]: 'Time',
+  [`${XSD}dateTime`]: 'DateTime',
+  [`${XSD}dateTimeStamp`]: 'DateTimeTz',
 };
 
 function datatypeFor(rangeIri: string|undefined): Field['type'] {
   if (rangeIri && XSD_DATATYPES[rangeIri]) return XSD_DATATYPES[rangeIri];
   return 'Opaque';
 }
+
+// The temporal OSI datatypes. A field of one of these is a time dimension by
+// OSI's own rule (see ir.isTimeDimension), so the mapper marks it with a
+// dimension block; OWL itself has no dimension concept.
+const TEMPORAL_TYPES: ReadonlySet<Field['type']> =
+    new Set<Field['type']>(['Date', 'Time', 'DateTime', 'DateTimeTz']);
 
 // --- Label / synonym policy. ------------------------------------------------
 
@@ -119,44 +166,67 @@ function fieldLabel(label: string|undefined, name: string): string|undefined {
 
 // The ai_context for a term that has NO label slot (classes, relationships): a
 // non-redundant rdfs:label becomes an alternate name, joined with any explicit
-// synonyms (extra labels / skos alt labels). Returns undefined when there are
-// none, so no empty ai_context is emitted.
+// synonyms (extra labels / skos labels) and examples. Returns undefined when
+// there is nothing, so no empty ai_context is emitted.
 function synonymAiContext(
-    label: string|undefined, name: string, synonyms: string[]): AiContext|
-    undefined {
-  const all: string[] = [];
-  if (label && !isRedundantLabel(label, name)) all.push(label);
-  all.push(...nonRedundant(synonyms, name));
-  return all.length ? {synonyms: dedupe(all)} : undefined;
+    label: string|undefined, name: string, synonyms: string[],
+    examples: string[]): AiContext|undefined {
+  const names: string[] = [];
+  if (label && !isRedundantLabel(label, name)) names.push(label);
+  names.push(...nonRedundant(synonyms, name));
+  return buildAiContext(undefined, names, examples);
 }
 
 // The ai_context for a FIELD (which already consumed its primary label into the
-// `label` slot): only the explicit synonyms remain. Undefined when empty.
+// `label` slot): only the explicit synonyms and examples remain. Undefined when
+// empty.
 function fieldAiContext(
-    synonyms: string[], name: string): AiContext|undefined {
-  const names = nonRedundant(synonyms, name);
-  return names.length ? {synonyms: dedupe(names)} : undefined;
+    synonyms: string[], name: string, examples: string[]): AiContext|undefined {
+  return buildAiContext(undefined, nonRedundant(synonyms, name), examples);
 }
 
 // The ai_context for a RELATIONSHIP. Unlike datasets/fields, the OSI
 // relationship has no `description` slot (see the Apache OSI schema), so an
-// object property's rdfs:comment is carried as ai_context `instructions`, and
-// its non-redundant label/synonyms as `synonyms`. Undefined when both are
-// empty.
+// object property's comment is carried as ai_context `instructions`, and its
+// non-redundant label/synonyms/examples as the remaining fields. Undefined when
+// all are empty.
 function relationshipAiContext(
     label: string|undefined, name: string, synonyms: string[],
-    comment: string|undefined): AiContext|undefined {
+    comment: string|undefined, examples: string[]): AiContext|undefined {
   const names: string[] = [];
   if (label && !isRedundantLabel(label, name)) names.push(label);
   names.push(...nonRedundant(synonyms, name));
+  return buildAiContext(comment, names, examples);
+}
+
+// The ai_context for the MODEL, from the ontology header: labels/synonyms and
+// examples (the description rides in the model `description`, not here).
+function ontologyAiContext(
+    ontology: OwlOntology|undefined, modelName: string): AiContext|undefined {
+  if (!ontology) return undefined;
+  return buildAiContext(
+      undefined, nonRedundant(ontology.synonyms, modelName), ontology.examples);
+}
+
+// Assembles an AiContext from its parts, deduping names/examples and dropping
+// empties, and returns undefined when nothing is left -- the single place the
+// {instructions, synonyms, examples} shape is built.
+function buildAiContext(
+    instructions: string|undefined, synonyms: string[],
+    examples: string[]): AiContext|undefined {
   const ai: AiContext = {};
-  if (comment) ai.instructions = comment;
-  if (names.length) ai.synonyms = dedupe(names);
-  return ai.instructions || ai.synonyms ? ai : undefined;
+  if (instructions) ai.instructions = instructions;
+  if (synonyms.length) ai.synonyms = dedupe(synonyms);
+  if (examples.length) ai.examples = dedupe(examples);
+  return ai.instructions || ai.synonyms || ai.examples ? ai : undefined;
 }
 
 function dedupe(items: string[]): string[] {
   return [...new Set(items)];
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
 }
 
 // --- Mapping. ---------------------------------------------------------------
@@ -182,16 +252,17 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
   for (const c of owl.classes) {
     if (entitiesByName.has(c.localName)) {
       warnings.push(
-          `class '${c.localName}' is declared more than once (same local name, ` +
+          `class '${
+              c.localName}' is declared more than once (same local name, ` +
           `possibly across namespaces); keeping the first and skipping the rest.`);
       continue;
     }
     const entity: Entity = {
       name: c.localName,
       dataSource: unboundSource(c.localName),
-      keys: [],
+      keys: dedupe(c.keys),  // owl:hasKey -> primary_key (grain)
       description: c.comment,
-      aiContext: synonymAiContext(c.label, c.localName, c.synonyms),
+      aiContext: synonymAiContext(c.label, c.localName, c.synonyms, c.examples),
       fields: [],
     };
     // rdfs:subClassOf -> entity-level `extends`. Recorded AS DECLARED (parent
@@ -208,7 +279,8 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       if (unknown.length) {
         warnings.push(
             `class '${c.localName}' declares rdfs:subClassOf a non-class ` +
-            `superclass (${unknown.join(', ')}); the extends link is recorded ` +
+            `superclass (${
+                unknown.join(', ')}); the extends link is recorded ` +
             `as declared but cannot be resolved (not an owl:Class in this ` +
             `ontology).`);
       }
@@ -217,52 +289,66 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     entities.push(entity);
   }
 
-  // Datatype properties -> fields on their domain's entity.
+  // Datatype properties -> fields on each domain's entity. A property with more
+  // than one domain appears on each; one with none has nowhere to live.
   for (const p of owl.datatypeProperties) {
-    if (!p.domain) {
+    if (!p.domains.length) {
       warnings.push(
           `datatype property '${p.localName}' has no rdfs:domain; skipped ` +
           `(a field must belong to a class).`);
       continue;
     }
-    const entity = entitiesByName.get(p.domain);
-    if (!entity) {
-      warnings.push(
-          `datatype property '${p.localName}' has domain '${p.domain}', ` +
-          `which is not an owl:Class in this ontology; skipped.`);
-      continue;
-    }
-    if (entity.fields.some(f => f.name === p.localName)) {
-      warnings.push(
-          `datatype property '${p.localName}' on '${p.domain}' duplicates an ` +
-          `existing field name; skipped (field names must be unique).`);
-      continue;
-    }
     if (p.subPropertyOf.length) {
       // Property inheritance is not supported (only entity-level
-      // rdfs:subClassOf -> extends). The field is still imported; only the
-      // subPropertyOf link is dropped.
+      // rdfs:subClassOf -> extends). The field is still imported on each
+      // domain; only the subPropertyOf link is dropped.
       warnings.push(
           `datatype property '${p.localName}' declares rdfs:subPropertyOf ` +
           `(${p.subPropertyOf.join(', ')}); property inheritance is not ` +
           `supported, so the subPropertyOf link is dropped (the field itself ` +
           `is still imported).`);
     }
-    const field: Field = {
-      name: p.localName,
-      // The property's local name is a valid column reference once the entity
-      // is bound to a real table; it is the default binding target.
-      expression: p.localName,
-      type: datatypeFor(p.rangeIri),
-      label: fieldLabel(p.label, p.localName),
-      description: p.comment,
-      aiContext: fieldAiContext(p.synonyms, p.localName),
-    };
-    entity.fields.push(field);
+    for (const domain of p.domains) {
+      const entity = entitiesByName.get(domain);
+      if (!entity) {
+        warnings.push(
+            `datatype property '${p.localName}' has domain '${domain}', ` +
+            `which is not an owl:Class in this ontology; skipped.`);
+        continue;
+      }
+      if (entity.fields.some(f => f.name === p.localName)) {
+        warnings.push(
+            `datatype property '${p.localName}' on '${domain}' duplicates an ` +
+            `existing field name; skipped (field names must be unique).`);
+        continue;
+      }
+      const type = datatypeFor(p.rangeIri);
+      const field: Field = {
+        name: p.localName,
+        // The property's local name is a valid column reference once the entity
+        // is bound to a real table; it is the default binding target.
+        expression: p.localName,
+        type,
+        // A temporal field is a time dimension by OSI's own rule; mark it so
+        // downstream (BigQuery Graph, BI) treats it as one.
+        dimension: TEMPORAL_TYPES.has(type) ? {isTime: true} : undefined,
+        label: fieldLabel(p.label, p.localName),
+        description: p.comment,
+        aiContext: fieldAiContext(p.synonyms, p.localName, p.examples),
+      };
+      entity.fields.push(field);
+      // An inverse-functional property uniquely identifies its subject -> a
+      // unique_keys constraint, unless it is already the primary key.
+      if (p.inverseFunctional && !arraysEqual(entity.keys, [p.localName])) {
+        (entity.uniqueKeys ??= []).push([p.localName]);
+      }
+    }
   }
 
   // Object properties -> relationships (edges). Both endpoints must be known
-  // classes; the join columns are unbound placeholders.
+  // classes. When the destination class declares a key, the edge's destination
+  // columns bind to it and only the source foreign-key columns stay unbound;
+  // otherwise both ends are placeholders.
   const relationships: Relationship[] = [];
   for (const p of owl.objectProperties) {
     if (!p.domain || !p.range) {
@@ -279,7 +365,8 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     }
     if (relationships.some(r => r.name === p.localName)) {
       warnings.push(
-          `object property '${p.localName}' duplicates an existing relationship ` +
+          `object property '${
+              p.localName}' duplicates an existing relationship ` +
           `name; skipped (relationship names must be unique).`);
       continue;
     }
@@ -293,28 +380,48 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `supported, so the subPropertyOf link is dropped (the relationship ` +
           `itself is still imported).`);
     }
+    const destKeys = entitiesByName.get(p.range)?.keys ?? [];
+    const bound = destKeys.length > 0;
     relationships.push({
       name: p.localName,
-      source: {entity: p.domain, columns: [TODO_BIND]},
-      destination: {entity: p.range, columns: [TODO_BIND]},
+      // Source FK columns are unknown until binding; keep the count aligned
+      // with the destination key so the positional join is well-formed.
+      source: {
+        entity: p.domain,
+        columns: bound ? destKeys.map(() => TODO_BIND) : [TODO_BIND],
+      },
+      destination: {
+        // Copy the key so the destination columns render inline rather than as
+        // a YAML alias of the entity's primary_key (same array object).
+        entity: p.range,
+        columns: bound ? [...destKeys] : [TODO_BIND],
+      },
       // No `description`: the OSI relationship has no such slot, so the comment
       // rides in ai_context.instructions (see relationshipAiContext).
-      aiContext:
-          relationshipAiContext(p.label, p.localName, p.synonyms, p.comment),
+      aiContext: relationshipAiContext(
+          p.label, p.localName, p.synonyms, p.comment, p.examples),
     });
   }
 
-  const description = owl.baseIri ?
-      `Imported from OWL ontology ${owl.baseIri}` :
-      'Imported from OWL ontology';
-
   const model: SemanticModel = {
     name: modelName,
-    description,
+    description: modelDescription(owl),
+    aiContext: ontologyAiContext(owl.ontology, modelName),
     entities,
     relationships,
     metrics: [],
   };
 
   return {model, warnings};
+}
+
+// The model description: the ontology header's own description when it has one,
+// otherwise a provenance line naming the source base IRI. An owl:versionInfo is
+// appended as provenance in either case.
+function modelDescription(owl: OwlModel): string {
+  const base = owl.ontology?.comment ??
+      (owl.baseIri ? `Imported from OWL ontology ${owl.baseIri}` :
+                     'Imported from OWL ontology');
+  const version = owl.ontology?.version;
+  return version ? `${base} (ontology version ${version})` : base;
 }

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -362,9 +362,10 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
   // per-element policy:
   //   1. owl:hasKey may name a property that is not a datatype property on the
   //      class (undeclared, or declared only on a different domain). That
-  //      column has no field, so leaving it in primary_key would name a phantom
-  //      column that only errors later at graph generation -- drop it with a
-  //      warning.
+  //      column has no field, so it would name a phantom column that only
+  //      errors later at graph generation. Drop the ENTIRE primary_key, not
+  //      just the phantom member -- keeping the survivors would silently narrow
+  //      a composite key to a possibly non-unique one, changing the grain.
   //   2. A class with no usable owl:hasKey but exactly one single-column
   //      inverse-functional property still has a natural identifier; promote
   //      that unique key to the primary_key so the entity is valid for graph
@@ -378,15 +379,16 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `class '${entity.name}' owl:hasKey names ${
               missing.map(m => `'${m}'`).join(', ')} which ${
               missing.length > 1 ? 'are' : 'is'} not a datatype property on ` +
-          `the class; dropped from primary_key.`);
-      entity.keys = entity.keys.filter(k => fieldNames.has(k));
+          `the class; dropping the entire primary_key (keeping only the ` +
+          `remaining columns would change the entity's grain).`);
+      entity.keys = [];
     }
     if (!entity.keys.length && entity.uniqueKeys?.length === 1 &&
         entity.uniqueKeys[0].length === 1) {
       entity.keys = [...entity.uniqueKeys[0]];
       entity.uniqueKeys = undefined;
       warnings.push(
-          `class '${entity.name}' declares no owl:hasKey; using the ` +
+          `class '${entity.name}' has no usable owl:hasKey; using the ` +
           `inverse-functional property '${
               entity.keys[0]}' as its primary_key.`);
     }
@@ -398,16 +400,33 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
   // otherwise both ends are placeholders.
   const relationships: Relationship[] = [];
   for (const p of owl.objectProperties) {
-    if (!p.domain || !p.range) {
+    const domain = p.domains[0];
+    const range = p.ranges[0];
+    if (!domain || !range) {
       warnings.push(
           `object property '${p.localName}' is missing an rdfs:domain or ` +
           `rdfs:range; skipped (a relationship needs both endpoints).`);
       continue;
     }
-    if (!classNames.has(p.domain) || !classNames.has(p.range)) {
+    // A relationship maps ONE source to ONE destination. Multiple domains or
+    // ranges mean an intersection in OWL, which has no clean single-edge shape,
+    // so keep the first of each and say what was dropped rather than losing it
+    // silently.
+    const ignored = [
+      ...p.domains.slice(1).map(d => `domain '${d}'`),
+      ...p.ranges.slice(1).map(r => `range '${r}'`),
+    ];
+    if (ignored.length) {
+      warnings.push(
+          `object property '${p.localName}' declares more than one endpoint ` +
+          `(${ignored.join(', ')}); a relationship maps one source to one ` +
+          `destination, so only domain '${domain}' -> range '${
+              range}' is kept.`);
+    }
+    if (!classNames.has(domain) || !classNames.has(range)) {
       warnings.push(
           `object property '${p.localName}' references a non-class endpoint ` +
-          `(domain '${p.domain}', range '${p.range}'); skipped.`);
+          `(domain '${domain}', range '${range}'); skipped.`);
       continue;
     }
     if (relationships.some(r => r.name === p.localName)) {
@@ -427,20 +446,20 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `supported, so the subPropertyOf link is dropped (the relationship ` +
           `itself is still imported).`);
     }
-    const destKeys = entitiesByName.get(p.range)?.keys ?? [];
+    const destKeys = entitiesByName.get(range)?.keys ?? [];
     const bound = destKeys.length > 0;
     relationships.push({
       name: p.localName,
       // Source FK columns are unknown until binding; keep the count aligned
       // with the destination key so the positional join is well-formed.
       source: {
-        entity: p.domain,
+        entity: domain,
         columns: bound ? destKeys.map(() => TODO_BIND) : [TODO_BIND],
       },
       destination: {
         // Copy the key so the destination columns render inline rather than as
         // a YAML alias of the entity's primary_key (same array object).
-        entity: p.range,
+        entity: range,
         columns: bound ? [...destKeys] : [TODO_BIND],
       },
       // No `description`: the OSI relationship has no such slot, so the comment

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -4,16 +4,16 @@
 // mechanical; every decision about how an ontology becomes a semantic model
 // lives here, in one place, so the mapping is easy to read and to evolve.
 //
-// The mapping (see the user guide's table):
-//   owl:Class                     -> dataset (entity), unbound source
-//   placeholder owl:DatatypeProperty          -> field on each domain class's
-//   dataset owl:ObjectProperty            -> relationship (edge) between domain
-//   and range rdfs:range xsd:*              -> field datatype (see
-//   XSD_DATATYPES; else Opaque) owl:hasKey                    -> dataset
-//   primary_key owl:InverseFunctionalProperty -> dataset unique_keys rdfs:label
-//   -> field label, or a synonym where there is no
-//                                    label slot (classes/relationships)
-//   rdfs:comment / skos:definition / dcterms:/dc:description -> description
+// The mapping (see the user guide's table). Each line is one construct, kept
+// short so a comment reflow cannot run the columns together:
+//   owl:Class                     -> dataset (entity) + unbound source
+//   owl:DatatypeProperty          -> field on each domain class's dataset
+//   owl:ObjectProperty            -> relationship (edge), domain -> range
+//   rdfs:range xsd:*              -> field datatype (see XSD_DATATYPES)
+//   owl:hasKey                    -> dataset primary_key
+//   owl:InverseFunctionalProperty -> dataset unique_keys (or primary_key)
+//   rdfs:label                    -> field label / synonym (no label slot)
+//   rdfs:comment/skos:definition/dcterms:/dc: -> description
 //   skos:example                  -> ai_context.examples
 //   owl:Ontology header           -> model description / ai_context
 //
@@ -35,6 +35,12 @@ export interface ToIrResult {
   // property with no domain). The caller prints these; they do not fail the
   // conversion.
   warnings: string[];
+  // Counts of what was actually converted (not the source-triple counts): a
+  // skipped class/property is excluded, and a multi-domain datatype property
+  // still counts once. The CLI reports these, so "converted N ..." is honest
+  // even when some elements were warned and skipped.
+  stats:
+      {classes: number; datatypeProperties: number; objectProperties: number};
 }
 
 // --- Seams: the isolated change-points for later work. ----------------------
@@ -291,6 +297,7 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
 
   // Datatype properties -> fields on each domain's entity. A property with more
   // than one domain appears on each; one with none has nowhere to live.
+  let datatypePropertiesConverted = 0;
   for (const p of owl.datatypeProperties) {
     if (!p.domains.length) {
       warnings.push(
@@ -308,6 +315,9 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `supported, so the subPropertyOf link is dropped (the field itself ` +
           `is still imported).`);
     }
+    // A property counts as converted once if it produces at least one field,
+    // regardless of how many domains it lands on.
+    let produced = false;
     for (const domain of p.domains) {
       const entity = entitiesByName.get(domain);
       if (!entity) {
@@ -337,11 +347,48 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
         aiContext: fieldAiContext(p.synonyms, p.localName, p.examples),
       };
       entity.fields.push(field);
+      produced = true;
       // An inverse-functional property uniquely identifies its subject -> a
       // unique_keys constraint, unless it is already the primary key.
       if (p.inverseFunctional && !arraysEqual(entity.keys, [p.localName])) {
         (entity.uniqueKeys ??= []).push([p.localName]);
       }
+    }
+    if (produced) datatypePropertiesConverted++;
+  }
+
+  // Reconcile each entity's keys with the fields that actually exist. Both
+  // corrections are fail-soft (warn, never throw), matching the converter's
+  // per-element policy:
+  //   1. owl:hasKey may name a property that is not a datatype property on the
+  //      class (undeclared, or declared only on a different domain). That
+  //      column has no field, so leaving it in primary_key would name a phantom
+  //      column that only errors later at graph generation -- drop it with a
+  //      warning.
+  //   2. A class with no usable owl:hasKey but exactly one single-column
+  //      inverse-functional property still has a natural identifier; promote
+  //      that unique key to the primary_key so the entity is valid for graph
+  //      generation rather than keyless. (Ambiguous cases -- several unique
+  //      keys, or a composite one -- are left alone.)
+  for (const entity of entities) {
+    const fieldNames = new Set(entity.fields.map(f => f.name));
+    const missing = entity.keys.filter(k => !fieldNames.has(k));
+    if (missing.length) {
+      warnings.push(
+          `class '${entity.name}' owl:hasKey names ${
+              missing.map(m => `'${m}'`).join(', ')} which ${
+              missing.length > 1 ? 'are' : 'is'} not a datatype property on ` +
+          `the class; dropped from primary_key.`);
+      entity.keys = entity.keys.filter(k => fieldNames.has(k));
+    }
+    if (!entity.keys.length && entity.uniqueKeys?.length === 1 &&
+        entity.uniqueKeys[0].length === 1) {
+      entity.keys = [...entity.uniqueKeys[0]];
+      entity.uniqueKeys = undefined;
+      warnings.push(
+          `class '${entity.name}' declares no owl:hasKey; using the ` +
+          `inverse-functional property '${
+              entity.keys[0]}' as its primary_key.`);
     }
   }
 
@@ -412,7 +459,15 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     metrics: [],
   };
 
-  return {model, warnings};
+  return {
+    model,
+    warnings,
+    stats: {
+      classes: entities.length,
+      datatypeProperties: datatypePropertiesConverted,
+      objectProperties: relationships.length,
+    },
+  };
 }
 
 // The model description: the ontology header's own description when it has one,

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -581,21 +581,23 @@ export async function owl(
   }
 
   const { classes, datatypeProperties, objectProperties } = result.stats;
+
+  // Guard: an ontology with no owl:Class yields a model with no datasets, which
+  // is not a loadable OSI model. Fail clearly -- before the summary, so we do
+  // not print a "converted 0 classes" line for a model we are about to reject --
+  // rather than writing an empty artifact that only errors on a later push/pull.
+  if (classes === 0) {
+    console.error(
+      `Error: no owl:Class declarations found in '${file}'; nothing to import.`);
+    return 1;
+  }
+
   console.log(
     `converted ${classes} ${plural(classes, 'class', 'classes')}, `
     + `${objectProperties} `
     + `${plural(objectProperties, 'object property', 'object properties')}, `
     + `${datatypeProperties} `
     + `${plural(datatypeProperties, 'datatype property', 'datatype properties')}`);
-
-  // Guard: an ontology with no owl:Class yields a model with no datasets, which
-  // is not a loadable OSI model. Fail clearly rather than writing an empty
-  // artifact that only errors on a later push/pull.
-  if (classes === 0) {
-    console.error(
-      `Error: no owl:Class declarations found in '${file}'; nothing to import.`);
-    return 1;
-  }
 
   // Sink: an explicit --out path writes directly; otherwise the semantic-model
   // layout places the document under the scope's entry group so `kcmd push`

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.osi.golden.yaml
@@ -1,16 +1,26 @@
 version: 0.2.0.dev0
 semantic_model:
   - name: org
-    description: Imported from OWL ontology http://example.com/org#
+    description: "An org chart: employees, the departments they work in, and the
+      projects they staff."
     datasets:
       - name: Employee
         source: unbound:Employee
+        primary_key:
+          - employeeId
         description: A person employed by the organization.
         ai_context:
           synonyms:
             - Staff member
             - Worker
         fields:
+          - name: employeeId
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: employeeId
+            datatype: String
+            description: The employee's unique staff number.
           - name: fullName
             expression:
               dialects:
@@ -24,31 +34,63 @@ semantic_model:
                 - dialect: BIGQUERY
                   expression: hireDate
             datatype: Date
+            dimension:
+              is_time: true
           - name: salary
             expression:
               dialects:
                 - dialect: BIGQUERY
                   expression: salary
             datatype: Decimal
-          - name: employeeId
+          - name: fteRatio
             expression:
               dialects:
                 - dialect: BIGQUERY
-                  expression: employeeId
-            datatype: Opaque
-          - name: isActive
+                  expression: fteRatio
+            datatype: Float
+          - name: level
             expression:
               dialects:
                 - dialect: BIGQUERY
-                  expression: isActive
-            datatype: Opaque
+                  expression: level
+            datatype: Integer
+          - name: isManager
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: isManager
+            datatype: Boolean
+          - name: lastLogin
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: lastLogin
+            datatype: DateTime
+            dimension:
+              is_time: true
+          - name: startDate
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: startDate
+            datatype: Date
+            dimension:
+              is_time: true
       - name: Department
         source: unbound:Department
+        primary_key:
+          - deptCode
         description: A functional unit that employees belong to.
         ai_context:
           synonyms:
             - Org unit
         fields:
+          - name: deptCode
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: deptCode
+            datatype: String
           - name: budget
             expression:
               dialects:
@@ -57,19 +99,31 @@ semantic_model:
             datatype: Decimal
       - name: Project
         source: unbound:Project
+        primary_key:
+          - portfolio
+          - projectNo
+        description: A body of work staffed by employees.
         fields:
+          - name: portfolio
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: portfolio
+            datatype: String
+          - name: projectNo
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: projectNo
+            datatype: Integer
           - name: startDate
             expression:
               dialects:
                 - dialect: BIGQUERY
                   expression: startDate
             datatype: Date
-          - name: code
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: code
-            datatype: String
+            dimension:
+              is_time: true
           - name: notes
             expression:
               dialects:
@@ -83,7 +137,7 @@ semantic_model:
         from_columns:
           - TODO_BIND
         to_columns:
-          - TODO_BIND
+          - deptCode
         ai_context:
           instructions: The department an employee belongs to.
           synonyms:
@@ -94,7 +148,7 @@ semantic_model:
         from_columns:
           - TODO_BIND
         to_columns:
-          - TODO_BIND
+          - employeeId
         ai_context:
           instructions: The manager an employee reports to.
       - name: worksOn
@@ -102,5 +156,7 @@ semantic_model:
         to: Project
         from_columns:
           - TODO_BIND
-        to_columns:
           - TODO_BIND
+        to_columns:
+          - portfolio
+          - projectNo

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.owl.ttl
@@ -1,16 +1,15 @@
-# A broader ontology than sales.owl.ttl, exercising the full range of OWL
-# constructs the converter maps today (see the user guide's mapping table):
-#   - a class whose label is redundant with its name (dropped), one whose label
-#     is a genuine alternate name (-> synonym), and a bare class with no
-#     annotations at all;
-#   - skos:altLabel / skos:prefLabel and extra labels collected as synonyms;
-#   - every mapped xsd datatype (string/date/decimal) plus ranges outside the
-#     mapped set (xsd:integer, xsd:boolean) and a property with no range at all,
-#     all of which fall back to Opaque;
-#   - a field label that adds a name (kept) vs. one that only recases (dropped);
-#   - multiple object properties, including a self-referential one, with
-#     comments (-> ai_context.instructions) and synonyms.
-# Everything here maps cleanly to native OSI (no warnings) and stays UNBOUND.
+# A stress fixture for the OWL -> OSI converter, broader than the guide's
+# sales.owl.ttl. It concentrates the cases the tutorial does not:
+#   - the full mapped xsd datatype range (String / Integer / Decimal / Float /
+#     Boolean / Date / DateTime), plus a range outside the set (-> Opaque);
+#   - a single key, a composite key, and an inverse-functional key that IS the
+#     primary key (so it is NOT also emitted as a unique_keys constraint);
+#   - a multi-domain datatype property (one field replicated onto two entities);
+#   - a self-referential edge and an edge into a composite-key class (so the
+#     destination binds to two columns);
+#   - redundant vs. genuine labels, skos synonyms, and comments.
+# Everything here maps cleanly to native OSI (no warnings) and stays UNBOUND
+# except where a declared key binds an edge's destination columns.
 
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -18,59 +17,81 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix ex:   <http://example.com/org#> .
 
-# Redundant label ("Employee" == name) dropped; comment + skos synonyms kept.
+<http://example.com/org> a owl:Ontology ;
+    rdfs:comment "An org chart: employees, the departments they work in, and the projects they staff." .
+
+# Redundant label ("Employee" == name) is not present; skos synonyms kept.
+# employeeId is both the key and inverse-functional -> primary_key only.
 ex:Employee a owl:Class ;
-    rdfs:label    "Employee" ;
     rdfs:comment  "A person employed by the organization." ;
     skos:altLabel "Staff member" ;
-    skos:prefLabel "Worker" .
+    skos:prefLabel "Worker" ;
+    owl:hasKey ( ex:employeeId ) .
 
-# Non-redundant label -> synonym; comment -> description.
+# Non-redundant label -> synonym; single key.
 ex:Department a owl:Class ;
     rdfs:label   "Org unit" ;
-    rdfs:comment "A functional unit that employees belong to." .
+    rdfs:comment "A functional unit that employees belong to." ;
+    owl:hasKey ( ex:deptCode ) .
 
-# Bare class: no annotations at all.
-ex:Project a owl:Class .
+# Composite key: a project is identified by (portfolio, projectNo).
+ex:Project a owl:Class ;
+    rdfs:comment "A body of work staffed by employees." ;
+    owl:hasKey ( ex:portfolio ex:projectNo ) .
 
-# The three mapped xsd types; "name" adds a display name over the field name.
+# --- Employee datatype properties: the mapped xsd range. ---
+ex:employeeId a owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:string ;
+    rdfs:comment "The employee's unique staff number." .
 ex:fullName a owl:DatatypeProperty ;
     rdfs:domain ex:Employee ; rdfs:range xsd:string ; rdfs:label "name" .
 ex:hireDate a owl:DatatypeProperty ;
     rdfs:domain ex:Employee ; rdfs:range xsd:date .
 ex:salary a owl:DatatypeProperty ;
     rdfs:domain ex:Employee ; rdfs:range xsd:decimal .
-# Outside today's mapped set -> Opaque.
-ex:employeeId a owl:DatatypeProperty ;
+ex:fteRatio a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:double .
+ex:level a owl:DatatypeProperty ;
     rdfs:domain ex:Employee ; rdfs:range xsd:integer .
-ex:isActive a owl:DatatypeProperty ;
+ex:isManager a owl:DatatypeProperty ;
     rdfs:domain ex:Employee ; rdfs:range xsd:boolean .
+ex:lastLogin a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:dateTime .
 
+# --- Department + Project fields (the key columns). ---
+ex:deptCode a owl:DatatypeProperty ;
+    rdfs:domain ex:Department ; rdfs:range xsd:string .
 ex:budget a owl:DatatypeProperty ;
     rdfs:domain ex:Department ; rdfs:range xsd:decimal .
+ex:portfolio a owl:DatatypeProperty ;
+    rdfs:domain ex:Project ; rdfs:range xsd:string .
+ex:projectNo a owl:DatatypeProperty ;
+    rdfs:domain ex:Project ; rdfs:range xsd:integer .
 
+# Multi-domain property: both employees and projects have a startDate, so the
+# field is added to each entity.
 ex:startDate a owl:DatatypeProperty ;
-    rdfs:domain ex:Project ; rdfs:range xsd:date .
-# Label "code" only recases the field name -> dropped.
-ex:code a owl:DatatypeProperty ;
-    rdfs:domain ex:Project ; rdfs:range xsd:string ; rdfs:label "code" .
-# No range declared -> Opaque.
-ex:notes a owl:DatatypeProperty ;
-    rdfs:domain ex:Project .
+    rdfs:domain ex:Employee ; rdfs:domain ex:Project ; rdfs:range xsd:date .
 
-# Relationship with a redundant label (dropped), a skos synonym (kept), and a
-# comment (-> ai_context.instructions).
+# A range outside the mapped set -> Opaque.
+ex:notes a owl:DatatypeProperty ;
+    rdfs:domain ex:Project ; rdfs:range xsd:anySimpleType .
+
+# --- Object properties. ---
+# Redundant edge label dropped, skos synonym kept, comment -> instructions.
+# Destination (Department) has a key -> the edge's `to` columns bind to it.
 ex:worksIn a owl:ObjectProperty ;
     rdfs:domain ex:Employee ; rdfs:range ex:Department ;
     rdfs:label    "works in" ;
     skos:altLabel "member of" ;
     rdfs:comment  "The department an employee belongs to." .
 
-# Self-referential relationship: Employee -> Employee.
+# Self-referential edge into a single-key class.
 ex:reportsTo a owl:ObjectProperty ;
     rdfs:domain ex:Employee ; rdfs:range ex:Employee ;
     rdfs:comment "The manager an employee reports to." .
 
+# Edge into a composite-key class: `to` binds to (portfolio, projectNo).
 ex:worksOn a owl:ObjectProperty ;
     rdfs:domain ex:Employee ; rdfs:range ex:Project ;
     rdfs:label "works on" .

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.osi.golden.yaml
@@ -1,12 +1,38 @@
 version: 0.2.0.dev0
 semantic_model:
   - name: sales
-    description: Imported from OWL ontology http://example.com/sales#
+    description: "A minimal sales domain: customers and the orders they place.
+      (ontology version 1.0)"
+    ai_context:
+      synonyms:
+        - Sales domain
+      examples:
+        - How many orders did each customer place last month?
     datasets:
       - name: Customer
         source: unbound:Customer
+        primary_key:
+          - customerId
+        unique_keys:
+          - - email
         description: A person or organization that places orders.
+        ai_context:
+          synonyms:
+            - Buyer
         fields:
+          - name: customerId
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: customerId
+            datatype: String
+          - name: email
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: email
+            datatype: String
+            description: The customer's unique email address.
           - name: customerName
             expression:
               dialects:
@@ -20,22 +46,50 @@ semantic_model:
                 - dialect: BIGQUERY
                   expression: signupDate
             datatype: Date
+            dimension:
+              is_time: true
+          - name: isVip
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: isVip
+            datatype: Boolean
+            description: Whether the customer is in the loyalty program.
       - name: Order
         source: unbound:Order
+        primary_key:
+          - orderId
         description: A purchase placed by a customer.
         fields:
+          - name: orderId
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: orderId
+            datatype: String
           - name: orderAmount
             expression:
               dialects:
                 - dialect: BIGQUERY
                   expression: orderAmount
             datatype: Decimal
+            ai_context:
+              examples:
+                - "19.99"
+          - name: quantity
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: quantity
+            datatype: Integer
           - name: orderDate
             expression:
               dialects:
                 - dialect: BIGQUERY
                   expression: orderDate
             datatype: Date
+            dimension:
+              is_time: true
     relationships:
       - name: placedBy
         from: Order
@@ -43,6 +97,6 @@ semantic_model:
         from_columns:
           - TODO_BIND
         to_columns:
-          - TODO_BIND
+          - customerId
         ai_context:
           instructions: Links an order to the customer who placed it.

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.owl.ttl
@@ -1,28 +1,65 @@
+# The user guide's "Importing an OWL ontology" walkthrough. A small sales
+# ontology that exercises the constructs the converter maps to native OSI:
+#   - an owl:Ontology header (-> model description / version / ai_context);
+#   - classes with an owl:hasKey (-> primary_key) and skos synonyms;
+#   - an owl:InverseFunctionalProperty (-> a unique_keys constraint);
+#   - datatype properties across several xsd ranges (String / Date / Decimal /
+#     Boolean / Integer), with a temporal field marked as a time dimension;
+#   - a skos:example (-> ai_context.examples);
+#   - an object property whose destination has a key (-> a half-bound edge).
+# Nothing here needs an OWL reasoner.
+
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix ex:   <http://example.com/sales#> .
 
+<http://example.com/sales> a owl:Ontology ;
+    rdfs:label      "Sales domain" ;
+    rdfs:comment    "A minimal sales domain: customers and the orders they place." ;
+    skos:example    "How many orders did each customer place last month?" ;
+    owl:versionInfo "1.0" .
+
 ex:Customer a owl:Class ;
-    rdfs:label   "Customer" ;
-    rdfs:comment "A person or organization that places orders." .
+    rdfs:label    "Customer" ;
+    rdfs:comment  "A person or organization that places orders." ;
+    skos:altLabel "Buyer" ;
+    owl:hasKey ( ex:customerId ) .
 
 ex:Order a owl:Class ;
     rdfs:label   "Order" ;
-    rdfs:comment "A purchase placed by a customer." .
+    rdfs:comment "A purchase placed by a customer." ;
+    owl:hasKey ( ex:orderId ) .
 
+# Customer fields. customerId is the key; email uniquely identifies a customer
+# (inverse-functional) so it becomes a unique_keys constraint.
+ex:customerId a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:string .
+ex:email a owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:string ;
+    rdfs:comment "The customer's unique email address." .
 ex:customerName a owl:DatatypeProperty ;
     rdfs:domain ex:Customer ; rdfs:range xsd:string ; rdfs:label "name" .
-
 ex:signupDate a owl:DatatypeProperty ;
     rdfs:domain ex:Customer ; rdfs:range xsd:date .
+ex:isVip a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:boolean ;
+    rdfs:comment "Whether the customer is in the loyalty program." .
 
+# Order fields.
+ex:orderId a owl:DatatypeProperty ;
+    rdfs:domain ex:Order ; rdfs:range xsd:string .
 ex:orderAmount a owl:DatatypeProperty ;
-    rdfs:domain ex:Order ; rdfs:range xsd:decimal .
-
+    rdfs:domain ex:Order ; rdfs:range xsd:decimal ;
+    skos:example "19.99" .
+ex:quantity a owl:DatatypeProperty ;
+    rdfs:domain ex:Order ; rdfs:range xsd:integer .
 ex:orderDate a owl:DatatypeProperty ;
     rdfs:domain ex:Order ; rdfs:range xsd:date .
 
+# Order -> Customer. Customer has a key, so the edge's destination binds to it
+# and only the source foreign-key column stays a placeholder.
 ex:placedBy a owl:ObjectProperty ;
     rdfs:domain  ex:Order ; rdfs:range ex:Customer ;
     rdfs:label   "placed by" ;

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -7,7 +7,7 @@
 //   1. the sales example produces exactly the documented OSI (golden), and
 //   2. that OSI loads through the OSI loader (the UNBOUND placeholders satisfy
 //      the schema, so `kcmd push --target kc` works on the result), and
-//   3. each row of the mapping table behaves as documented.
+//   3. each mapped construct behaves as documented.
 // The scope is exactly the user guide; richer OWL is out of scope by design.
 
 import {describe, expect, test} from 'bun:test';
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 
 import {convertOwlToOsi} from '../../../src/libts/semantic/converters/owl/convert';
 import {googleOntologyExtension} from '../../../src/libts/semantic/converters/owl/to_ir';
+import {isTimeDimension} from '../../../src/libts/semantic/ir';
 import {loadModels} from '../../../src/libts/semantic/loader';
 
 const FIXTURES = path.join(__dirname, 'fixtures', 'owl');
@@ -24,40 +25,72 @@ function readFixture(name: string): string {
   return fs.readFileSync(path.join(FIXTURES, name), 'utf8');
 }
 
+// Converts an inline ontology and loads the result, the common path for the
+// focused rule tests below.
+function loadOwl(ttl: string) {
+  return loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+}
+
+const PREFIXES = `
+  @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+  @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+  @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+  @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+  @prefix dct:  <http://purl.org/dc/terms/> .
+  @prefix ex:   <http://example.com/x#> .
+`;
+
 
 describe('sales ontology matches the user-guide CUJ', () => {
   const ttl = readFixture('sales.owl.ttl');
 
   test('produces exactly the documented OSI (golden)', () => {
     const {yaml} = convertOwlToOsi(ttl, 'sales');
-    const golden = readFixture('sales.osi.golden.yaml');
-    expect(yaml).toEqual(golden);
+    expect(yaml).toEqual(readFixture('sales.osi.golden.yaml'));
   });
 
   test('reports the documented conversion counts', () => {
     const {stats, warnings} = convertOwlToOsi(ttl, 'sales');
     expect(stats).toEqual(
-        {classes: 2, datatypeProperties: 4, objectProperties: 1});
-    // The minimal example maps entirely to native OSI, so nothing is dropped.
+        {classes: 2, datatypeProperties: 9, objectProperties: 1});
+    // Every construct in the walkthrough maps to native OSI, so nothing is
+    // dropped.
     expect(warnings).toEqual([]);
   });
 
-  test(
-      'the generated OSI loads (UNBOUND placeholders are schema-valid)', () => {
-        const {yaml} = convertOwlToOsi(ttl, 'sales');
-        // loadModels throws on a schema violation; a clean return proves the
-        // model is loadable and thus KC-pushable as-is.
-        const loaded = loadModels(yaml);
-        expect(loaded.models).toHaveLength(1);
-        const model = loaded.models[0];
-        expect(model.name).toBe('sales');
-        expect(model.entities.map(e => e.name)).toEqual(['Customer', 'Order']);
-        expect(model.relationships.map(r => r.name)).toEqual(['placedBy']);
-      });
+  test('the generated OSI loads and carries the guide highlights', () => {
+    const {yaml} = convertOwlToOsi(ttl, 'sales');
+    // loadModels throws on a schema violation; a clean return proves the model
+    // is loadable and thus KC-pushable as-is.
+    const model = loadModels(yaml).models[0];
+    expect(model.name).toBe('sales');
+    expect(model.entities.map(e => e.name)).toEqual(['Customer', 'Order']);
+
+    // Ontology header -> model description (+ version) and ai_context.
+    expect(model.description)
+        .toBe(
+            'A minimal sales domain: customers and the orders they place. ' +
+            '(ontology version 1.0)');
+    expect(model.aiContext?.synonyms).toEqual(['Sales domain']);
+    expect(model.aiContext?.examples).toEqual([
+      'How many orders did each customer place last month?'
+    ]);
+
+    const customer = model.entities[0];
+    // owl:hasKey -> primary_key; inverse-functional email -> unique_keys.
+    expect(customer.keys).toEqual(['customerId']);
+    expect(customer.uniqueKeys).toEqual([['email']]);
+
+    // The edge's destination binds to Customer's key; only the source FK stays
+    // a placeholder.
+    const placedBy = model.relationships.find(r => r.name === 'placedBy')!;
+    expect(placedBy.destination.columns).toEqual(['customerId']);
+    expect(placedBy.source.columns).toEqual(['TODO_BIND']);
+  });
 });
 
 
-describe('org ontology exercises the full range of mapped constructs', () => {
+describe('org ontology exercises datatypes, keys, and binding', () => {
   const ttl = readFixture('org.owl.ttl');
 
   test('produces exactly the documented OSI (golden)', () => {
@@ -66,53 +99,71 @@ describe('org ontology exercises the full range of mapped constructs', () => {
   });
 
   test('maps cleanly with no warnings', () => {
-    // Every construct here is supported, so nothing is dropped.
     expect(convertOwlToOsi(ttl, 'org').warnings).toEqual([]);
   });
 
-  test('the generated OSI loads and covers the mapping table', () => {
+  test('the generated OSI loads and covers the mapping', () => {
     const model = loadModels(convertOwlToOsi(ttl, 'org').yaml).models[0];
-
-    // Classes in declaration order; a bare class carries no metadata.
-    expect(model.entities.map(e => e.name))
-        .toEqual(['Employee', 'Department', 'Project']);
+    expect(model.entities.map(e => e.name)).toEqual([
+      'Employee', 'Department', 'Project'
+    ]);
     const [employee, department, project] = model.entities;
 
-    // Redundant class label dropped; skos alt/pref labels -> synonyms.
+    // skos alt/pref labels -> synonyms; non-redundant class label -> synonym.
     expect(employee.aiContext?.synonyms).toEqual(['Staff member', 'Worker']);
-    // Non-redundant class label -> synonym.
     expect(department.aiContext?.synonyms).toEqual(['Org unit']);
-    // Bare class: no description, no ai_context.
-    expect(project.description).toBeUndefined();
-    expect(project.aiContext).toBeUndefined();
 
-    // Datatypes: the three mapped xsd types, and Opaque for everything else
-    // (xsd:integer, xsd:boolean, and a property with no range).
-    const empTypes = Object.fromEntries(
-        employee.fields.map(f => [f.name, f.type]));
+    // The full mapped xsd datatype range.
+    const empTypes =
+        Object.fromEntries(employee.fields.map(f => [f.name, f.type]));
     expect(empTypes).toEqual({
+      employeeId: 'String',
       fullName: 'String',
       hireDate: 'Date',
       salary: 'Decimal',
-      employeeId: 'Opaque',
-      isActive: 'Opaque',
+      fteRatio: 'Float',
+      level: 'Integer',
+      isManager: 'Boolean',
+      lastLogin: 'DateTime',
+      startDate: 'Date',
     });
+    // A range outside the mapped set falls back to Opaque.
     expect(project.fields.find(f => f.name === 'notes')!.type).toBe('Opaque');
 
-    // Field label kept when it adds a name, dropped when it only recases.
-    expect(employee.fields.find(f => f.name === 'fullName')!.label).toBe('name');
-    expect(project.fields.find(f => f.name === 'code')!.label).toBeUndefined();
+    // Keys: single, and inverse-functional employeeId that IS the key is NOT
+    // also emitted as a unique_keys constraint.
+    expect(employee.keys).toEqual(['employeeId']);
+    expect(employee.uniqueKeys).toBeUndefined();
+    expect(department.keys).toEqual(['deptCode']);
+    // Composite key.
+    expect(project.keys).toEqual(['portfolio', 'projectNo']);
 
-    // Relationships, including a self-referential one; comments -> instructions.
-    const byName = Object.fromEntries(model.relationships.map(r => [r.name, r]));
-    expect(Object.keys(byName)).toEqual(['worksIn', 'reportsTo', 'worksOn']);
-    // Redundant edge label dropped, skos synonym kept, comment -> instructions.
-    expect(byName['worksIn'].aiContext)
-        .toEqual({instructions: 'The department an employee belongs to.',
-                  synonyms: ['member of']});
-    // Self-referential edge: both endpoints are the same entity.
+    // Multi-domain property: startDate is a field on both entities it declares.
+    expect(employee.fields.some(f => f.name === 'startDate')).toBe(true);
+    expect(project.fields.some(f => f.name === 'startDate')).toBe(true);
+
+    // Temporal fields are marked as time dimensions.
+    expect(isTimeDimension(employee.fields.find(f => f.name === 'hireDate')!))
+        .toBe(true);
+    expect(isTimeDimension(employee.fields.find(f => f.name === 'lastLogin')!))
+        .toBe(true);
+    expect(isTimeDimension(employee.fields.find(f => f.name === 'salary')!))
+        .toBe(false);
+
+    // Edges bind their destination columns to the destination's key: single,
+    // self-referential, and composite (two columns, two source placeholders).
+    const byName =
+        Object.fromEntries(model.relationships.map(r => [r.name, r]));
+    expect(byName['worksIn'].destination.columns).toEqual(['deptCode']);
     expect(byName['reportsTo'].source.entity).toBe('Employee');
     expect(byName['reportsTo'].destination.entity).toBe('Employee');
+    expect(byName['reportsTo'].destination.columns).toEqual(['employeeId']);
+    expect(byName['worksOn'].destination.columns).toEqual([
+      'portfolio', 'projectNo'
+    ]);
+    expect(byName['worksOn'].source.columns).toEqual([
+      'TODO_BIND', 'TODO_BIND'
+    ]);
   });
 });
 
@@ -125,22 +176,25 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
     expect(yaml).toEqual(readFixture('hierarchy.osi.golden.yaml'));
   });
 
-  test('the generated OSI reloads through the loader with extends intact', () => {
-    // The point of the golden: `extends` survives import -> serialize -> load.
-    // If the loader schema did not accept `extends`, loadModels would throw or
-    // drop it; a clean reload with the parents present proves the round trip.
-    const {yaml} = convertOwlToOsi(ttl, 'hierarchy');
-    const model = loadModels(yaml).models[0];
-    const byName = Object.fromEntries(model.entities.map(e => [e.name, e]));
-    // Single-parent subclass.
-    expect(byName['Customer'].extends).toEqual(['Person']);
-    // Multi-parent subclass, parents in document order; the blank-node
-    // owl:Restriction superclass is not a named class and is excluded.
-    expect(byName['Manager'].extends).toEqual(['Person', 'Employee']);
-    // A base class with no rdfs:subClassOf carries no `extends`.
-    expect(byName['Person'].extends).toBeUndefined();
-    expect(byName['Employee'].extends).toBeUndefined();
-  });
+  test(
+      'the generated OSI reloads through the loader with extends intact',
+      () => {
+        // The point of the golden: `extends` survives import -> serialize ->
+        // load. If the loader schema did not accept `extends`, loadModels would
+        // throw or drop it; a clean reload with the parents present proves the
+        // round trip.
+        const {yaml} = convertOwlToOsi(ttl, 'hierarchy');
+        const model = loadModels(yaml).models[0];
+        const byName = Object.fromEntries(model.entities.map(e => [e.name, e]));
+        // Single-parent subclass.
+        expect(byName['Customer'].extends).toEqual(['Person']);
+        // Multi-parent subclass, parents in document order; the blank-node
+        // owl:Restriction superclass is not a named class and is excluded.
+        expect(byName['Manager'].extends).toEqual(['Person', 'Employee']);
+        // A base class with no rdfs:subClassOf carries no `extends`.
+        expect(byName['Person'].extends).toBeUndefined();
+        expect(byName['Employee'].extends).toBeUndefined();
+      });
 
   test('inheritance is recorded, not flattened (no fields copied down)', () => {
     // This cut only RECORDS the hierarchy; it does not resolve it. A subclass
@@ -153,30 +207,33 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
     expect(manager.fields).toHaveLength(0);
   });
 
-  test('property inheritance (rdfs:subPropertyOf) is warned and dropped', () => {
-    // Only entity-level inheritance is supported. A datatype/object property's
-    // rdfs:subPropertyOf is dropped with a warning, but the field/relationship
-    // itself is still imported.
-    const {yaml, warnings} = convertOwlToOsi(ttl, 'hierarchy');
-    expect(warnings).toHaveLength(2);
-    expect(warnings.some(
-               w => w.includes('legalName') && w.includes('subPropertyOf')))
-        .toBe(true);
-    expect(warnings.some(
-               w => w.includes('managedBy') && w.includes('subPropertyOf')))
-        .toBe(true);
-    // The field and relationship survive despite the dropped subPropertyOf link.
-    const model = loadModels(yaml).models[0];
-    const employee = model.entities.find(e => e.name === 'Employee')!;
-    expect(employee.fields.some(f => f.name === 'legalName')).toBe(true);
-    expect(model.relationships.some(r => r.name === 'managedBy')).toBe(true);
-  });
+  test(
+      'property inheritance (rdfs:subPropertyOf) is warned and dropped', () => {
+        // Only entity-level inheritance is supported. A datatype/object
+        // property's rdfs:subPropertyOf is dropped with a warning, but the
+        // field/relationship itself is still imported.
+        const {yaml, warnings} = convertOwlToOsi(ttl, 'hierarchy');
+        expect(warnings).toHaveLength(2);
+        expect(warnings.some(
+                   w => w.includes('legalName') && w.includes('subPropertyOf')))
+            .toBe(true);
+        expect(warnings.some(
+                   w => w.includes('managedBy') && w.includes('subPropertyOf')))
+            .toBe(true);
+        // The field and relationship survive despite the dropped subPropertyOf
+        // link.
+        const model = loadModels(yaml).models[0];
+        const employee = model.entities.find(e => e.name === 'Employee')!;
+        expect(employee.fields.some(f => f.name === 'legalName')).toBe(true);
+        expect(model.relationships.some(r => r.name === 'managedBy'))
+            .toBe(true);
+      });
 
   test('an extends parent that is not a class is recorded but warned', () => {
-    // subClassOf a superclass that is not an owl:Class in this ontology (a typo,
-    // or an external superclass) is still recorded as `extends`, but -- like
-    // every other unresolved cross-reference in the converter -- it is warned
-    // about rather than emitted silently.
+    // subClassOf a superclass that is not an owl:Class in this ontology (a
+    // typo, or an external superclass) is still recorded as `extends`, but --
+    // like every other unresolved cross-reference in the converter -- it is
+    // warned about rather than emitted silently.
     const ttl = [
       '@prefix owl:  <http://www.w3.org/2002/07/owl#> .',
       '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
@@ -194,37 +251,248 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
     expect(customer.extends).toEqual(['Persn']);
   });
 
-  test('the universal superclass owl:Thing is ignored (no extends, no warning)',
-     () => {
-       // Every class is trivially a subclass of owl:Thing / rdfs:Resource, so
-       // an explicit rdfs:subClassOf naming one is neither recorded as `extends`
-       // nor warned about -- unlike a genuine unresolved superclass.
-       const ttl = [
-         '@prefix owl:  <http://www.w3.org/2002/07/owl#> .',
-         '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
-         '@prefix ex:   <http://example.com/hr#> .',
-         'ex:Person a owl:Class ; rdfs:subClassOf owl:Thing .',
-       ].join('\n');
-       const {yaml, warnings} = convertOwlToOsi(ttl, 'top');
-       expect(warnings).toEqual([]);
-       const person =
-           loadModels(yaml).models[0].entities.find(e => e.name === 'Person')!;
-       expect(person.extends).toBeUndefined();
-     });
+  test(
+      'the universal superclass owl:Thing is ignored (no extends, no warning)',
+      () => {
+        // Every class is trivially a subclass of owl:Thing / rdfs:Resource, so
+        // an explicit rdfs:subClassOf naming one is neither recorded as
+        // `extends` nor warned about -- unlike a genuine unresolved superclass.
+        const ttl = [
+          '@prefix owl:  <http://www.w3.org/2002/07/owl#> .',
+          '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
+          '@prefix ex:   <http://example.com/hr#> .',
+          'ex:Person a owl:Class ; rdfs:subClassOf owl:Thing .',
+        ].join('\n');
+        const {yaml, warnings} = convertOwlToOsi(ttl, 'top');
+        expect(warnings).toEqual([]);
+        const person =
+            loadModels(yaml).models[0].entities.find(e => e.name === 'Person')!;
+        expect(person.extends).toBeUndefined();
+      });
 });
 
 
-describe('mapping table rules', () => {
+describe('datatype mapping (rdfs:range xsd:* -> DataType)', () => {
+  // The documented xsd -> OSI table. Widths collapse (every integer ->
+  // Integer, float/double -> Float); anything outside the set falls back to
+  // Opaque.
+  test('maps the supported xsd ranges, else Opaque', () => {
+    const ttl = `${PREFIXES}
+      ex:T a owl:Class .
+      ex:s   a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:string .
+      ex:uri a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:anyURI .
+      ex:i   a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:integer .
+      ex:l   a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:long .
+      ex:pi  a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:positiveInteger .
+      ex:dec a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:decimal .
+      ex:f   a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:float .
+      ex:dbl a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:double .
+      ex:b   a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:boolean .
+      ex:dt  a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:date .
+      ex:tm  a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:time .
+      ex:dtm a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:dateTime .
+      ex:tz  a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:dateTimeStamp .
+      ex:un  a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:hexBinary .
+      ex:nr  a owl:DatatypeProperty ; rdfs:domain ex:T .
+    `;
+    const types = Object.fromEntries(
+        loadOwl(ttl).entities[0].fields.map(f => [f.name, f.type]));
+    expect(types).toEqual({
+      s: 'String',
+      uri: 'String',
+      i: 'Integer',
+      l: 'Integer',
+      pi: 'Integer',
+      dec: 'Decimal',
+      f: 'Float',
+      dbl: 'Float',
+      b: 'Boolean',
+      dt: 'Date',
+      tm: 'Time',
+      dtm: 'DateTime',
+      tz: 'DateTimeTz',
+      un: 'Opaque',  // range outside the set
+      nr: 'Opaque',  // no range at all
+    });
+  });
+
+  // A temporal-typed field is a time dimension by OSI's own rule; a
+  // non-temporal one is not a dimension.
+  test('temporal fields are marked as time dimensions', () => {
+    const ttl = `${PREFIXES}
+      ex:T a owl:Class .
+      ex:when a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:dateTime .
+      ex:qty  a owl:DatatypeProperty ; rdfs:domain ex:T ; rdfs:range xsd:integer .
+    `;
+    const fields = loadOwl(ttl).entities[0].fields;
+    expect(isTimeDimension(fields.find(f => f.name === 'when')!)).toBe(true);
+    expect(isTimeDimension(fields.find(f => f.name === 'qty')!)).toBe(false);
+  });
+});
+
+
+describe('keys and edge binding', () => {
+  // owl:hasKey names the class's key properties -> primary_key (grain).
+  test('owl:hasKey becomes the entity primary_key', () => {
+    const ttl = `${PREFIXES}
+      ex:Order a owl:Class ; owl:hasKey ( ex:orderId ) .
+      ex:orderId a owl:DatatypeProperty ; rdfs:domain ex:Order ; rdfs:range xsd:string .
+    `;
+    expect(loadOwl(ttl).entities[0].keys).toEqual(['orderId']);
+  });
+
+  // A multi-property owl:hasKey is a composite primary_key, in list order.
+  test('a composite owl:hasKey preserves order', () => {
+    const ttl = `${PREFIXES}
+      ex:Line a owl:Class ; owl:hasKey ( ex:orderId ex:lineNo ) .
+      ex:orderId a owl:DatatypeProperty ; rdfs:domain ex:Line ; rdfs:range xsd:string .
+      ex:lineNo  a owl:DatatypeProperty ; rdfs:domain ex:Line ; rdfs:range xsd:integer .
+    `;
+    expect(loadOwl(ttl).entities[0].keys).toEqual(['orderId', 'lineNo']);
+  });
+
+  // An inverse-functional datatype property uniquely identifies its subject
+  // -> a unique_keys constraint (distinct from the primary key).
+  test('owl:InverseFunctionalProperty becomes a unique_keys constraint', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ; owl:hasKey ( ex:pid ) .
+      ex:pid   a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
+      ex:ssn   a owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+               rdfs:domain ex:Person ; rdfs:range xsd:string .
+    `;
+    const person = loadOwl(ttl).entities[0];
+    expect(person.keys).toEqual(['pid']);
+    expect(person.uniqueKeys).toEqual([['ssn']]);
+  });
+
+  // When the inverse-functional property IS the declared key, it is not also
+  // emitted as a redundant unique_keys constraint.
+  test('an inverse-functional key is not duplicated as a unique key', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ; owl:hasKey ( ex:ssn ) .
+      ex:ssn a owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+             rdfs:domain ex:Person ; rdfs:range xsd:string .
+    `;
+    const person = loadOwl(ttl).entities[0];
+    expect(person.keys).toEqual(['ssn']);
+    expect(person.uniqueKeys).toBeUndefined();
+  });
+
+  // An edge into a class with a key binds its destination columns to that
+  // key; the source foreign-key columns stay placeholders (one per key
+  // column).
+  test('an edge binds its destination to the destination key', () => {
+    const ttl = `${PREFIXES}
+      ex:Order a owl:Class .
+      ex:Customer a owl:Class ; owl:hasKey ( ex:cid ) .
+      ex:cid a owl:DatatypeProperty ; rdfs:domain ex:Customer ; rdfs:range xsd:string .
+      ex:placedBy a owl:ObjectProperty ; rdfs:domain ex:Order ; rdfs:range ex:Customer .
+    `;
+    const edge = loadOwl(ttl).relationships[0];
+    expect(edge.destination.columns).toEqual(['cid']);
+    expect(edge.source.columns).toEqual(['TODO_BIND']);
+  });
+
+  // Without a key on the destination, both ends stay fully unbound.
+  test('an edge into a keyless class is fully unbound', () => {
+    const ttl = `${PREFIXES}
+      ex:Order a owl:Class .
+      ex:Customer a owl:Class .
+      ex:placedBy a owl:ObjectProperty ; rdfs:domain ex:Order ; rdfs:range ex:Customer .
+    `;
+    const edge = loadOwl(ttl).relationships[0];
+    expect(edge.destination.columns).toEqual(['TODO_BIND']);
+    expect(edge.source.columns).toEqual(['TODO_BIND']);
+  });
+});
+
+
+describe('ai_context enrichment', () => {
+  // skos:example on a term -> ai_context.examples.
+  test('skos:example becomes ai_context.examples', () => {
+    const ttl = `${PREFIXES}
+      ex:Order a owl:Class ; skos:example "A weekly grocery order." .
+      ex:amount a owl:DatatypeProperty ; rdfs:domain ex:Order ; rdfs:range xsd:decimal ;
+          skos:example "19.99" .
+    `;
+    const model = loadOwl(ttl);
+    expect(model.entities[0].aiContext?.examples).toEqual([
+      'A weekly grocery order.'
+    ]);
+    expect(model.entities[0].fields[0].aiContext?.examples).toEqual(['19.99']);
+  });
+
+  // The owl:Ontology header -> model description (+ version) and ai_context.
+  test('the ontology header becomes model-level metadata', () => {
+    const ttl = `${PREFIXES}
+      <http://example.com/x> a owl:Ontology ;
+          rdfs:label "Widgets" ;
+          rdfs:comment "The widget catalog." ;
+          skos:example "Which widgets are discontinued?" ;
+          owl:versionInfo "2.3" .
+      ex:Widget a owl:Class .
+    `;
+    const model = loadOwl(ttl);
+    expect(model.description)
+        .toBe('The widget catalog. (ontology version 2.3)');
+    expect(model.aiContext?.synonyms).toEqual(['Widgets']);
+    expect(model.aiContext?.examples).toEqual([
+      'Which widgets are discontinued?'
+    ]);
+  });
+
+  // Descriptions come from rdfs:comment, or skos:definition / dcterms: / dc:
+  // when there is no rdfs:comment (a fixed precedence).
+  test('skos:definition and dcterms:description fill the description', () => {
+    const ttl = `${PREFIXES}
+      ex:A a owl:Class ; skos:definition "Defined via SKOS." .
+      ex:B a owl:Class ; dct:description "Described via Dublin Core." .
+    `;
+    const model = loadOwl(ttl);
+    expect(model.entities.find(e => e.name === 'A')!.description)
+        .toBe('Defined via SKOS.');
+    expect(model.entities.find(e => e.name === 'B')!.description)
+        .toBe('Described via Dublin Core.');
+  });
+
+  // rdfs:comment wins when more than one description predicate is present.
+  test('rdfs:comment takes precedence over skos:definition', () => {
+    const ttl = `${PREFIXES}
+      ex:A a owl:Class ; rdfs:comment "The comment." ; skos:definition "The definition." .
+    `;
+    expect(loadOwl(ttl).entities[0].description).toBe('The comment.');
+  });
+});
+
+
+describe('multi-domain properties', () => {
+  // A datatype property with more than one rdfs:domain becomes a field on
+  // each domain entity.
+  test('a property with two domains lands on both entities', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      ex:Company a owl:Class .
+      ex:name a owl:DatatypeProperty ;
+          rdfs:domain ex:Person ; rdfs:domain ex:Company ; rdfs:range xsd:string .
+    `;
+    const model = loadOwl(ttl);
+    expect(model.entities.find(e => e.name === 'Person')!.fields.some(
+               f => f.name === 'name'))
+        .toBe(true);
+    expect(model.entities.find(e => e.name === 'Company')!.fields.some(
+               f => f.name === 'name'))
+        .toBe(true);
+  });
+});
+
+
+describe('mapping table rules (labels, comments, skips)', () => {
   // A datatype property's rdfs:label is a display name -> the field `label`
   // slot; a class/object-property label has no slot, so a *non-redundant* one
-  // becomes a synonym; a label that only respaces/recases the name is dropped.
+  // becomes a synonym; a label that only respaces/recases the name is
+  // dropped.
   test('labels route to field label vs. synonyms vs. dropped', () => {
-    const ttl = `
-      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
-      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-      @prefix ex:   <http://example.com/x#> .
-
+    const ttl = `${PREFIXES}
       ex:Client a owl:Class ; rdfs:label "Customer account" .
       ex:Widget a owl:Class ; rdfs:label "Widget" .
       ex:fullName a owl:DatatypeProperty ;
@@ -232,8 +500,7 @@ describe('mapping table rules', () => {
       ex:code a owl:DatatypeProperty ;
           rdfs:domain ex:Widget ; rdfs:range xsd:string ; rdfs:label "code" .
     `;
-    const {yaml} = convertOwlToOsi(ttl, 'x');
-    const model = loadModels(yaml).models[0];
+    const model = loadOwl(ttl);
     const client = model.entities.find(e => e.name === 'Client')!;
     const widget = model.entities.find(e => e.name === 'Widget')!;
     // Non-redundant class label -> synonym.
@@ -241,43 +508,16 @@ describe('mapping table rules', () => {
     // Redundant class label ("Widget" == name) -> dropped, no ai_context.
     expect(widget.aiContext).toBeUndefined();
     // A datatype-property label that adds a name -> field label slot.
-    const fullName = client.fields.find(f => f.name === 'fullName')!;
-    expect(fullName.label).toBe('Legal name');
+    expect(client.fields.find(f => f.name === 'fullName')!.label)
+        .toBe('Legal name');
     // A datatype-property label that only recases the field name -> dropped.
-    const code = widget.fields.find(f => f.name === 'code')!;
-    expect(code.label).toBeUndefined();
-  });
-
-  // rdfs:range xsd:* maps string/date/decimal to the OSI datatype; every other
-  // range falls back to Opaque (the documented set).
-  test('xsd ranges map to datatypes, else Opaque', () => {
-    const ttl = `
-      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
-      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-      @prefix ex:   <http://example.com/x#> .
-
-      ex:Thing a owl:Class .
-      ex:s a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:string .
-      ex:d a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:date .
-      ex:m a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:decimal .
-      ex:i a owl:DatatypeProperty ; rdfs:domain ex:Thing ; rdfs:range xsd:integer .
-    `;
-    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
-    const types =
-        Object.fromEntries(model.entities[0].fields.map(f => [f.name, f.type]));
-    expect(types).toEqual({s: 'String', d: 'Date', m: 'Decimal', i: 'Opaque'});
+    expect(widget.fields.find(f => f.name === 'code')!.label).toBeUndefined();
   });
 
   // A property with no usable endpoint can't be placed; it is skipped with a
   // warning rather than failing the conversion.
   test('unmappable properties are warned and skipped', () => {
-    const ttl = `
-      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
-      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-      @prefix ex:   <http://example.com/x#> .
-
+    const ttl = `${PREFIXES}
       ex:Thing a owl:Class .
       ex:orphan a owl:DatatypeProperty ; rdfs:range xsd:string .
       ex:danglingEdge a owl:ObjectProperty ; rdfs:domain ex:Thing .
@@ -297,122 +537,68 @@ describe('mapping table rules', () => {
   test(
       'rdfs:comment routes to description, or relationship instructions',
       () => {
-        const ttl = `
-      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
-      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-      @prefix ex:   <http://example.com/x#> .
-
+        const ttl = `${PREFIXES}
       ex:Order a owl:Class ; rdfs:comment "A purchase." .
       ex:Customer a owl:Class .
       ex:amount a owl:DatatypeProperty ;
           rdfs:domain ex:Order ; rdfs:range xsd:decimal ; rdfs:comment "Total charged." .
       ex:placedBy a owl:ObjectProperty ;
-          rdfs:domain ex:Order ; rdfs:range ex:Customer ;
-          rdfs:comment "Who placed the order." .
+          rdfs:domain ex:Order ; rdfs:range ex:Customer ; rdfs:comment "Who placed the order." .
     `;
-        const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+        const model = loadOwl(ttl);
         const order = model.entities.find(e => e.name === 'Order')!;
-        // Class comment -> entity description.
         expect(order.description).toBe('A purchase.');
-        // Datatype-property comment -> field description.
         expect(order.fields.find(f => f.name === 'amount')!.description)
             .toBe('Total charged.');
-        // Object-property comment -> relationship ai_context.instructions.
         const placedBy = model.relationships.find(r => r.name === 'placedBy')!;
         expect(placedBy.aiContext?.instructions).toBe('Who placed the order.');
       });
 
-  // An object property is an edge between its domain and range; the real join
-  // columns are unknown until sources are bound, so both ends carry TODO_BIND.
-  test('an object property becomes an edge with UNBOUND join columns', () => {
-    const ttl = `
-      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
-      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      @prefix ex:   <http://example.com/x#> .
-
-      ex:Order a owl:Class .
-      ex:Customer a owl:Class .
-      ex:placedBy a owl:ObjectProperty ;
-          rdfs:domain ex:Order ; rdfs:range ex:Customer .
-    `;
-    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
-    const edge = model.relationships.find(r => r.name === 'placedBy')!;
-    expect(edge.source.entity).toBe('Order');
-    expect(edge.destination.entity).toBe('Customer');
-    expect(edge.source.columns).toEqual(['TODO_BIND']);
-    expect(edge.destination.columns).toEqual(['TODO_BIND']);
-  });
-
   // A class has no label slot, so its first (non-redundant) label and every
-  // further rdfs:label / skos label all collect as synonyms, in document order.
+  // further rdfs:label / skos label all collect as synonyms, in document
+  // order.
   test('skos and extra rdfs:label values collect as synonyms', () => {
-    const ttl = `
-      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
-      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-      @prefix ex:   <http://example.com/x#> .
-
+    const ttl = `${PREFIXES}
       ex:Client a owl:Class ;
           rdfs:label "Customer account" ;
           rdfs:label "Buyer" ;
           skos:altLabel "Account holder" ;
-          skos:prefLabel "Patron" .
+          skos:hiddenLabel "acct" .
     `;
-    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
-    const client = model.entities.find(e => e.name === 'Client')!;
-    expect(client.aiContext?.synonyms).toEqual([
-      'Customer account', 'Buyer', 'Account holder', 'Patron'
+    expect(loadOwl(ttl).entities[0].aiContext?.synonyms).toEqual([
+      'Customer account', 'Buyer', 'Account holder', 'acct'
     ]);
+  });
+
+  // A synonym that only respaces/recases the term's own name is redundant
+  // with the name and dropped -- the same rule the primary label gets.
+  test('synonyms redundant with the term name are dropped', () => {
+    const ttl = `${PREFIXES}
+      ex:Customer a owl:Class ;
+          rdfs:label "Customer" ; skos:altLabel "customer" ; skos:altLabel "Buyer" .
+    `;
+    expect(loadOwl(ttl).entities[0].aiContext?.synonyms).toEqual(['Buyer']);
   });
 
   // A domain that names something not declared as an owl:Class cannot host a
   // field; it is skipped with a warning naming the property and the domain.
   test('a datatype property whose domain is not a class is skipped', () => {
-    const ttl = `
-      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
-      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-      @prefix ex:   <http://example.com/x#> .
-
+    const ttl = `${PREFIXES}
       ex:Thing a owl:Class .
-      ex:stray a owl:DatatypeProperty ;
-          rdfs:domain ex:NotAClass ; rdfs:range xsd:string .
+      ex:stray a owl:DatatypeProperty ; rdfs:domain ex:NotAClass ; rdfs:range xsd:string .
     `;
     const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
     expect(warnings.some(w => w.includes('stray') && w.includes('NotAClass')))
         .toBe(true);
-    const model = loadModels(yaml).models[0];
-    expect(model.entities.find(e => e.name === 'Thing')!.fields)
+    expect(
+        loadModels(yaml).models[0].entities.find(
+                                               e => e.name === 'Thing')!.fields)
         .toHaveLength(0);
   });
 
-  // A synonym (skos alt label or extra rdfs:label) that only respaces/recases
-  // the term's own name is redundant with the name and dropped -- the same rule
-  // the primary label gets.
-  test('synonyms redundant with the term name are dropped', () => {
-    const ttl = `
-      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
-      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-      @prefix ex:   <http://example.com/x#> .
-
-      ex:Customer a owl:Class ;
-          rdfs:label "Customer" ;
-          skos:altLabel "customer" ;
-          skos:altLabel "Buyer" .
-    `;
-    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
-    const customer = model.entities.find(e => e.name === 'Customer')!;
-    // Both "Customer" and "customer" collapse to the name; only "Buyer" survives.
-    expect(customer.aiContext?.synonyms).toEqual(['Buyer']);
-  });
-
-  // Terms are named by their namespace-stripped local name, so two terms that
-  // share a local name (e.g. across namespaces) would collapse to one OSI name.
-  // OSI names must be unique, so the first wins and the rest are warned and
-  // skipped -- the output stays valid and loadable rather than emitting a
-  // duplicate.
+  // Terms are named by their local name, so two terms sharing one (e.g.
+  // across namespaces) would collapse to one OSI name. The first wins; the
+  // rest are warned and skipped, so the output stays valid and loadable.
   test('local-name collisions are warned and deduped (first wins)', () => {
     const ttl = `
       @prefix owl:  <http://www.w3.org/2002/07/owl#> .
@@ -424,24 +610,23 @@ describe('mapping table rules', () => {
       b:Customer a owl:Class ; rdfs:comment "from b" .
     `;
     const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
-    expect(warnings.some(w => w.includes('Customer') && w.includes('more than once')))
+    expect(warnings.some(
+               w => w.includes('Customer') && w.includes('more than once')))
         .toBe(true);
-    // The result still loads: a single Customer entity, the first declaration.
     const model = loadModels(yaml).models[0];
     expect(model.entities.map(e => e.name)).toEqual(['Customer']);
     expect(model.entities[0].description).toBe('from a');
   });
 
-  // The source ontology's base IRI is not carried on terms, but is preserved
-  // once as provenance in the model description.
+  // With no ontology header, the model description records the source base
+  // IRI as provenance.
   test('the model description records the source ontology base IRI', () => {
     const ttl = `
       @prefix owl:  <http://www.w3.org/2002/07/owl#> .
       @prefix ex:   <http://example.com/sales#> .
       ex:Customer a owl:Class .
     `;
-    const model = loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
-    expect(model.description)
+    expect(loadOwl(ttl).description)
         .toBe('Imported from OWL ontology http://example.com/sales#');
   });
 });
@@ -449,8 +634,8 @@ describe('mapping table rules', () => {
 
 // The GOOGLE data.ontology extension is the promotion seam for OWL constructs
 // OSI cannot yet express natively (subClassOf, inverseOf, ...). It is defined
-// and shape-tested but unused by the minimal example, which maps entirely to
-// native OSI -- see to_ir.ts.
+// and shape-tested but unused by the current cut, which maps everything it
+// reads to native OSI -- see to_ir.ts.
 describe('the GOOGLE ontology extension seam (defined-but-unused)', () => {
   test(
       'wraps its payload as a GOOGLE custom extension under data.ontology',
@@ -463,13 +648,9 @@ describe('the GOOGLE ontology extension seam (defined-but-unused)', () => {
         });
       });
 
-  test(
-      'is not exercised by the minimal example (nothing to promote yet)',
-      () => {
-        const {yaml} = convertOwlToOsi(readFixture('sales.owl.ttl'), 'sales');
-        // Everything maps natively, so no custom_extensions / GOOGLE block
-        // appears.
-        expect(yaml).not.toContain('custom_extensions');
-        expect(yaml).not.toContain('GOOGLE');
-      });
+  test('is not exercised by the sales example (nothing to promote yet)', () => {
+    const {yaml} = convertOwlToOsi(readFixture('sales.owl.ttl'), 'sales');
+    expect(yaml).not.toContain('custom_extensions');
+    expect(yaml).not.toContain('GOOGLE');
+  });
 });

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -405,19 +405,41 @@ describe('keys and edge binding', () => {
     expect(edge.source.columns).toEqual(['TODO_BIND']);
   });
 
+  // A relationship maps ONE source to ONE destination. An object property with
+  // more than one rdfs:domain (or rdfs:range) keeps the first of each and warns
+  // about the rest, rather than silently dropping the extra endpoints.
+  test('a multi-endpoint object property keeps the first and warns', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class . ex:Company a owl:Class . ex:Asset a owl:Class .
+      ex:owns a owl:ObjectProperty ;
+          rdfs:domain ex:Person ; rdfs:domain ex:Company ;
+          rdfs:range ex:Asset .
+    `;
+    const {warnings} = convertOwlToOsi(ttl, 'x');
+    const model = loadOwl(ttl);
+    expect(model.relationships.length).toBe(1);
+    expect(model.relationships[0].source.entity).toBe('Person');
+    expect(model.relationships[0].destination.entity).toBe('Asset');
+    expect(warnings.some(
+               w => w.includes(`'owns'`) && w.includes(`domain 'Company'`) &&
+                   w.includes('one source to one destination')))
+        .toBe(true);
+  });
+
   // An owl:hasKey column that has no datatype property on the class
   // (undeclared, or declared only on another class) would name a phantom
-  // primary_key column that only errors later at graph generation. It is
-  // dropped with a warning, keeping the columns that do exist.
+  // primary_key column that only errors later at graph generation. Because a
+  // partial composite key would silently change the entity's grain, the ENTIRE
+  // primary_key is dropped -- not just the phantom member -- with a warning.
   test(
-      'a hasKey column with no matching field is dropped with a warning',
+      'a hasKey with a phantom column drops the whole key with a warning',
       () => {
         const ttl = `${PREFIXES}
       ex:Order a owl:Class ; owl:hasKey ( ex:orderId ex:ghost ) .
       ex:orderId a owl:DatatypeProperty ; rdfs:domain ex:Order ; rdfs:range xsd:string .
     `;
         const {warnings} = convertOwlToOsi(ttl, 'x');
-        expect(loadOwl(ttl).entities[0].keys).toEqual(['orderId']);
+        expect(loadOwl(ttl).entities[0].keys).toEqual([]);
         expect(warnings.some(
                    w => w.includes(`'ghost'`) && w.includes('primary_key')))
             .toBe(true);
@@ -437,8 +459,8 @@ describe('keys and edge binding', () => {
     const person = loadOwl(ttl).entities[0];
     expect(person.keys).toEqual(['email']);
     expect(person.uniqueKeys).toBeUndefined();
-    expect(
-        warnings.some(w => w.includes('no owl:hasKey') && w.includes('email')))
+    expect(warnings.some(
+               w => w.includes('no usable owl:hasKey') && w.includes('email')))
         .toBe(true);
   });
 
@@ -453,6 +475,25 @@ describe('keys and edge binding', () => {
     const person = loadOwl(ttl).entities[0];
     expect(person.keys).toEqual([]);
     expect(person.uniqueKeys).toEqual([['email'], ['ssn']]);
+  });
+
+  // A class whose declared owl:hasKey is entirely phantom still has usable key
+  // material if it carries a lone inverse-functional property: the phantom key
+  // is dropped and the IFP promoted. The promotion warning must not claim the
+  // class "declares no owl:hasKey" (it did -- the key was dropped), so it reads
+  // "no usable owl:hasKey".
+  test('a dropped phantom key still allows IFP promotion', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ; owl:hasKey ( ex:ghost ) .
+      ex:email a owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+               rdfs:domain ex:Person ; rdfs:range xsd:string .
+    `;
+    const {warnings} = convertOwlToOsi(ttl, 'x');
+    const person = loadOwl(ttl).entities[0];
+    expect(person.keys).toEqual(['email']);
+    expect(person.uniqueKeys).toBeUndefined();
+    expect(warnings.some(w => w.includes(`'ghost'`))).toBe(true);
+    expect(warnings.some(w => w.includes('no usable owl:hasKey'))).toBe(true);
   });
 });
 

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -404,6 +404,106 @@ describe('keys and edge binding', () => {
     expect(edge.destination.columns).toEqual(['TODO_BIND']);
     expect(edge.source.columns).toEqual(['TODO_BIND']);
   });
+
+  // An owl:hasKey column that has no datatype property on the class
+  // (undeclared, or declared only on another class) would name a phantom
+  // primary_key column that only errors later at graph generation. It is
+  // dropped with a warning, keeping the columns that do exist.
+  test(
+      'a hasKey column with no matching field is dropped with a warning',
+      () => {
+        const ttl = `${PREFIXES}
+      ex:Order a owl:Class ; owl:hasKey ( ex:orderId ex:ghost ) .
+      ex:orderId a owl:DatatypeProperty ; rdfs:domain ex:Order ; rdfs:range xsd:string .
+    `;
+        const {warnings} = convertOwlToOsi(ttl, 'x');
+        expect(loadOwl(ttl).entities[0].keys).toEqual(['orderId']);
+        expect(warnings.some(
+                   w => w.includes(`'ghost'`) && w.includes('primary_key')))
+            .toBe(true);
+      });
+
+  // A class whose only key material is a single inverse-functional property (no
+  // owl:hasKey) has a natural identifier; it is promoted to primary_key so the
+  // entity is valid for graph generation rather than keyless, and is then not
+  // also repeated as a unique_keys constraint.
+  test('a sole inverse-functional property is promoted to primary_key', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      ex:email a owl:DatatypeProperty, owl:InverseFunctionalProperty ;
+               rdfs:domain ex:Person ; rdfs:range xsd:string .
+    `;
+    const {warnings} = convertOwlToOsi(ttl, 'x');
+    const person = loadOwl(ttl).entities[0];
+    expect(person.keys).toEqual(['email']);
+    expect(person.uniqueKeys).toBeUndefined();
+    expect(
+        warnings.some(w => w.includes('no owl:hasKey') && w.includes('email')))
+        .toBe(true);
+  });
+
+  // Ambiguous key material (more than one inverse-functional property) is left
+  // alone: no primary_key is guessed, and each stays a unique_keys constraint.
+  test('multiple inverse-functional properties are not promoted', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      ex:email a owl:DatatypeProperty, owl:InverseFunctionalProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
+      ex:ssn   a owl:DatatypeProperty, owl:InverseFunctionalProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
+    `;
+    const person = loadOwl(ttl).entities[0];
+    expect(person.keys).toEqual([]);
+    expect(person.uniqueKeys).toEqual([['email'], ['ssn']]);
+  });
+});
+
+
+describe('converted counts and provenance', () => {
+  // The CLI summary counts what was actually converted, not source triples: a
+  // skipped element (duplicate class, domain-less or endpoint-less property) is
+  // not reported, and a multi-domain property counts once.
+  test('stats count conversions, excluding skipped elements', () => {
+    const ttl = `${PREFIXES}
+      @prefix ex2: <http://example.com/other#> .
+      ex:Order  a owl:Class .
+      ex2:Order a owl:Class .                                    # dup name -> skipped
+      ex:amount a owl:DatatypeProperty ; rdfs:domain ex:Order ; rdfs:range xsd:decimal .
+      ex:orphan a owl:DatatypeProperty ; rdfs:range xsd:string . # no domain -> skipped
+      ex:ghost  a owl:ObjectProperty ; rdfs:domain ex:Order .    # no range -> skipped
+    `;
+    const {stats} = convertOwlToOsi(ttl, 'x');
+    expect(stats.classes).toBe(1);
+    expect(stats.datatypeProperties).toBe(1);
+    expect(stats.objectProperties).toBe(0);
+  });
+
+  // A multi-domain datatype property is one conversion, not one per domain.
+  test('a multi-domain property counts once', () => {
+    const ttl = `${PREFIXES}
+      ex:A a owl:Class . ex:B a owl:Class .
+      ex:shared a owl:DatatypeProperty ; rdfs:domain ex:A ; rdfs:domain ex:B ; rdfs:range xsd:string .
+    `;
+    expect(convertOwlToOsi(ttl, 'x').stats.datatypeProperties).toBe(1);
+  });
+
+  // The base-IRI provenance is taken from an actual term's namespace (exact,
+  // delimiter and all), not from the ontology IRI's guessed `#` suffix -- so a
+  // slash-namespaced ontology is recorded correctly.
+  test(
+      'base IRI provenance follows the term namespace, not a guessed suffix',
+      () => {
+        const ttl = `
+      @prefix owl:  <http://www.w3.org/2002/07/owl#> .
+      @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+      @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+      @prefix ex:   <http://example.com/sales/> .
+      <http://example.com/sales> a owl:Ontology .
+      ex:Order  a owl:Class .
+      ex:amount a owl:DatatypeProperty ; rdfs:domain ex:Order ; rdfs:range xsd:decimal .
+    `;
+        const description = loadOwl(ttl).description ?? '';
+        expect(description).toContain('http://example.com/sales/');
+        expect(description).not.toContain('sales#');
+      });
 });
 
 


### PR DESCRIPTION
## What

Second cut of the one-way **OWL → OSI** import (`kcmd owl import`), building on #327. It maps more of what an ontology already carries onto **native** semantic-model fields — no OSI schema changes, no custom extensions, and the existing `kcmd push` / `kcmd pull` rails are untouched.

## Changes

| Area | Before | After |
|---|---|---|
| **Datatypes** | only `string`/`date`/`decimal`, else `Opaque` | full mapped `xsd` range → `Integer` / `Float` / `Boolean` / `Time` / `DateTime` / `DateTimeTz` + `String` aliases; unmapped → `Opaque` |
| **Time dimensions** | — | temporal fields marked `dimension: { is_time: true }` |
| **Keys** | none (empty `primary_key`) | `owl:hasKey` → `primary_key` (single/composite); `owl:InverseFunctionalProperty` → `unique_keys` (skipped when it is the key) |
| **Edge binding** | both ends `TODO_BIND` | edge into a keyed class binds its **destination** columns to that key; only the source FK stays `TODO_BIND` |
| **AI metadata** | — | `skos:example` → `ai_context.examples`; `skos:definition` / `dcterms:`/`dc:description` → `description`; `owl:Ontology` header → model `description` / version / `ai_context` |
| **Multi-domain** | single domain | a property with several `rdfs:domain` values lands as a field on **each** entity |

## Testing

- `npx tsc --noEmit` clean
- Full suite green (420 tests)
- `sales` / `org` goldens regenerated from the built binary and reproduced byte-identically; the recursive `osi_schema.test.ts` guardrail validates them against the vendored OSI schema (so `unique_keys`, `dimension`, `examples`, model `ai_context`, and the new datatypes are all schema-valid)
- Focused rule tests added for each construct (datatype table, keys/composite/inverse-functional, half-binding, examples, ontology header, description precedence, multi-domain)
- User-guide section **"Importing an OWL ontology"** rewritten to document every construct above

## Not covered yet

`subClassOf` / `inverseOf` / `subPropertyOf` / `equivalentClass`, cardinality / enumerations / property characteristics, SHACL, individuals, and OSI → OWL export — see the guide's "What is not covered yet". These need the (defined-but-unused) GOOGLE `data.ontology` extension seam, not native fields.