### PR TITLE
mdcode: import OWL subClassOf as native entity `extends`

### DIFF
--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -566,7 +566,9 @@ the `Customer` dataset carries `extends: [Person]`:
 
 Multiple superclasses are allowed (`extends: [Person, Employee]`, in document
 order). A `subClassOf` whose object is a blank-node axiom (`owl:Restriction` and
-similar) is not a named class, so it is ignored.
+similar) is not a named class, so it is ignored, as are the implicit universal
+superclasses `owl:Thing` / `rdfs:Resource` (every class subclasses them, so they
+carry no inheritance information).
 
 Two boundaries to be clear about:
 

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -392,10 +392,12 @@ does not learn a second format — it **converts OWL into a semantic model** onc
 then the ontology rides the normal `kcmd push` / `kcmd pull` above. The semantic
 model stays the single canonical form.
 
-This first cut converts only the OWL constructs that have a clean BigQuery Graph
-shape (class → node, object property → edge, datatype property → property).
-Richer OWL (`subClassOf`, `inverseOf`, SHACL, cardinality, individuals) is not
-read yet — see [What is not covered yet](#what-is-not-covered-yet).
+This first cut converts the OWL constructs that have a clean BigQuery Graph
+shape (class → node, object property → edge, datatype property → property), plus
+**class hierarchies** (`rdfs:subClassOf` → entity `extends`, see
+[Class hierarchies](#class-hierarchies-rdfssubclassof)). Richer OWL
+(`inverseOf`, `rdfs:subPropertyOf`, SHACL, cardinality, individuals) is not read
+yet — see [What is not covered yet](#what-is-not-covered-yet).
 
 ### 1. The OWL file
 
@@ -517,16 +519,69 @@ semantic_model:
 | `owl:DatatypeProperty` | `fields[]` on the domain's dataset | `expression` defaults to the property's local name (a valid column ref once bound) |
 | `rdfs:range xsd:*` | field `datatype` | `xsd:string→String`, `xsd:date→Date`, `xsd:decimal→Decimal`, else `Opaque` |
 | `owl:ObjectProperty` | `relationships[]` | `from`=domain, `to`=range; join columns unbound (`TODO_BIND`) |
+| `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
 | `rdfs:label` on a datatype property | field `label` | the field's display name (a `label` slot exists only on fields); dropped when it only respaces/recases the name |
 | `rdfs:label` on a class / object property | `ai_context.synonyms` | no `label` slot there, so a distinct label becomes an alternate name; dropped when it only respaces/recases the name |
 | extra `rdfs:label` / `skos:altLabel` / `skos:prefLabel` | `ai_context.synonyms` | genuinely alternate names; feed NL search |
 | `rdfs:comment` on a class / datatype property | `description` | |
 | `rdfs:comment` on an object property | `ai_context.instructions` | a relationship has no `description` slot, so its comment rides in `ai_context` |
-| term IRIs, `@prefix` | dropped (provenance kept in model `description`) | reconstructable as `<base><name>`; re-carried only if reverse export or `subClassOf` needs them |
+| term IRIs, `@prefix` | dropped (provenance kept in model `description`) | reconstructable as `<base><name>`; re-carried only if reverse export needs them |
 
 A datatype property whose domain is not a class in the ontology, or an object
 property missing an endpoint, cannot be placed; it is **skipped with a warning**
 rather than failing the whole import.
+
+#### Class hierarchies (`rdfs:subClassOf`)
+
+`rdfs:subClassOf` maps to a dataset's `extends` — the one keyword borrowed from
+[Ossie's ontology proposal](https://github.com/apache/ossie/blob/main/ontology/ontology.md)
+onto our existing `datasets`. Given `Customer rdfs:subClassOf Person`:
+
+```turtle
+ex:Person a owl:Class ; rdfs:comment "A human being." .
+ex:fullName a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
+
+ex:Customer a owl:Class ;
+    rdfs:subClassOf ex:Person ;
+    rdfs:comment "A person who buys." .
+ex:loyaltyTier a owl:DatatypeProperty ; rdfs:domain ex:Customer ; rdfs:range xsd:string .
+```
+
+the `Customer` dataset carries `extends: [Person]`:
+
+```yaml
+  - name: Customer
+    source: unbound:Customer
+    extends:
+      - Person
+    description: A person who buys.
+    fields:
+      - name: loyaltyTier          # Customer's OWN field only
+        expression:
+          dialects:
+            - dialect: BIGQUERY
+              expression: loyaltyTier
+        datatype: String
+```
+
+Multiple superclasses are allowed (`extends: [Person, Employee]`, in document
+order). A `subClassOf` whose object is a blank-node axiom (`owl:Restriction` and
+similar) is not a named class, so it is ignored.
+
+Two boundaries to be clear about:
+
+- **This import *records* the hierarchy; it does not *resolve* it.** `Customer`
+  carries `extends: [Person]` and **only its own fields** — `Person`'s `fullName`
+  is **not copied down**. Nothing is pushed differently yet: a `kcmd push` today
+  publishes each dataset with exactly the fields it declares. Flattening
+  inherited fields into Knowledge Catalog entries and BigQuery Graph node tables
+  (fields flow down; edges do not) is a **follow-on** — this PR is the faithful
+  representation it will build on.
+- **Inheritance is entity-level only.** `extends` lives on `datasets`, never on
+  relationships — the boundary is structural. `rdfs:subPropertyOf` (property /
+  relationship inheritance) is **not supported**: the field or relationship is
+  still imported, but the `subPropertyOf` link is **dropped with a warning**. See
+  [What is not covered yet](#what-is-not-covered-yet).
 
 ### 4. Going from ontology to a running graph (binding)
 
@@ -569,10 +624,18 @@ before a BigQuery push. Binding is a manual edit in this first cut.
 
 ### What is not covered yet
 
-- `rdfs:subClassOf`, `owl:inverseOf`, `rdfs:subPropertyOf` — not read yet. When
-  added, they will land in a GOOGLE `custom_extensions` block (under a
-  `data.ontology` key), which is also where the base IRI + prefixes come back
-  (needed to expand parent-class/property references).
+- `rdfs:subClassOf` (class hierarchy) **is** read now — it maps to dataset
+  `extends` (see [Class hierarchies](#class-hierarchies-rdfssubclassof)).
+  *Resolving* that inheritance into Knowledge Catalog entries / BigQuery Graph
+  node tables (copying inherited fields down) is a follow-on; this cut only
+  records the hierarchy.
+- `owl:inverseOf`, `rdfs:subPropertyOf` (property / relationship inheritance) —
+  not supported. A `subPropertyOf` link is dropped with a warning (the field or
+  relationship itself is still imported); only entity-level inheritance exists.
+  When richer constructs are added, they will land in a GOOGLE
+  `custom_extensions` block (under a `data.ontology` key), which is also where the
+  base IRI + prefixes would come back (needed to expand parent-property
+  references).
 - SHACL shapes, cardinality, `owl:unionOf` domains, symmetric/transitive
   properties, `equivalentClass`, individuals — not read.
 - Semantic model → OWL export (reverse) — not built; import is one-way.

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -25,6 +25,10 @@ export interface OwlClass {
   // Additional human names (extra rdfs:label / skos:altLabel|prefLabel) ->
   // ai_context.synonyms.
   synonyms: string[];
+  // Local names of `rdfs:subClassOf` superclasses, in document order -> the
+  // entity's `extends` (entity-level inheritance). Named superclasses only;
+  // blank-node axioms (owl:Restriction, ...) are not recorded. Empty when none.
+  subClassOf: string[];
 }
 
 /**
@@ -42,6 +46,10 @@ export interface OwlDatatypeProperty {
   label?: string;
   comment?: string;
   synonyms: string[];
+  // Local names of `rdfs:subPropertyOf` superproperties, if any. Property
+  // inheritance is NOT supported (only entity-level `rdfs:subClassOf`); this is
+  // recorded solely so the mapper can warn and drop it. Empty when none.
+  subPropertyOf: string[];
 }
 
 /**
@@ -58,6 +66,10 @@ export interface OwlObjectProperty {
   label?: string;
   comment?: string;
   synonyms: string[];
+  // Local names of `rdfs:subPropertyOf` superproperties, if any. Relationship
+  // inheritance is NOT supported (only entity-level `rdfs:subClassOf`); this is
+  // recorded solely so the mapper can warn and drop it. Empty when none.
+  subPropertyOf: string[];
 }
 
 /**

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -21,6 +21,7 @@ const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const OWL_CLASS = 'http://www.w3.org/2002/07/owl#Class';
 const OWL_DATATYPE_PROPERTY = 'http://www.w3.org/2002/07/owl#DatatypeProperty';
 const OWL_OBJECT_PROPERTY = 'http://www.w3.org/2002/07/owl#ObjectProperty';
+const OWL_THING = 'http://www.w3.org/2002/07/owl#Thing';
 const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
 const RDFS_COMMENT = 'http://www.w3.org/2000/01/rdf-schema#comment';
 const RDFS_DOMAIN = 'http://www.w3.org/2000/01/rdf-schema#domain';
@@ -28,6 +29,11 @@ const RDFS_RANGE = 'http://www.w3.org/2000/01/rdf-schema#range';
 const RDFS_SUBCLASS_OF = 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
 const RDFS_SUBPROPERTY_OF =
     'http://www.w3.org/2000/01/rdf-schema#subPropertyOf';
+const RDFS_RESOURCE = 'http://www.w3.org/2000/01/rdf-schema#Resource';
+// The implicit universal superclasses: every class is trivially a subclass of
+// owl:Thing / rdfs:Resource, so an explicit `rdfs:subClassOf` naming one carries
+// no inheritance information and is not recorded as `extends` (nor warned about).
+const TOP_CLASS_IRIS = new Set([OWL_THING, RDFS_RESOURCE]);
 const SKOS_ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
 const SKOS_PREF_LABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel';
 
@@ -139,8 +145,11 @@ export function parseOwl(turtle: string): OwlModel {
       case RDFS_SUBCLASS_OF:
         // Class hierarchy -> the entity's `extends`. Named superclasses only:
         // a blank-node object (an owl:Restriction and similar axioms) is not a
-        // named class, so it is ignored here (out of scope).
-        if (q.object.termType === 'NamedNode')
+        // named class, so it is ignored here (out of scope). The implicit
+        // universal superclasses (owl:Thing / rdfs:Resource) are ignored too --
+        // every class subclasses them, so they carry no inheritance information.
+        if (q.object.termType === 'NamedNode' &&
+            !TOP_CLASS_IRIS.has(q.object.value))
           a.subClassOf.push(localName(q.object.value));
         break;
       case RDFS_SUBPROPERTY_OF:

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -25,6 +25,9 @@ const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
 const RDFS_COMMENT = 'http://www.w3.org/2000/01/rdf-schema#comment';
 const RDFS_DOMAIN = 'http://www.w3.org/2000/01/rdf-schema#domain';
 const RDFS_RANGE = 'http://www.w3.org/2000/01/rdf-schema#range';
+const RDFS_SUBCLASS_OF = 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
+const RDFS_SUBPROPERTY_OF =
+    'http://www.w3.org/2000/01/rdf-schema#subPropertyOf';
 const SKOS_ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
 const SKOS_PREF_LABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel';
 
@@ -63,10 +66,12 @@ interface Annotations {
   domain?: string;
   range?: string;
   synonyms: string[];
+  subClassOf: string[];
+  subPropertyOf: string[];
 }
 
 function emptyAnnotations(): Annotations {
-  return {synonyms: []};
+  return {synonyms: [], subClassOf: [], subPropertyOf: []};
 }
 
 /**
@@ -131,6 +136,20 @@ export function parseOwl(turtle: string): OwlModel {
       case RDFS_RANGE:
         a.range = q.object.value;  // kept as IRI; mapper maps xsd:* -> datatype
         break;
+      case RDFS_SUBCLASS_OF:
+        // Class hierarchy -> the entity's `extends`. Named superclasses only:
+        // a blank-node object (an owl:Restriction and similar axioms) is not a
+        // named class, so it is ignored here (out of scope).
+        if (q.object.termType === 'NamedNode')
+          a.subClassOf.push(localName(q.object.value));
+        break;
+      case RDFS_SUBPROPERTY_OF:
+        // Property hierarchy -> NOT supported (entity-level inheritance only).
+        // Recorded so the mapper can warn and drop it; named superproperties
+        // only.
+        if (q.object.termType === 'NamedNode')
+          a.subPropertyOf.push(localName(q.object.value));
+        break;
       default:
         break;
     }
@@ -151,6 +170,7 @@ export function parseOwl(turtle: string): OwlModel {
           label: a.label,
           comment: a.comment,
           synonyms: a.synonyms,
+          subClassOf: a.subClassOf,
         });
         break;
       case 'datatypeProperty':
@@ -161,6 +181,7 @@ export function parseOwl(turtle: string): OwlModel {
           label: a.label,
           comment: a.comment,
           synonyms: a.synonyms,
+          subPropertyOf: a.subPropertyOf,
         });
         break;
       case 'objectProperty':
@@ -171,6 +192,7 @@ export function parseOwl(turtle: string): OwlModel {
           label: a.label,
           comment: a.comment,
           synonyms: a.synonyms,
+          subPropertyOf: a.subPropertyOf,
         });
         break;
       default:

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -195,9 +195,24 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       fields: [],
     };
     // rdfs:subClassOf -> entity-level `extends`. Recorded AS DECLARED (parent
-    // local names, deduped); parents are not validated or flattened here -- a
-    // later resolution pass expands inherited fields (see ir.ts Entity.extends).
-    if (c.subClassOf.length) entity.extends = dedupe(c.subClassOf);
+    // local names, deduped); parents are not flattened here -- a later
+    // resolution pass expands inherited fields (see ir.ts Entity.extends). A
+    // parent that is not an owl:Class in this ontology (a typo, or a superclass
+    // imported from another ontology) is still recorded, but warned about -- as
+    // every other cross-reference here is -- so a dangling `extends` is never
+    // emitted silently.
+    if (c.subClassOf.length) {
+      const parents = dedupe(c.subClassOf);
+      entity.extends = parents;
+      const unknown = parents.filter(name => !classNames.has(name));
+      if (unknown.length) {
+        warnings.push(
+            `class '${c.localName}' declares rdfs:subClassOf a non-class ` +
+            `superclass (${unknown.join(', ')}); the extends link is recorded ` +
+            `as declared but cannot be resolved (not an owl:Class in this ` +
+            `ontology).`);
+      }
+    }
     entitiesByName.set(c.localName, entity);
     entities.push(entity);
   }

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -194,6 +194,10 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       aiContext: synonymAiContext(c.label, c.localName, c.synonyms),
       fields: [],
     };
+    // rdfs:subClassOf -> entity-level `extends`. Recorded AS DECLARED (parent
+    // local names, deduped); parents are not validated or flattened here -- a
+    // later resolution pass expands inherited fields (see ir.ts Entity.extends).
+    if (c.subClassOf.length) entity.extends = dedupe(c.subClassOf);
     entitiesByName.set(c.localName, entity);
     entities.push(entity);
   }
@@ -218,6 +222,16 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `datatype property '${p.localName}' on '${p.domain}' duplicates an ` +
           `existing field name; skipped (field names must be unique).`);
       continue;
+    }
+    if (p.subPropertyOf.length) {
+      // Property inheritance is not supported (only entity-level
+      // rdfs:subClassOf -> extends). The field is still imported; only the
+      // subPropertyOf link is dropped.
+      warnings.push(
+          `datatype property '${p.localName}' declares rdfs:subPropertyOf ` +
+          `(${p.subPropertyOf.join(', ')}); property inheritance is not ` +
+          `supported, so the subPropertyOf link is dropped (the field itself ` +
+          `is still imported).`);
     }
     const field: Field = {
       name: p.localName,
@@ -253,6 +267,16 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `object property '${p.localName}' duplicates an existing relationship ` +
           `name; skipped (relationship names must be unique).`);
       continue;
+    }
+    if (p.subPropertyOf.length) {
+      // Relationship inheritance is not supported (only entity-level
+      // rdfs:subClassOf -> extends). The relationship is still imported; only
+      // the subPropertyOf link is dropped.
+      warnings.push(
+          `object property '${p.localName}' declares rdfs:subPropertyOf ` +
+          `(${p.subPropertyOf.join(', ')}); relationship inheritance is not ` +
+          `supported, so the subPropertyOf link is dropped (the relationship ` +
+          `itself is still imported).`);
     }
     relationships.push({
       name: p.localName,

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -81,6 +81,18 @@ export interface Entity {
   // Additional uniqueness constraints beyond the primary key; each inner array
   // is one unique column set (maps to the Schema aspect's uniqueConstraints).
   uniqueKeys?: string[][];
+  // Names of supertype entities this entity inherits from -- Apache Ossie's
+  // `extends` (see ontology/ontology.md), the target of OWL `rdfs:subClassOf`.
+  // Inheritance is ENTITY-LEVEL ONLY: only entities carry `extends`;
+  // relationships never do (there is no relationship-inheritance field), so OWL
+  // `rdfs:subPropertyOf` has no representation here by design.
+  //
+  // This is the hierarchy AS DECLARED: it records the fact, it does not itself
+  // flatten anything. Resolving `extends` into inherited fields (so an emitter
+  // sees a self-contained entity) is a separate pass, not yet wired -- so a
+  // consumer may observe `extends` on an entity whose `fields` do NOT yet
+  // include the supertype's fields.
+  extends?: string[];
   description?: string;
   aiContext?: AiContext;
   fields: Field[];       // dimensions / attributes

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -89,6 +89,9 @@ const datasetSchema = z.object({
   source: z.string(),
   primary_key: z.array(z.string()).optional(),
   unique_keys: z.array(z.array(z.string())).optional(),
+  // Supertype entity names (Ossie `extends`) -- entity-level inheritance. Only
+  // datasets carry it; relationships have no `extends`.
+  extends: z.array(z.string()).optional(),
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
   fields: z.array(fieldSchema).optional(),
@@ -285,6 +288,7 @@ function convertDataset(ds: DatasetDoc, opts: LoadOptions,
 
   const entity: Entity = { name: ds.name, dataSource, keys, fields };
   if (ds.unique_keys && ds.unique_keys.length) entity.uniqueKeys = ds.unique_keys;
+  if (ds.extends && ds.extends.length) entity.extends = ds.extends;
   const description = composeDescription(ds.description);
   if (description) entity.description = description;
   const ai = aiContextOrUndefined(ds.ai_context);

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -121,6 +121,8 @@ function datasetDoc(
   return compact({
     name: entity.name,
     source: entity.dataSource,
+    // Supertype entities (entity-level inheritance); omitted when none.
+    extends: nonEmpty(entity.extends),
     primary_key: nonEmpty(entity.keys),
     unique_keys: nonEmpty(entity.uniqueKeys),
     description: entity.description,

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
@@ -1,0 +1,64 @@
+version: 0.2.0.dev0
+semantic_model:
+  - name: hierarchy
+    description: Imported from OWL ontology http://example.com/hr#
+    datasets:
+      - name: Person
+        source: unbound:Person
+        description: A human being.
+        fields:
+          - name: fullName
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: fullName
+            datatype: String
+      - name: Employee
+        source: unbound:Employee
+        description: A person employed by the organization.
+        fields:
+          - name: employeeId
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: employeeId
+            datatype: String
+          - name: legalName
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: legalName
+            datatype: String
+      - name: Customer
+        source: unbound:Customer
+        extends:
+          - Person
+        description: A person who buys.
+        fields:
+          - name: loyaltyTier
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: loyaltyTier
+            datatype: String
+      - name: Manager
+        source: unbound:Manager
+        extends:
+          - Person
+          - Employee
+        description: An employee who manages others.
+    relationships:
+      - name: managedBy
+        from: Employee
+        to: Manager
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - TODO_BIND
+      - name: worksWith
+        from: Employee
+        to: Employee
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - TODO_BIND

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.owl.ttl
@@ -1,0 +1,64 @@
+# An ontology exercising OWL class/property hierarchies (see the user guide's
+# "Class hierarchies (rdfs:subClassOf)" section):
+#   - a single-parent subclass (Customer rdfs:subClassOf Person);
+#   - a multi-parent subclass (Manager rdfs:subClassOf Person, Employee), whose
+#     parents are recorded in document order;
+#   - a subclass of a blank-node axiom (owl:Restriction), which is NOT a named
+#     class and so is ignored (only named superclasses become `extends`);
+#   - a datatype property with rdfs:subPropertyOf (property inheritance, NOT
+#     supported: warned and dropped, the field is still imported);
+#   - an object property with rdfs:subPropertyOf (relationship inheritance, NOT
+#     supported: warned and dropped, the relationship is still imported).
+# Class inheritance is recorded as the entity's `extends`; it is NOT flattened
+# (fields are not copied down) -- see the user guide.
+
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <http://example.com/hr#> .
+
+ex:Person a owl:Class ;
+    rdfs:comment "A human being." .
+ex:fullName a owl:DatatypeProperty ;
+    rdfs:domain ex:Person ; rdfs:range xsd:string .
+
+# Employee is a second base class Manager will also extend.
+ex:Employee a owl:Class ;
+    rdfs:comment "A person employed by the organization." .
+ex:employeeId a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:string .
+
+# Single-parent subclass -> extends: [Person]. No fields are copied down; the
+# subclass only records that it extends Person.
+ex:Customer a owl:Class ;
+    rdfs:subClassOf ex:Person ;
+    rdfs:comment "A person who buys." .
+ex:loyaltyTier a owl:DatatypeProperty ;
+    rdfs:domain ex:Customer ; rdfs:range xsd:string .
+
+# Multi-parent subclass -> extends: [Person, Employee], in document order. Also
+# subClassOf a blank-node owl:Restriction, which is not a named class and is
+# ignored.
+ex:Manager a owl:Class ;
+    rdfs:subClassOf ex:Person ;
+    rdfs:subClassOf ex:Employee ;
+    rdfs:subClassOf [ a owl:Restriction ;
+                      owl:onProperty ex:employeeId ;
+                      owl:minCardinality 1 ] ;
+    rdfs:comment "An employee who manages others." .
+
+# A datatype property with rdfs:subPropertyOf: property inheritance is not
+# supported, so the subPropertyOf link is warned and dropped -- but the field is
+# still imported onto Employee.
+ex:legalName a owl:DatatypeProperty ;
+    rdfs:domain ex:Employee ; rdfs:range xsd:string ;
+    rdfs:subPropertyOf ex:fullName .
+
+# An object property with rdfs:subPropertyOf: relationship inheritance is not
+# supported, so the subPropertyOf link is warned and dropped -- but the
+# relationship is still imported.
+ex:managedBy a owl:ObjectProperty ;
+    rdfs:domain ex:Employee ; rdfs:range ex:Manager ;
+    rdfs:subPropertyOf ex:worksWith .
+ex:worksWith a owl:ObjectProperty ;
+    rdfs:domain ex:Employee ; rdfs:range ex:Employee .

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -92,8 +92,11 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
         }
         // A dataset `extends` is a deliberate superset of released OSI (OWL
         // rdfs:subClassOf -> entity-level inheritance); tolerate exactly that
-        // extra property and nothing else.
-        if (onlyExtendsExtension(validate.errors)) {
+        // extra property and nothing else, and only on the OWL import goldens
+        // (.osi.golden.yaml) that legitimately carry it -- so a stray `extends`
+        // slipping into any other fixture still fails this guardrail.
+        if (rel.endsWith('.osi.golden.yaml') &&
+            onlyExtendsExtension(validate.errors)) {
           return;
         }
         const details = (validate.errors ?? [])

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -53,6 +53,25 @@ function onlyMissingExpression(errors: typeof validate.errors): boolean {
           'expression');
 }
 
+// `extends` (entity-level inheritance, the target of OWL rdfs:subClassOf) is a
+// deliberate SUPERSET of released Apache OSI: the keyword is borrowed from
+// Ossie's draft ontology proposal (ontology/ontology.md) and the vendored
+// osi-schema.json -- pinned to released v0.2.0.dev0 -- does not yet know it, so a
+// dataset carrying `extends` trips `additionalProperties: false` on the Dataset
+// def. We tolerate EXACTLY that one extra property (an additionalProperties error
+// naming `extends` on a datasets path) and nothing else, so an OWL hierarchy
+// golden validates while every other drift from the spec still fails. When
+// upstream OSI adopts `extends`, re-vendoring the schema makes this pass with no
+// special-casing and this tolerance can be removed.
+function onlyExtendsExtension(errors: typeof validate.errors): boolean {
+  return !!errors && errors.length > 0 &&
+    errors.every(
+      e => e.keyword === 'additionalProperties' &&
+        (e.params as {additionalProperty?: string}).additionalProperty ===
+          'extends' &&
+        /\/datasets\/\d+$/.test(e.instancePath));
+}
+
 describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () => {
   test('at least one fixture is discovered', () => {
     expect(fixtures.length).toBeGreaterThan(0);
@@ -69,6 +88,12 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
         // real regression and still fails.
         if (rel.endsWith('.pull.golden.yaml') &&
             onlyMissingExpression(validate.errors)) {
+          return;
+        }
+        // A dataset `extends` is a deliberate superset of released OSI (OWL
+        // rdfs:subClassOf -> entity-level inheritance); tolerate exactly that
+        // extra property and nothing else.
+        if (onlyExtendsExtension(validate.errors)) {
           return;
         }
         const details = (validate.errors ?? [])

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -193,6 +193,24 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
         loadModels(yaml).models[0].entities.find(e => e.name === 'Customer')!;
     expect(customer.extends).toEqual(['Persn']);
   });
+
+  test('the universal superclass owl:Thing is ignored (no extends, no warning)',
+     () => {
+       // Every class is trivially a subclass of owl:Thing / rdfs:Resource, so
+       // an explicit rdfs:subClassOf naming one is neither recorded as `extends`
+       // nor warned about -- unlike a genuine unresolved superclass.
+       const ttl = [
+         '@prefix owl:  <http://www.w3.org/2002/07/owl#> .',
+         '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
+         '@prefix ex:   <http://example.com/hr#> .',
+         'ex:Person a owl:Class ; rdfs:subClassOf owl:Thing .',
+       ].join('\n');
+       const {yaml, warnings} = convertOwlToOsi(ttl, 'top');
+       expect(warnings).toEqual([]);
+       const person =
+           loadModels(yaml).models[0].entities.find(e => e.name === 'Person')!;
+       expect(person.extends).toBeUndefined();
+     });
 });
 
 

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -117,6 +117,63 @@ describe('org ontology exercises the full range of mapped constructs', () => {
 });
 
 
+describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
+  const ttl = readFixture('hierarchy.owl.ttl');
+
+  test('produces exactly the documented OSI (golden)', () => {
+    const {yaml} = convertOwlToOsi(ttl, 'hierarchy');
+    expect(yaml).toEqual(readFixture('hierarchy.osi.golden.yaml'));
+  });
+
+  test('the generated OSI reloads through the loader with extends intact', () => {
+    // The point of the golden: `extends` survives import -> serialize -> load.
+    // If the loader schema did not accept `extends`, loadModels would throw or
+    // drop it; a clean reload with the parents present proves the round trip.
+    const {yaml} = convertOwlToOsi(ttl, 'hierarchy');
+    const model = loadModels(yaml).models[0];
+    const byName = Object.fromEntries(model.entities.map(e => [e.name, e]));
+    // Single-parent subclass.
+    expect(byName['Customer'].extends).toEqual(['Person']);
+    // Multi-parent subclass, parents in document order; the blank-node
+    // owl:Restriction superclass is not a named class and is excluded.
+    expect(byName['Manager'].extends).toEqual(['Person', 'Employee']);
+    // A base class with no rdfs:subClassOf carries no `extends`.
+    expect(byName['Person'].extends).toBeUndefined();
+    expect(byName['Employee'].extends).toBeUndefined();
+  });
+
+  test('inheritance is recorded, not flattened (no fields copied down)', () => {
+    // This cut only RECORDS the hierarchy; it does not resolve it. A subclass
+    // keeps exactly its own fields -- Person's fullName does NOT appear on
+    // Customer. Resolving inherited fields is a follow-on.
+    const model = loadModels(convertOwlToOsi(ttl, 'hierarchy').yaml).models[0];
+    const customer = model.entities.find(e => e.name === 'Customer')!;
+    expect(customer.fields.map(f => f.name)).toEqual(['loyaltyTier']);
+    const manager = model.entities.find(e => e.name === 'Manager')!;
+    expect(manager.fields).toHaveLength(0);
+  });
+
+  test('property inheritance (rdfs:subPropertyOf) is warned and dropped', () => {
+    // Only entity-level inheritance is supported. A datatype/object property's
+    // rdfs:subPropertyOf is dropped with a warning, but the field/relationship
+    // itself is still imported.
+    const {yaml, warnings} = convertOwlToOsi(ttl, 'hierarchy');
+    expect(warnings).toHaveLength(2);
+    expect(warnings.some(
+               w => w.includes('legalName') && w.includes('subPropertyOf')))
+        .toBe(true);
+    expect(warnings.some(
+               w => w.includes('managedBy') && w.includes('subPropertyOf')))
+        .toBe(true);
+    // The field and relationship survive despite the dropped subPropertyOf link.
+    const model = loadModels(yaml).models[0];
+    const employee = model.entities.find(e => e.name === 'Employee')!;
+    expect(employee.fields.some(f => f.name === 'legalName')).toBe(true);
+    expect(model.relationships.some(r => r.name === 'managedBy')).toBe(true);
+  });
+});
+
+
 describe('mapping table rules', () => {
   // A datatype property's rdfs:label is a display name -> the field `label`
   // slot; a class/object-property label has no slot, so a *non-redundant* one

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -171,6 +171,28 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
     expect(employee.fields.some(f => f.name === 'legalName')).toBe(true);
     expect(model.relationships.some(r => r.name === 'managedBy')).toBe(true);
   });
+
+  test('an extends parent that is not a class is recorded but warned', () => {
+    // subClassOf a superclass that is not an owl:Class in this ontology (a typo,
+    // or an external superclass) is still recorded as `extends`, but -- like
+    // every other unresolved cross-reference in the converter -- it is warned
+    // about rather than emitted silently.
+    const ttl = [
+      '@prefix owl:  <http://www.w3.org/2002/07/owl#> .',
+      '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
+      '@prefix ex:   <http://example.com/hr#> .',
+      'ex:Customer a owl:Class ; rdfs:subClassOf ex:Persn .',
+    ].join('\n');
+    const {yaml, warnings} = convertOwlToOsi(ttl, 'dangling');
+    expect(warnings.some(
+               w => w.includes('Customer') && w.includes('Persn') &&
+                   w.includes('subClassOf')))
+        .toBe(true);
+    // Still recorded as declared -- the warning does not drop the link.
+    const customer =
+        loadModels(yaml).models[0].entities.find(e => e.name === 'Customer')!;
+    expect(customer.extends).toEqual(['Persn']);
+  });
 });
 
 


### PR DESCRIPTION
## What

Adds an `extends` keyword to the semantic model (OSI) and maps OWL `rdfs:subClassOf` onto it, so an imported ontology carries its **class hierarchy** faithfully instead of losing it.

Follows on from #327 (the merged one-way OWL→OSI import), which did not read `rdfs:subClassOf`.

## Scope — representation only

- **IR** (`ir.ts`): `Entity.extends?: string[]`. Entity-level inheritance **only** — relationships never carry `extends`. Records the hierarchy *as declared*; does not flatten.
- **Loader** (`loader.ts`): accepts `extends` on `datasets`; **serializer** (`osi_converter.ts`) re-emits it, so an imported model round-trips through load.
- **OWL importer** (`converters/owl/*`): `rdfs:subClassOf` (named superclasses, in document order) → dataset `extends`. Blank-node axioms (`owl:Restriction`, …) are not named classes and are ignored. `rdfs:subPropertyOf` on datatype/object properties is **warned-and-dropped** — the field/relationship is still imported; only the inheritance link is dropped.

Nothing is pushed differently yet: a `kcmd push` still publishes each dataset with exactly its own fields. **Resolving** inherited fields into Knowledge Catalog entries / BigQuery Graph node tables (fields flow down, edges do not) is a **follow-on PR** — this is the faithful representation it builds on.

## Why `extends`

The keyword is borrowed from [Apache Ossie's draft ontology proposal](https://github.com/apache/ossie/blob/main/ontology/ontology.md) — one keyword onto our existing `datasets`, not the wider ontology layer. It is a deliberate **superset** of released OSI; the vendored `osi-schema.json` guardrail tolerates exactly that one extra dataset property (and nothing else) until upstream OSI adopts it.

## Tests & docs

- New fixture `hierarchy.owl.ttl` (single-parent, multi-parent, blank-node restriction, subPropertyOf) + golden `hierarchy.osi.golden.yaml`.
- Behavior tests: subClassOf → `extends` (single + multiple, document order), blank-node excluded, no field flattening, subPropertyOf warn-and-skip; golden reloads through `loadModels` with `extends` intact.
- `docs/semantic-model.md`: new "Class hierarchies" section; mapping-table row; removes the earlier (now false) promise that subClassOf would ride `custom_extensions`.

`npx tsc --noEmit` clean; full `bun test` suite green (391 semantic tests); live `kcmd owl import` emits `extends: [Person]` / `[Person, Employee]`.