### PR TITLE
Push OWL/extends class hierarchy to BigQuery Graph (labels + field flattening)

### DIFF
--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -186,6 +186,26 @@ per supertype**, walking the full transitive chain. A node then matches its
 supertype in a query — `MATCH (:Person)` returns `Person`, `Customer`,
 `Employee`, and `Manager` nodes alike.
 
+You author only each entity's **own** fields plus the one `extends` keyword; the
+push does the rest:
+
+```yaml
+datasets:
+  - name: Person
+    source: proj.ds.person
+    primary_key: [id]
+    fields:
+      - {name: id,        expression: {dialects: [{dialect: BIGQUERY, expression: id}]}}
+      - {name: full_name, expression: {dialects: [{dialect: BIGQUERY, expression: full_name}]}}
+      - {name: email,     expression: {dialects: [{dialect: BIGQUERY, expression: email}]}}
+  - name: Customer
+    source: proj.ds.customer
+    primary_key: [id]          # each subclass keeps its OWN key; keys do not inherit
+    extends: [Person]          # the one keyword you add
+    fields:
+      - {name: loyalty_tier, expression: {dialects: [{dialect: BIGQUERY, expression: loyalty_tier}]}}
+```
+
 For those shared labels to work, **the supertype's fields flatten down** onto the
 subclass. BigQuery requires every table exposing a label to expose the **same
 property signature**, so a subclass's `LABEL Person` block must list exactly what
@@ -207,12 +227,13 @@ GRAPH proj.ds.people
 MATCH (p:Person) RETURN p.full_name   -- resolves on Customer/Employee/Manager too
 ```
 
-Three boundaries:
+Four boundaries:
 
-- **Fields flow down, edges do not.** A subclass gains its supertypes' fields but
-  **not** their relationships: an edge stays bound to the exact node table it was
-  declared on. If `Person —livesIn→ City`, a `Customer` node does not get a
-  `livesIn` edge.
+- **Fields flow down; edges and keys do not.** A subclass gains its supertypes'
+  fields but **not** their relationships or their key: an edge stays bound to the
+  exact node table it was declared on, and each subclass keeps its own `KEY` (a
+  node table is identified by its own grain, never its supertype's). If
+  `Person —livesIn→ City`, a `Customer` node does not get a `livesIn` edge.
 - **The subclass's `source` must physically expose the inherited columns.** The
   flattened `full_name`/`email` above are read from `proj.ds.customer`, so that
   table (or a view over it) must include those columns. Parent and child are
@@ -226,6 +247,11 @@ Three boundaries:
   warning), and a metric that targets a supertype is skipped (with a warning) —
   attach metrics to a leaf class instead. Subclass and leaf labels are
   unaffected.
+- **An inherited field cannot be redefined.** A shared label requires one
+  identical definition per property across every table that binds it, so if a
+  subclass declares a field of the same name as an inherited one but with a
+  different expression, the supertype's definition wins and the subclass's is
+  dropped (with a warning). Redeclaring it identically is a harmless no-op.
 
 An entity may also be marked **`abstract: true`** — a conceptual class with no
 physical table (so it has no `source` and no key). It produces **no node table**;

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -132,6 +132,7 @@ becomes one part of that graph:
 | Entity | `NODE TABLE` | backed by the entity's `source` table, keyed by its primary key |
 | Relationship | `EDGE TABLE` | connects the two entities' node tables |
 | Metric | `MEASURE` on a node table | must resolve to a single entity (otherwise the push is rejected — see [Validation](#validation)) and reduce to one supported aggregate over one operand (otherwise that metric is skipped with a warning) |
+| Entity `extends` | extra `LABEL` clauses on the subclass node table | the subclass also matches its supertypes; the supertypes' fields flatten down (see [Class hierarchies](#class-hierarchies-extends--labels)) |
 
 `push` reads the target dataset's location (`bigquery.datasets.get`) so the
 statement runs in the right region; without that permission it falls back to
@@ -175,6 +176,57 @@ dedicated BigQuery option. The rest — `description`, `instructions`, `examples
 and a field's `label` — share the single `description` string, so they are
 combined into it (examples as an `Examples: …` line). Their content is
 preserved; their separate structure is not.
+
+#### Class hierarchies (`extends` → labels)
+
+An entity that declares `extends: [Parent]` is a **subclass**. BigQuery Graph has
+no inheritance keyword, so the push expresses the hierarchy with **labels**: a
+subclass node table declares its own default label **plus one `LABEL <Ancestor>`
+per supertype**, walking the full transitive chain. A node then matches its
+supertype in a query — `MATCH (:Person)` returns `Person`, `Customer`,
+`Employee`, and `Manager` nodes alike.
+
+For those shared labels to work, **the supertype's fields flatten down** onto the
+subclass. BigQuery requires every table exposing a label to expose the **same
+property signature**, so a subclass's `LABEL Person` block must list exactly what
+`Person`'s own table lists. The push copies each ancestor's fields onto the
+subclass (a nearer definition wins on a name clash) so those signatures line up,
+and the subclass's default label carries the inherited fields too:
+
+```sql
+`proj.ds.customer` AS Customer
+  KEY(id)
+  PROPERTIES( id, loyalty_tier, full_name, email )   -- own + inherited (flattened)
+  LABEL Person
+  PROPERTIES( id, full_name, email )                 -- matches Person's own signature
+```
+
+```
+GRAPH proj.ds.people
+MATCH (p:Person) RETURN p.full_name   -- resolves on Customer/Employee/Manager too
+```
+
+Two boundaries:
+
+- **Fields flow down, edges do not.** A subclass gains its supertypes' fields but
+  **not** their relationships: an edge stays bound to the exact node table it was
+  declared on. If `Person —livesIn→ City`, a `Customer` node does not get a
+  `livesIn` edge.
+- **The subclass's `source` must physically expose the inherited columns.** The
+  flattened `full_name`/`email` above are read from `proj.ds.customer`, so that
+  table (or a view over it) must include those columns. Parent and child are
+  separate physical tables, so the same real-world entity present in both
+  `person` and `customer` appears as two nodes under `MATCH (:Person)` — a
+  modeling choice for the binding step, not something the DDL enforces.
+
+An entity may also be marked **`abstract: true`** — a conceptual class with no
+physical table (so it has no `source` and no key). It produces **no node table**;
+it survives only as a `LABEL` on its concrete descendants (its fields still
+flatten down so the label's signature is present). An abstract entity that no
+concrete entity extends has nothing to attach to and is dropped with a warning.
+`abstract` is an explicit marker: an entity left with an unbound `source`
+placeholder is treated as a binding error and fails the push, never silently
+dropped as if it were table-less.
 
 ### What gets created in Knowledge Catalog
 
@@ -717,13 +769,14 @@ carry no inheritance information).
 
 Two boundaries to be clear about:
 
-- **This import *records* the hierarchy; it does not *resolve* it.** `Customer`
-  carries `extends: [Person]` and **only its own fields** — `Person`'s `fullName`
-  is **not copied down**. Nothing is pushed differently yet: a `kcmd push` today
-  publishes each dataset with exactly the fields it declares. Flattening
-  inherited fields into Knowledge Catalog entries and BigQuery Graph node tables
-  (fields flow down; edges do not) is a **follow-on** — this PR is the faithful
-  representation it will build on.
+- **The import *records* the hierarchy; the BigQuery push *resolves* it.** The
+  importer writes `Customer` with `extends: [Person]` and **only its own fields**.
+  A **BigQuery** push then resolves that inheritance: it emits a `LABEL Person`
+  clause on the `Customer` node table and flattens `Person`'s fields down (fields
+  flow down; edges do not) — see [Class hierarchies (`extends` →
+  labels)](#class-hierarchies-extends--labels). The **Knowledge Catalog** push is
+  unchanged: it still publishes each entry with exactly the fields it declares
+  (KC-side inheritance is a separate, later opt-in).
 - **Inheritance is entity-level only.** `extends` lives on `datasets`, never on
   relationships — the boundary is structural. `rdfs:subPropertyOf` (property /
   relationship inheritance) is **not supported**: the field or relationship is
@@ -775,10 +828,12 @@ in this first cut.
 ### What is not covered yet
 
 - `rdfs:subClassOf` (class hierarchy) **is** read now — it maps to dataset
-  `extends` (see [Class hierarchies](#class-hierarchies-rdfssubclassof)).
-  *Resolving* that inheritance into Knowledge Catalog entries / BigQuery Graph
-  node tables (copying inherited fields down) is a follow-on; this cut only
-  records the hierarchy.
+  `extends` (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) — and a
+  **BigQuery** push resolves it into node-table labels with inherited fields
+  flattened down (see [Class hierarchies (`extends` →
+  labels)](#class-hierarchies-extends--labels)). Resolving the same inheritance
+  into **Knowledge Catalog** entries is still a follow-on; the KC push publishes
+  each entry with only its own fields.
 - `owl:inverseOf`, `rdfs:subPropertyOf` (property / relationship inheritance),
   `owl:equivalentClass` — not supported. A `subPropertyOf` link is dropped with a
   warning (the field or relationship itself is still imported); only entity-level

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -196,6 +196,7 @@ and the subclass's default label carries the inherited fields too:
 ```sql
 `proj.ds.customer` AS Customer
   KEY(id)
+  DEFAULT LABEL
   PROPERTIES( id, loyalty_tier, full_name, email )   -- own + inherited (flattened)
   LABEL Person
   PROPERTIES( id, full_name, email )                 -- matches Person's own signature
@@ -206,7 +207,7 @@ GRAPH proj.ds.people
 MATCH (p:Person) RETURN p.full_name   -- resolves on Customer/Employee/Manager too
 ```
 
-Two boundaries:
+Three boundaries:
 
 - **Fields flow down, edges do not.** A subclass gains its supertypes' fields but
   **not** their relationships: an edge stays bound to the exact node table it was
@@ -218,6 +219,13 @@ Two boundaries:
   separate physical tables, so the same real-world entity present in both
   `person` and `customer` appears as two nodes under `MATCH (:Person)` — a
   modeling choice for the binding step, not something the DDL enforces.
+- **A shared supertype label carries no OPTIONS and no measures.** A supertype's
+  label is bound by every subclass table, and BigQuery forbids a label carried by
+  more than one element table from carrying an `OPTIONS` clause or a `MEASURE`. So
+  a supertype's own `description`/synonyms are dropped from its label (with a
+  warning), and a metric that targets a supertype is skipped (with a warning) —
+  attach metrics to a leaf class instead. Subclass and leaf labels are
+  unaffected.
 
 An entity may also be marked **`abstract: true`** — a conceptual class with no
 physical table (so it has no `source` and no key). It produces **no node table**;

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -234,7 +234,10 @@ flatten down so the label's signature is present). An abstract entity that no
 concrete entity extends has nothing to attach to and is dropped with a warning.
 `abstract` is an explicit marker: an entity left with an unbound `source`
 placeholder is treated as a binding error and fails the push, never silently
-dropped as if it were table-less.
+dropped as if it were table-less. The Knowledge Catalog leg does not
+model inheritance today, so an abstract entity has no physical resource to
+catalog and is skipped there (with a warning); its concrete subtypes are
+published normally.
 
 ### What gets created in Knowledge Catalog
 

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -20,6 +20,7 @@
 //
 
 import {AiContext, Association, Entity, Field, isTimeDimension, Metric, Relationship, SemanticModel,} from './ir';
+import {resolveInheritance} from './resolve_inheritance';
 import {referencedEntityNames, stripQualifier} from './sql_expr_utils';
 
 export interface GenerateOptions {
@@ -60,11 +61,26 @@ export function generatePropertyGraph(
     model: SemanticModel, opts: GenerateOptions = {}): GenerateResult {
   const warnings: string[] = [];
 
+  // Resolve entity-level inheritance (`extends`) before generating: this
+  // flattens each subclass's inherited fields down and expands `extends` to the
+  // full transitive ancestor set, so labels and property signatures can be read
+  // straight off the resolved model. Only the BigQuery leg runs this; the KC
+  // push consumes the raw model, so its output is unaffected.
+  const resolved = resolveInheritance(model);
+  warnings.push(...resolved.warnings);
+
   // The IR requires entities/relationships/metrics, but be defensive against a
   // hand-built or partially-deserialized model rather than throwing on `.map`.
-  const entities = model.entities ?? [];
-  const relationships = model.relationships ?? [];
-  const metrics = model.metrics ?? [];
+  const entities = resolved.model.entities ?? [];
+  const relationships = resolved.model.relationships ?? [];
+  const metrics = resolved.model.metrics ?? [];
+
+  // An abstract entity is conceptual: it has no physical table and produces no
+  // NODE TABLE, surviving only as a LABEL on its concrete descendants (whose
+  // node tables carry its flattened fields). Collect the abstract names so the
+  // node-table filter drops them while label emission still sees them.
+  const abstractNames =
+      new Set(entities.filter(e => e.abstract).map(e => e.name));
 
   // A graph node table requires a non-empty KEY. An entity whose primary key is
   // empty cannot form a valid node, so skip it (and, below, any edge that
@@ -72,6 +88,13 @@ export function generatePropertyGraph(
   // warns about the missing key; this records the resulting structural drop.
   const skipped = new Set<string>();
   const validEntities = entities.filter(entity => {
+    // An abstract entity is intentionally table-less: skip its node table (it
+    // still contributes LABELs to descendants) without warning -- unlike a
+    // missing KEY, this is by design, not a defect.
+    if (abstractNames.has(entity.name)) {
+      skipped.add(entity.name);
+      return false;
+    }
     if (entity.keys && entity.keys.length) return true;
     warnings.push(
         `entity '${
@@ -80,6 +103,22 @@ export function generatePropertyGraph(
     skipped.add(entity.name);
     return false;
   });
+
+  // An abstract class exists only to be a supertype; one that is no concrete
+  // (valid) entity's ancestor produces no graph element at all, so warn and drop
+  // it rather than let it vanish silently.
+  const ancestorsUsed = new Set<string>();
+  for (const entity of validEntities) {
+    for (const a of entity.extends ?? []) ancestorsUsed.add(a);
+  }
+  for (const name of abstractNames) {
+    if (!ancestorsUsed.has(name)) {
+      warnings.push(
+          `abstract entity '${name}' is not a supertype of any concrete ` +
+          `entity; it has no table and no descendant to label, so it produces ` +
+          `no graph element`);
+    }
+  }
 
   // A property graph must have at least one NODE TABLE; an empty `NODE TABLES
   // ()` block is invalid DDL under any circumstance. When no entity can form a
@@ -105,14 +144,20 @@ export function generatePropertyGraph(
   const loweringByEntity = new Map<string, MeasureLowering>();
   for (const metric of metrics) {
     placeMetric(
-        metric, model, entityByName, skipped, metricsByEntity, loweringByEntity,
-        warnings);
+        metric, resolved.model, entityByName, skipped, metricsByEntity,
+        loweringByEntity, warnings);
   }
+
+  // A subclass's `LABEL <ancestor>` block lists that ancestor's own (flattened)
+  // signature, so the label renderer must reach every entity by name --
+  // including abstract ones, which have no node table but still contribute a
+  // label signature. Index all entities, not just the node-forming ones.
+  const allByName = new Map(entities.map(e => [e.name, e]));
 
   const nodeTables = validEntities.map(
       entity => renderNodeTable(
           entity, loweringByEntity.get(entity.name)?.derivedProperties ?? [],
-          metricsByEntity.get(entity.name) ?? [], opts, warnings));
+          metricsByEntity.get(entity.name) ?? [], allByName, opts, warnings));
 
   const entitiesByName = new Map(validEntities.map(e => [e.name, e]));
   const edgeTables =
@@ -130,7 +175,7 @@ export function generatePropertyGraph(
           })
           .map(rel => renderEdgeTable(rel, entitiesByName, opts, warnings));
 
-  const graphName = qualifyGraph(model, opts);
+  const graphName = qualifyGraph(resolved.model, opts);
 
   const blocks: string[] = [
     `CREATE OR REPLACE PROPERTY GRAPH ${graphName}`,
@@ -460,7 +505,8 @@ function referencedEntities(
 
 function renderNodeTable(
     entity: Entity, derivedProperties: string[], measures: string[],
-    opts: GenerateOptions, warnings: string[]): string {
+    allByName: Map<string, Entity>, opts: GenerateOptions,
+    warnings: string[]): string {
   const table = qualifyTable(
       entity.dataSource, opts, warnings, `entity '${entity.name}'`);
   // Order: declared fields, then any operand properties synthesized for
@@ -485,6 +531,24 @@ function renderNodeTable(
   // Omit the PROPERTIES block when there is nothing to list, rather than emit
   // an empty `PROPERTIES()` (a node table may declare just its KEY).
   if (properties.length) lines.push(propertiesBlock(properties));
+
+  // Inheritance: declare one LABEL per transitive ancestor (resolveInheritance
+  // expanded `extends` to the full ancestor set), each exposing that ancestor's
+  // own flattened signature. This makes `MATCH (:Ancestor)` also match this
+  // subclass node, and BigQuery requires every table sharing a label to list an
+  // identical property signature -- which holds because the ancestor's fields
+  // were flattened onto this entity too. The ancestor's description/synonyms
+  // stay on its own DEFAULT LABEL (or, for an abstract ancestor, are dropped);
+  // the descendant's LABEL clause carries no OPTIONS, to avoid conflicting
+  // duplicate options for the same shared label.
+  for (const ancestorName of entity.extends ?? []) {
+    const ancestor = allByName.get(ancestorName);
+    if (!ancestor) continue;
+    lines.push(line(2, `LABEL ${ancestorName}`));
+    const signature =
+        ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
+    if (signature.length) lines.push(propertiesBlock(signature));
+  }
   return lines.join('\n');
 }
 
@@ -659,7 +723,11 @@ function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
   let project = opts.project;
   let dataset = opts.dataset;
 
-  const first = (model.entities ?? [])[0];
+  // Pick the first entity with a plain `project.dataset.table` source to derive
+  // the graph's location; skip abstract entities (empty source) and query-based
+  // sources (whitespace), which carry no usable location.
+  const first = (model.entities ?? [])
+                    .find(e => e.dataSource && !/\s/.test(e.dataSource));
   if ((!project || !dataset) && first?.dataSource &&
       !/\s/.test(first.dataSource)) {
     const p = first.dataSource.trim().split('.');

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -149,15 +149,22 @@ export function generatePropertyGraph(
   }
 
   // A subclass's `LABEL <ancestor>` block lists that ancestor's own (flattened)
-  // signature, so the label renderer must reach every entity by name --
-  // including abstract ones, which have no node table but still contribute a
-  // label signature. Index all entities, not just the node-forming ones.
-  const allByName = new Map(entities.map(e => [e.name, e]));
+  // signature, so the label renderer must reach every LABEL CARRIER by name:
+  // node-forming entities plus abstract (table-less) supertypes, which have no
+  // node table but still contribute a label signature. A concrete entity
+  // dropped for an empty KEY is deliberately excluded -- it was reported as a
+  // structural defect, so it must not silently reappear as a shared label on a
+  // subclass (which would contradict the drop and expose a half-defined class);
+  // a subclass extending it drops that LABEL with a warning (see
+  // renderNodeTable).
+  const labelByName = new Map(
+      entities.filter(e => e.abstract || !skipped.has(e.name))
+          .map(e => [e.name, e]));
 
   const nodeTables = validEntities.map(
       entity => renderNodeTable(
           entity, loweringByEntity.get(entity.name)?.derivedProperties ?? [],
-          metricsByEntity.get(entity.name) ?? [], allByName,
+          metricsByEntity.get(entity.name) ?? [], labelByName,
           ancestorsUsed.has(entity.name), opts, warnings));
 
   const entitiesByName = new Map(validEntities.map(e => [e.name, e]));
@@ -530,8 +537,8 @@ function referencedEntities(
 
 function renderNodeTable(
     entity: Entity, derivedProperties: string[], measures: string[],
-    allByName: Map<string, Entity>, isSupertype: boolean, opts: GenerateOptions,
-    warnings: string[]): string {
+    labelByName: Map<string, Entity>, isSupertype: boolean,
+    opts: GenerateOptions, warnings: string[]): string {
   const table = qualifyTable(
       entity.dataSource, opts, warnings, `entity '${entity.name}'`);
 
@@ -545,12 +552,14 @@ function renderNodeTable(
   // copies on this entity, so in a well-formed hierarchy `renderOwn` below is a
   // no-op; the map's real job is to catch and neutralize a genuine override.
   const inheritedRender = new Map<string, string>();
+  const inheritedCore = new Map<string, string>();
   for (const ancestorName of entity.extends ?? []) {
-    const ancestor = allByName.get(ancestorName);
+    const ancestor = labelByName.get(ancestorName);
     if (!ancestor) continue;
     for (const f of ancestor.fields) {
       if (!inheritedRender.has(f.name)) {
         inheritedRender.set(f.name, renderFieldProperty(f, ancestor.name));
+        inheritedCore.set(f.name, renderFieldPropertyCore(f, ancestor.name));
       }
     }
   }
@@ -558,18 +567,30 @@ function renderNodeTable(
   // canonical definition for any inherited name. A subclass CANNOT give an
   // inherited property a different definition -- BigQuery requires one
   // definition per property under a shared label -- so a divergent override is
-  // warned and dropped in favor of the supertype's, keeping the DDL valid.
+  // warned and dropped in favor of the supertype's, keeping the DDL valid. The
+  // warning distinguishes a STRUCTURAL remap (a different column/expression --
+  // the property is genuinely rebound) from a METADATA-only refinement (same
+  // column, different description/synonyms) so it states precisely what the
+  // subclass loses, rather than mislabeling an added description as a redefined
+  // column.
   const renderOwn = (f: Field): string => {
     const own = renderFieldProperty(f, entity.name);
     const canonical = inheritedRender.get(f.name);
-    if (canonical === undefined) return own;
-    if (canonical !== own) {
+    if (canonical === undefined) return own;  // not inherited: render as-is
+    if (canonical === own) return canonical;  // identical: nothing to warn
+    if (renderFieldPropertyCore(f, entity.name) !== inheritedCore.get(f.name)) {
       warnings.push(
-          `entity '${entity.name}' redefines inherited property '${
-              f.name}' with a definition that differs from its supertype's; ` +
+          `entity '${entity.name}' remaps inherited property '${
+              f.name}' to a different column/expression than its supertype; ` +
           `BigQuery allows only one definition per property under a shared ` +
-          `label, so the supertype's is used and the subclass override is ` +
+          `label, so the supertype's is used and the subclass's remapping is ` +
           `dropped`);
+    } else {
+      warnings.push(
+          `entity '${entity.name}' overrides the description/synonyms of ` +
+          `inherited property '${f.name}'; under a shared label every binding ` +
+          `must declare it identically, so the supertype's metadata is used ` +
+          `and the subclass's is dropped`);
     }
     return canonical;
   };
@@ -630,8 +651,19 @@ function renderNodeTable(
   // renders the same inherited names via `renderOwn`, which also defers to the
   // ancestor, so the label is consistent within this table too.
   for (const ancestorName of entity.extends ?? []) {
-    const ancestor = allByName.get(ancestorName);
-    if (!ancestor) continue;
+    const ancestor = labelByName.get(ancestorName);
+    if (!ancestor) {
+      // The ancestor exists in the model (resolveInheritance already dropped
+      // unknown parents) but is not a label carrier -- it was dropped for an
+      // empty KEY. Its fields still flattened onto this node (they render as
+      // own properties above); it just forms no queryable label, so omit the
+      // LABEL and say so rather than reference a class reported as gone.
+      warnings.push(
+          `entity '${entity.name}' extends '${ancestorName}', which has no ` +
+          `node table and is not abstract (it was dropped, e.g. for an empty ` +
+          `KEY); the '${ancestorName}' label is omitted from '${entity.name}'`);
+      continue;
+    }
     lines.push(line(2, `LABEL ${ancestorName}`));
     const signature =
         ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
@@ -646,12 +678,27 @@ function renderNodeTable(
 // `derived_property` rule. A field with no expression is exposed as a bare
 // column under its name.
 function renderFieldProperty(field: Field, entity: string): string {
-  const expr = fieldExpression(field);
-  const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
-  const prop = local === field.name ? field.name : `${local} AS ${field.name}`;
+  const core = renderFieldPropertyCore(field, entity);
   const opts =
       optionsClause(fieldDescription(field), field.aiContext?.synonyms);
-  return opts ? `${prop} ${opts}` : prop;
+  return opts ? `${core} ${opts}` : core;
+}
+
+// Renders just the STRUCTURAL core of a field property -- the bare column, or
+// `<expr> AS <name>` when the field maps a non-trivial expression -- with no
+// trailing OPTIONS. This is the part BigQuery requires to be byte-for-byte
+// identical across every element table binding a shared label; metadata
+// (OPTIONS) is compared separately so a subclass's metadata-only refinement is
+// reported distinctly from a structural remap (see renderNodeTable's
+// renderOwn). This is also the single place a field expression is lowered to
+// its table-local form: the resolve-inheritance pass first rewrites an
+// inherited field's expression into the child's frame (localizeInheritedField),
+// then this strips the entity's own qualifier -- one normalization, in one
+// place, applied to own and inherited fields alike.
+function renderFieldPropertyCore(field: Field, entity: string): string {
+  const expr = fieldExpression(field);
+  const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
+  return local === field.name ? field.name : `${local} AS ${field.name}`;
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -144,8 +144,8 @@ export function generatePropertyGraph(
   const loweringByEntity = new Map<string, MeasureLowering>();
   for (const metric of metrics) {
     placeMetric(
-        metric, resolved.model, entityByName, skipped, metricsByEntity,
-        loweringByEntity, warnings);
+        metric, resolved.model, entityByName, skipped, ancestorsUsed,
+        metricsByEntity, loweringByEntity, warnings);
   }
 
   // A subclass's `LABEL <ancestor>` block lists that ancestor's own (flattened)
@@ -157,7 +157,8 @@ export function generatePropertyGraph(
   const nodeTables = validEntities.map(
       entity => renderNodeTable(
           entity, loweringByEntity.get(entity.name)?.derivedProperties ?? [],
-          metricsByEntity.get(entity.name) ?? [], allByName, opts, warnings));
+          metricsByEntity.get(entity.name) ?? [], allByName,
+          ancestorsUsed.has(entity.name), opts, warnings));
 
   const entitiesByName = new Map(validEntities.map(e => [e.name, e]));
   const edgeTables =
@@ -234,7 +235,8 @@ function newLowering(entity: Entity): MeasureLowering {
 // single supported aggregate over one operand.
 function placeMetric(
     metric: Metric, model: SemanticModel, entityByName: Map<string, Entity>,
-    skipped: Set<string>, metricsByEntity: Map<string, string[]>,
+    skipped: Set<string>, ancestorsUsed: Set<string>,
+    metricsByEntity: Map<string, string[]>,
     loweringByEntity: Map<string, MeasureLowering>, warnings: string[]): void {
   // The IR keeps at most two expression forms; a measure is emitted from the
   // target/canonical `expression`, falling back to the imported vendor SQL when
@@ -297,6 +299,19 @@ function placeMetric(
   if (skipped.has(entityName)) {
     warnings.push(`metric '${metric.name}' targets entity '${
         entityName}', which has no KEY and was skipped; metric dropped`);
+    return;
+  }
+  // A metric lowers to a MEASURE on the target entity's DEFAULT LABEL. When that
+  // entity is a supertype, its label is shared with every subclass table, and
+  // BigQuery forbids binding a MEASURE to a label carried by more than one
+  // element table (a measure cannot be replicated across tables -- verified live
+  // "defined as MEASURE, but there are other declarations with the same name").
+  // Drop it with a warning rather than emit DDL BigQuery rejects.
+  if (ancestorsUsed.has(entityName)) {
+    warnings.push(
+        `metric '${metric.name}' targets entity '${entityName}', which is a ` +
+        `supertype whose label is shared across subclass tables; skipped ` +
+        `(BigQuery cannot bind a MEASURE to a shared label)`);
     return;
   }
 
@@ -505,7 +520,7 @@ function referencedEntities(
 
 function renderNodeTable(
     entity: Entity, derivedProperties: string[], measures: string[],
-    allByName: Map<string, Entity>, opts: GenerateOptions,
+    allByName: Map<string, Entity>, isSupertype: boolean, opts: GenerateOptions,
     warnings: string[]): string {
   const table = qualifyTable(
       entity.dataSource, opts, warnings, `entity '${entity.name}'`);
@@ -522,31 +537,55 @@ function renderNodeTable(
     line(1, `${table} AS ${entity.name}`),
     line(2, `KEY(${entity.keys.join(', ')})`),
   ];
-  // Element-table description and synonyms attach to the DEFAULT LABEL: after
-  // the key clause, before PROPERTIES (grammar: element_table_definition).
-  const labelOpts = optionsClause(
+  // Element-table description and synonyms attach to the node's DEFAULT LABEL --
+  // UNLESS this entity is a supertype whose label is shared by subclass tables.
+  // BigQuery forbids a label that carries an OPTIONS clause from being bound to
+  // more than one element table (verified live -- "the label ... is defined with
+  // OPTIONS clause in one of the element tables and cannot be bound to another
+  // element table"), so a shared supertype label must be options-free; its
+  // description/synonyms are dropped (with a warning).
+  let labelOpts = optionsClause(
       elementDescription(entity.description, entity.aiContext),
       entity.aiContext?.synonyms);
+  if (isSupertype && labelOpts) {
+    warnings.push(
+        `entity '${entity.name}' is a supertype in a class hierarchy; its ` +
+        `description/synonyms are dropped from the shared '${entity.name}' ` +
+        `label (BigQuery forbids OPTIONS on a label bound by multiple tables)`);
+    labelOpts = undefined;
+  }
+  // A node participating in the hierarchy -- as a subclass (it declares ancestor
+  // LABELs) or as a shared supertype (a subclass binds its label) -- must use an
+  // EXPLICIT `DEFAULT LABEL`: BigQuery rejects a bare (implicit default)
+  // PROPERTIES clause immediately followed by explicit LABEL clauses (verified
+  // live -- "Expected \")\" ... but got keyword LABEL"), and the validated
+  // shared-label shape is `DEFAULT LABEL PROPERTIES(...)`. A node outside any
+  // hierarchy keeps the implicit form so existing output is byte-for-byte
+  // unchanged.
+  const hasAncestors = !!(entity.extends && entity.extends.length);
+  if (hasAncestors || isSupertype) lines.push(line(2, 'DEFAULT LABEL'));
   if (labelOpts) lines.push(line(2, labelOpts));
   // Omit the PROPERTIES block when there is nothing to list, rather than emit
   // an empty `PROPERTIES()` (a node table may declare just its KEY).
   if (properties.length) lines.push(propertiesBlock(properties));
 
   // Inheritance: declare one LABEL per transitive ancestor (resolveInheritance
-  // expanded `extends` to the full ancestor set), each exposing that ancestor's
-  // own flattened signature. This makes `MATCH (:Ancestor)` also match this
-  // subclass node, and BigQuery requires every table sharing a label to list an
-  // identical property signature -- which holds because the ancestor's fields
-  // were flattened onto this entity too. The ancestor's description/synonyms
-  // stay on its own DEFAULT LABEL (or, for an abstract ancestor, are dropped);
-  // the descendant's LABEL clause carries no OPTIONS, to avoid conflicting
-  // duplicate options for the same shared label.
+  // expanded `extends` to the full ancestor set), each re-listing that
+  // ancestor's properties so `MATCH (:Ancestor)` also matches this subclass
+  // node. BigQuery requires a property shared across an element table's label
+  // blocks to have an IDENTICAL definition in each (verified live -- "Property
+  // ... has more than one definition"), so the ancestor block reuses THIS
+  // entity's own rendered property strings (by name) rather than re-rendering
+  // from the ancestor, guaranteeing they match byte-for-byte even when a field
+  // carries OPTIONS or a qualified expression.
+  const ownRender = new Map(
+      entity.fields.map(f => [f.name, renderFieldProperty(f, entity.name)]));
   for (const ancestorName of entity.extends ?? []) {
     const ancestor = allByName.get(ancestorName);
     if (!ancestor) continue;
     lines.push(line(2, `LABEL ${ancestorName}`));
-    const signature =
-        ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
+    const signature = ancestor.fields.map(f => ownRender.get(f.name))
+                          .filter((s): s is string => s !== undefined);
     if (signature.length) lines.push(propertiesBlock(signature));
   }
   return lines.join('\n');

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -292,6 +292,16 @@ function placeMetric(
         entityName}'; skipped (cannot be a single MEASURE)`);
     return;
   }
+  // An abstract entity is a table-less supertype with no node table, so it can
+  // carry no MEASURE. Report that specifically -- it is also in `skipped`, so
+  // this must precede the generic no-KEY message below to stay accurate.
+  if (entity.abstract) {
+    warnings.push(
+        `metric '${metric.name}' targets entity '${entityName}', which is ` +
+        `abstract (a table-less supertype with no node table to carry a ` +
+        `MEASURE); metric dropped`);
+    return;
+  }
   // A metric can only become a MEASURE on a node table, but an entity that was
   // skipped upstream (empty KEY) has no node table to carry it. Check the skip
   // set already computed, and report the drop directly, instead of letting it
@@ -524,11 +534,51 @@ function renderNodeTable(
     warnings: string[]): string {
   const table = qualifyTable(
       entity.dataSource, opts, warnings, `entity '${entity.name}'`);
+
+  // Canonical rendering of every inherited property: its supertype's OWN
+  // definition, keyed by property name (nearest ancestor wins, matching field
+  // flattening). A property that appears under a label shared across element
+  // tables must have one identical definition everywhere it appears, so the
+  // supertype is authoritative -- both this node's DEFAULT LABEL and its
+  // `LABEL <ancestor>` blocks render an inherited property exactly as the
+  // supertype's node table does. resolveInheritance localizes the inherited
+  // copies on this entity, so in a well-formed hierarchy `renderOwn` below is a
+  // no-op; the map's real job is to catch and neutralize a genuine override.
+  const inheritedRender = new Map<string, string>();
+  for (const ancestorName of entity.extends ?? []) {
+    const ancestor = allByName.get(ancestorName);
+    if (!ancestor) continue;
+    for (const f of ancestor.fields) {
+      if (!inheritedRender.has(f.name)) {
+        inheritedRender.set(f.name, renderFieldProperty(f, ancestor.name));
+      }
+    }
+  }
+  // Renders one of this entity's own fields, deferring to the supertype's
+  // canonical definition for any inherited name. A subclass CANNOT give an
+  // inherited property a different definition -- BigQuery requires one
+  // definition per property under a shared label -- so a divergent override is
+  // warned and dropped in favor of the supertype's, keeping the DDL valid.
+  const renderOwn = (f: Field): string => {
+    const own = renderFieldProperty(f, entity.name);
+    const canonical = inheritedRender.get(f.name);
+    if (canonical === undefined) return own;
+    if (canonical !== own) {
+      warnings.push(
+          `entity '${entity.name}' redefines inherited property '${
+              f.name}' with a definition that differs from its supertype's; ` +
+          `BigQuery allows only one definition per property under a shared ` +
+          `label, so the supertype's is used and the subclass override is ` +
+          `dropped`);
+    }
+    return canonical;
+  };
+
   // Order: declared fields, then any operand properties synthesized for
   // measures, then the measures themselves (which reference those operand
   // properties).
   const properties = [
-    ...entity.fields.map(f => renderFieldProperty(f, entity.name)),
+    ...entity.fields.map(renderOwn),
     ...derivedProperties,
     ...measures,
   ];
@@ -572,20 +622,19 @@ function renderNodeTable(
   // Inheritance: declare one LABEL per transitive ancestor (resolveInheritance
   // expanded `extends` to the full ancestor set), each re-listing that
   // ancestor's properties so `MATCH (:Ancestor)` also matches this subclass
-  // node. BigQuery requires a property shared across an element table's label
-  // blocks to have an IDENTICAL definition in each (verified live -- "Property
-  // ... has more than one definition"), so the ancestor block reuses THIS
-  // entity's own rendered property strings (by name) rather than re-rendering
-  // from the ancestor, guaranteeing they match byte-for-byte even when a field
-  // carries OPTIONS or a qualified expression.
-  const ownRender = new Map(
-      entity.fields.map(f => [f.name, renderFieldProperty(f, entity.name)]));
+  // node. The block is rendered straight from the ANCESTOR's own fields with
+  // the ancestor as qualifier, so it is byte-for-byte identical to the
+  // ancestor's own DEFAULT LABEL -- the exact match BigQuery requires for a
+  // property shared across the element tables that bind a label ("same set of
+  // property declarations under the same label"). This node's DEFAULT LABEL
+  // renders the same inherited names via `renderOwn`, which also defers to the
+  // ancestor, so the label is consistent within this table too.
   for (const ancestorName of entity.extends ?? []) {
     const ancestor = allByName.get(ancestorName);
     if (!ancestor) continue;
     lines.push(line(2, `LABEL ${ancestorName}`));
-    const signature = ancestor.fields.map(f => ownRender.get(f.name))
-                          .filter((s): s is string => s !== undefined);
+    const signature =
+        ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
     if (signature.length) lines.push(propertiesBlock(signature));
   }
   return lines.join('\n');
@@ -767,8 +816,7 @@ function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
   // sources (whitespace), which carry no usable location.
   const first = (model.entities ?? [])
                     .find(e => e.dataSource && !/\s/.test(e.dataSource));
-  if ((!project || !dataset) && first?.dataSource &&
-      !/\s/.test(first.dataSource)) {
+  if ((!project || !dataset) && first) {
     const p = first.dataSource.trim().split('.');
     if (p.length >= 3) {
       project = project ?? p[0];

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -89,10 +89,23 @@ export interface Entity {
   //
   // This is the hierarchy AS DECLARED: it records the fact, it does not itself
   // flatten anything. Resolving `extends` into inherited fields (so an emitter
-  // sees a self-contained entity) is a separate pass, not yet wired -- so a
-  // consumer may observe `extends` on an entity whose `fields` do NOT yet
-  // include the supertype's fields.
+  // sees a self-contained entity) is a separate pass (see resolve_inheritance);
+  // the BigQuery leg runs it, so a consumer of the raw IR may still observe
+  // `extends` on an entity whose `fields` do NOT yet include the supertype's.
   extends?: string[];
+  // Marks a conceptual (abstract) entity with NO physical table: a class used
+  // only to group its subtypes (e.g. an abstract `Party` over `Person` and
+  // `Organization`). It is never materialized, so it forms no NODE TABLE in the
+  // BigQuery graph -- it survives only as a LABEL on its concrete descendants
+  // (its fields still flatten down so that shared label's signature is present).
+  // An abstract entity therefore has no meaningful `dataSource` or `keys`.
+  //
+  // This is an EXPLICIT marker, deliberately distinct from the OWL importer's
+  // `unbound:<Name>` source placeholder: an unbound source means "should be
+  // bound but isn't yet" and must fail the push loudly, whereas `abstract`
+  // asserts "intentionally has no table". Overloading one for the other would
+  // silently drop an entity someone merely forgot to bind.
+  abstract?: boolean;
   description?: string;
   aiContext?: AiContext;
   fields: Field[];       // dimensions / attributes

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -140,6 +140,19 @@ export function generateCatalogResources(
   // actually emitted (not skipped for a duplicate id) are recorded.
   const entityEntryName = new Map<string, string>();
   for (const entity of entities) {
+    // An abstract entity is a conceptual (table-less) supertype: it has no
+    // physical resource to catalog. The Knowledge Catalog leg does not model
+    // inheritance (that is BigQuery-only today, via resolveInheritance), so
+    // rather than publish a malformed entry -- an empty linked resource and no
+    // key -- skip it with a warning. Its concrete subtypes are published
+    // normally, and any edge naming it as an endpoint is dropped downstream
+    // (its name never enters `entityEntryName`).
+    if (entity.abstract) {
+      warnings.push(
+          `entity '${entity.name}' is abstract (no physical table); skipped ` +
+          `for Knowledge Catalog (KC does not yet model class hierarchies)`);
+      continue;
+    }
     const entityId = names.entityId(model, entity);
     if (!claim(seen, entityId, 'entry', `entity '${entity.name}'`, warnings))
       continue;

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -115,6 +115,19 @@ const datasetSchema = z.object({
           `source; set 'source', or mark it 'abstract: true' if it has no table`,
     });
   }
+  // The converse: an abstract dataset has no physical table, so declaring a
+  // `source` on it is contradictory -- the BigQuery leg forms no node table for
+  // an abstract entity and would silently ignore the source, dropping a table
+  // the author clearly intended. Reject it so the ambiguity is resolved
+  // explicitly rather than lost.
+  if (ds.abstract && ds.source !== undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['source'],
+      message: `dataset '${ds.name}': an abstract dataset has no table; ` +
+          `remove 'source', or drop 'abstract: true' to bind it to that table`,
+    });
+  }
 });
 
 const relationshipSchema = z.object({

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -86,16 +86,35 @@ const fieldSchema = z.object({
 
 const datasetSchema = z.object({
   name: z.string(),
-  source: z.string(),
+  // A concrete dataset is backed by a physical `source` table; an `abstract`
+  // one has no table, so `source` is optional here and required-unless-abstract
+  // by the refinement below.
+  source: z.string().optional(),
   primary_key: z.array(z.string()).optional(),
   unique_keys: z.array(z.array(z.string())).optional(),
   // Supertype entity names (Ossie `extends`) -- entity-level inheritance. Only
   // datasets carry it; relationships have no `extends`.
   extends: z.array(z.string()).optional(),
+  // Marks a conceptual entity with no physical table (see Entity.abstract): it
+  // forms no node table and survives only as a label on its concrete
+  // descendants. Distinct from an unbound `source` placeholder, which must fail
+  // loudly rather than be silently treated as table-less.
+  abstract: z.boolean().optional(),
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
   fields: z.array(fieldSchema).optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
+}).superRefine((ds, ctx) => {
+  // A concrete (non-abstract) dataset must name its backing table; only an
+  // abstract one may omit `source`.
+  if (!ds.abstract && ds.source === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['source'],
+      message: `dataset '${ds.name}': a non-abstract dataset requires a ` +
+          `source; set 'source', or mark it 'abstract: true' if it has no table`,
+    });
+  }
 });
 
 const relationshipSchema = z.object({
@@ -278,9 +297,14 @@ function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): Seman
 function convertDataset(ds: DatasetDoc, opts: LoadOptions,
                         warnings: string[], dialect: string): Entity {
   const ctxLabel = `dataset '${ds.name}'`;
-  const dataSource = parseSource(ds.source, opts, warnings, ctxLabel);
+  // An abstract entity has no physical table, so it carries no source (empty
+  // dataSource) and no key -- both are meaningless for a class never
+  // materialized. Only a concrete entity is parsed/warned for those.
+  const dataSource = ds.source !== undefined ?
+      parseSource(ds.source, opts, warnings, ctxLabel) :
+      '';
   const keys = ds.primary_key ?? [];
-  if (!keys.length) {
+  if (!keys.length && !ds.abstract) {
     warnings.push(`${ctxLabel}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
   }
   const fields = (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
@@ -289,6 +313,7 @@ function convertDataset(ds: DatasetDoc, opts: LoadOptions,
   const entity: Entity = { name: ds.name, dataSource, keys, fields };
   if (ds.unique_keys && ds.unique_keys.length) entity.uniqueKeys = ds.unique_keys;
   if (ds.extends && ds.extends.length) entity.extends = ds.extends;
+  if (ds.abstract) entity.abstract = true;
   const description = composeDescription(ds.description);
   if (description) entity.description = description;
   const ai = aiContextOrUndefined(ds.ai_context);

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -118,6 +118,16 @@ function modelDoc(
 
 function datasetDoc(
     entity: Entity, warnings: string[]): Record<string, any> {
+  // A concrete (non-abstract) entity with no source cannot be reloaded -- the
+  // loader requires `source` unless the dataset is abstract -- so surface the
+  // gap at write time instead of emitting a document that fails to load. This
+  // never fires for a well-formed IR; it catches a lossy pull that dropped a
+  // binding without marking the entity abstract.
+  if (!entity.abstract && !entity.dataSource) {
+    warnings.push(
+        `entity '${entity.name}' has no source and is not abstract; the ` +
+        `serialized document will not reload until a source is set`);
+  }
   return compact({
     name: entity.name,
     // An abstract entity has no physical table, so its source is empty; omit the

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -120,9 +120,14 @@ function datasetDoc(
     entity: Entity, warnings: string[]): Record<string, any> {
   return compact({
     name: entity.name,
-    source: entity.dataSource,
+    // An abstract entity has no physical table, so its source is empty; omit the
+    // key rather than emit `source: ""` (which the loader reads as a
+    // concrete-but-empty reference).
+    source: entity.dataSource || undefined,
     // Supertype entities (entity-level inheritance); omitted when none.
     extends: nonEmpty(entity.extends),
+    // Conceptual (table-less) marker; omitted when false/absent.
+    abstract: entity.abstract || undefined,
     primary_key: nonEmpty(entity.keys),
     unique_keys: nonEmpty(entity.uniqueKeys),
     description: entity.description,

--- a/toolbox/mdcode/src/libts/semantic/resolve_inheritance.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_inheritance.ts
@@ -34,6 +34,7 @@
 // signature).
 
 import {Entity, Field, SemanticModel} from './ir';
+import {stripQualifier} from './sql_expr_utils';
 
 export interface ResolveResult {
   model: SemanticModel;
@@ -81,7 +82,7 @@ export function resolveInheritance(model: SemanticModel): ResolveResult {
       for (const f of ownFields.get(anc) ?? []) {
         if (seenField.has(f.name)) continue;
         seenField.add(f.name);
-        flattened.push(structuredClone(f));
+        flattened.push(localizeInheritedField(f, anc));
       }
     }
     entity.fields = flattened;
@@ -97,6 +98,28 @@ export function resolveInheritance(model: SemanticModel): ResolveResult {
   }
 
   return {model: clone, warnings: [...new Set(warnings)]};
+}
+
+// Clones an ancestor's field for a descendant, rewriting its expression to be
+// TABLE-LOCAL. A field expression written on the ancestor as `<Ancestor>.col`
+// means "the `col` column of the ancestor's own table"; inherited onto a
+// descendant -- whose backing table carries the same column, since inherited
+// fields must physically exist on the child -- it must reference the
+// DESCENDANT's column, so the ancestor's own-name qualifier is stripped.
+// Without this the descendant would render `<Ancestor>.col AS col` while the
+// ancestor renders `col`, and an emitter that reuses one label across both
+// tables (e.g. BigQuery's shared labels) would see two different definitions of
+// the same property and reject the graph.
+function localizeInheritedField(field: Field, ancestor: string): Field {
+  const clone = structuredClone(field);
+  if (clone.expression !== undefined) {
+    clone.expression = stripQualifier(clone.expression, ancestor);
+  }
+  if (clone.importedExpression !== undefined) {
+    clone.importedExpression =
+        stripQualifier(clone.importedExpression, ancestor);
+  }
+  return clone;
 }
 
 // Computes the de-duplicated transitive ancestor set for `start`, ORDERED

--- a/toolbox/mdcode/src/libts/semantic/resolve_inheritance.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_inheritance.ts
@@ -110,6 +110,13 @@ export function resolveInheritance(model: SemanticModel): ResolveResult {
 // ancestor renders `col`, and an emitter that reuses one label across both
 // tables (e.g. BigQuery's shared labels) would see two different definitions of
 // the same property and reject the graph.
+//
+// This composes with (does not duplicate) the emitter's own qualifier
+// stripping: this pass normalizes an inherited expression INTO the child's
+// frame once here, and the emitter's table-local renderer then strips the
+// child's own qualifier uniformly for every field (see
+// bigquery.renderFieldPropertyCore). Both route through the same `stripQualifier`
+// primitive; they differ only in which qualifier they remove.
 function localizeInheritedField(field: Field, ancestor: string): Field {
   const clone = structuredClone(field);
   if (clone.expression !== undefined) {

--- a/toolbox/mdcode/src/libts/semantic/resolve_inheritance.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_inheritance.ts
@@ -1,0 +1,153 @@
+// Resolves entity-level inheritance (`extends`) into self-contained entities.
+//
+// The IR records inheritance AS DECLARED: an entity's `extends` names its
+// direct supertypes, and its `fields` are only the ones it declares itself (see
+// ir.Entity.extends). That is faithful but not directly consumable -- an
+// emitter that wants to publish a subclass as a first-class node needs the
+// supertype's fields present on the child, and the full ancestor set (not just
+// the direct parents) to label it. This pass performs that resolution,
+// mirroring the shape of ./transpile: it `structuredClone`s the model and NEVER
+// mutates its input, returning a resolved clone plus warnings.
+//
+// What it does, per entity:
+//   - Fields FLOW DOWN (flattening). The entity's own fields come first
+//   (declared
+//     order), then each ancestor's own fields whose name is not already
+//     present, walking ancestors nearest-first. So the NEAREST definition of a
+//     name wins (child overrides parent overrides grandparent), and every
+//     transitive ancestor's own fields are included.
+//   - `extends` is expanded from the direct parents to the full, de-duplicated
+//     TRANSITIVE ancestor set, ordered nearest-first (a diamond lists each
+//     ancestor once). An emitter reads labels straight off this list.
+//
+// What it deliberately does NOT do:
+//   - Keys are NOT inherited: each entity keeps its own KEY (a node table is
+//     identified by its own grain, not its supertype's).
+//   - Relationships (edges) are NOT inherited: a subclass does not gain its
+//     supertype's edges. Only node properties flow down.
+//   - It does not classify abstract vs concrete or drop anything -- that is the
+//     consuming leg's concern (see bigquery.ts). This pass is leg-agnostic.
+//
+// Robustness: a cycle in `extends` is broken (warned, no infinite loop); a
+// parent that is not an entity in the model is warned and excluded from the
+// resolved ancestor list (so the emitter never references a label with no
+// signature).
+
+import {Entity, Field, SemanticModel} from './ir';
+
+export interface ResolveResult {
+  model: SemanticModel;
+  warnings: string[];
+}
+
+/**
+ * Returns a clone of `model` with every entity's `extends` expanded to its full
+ * transitive ancestor set and its `fields` flattened to include inherited
+ * fields. The input is never mutated. An entity with no `extends` is returned
+ * byte-for-byte unchanged (same fields, no `extends`), so a model with no
+ * inheritance resolves to an equivalent model.
+ */
+export function resolveInheritance(model: SemanticModel): ResolveResult {
+  const clone: SemanticModel = structuredClone(model);
+  const warnings: string[] = [];
+  const entities = clone.entities ?? [];
+  const byName = new Map(entities.map(e => [e.name, e]));
+
+  // Snapshot the AS-DECLARED direct parents and own fields BEFORE mutating any
+  // entity, so resolution reads a stable view regardless of iteration order
+  // (each entity is flattened from originals, not from an already-flattened
+  // ancestor).
+  const directParents = new Map<string, string[]>();
+  const ownFields = new Map<string, Field[]>();
+  for (const e of entities) {
+    directParents.set(e.name, [...(e.extends ?? [])]);
+    ownFields.set(e.name, [...e.fields]);
+  }
+
+  for (const entity of entities) {
+    const ancestors =
+        transitiveAncestors(entity.name, byName, directParents, warnings);
+
+    // Flatten: own fields first, then each ancestor's own fields by name unless
+    // already present (nearest definition wins).
+    const seenField = new Set<string>();
+    const flattened: Field[] = [];
+    for (const f of ownFields.get(entity.name) ?? []) {
+      if (seenField.has(f.name)) continue;  // a self-duplicate; keep the first
+      seenField.add(f.name);
+      flattened.push(f);
+    }
+    for (const anc of ancestors) {
+      for (const f of ownFields.get(anc) ?? []) {
+        if (seenField.has(f.name)) continue;
+        seenField.add(f.name);
+        flattened.push(structuredClone(f));
+      }
+    }
+    entity.fields = flattened;
+
+    // Expand `extends` to the resolved ancestor list (existing entities only).
+    // Drop the key when it resolves to nothing (no parents, or every parent
+    // unknown/cyclic), so a consumer reads `extends` as the exact label set.
+    if (ancestors.length) {
+      entity.extends = ancestors;
+    } else {
+      delete entity.extends;
+    }
+  }
+
+  return {model: clone, warnings: [...new Set(warnings)]};
+}
+
+// Computes the de-duplicated transitive ancestor set for `start`, ORDERED
+// NEAREST-FIRST (breadth-first by distance): direct parents in declared order,
+// then grandparents, and so on. Nearest-first is what makes field flattening's
+// "nearest definition wins" correct -- a field defined by both a direct parent
+// and a grandparent must resolve to the direct parent's. Direct parents are
+// read from the pre-mutation snapshot so resolution is order-independent.
+//
+// A parent edge that points back to `start` is a cycle (warned, skipped so the
+// walk terminates); a parent that is not an entity in the model is warned and
+// excluded (an emitter cannot label with a signature it does not have). A node
+// re-reached through a second path (a diamond) is simply skipped -- it is
+// already included at its nearest distance.
+function transitiveAncestors(
+    start: string, byName: Map<string, Entity>,
+    directParents: Map<string, string[]>, warnings: string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>([start]);
+  const missingWarned = new Set<string>();
+
+  // Queue of (child that declared the edge, parent) so a cycle warning can name
+  // the offending child. Seeded with `start`'s direct parents in declared
+  // order.
+  const queue: Array<{from: string; name: string}> =
+      (directParents.get(start) ?? []).map(name => ({from: start, name}));
+
+  while (queue.length) {
+    const {from, name} = queue.shift()!;
+    if (name === start) {
+      warnings.push(
+          `entity '${from}' extends '${name}', which is already a supertype ` +
+          `on this chain (cycle); breaking the cycle`);
+      continue;
+    }
+    if (!byName.has(name)) {
+      if (!missingWarned.has(name)) {
+        missingWarned.add(name);
+        warnings.push(
+            `entity '${from}' extends unknown entity '${name}'; it is not ` +
+            `defined in the model, so it is ignored`);
+      }
+      continue;
+    }
+    if (seen.has(name)) continue;  // diamond: already included at its nearest
+    seen.add(name);
+    result.push(name);
+    for (const gp of directParents.get(name) ?? []) {
+      queue.push({from: name, name: gp});
+    }
+  }
+
+  return result;
+}

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.e2e.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.e2e.test.ts
@@ -41,6 +41,7 @@ const CORPUS = [
   'measure_lowering.yaml',
   'metric_skips.yaml',
   'keyless_dimension.yaml',
+  'hierarchy_graph.yaml',
 ];
 
 // Loads a fixture file to its IR. Split out from `build` so a test that only

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -633,3 +633,67 @@ describe('abstract (table-less) superclasses are eliminated to labels', () => {
     expect(ddl).not.toContain('Ghost');
   });
 });
+
+
+describe('supertype shared-label constraints (inheritance)', () => {
+  // Person is a supertype (Customer extends it), so its label is shared across
+  // both element tables. BigQuery forbids OPTIONS on a shared label and forbids
+  // a MEASURE bound to more than one element table, so the generator must (a)
+  // drop Person's label OPTIONS with a warning and (b) skip a metric that
+  // targets a supertype with a warning -- while a metric on a leaf still emits.
+  function hierModel(): SemanticModel {
+    return {
+      name: 'hier',
+      entities: [
+        {
+          name: 'Person',
+          dataSource: 'proj.ds.person',
+          keys: ['id'],
+          description: 'A human being',
+          fields: [{name: 'id'}, {name: 'name'}],
+        },
+        {
+          name: 'Customer',
+          dataSource: 'proj.ds.customer',
+          keys: ['id'],
+          extends: ['Person'],
+          fields: [{name: 'id'}, {name: 'tier'}],
+        },
+      ],
+      relationships: [],
+      metrics: [{name: 'total_people', expression: 'COUNT(Person.id)'}],
+    };
+  }
+
+  test('a shared supertype label drops its OPTIONS (with a warning)', () => {
+    const {ddl, warnings} = generatePropertyGraph(hierModel(), GEN_OPTS);
+    // Person's description would normally ride its DEFAULT LABEL OPTIONS; because
+    // the label is shared with Customer it must be options-free.
+    expect(ddl).not.toContain('A human being');
+    expect(warnings.some(
+               w => w.includes(`entity 'Person' is a supertype`) &&
+                   w.includes('dropped from the shared')))
+        .toBe(true);
+    // The shared supertype still uses an explicit DEFAULT LABEL.
+    expect(ddl).toContain('DEFAULT LABEL');
+  });
+
+  test('a metric targeting a supertype is skipped (with a warning)', () => {
+    const {ddl, warnings} = generatePropertyGraph(hierModel(), GEN_OPTS);
+    expect(ddl).not.toContain('total_people');
+    expect(warnings.some(
+               w => w.includes(`metric 'total_people'`) &&
+                   w.includes('shared label')))
+        .toBe(true);
+  });
+
+  test('a metric on a leaf (non-supertype) entity is still emitted', () => {
+    const model = hierModel();
+    // Retarget to the leaf Customer -- nobody extends it, so its label is not
+    // shared and a MEASURE binds cleanly.
+    model.metrics = [{name: 'total_customers', expression: 'COUNT(Customer.id)'}];
+    const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
+    expect(ddl).toContain('AS total_customers');
+    expect(warnings.some(w => w.includes('total_customers'))).toBe(false);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -555,3 +555,81 @@ describe(
         expect(ddl).not.toContain('MEASURE(COUNT(*))');
       });
     });
+
+
+describe('abstract (table-less) superclasses are eliminated to labels', () => {
+  // An abstract `Party` has no physical table; two concrete subtypes, `Person`
+  // and `Organization`, bind it. resolveInheritance flattens Party's `name`
+  // onto each subtype and expands their `extends` to [Party], so each concrete
+  // node table declares `LABEL Party` with Party's own signature. Party itself
+  // must produce NO node table -- it survives only as that shared label.
+  function partyModel(): SemanticModel {
+    return {
+      name: 'party_graph',
+      entities: [
+        {
+          name: 'Party',
+          dataSource: '',
+          keys: [],
+          abstract: true,
+          fields: [{name: 'id'}, {name: 'name'}],
+        },
+        {
+          name: 'Person',
+          dataSource: 'sqlgen-testing.demo.person',
+          keys: ['id'],
+          extends: ['Party'],
+          fields: [{name: 'id'}, {name: 'ssn'}],
+        },
+        {
+          name: 'Organization',
+          dataSource: 'sqlgen-testing.demo.organization',
+          keys: ['id'],
+          extends: ['Party'],
+          fields: [{name: 'id'}, {name: 'taxId'}],
+        },
+      ],
+      relationships: [],
+      metrics: [],
+    };
+  }
+
+  test('the abstract class produces no node table but survives as a label', () => {
+    const {ddl} = generatePropertyGraph(partyModel(), GEN_OPTS);
+    // No `AS Party` node table (it has no source/KEY to materialize)...
+    expect(ddl).not.toContain('AS Party');
+    // ...but its label is present on the concrete descendants.
+    expect(ddl).toContain('LABEL Party');
+  });
+
+  test('concrete subclasses share the abstract label and its flattened fields', () => {
+    const {ddl} = generatePropertyGraph(partyModel(), GEN_OPTS);
+    // Both Person and Organization declare the shared Party label.
+    expect(ddl.match(/LABEL Party/g)?.length).toBe(2);
+    // Party's `name` field flattened down so the shared signature is present.
+    expect(ddl).toContain('name');
+  });
+
+  test('both concrete node tables are still emitted', () => {
+    const {ddl} = generatePropertyGraph(partyModel(), GEN_OPTS);
+    expect(ddl).toContain('AS Person');
+    expect(ddl).toContain('AS Organization');
+  });
+
+  test('an abstract class that is nobody\'s supertype is warned and dropped', () => {
+    const model = partyModel();
+    model.entities!.push({
+      name: 'Ghost',
+      dataSource: '',
+      keys: [],
+      abstract: true,
+      fields: [{name: 'id'}],
+    });
+    const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
+    expect(warnings.some(
+               w => w.includes(`abstract entity 'Ghost'`) &&
+                   w.includes('no graph element')))
+        .toBe(true);
+    expect(ddl).not.toContain('Ghost');
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -604,10 +604,16 @@ describe('abstract (table-less) superclasses are eliminated to labels', () => {
 
   test('concrete subclasses share the abstract label and its flattened fields', () => {
     const {ddl} = generatePropertyGraph(partyModel(), GEN_OPTS);
-    // Both Person and Organization declare the shared Party label.
-    expect(ddl.match(/LABEL Party/g)?.length).toBe(2);
-    // Party's `name` field flattened down so the shared signature is present.
-    expect(ddl).toContain('name');
+    // Both Person and Organization declare the shared Party label, each with a
+    // PROPERTIES block that lists Party's flattened `name` (assert inside the
+    // block, so an unrelated `name` substring elsewhere can't satisfy this).
+    const partyBlocks =
+        [...ddl.matchAll(/LABEL Party\s*\n\s*PROPERTIES\(([\s\S]*?)\)/g)];
+    expect(partyBlocks.length).toBe(2);
+    for (const [, props] of partyBlocks) {
+      expect(props).toContain('name');
+      expect(props).toContain('id');
+    }
   });
 
   test('both concrete node tables are still emitted', () => {
@@ -695,5 +701,64 @@ describe('supertype shared-label constraints (inheritance)', () => {
     const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
     expect(ddl).toContain('AS total_customers');
     expect(warnings.some(w => w.includes('total_customers'))).toBe(false);
+  });
+});
+
+
+describe('inherited property rendering (shared-label consistency)', () => {
+  // BigQuery requires a property carried by a label bound to more than one
+  // element table to have an IDENTICAL definition in every table. These tests
+  // pin the two ways a naive renderer would violate that: a supertype field
+  // whose expression is qualified with its own name, and a subclass that
+  // redefines an inherited field.
+  function base(customerFields: Array<{name: string; expression?: string}>,
+                personFields: Array<{name: string; expression?: string}>):
+      SemanticModel {
+    return {
+      name: 'hier',
+      entities: [
+        {name: 'Person', dataSource: 'proj.ds.person', keys: ['id'],
+         fields: personFields},
+        {name: 'Customer', dataSource: 'proj.ds.customer', keys: ['id'],
+         extends: ['Person'], fields: customerFields},
+      ],
+      relationships: [],
+      metrics: [],
+    };
+  }
+
+  test('a supertype expression qualified with its own name is localized', () => {
+    // Person.email references Person's table; inherited onto Customer it must be
+    // the local `email`, so the qualifier appears NOWHERE in the DDL and every
+    // binding of the Person label lists an identical `email` property.
+    const model = base(
+        [{name: 'id', expression: 'id'}],
+        [{name: 'id', expression: 'id'},
+         {name: 'email', expression: 'Person.email'}]);
+    const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
+    expect(ddl).not.toContain('Person.email');
+    // Person's own DEFAULT LABEL, Customer's DEFAULT LABEL, and Customer's
+    // LABEL Person block must all list `email` the same way -> three occurrences.
+    expect(ddl.match(/\bemail\b/g)?.length).toBe(3);
+    // A well-formed hierarchy raises no override warning.
+    expect(warnings.some(w => w.includes('redefines inherited'))).toBe(false);
+  });
+
+  test('a subclass overriding an inherited field is warned and neutralized', () => {
+    // Customer redefines `email` (inherited from Person) with a different
+    // expression. That cannot be represented under the shared Person label, so
+    // the supertype's definition wins and the override is dropped with a warning.
+    const model = base(
+        [{name: 'id', expression: 'id'},
+         {name: 'email', expression: 'LOWER(email)'}],
+        [{name: 'id', expression: 'id'},
+         {name: 'email', expression: 'email'}]);
+    const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
+    expect(warnings.some(
+               w => w.includes(`redefines inherited property 'email'`) &&
+                   w.includes('override is dropped')))
+        .toBe(true);
+    // The overriding expression is gone; only the supertype's `email` remains.
+    expect(ddl).not.toContain('LOWER(email)');
   });
 });

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -744,10 +744,11 @@ describe('inherited property rendering (shared-label consistency)', () => {
     expect(warnings.some(w => w.includes('redefines inherited'))).toBe(false);
   });
 
-  test('a subclass overriding an inherited field is warned and neutralized', () => {
-    // Customer redefines `email` (inherited from Person) with a different
-    // expression. That cannot be represented under the shared Person label, so
-    // the supertype's definition wins and the override is dropped with a warning.
+  test('a subclass structurally remapping an inherited field is warned', () => {
+    // Customer remaps `email` (inherited from Person) to a different expression.
+    // That cannot be represented under the shared Person label, so the
+    // supertype's definition wins and the remap is dropped with a warning that
+    // names it as a column/expression remap.
     const model = base(
         [{name: 'id', expression: 'id'},
          {name: 'email', expression: 'LOWER(email)'}],
@@ -755,10 +756,90 @@ describe('inherited property rendering (shared-label consistency)', () => {
          {name: 'email', expression: 'email'}]);
     const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
     expect(warnings.some(
-               w => w.includes(`redefines inherited property 'email'`) &&
-                   w.includes('override is dropped')))
+               w => w.includes(`remaps inherited property 'email'`) &&
+                   w.includes('remapping is dropped')))
         .toBe(true);
-    // The overriding expression is gone; only the supertype's `email` remains.
+    // The remapping expression is gone; only the supertype's `email` remains.
     expect(ddl).not.toContain('LOWER(email)');
   });
+
+  test('a subclass refining only inherited metadata is warned as metadata-only',
+       () => {
+         // Customer keeps `email`'s column but adds a description. The structural
+         // core matches the supertype, so under the shared label the supertype's
+         // (option-free) definition still wins -- but the warning must say the
+         // refinement was METADATA, not a redefined column, and the added text
+         // must not leak into the DDL.
+         const model: SemanticModel = {
+           name: 'hier',
+           entities: [
+             {
+               name: 'Person', dataSource: 'proj.ds.person', keys: ['id'],
+               fields: [{name: 'id', expression: 'id'},
+                        {name: 'email', expression: 'email'}],
+             },
+             {
+               name: 'Customer', dataSource: 'proj.ds.customer', keys: ['id'],
+               extends: ['Person'],
+               fields: [{name: 'id', expression: 'id'}, {
+                 name: 'email',
+                 expression: 'email',
+                 description: 'Customer-specific email',
+               }],
+             },
+           ],
+           relationships: [],
+           metrics: [],
+         };
+         const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
+         expect(
+             warnings.some(
+                 w => w.includes(
+                          `overrides the description/synonyms of inherited property 'email'`) &&
+                     w.includes('metadata is used')))
+             .toBe(true);
+         // Not mislabeled as a structural remap...
+         expect(warnings.some(w => w.includes('remaps inherited property')))
+             .toBe(false);
+         // ...and the subclass metadata is dropped, not emitted.
+         expect(ddl).not.toContain('Customer-specific email');
+       });
+
+  test('a subclass extending a KEY-less (dropped) supertype omits that label',
+       () => {
+         // Person is concrete but has no KEY, so it forms no node table. It must
+         // NOT be resurrected as a shared label on its subclass -- that would
+         // contradict the "skipped, invalid" report. The subclass keeps the
+         // flattened columns but drops the LABEL, with a warning explaining why.
+         const model: SemanticModel = {
+           name: 'hier',
+           entities: [
+             {
+               name: 'Person', dataSource: 'proj.ds.person', keys: [],
+               fields: [{name: 'id', expression: 'id'},
+                        {name: 'email', expression: 'email'}],
+             },
+             {
+               name: 'Customer', dataSource: 'proj.ds.customer', keys: ['id'],
+               extends: ['Person'],
+               fields: [{name: 'id', expression: 'id'},
+                        {name: 'loyalty', expression: 'loyalty'}],
+             },
+           ],
+           relationships: [],
+           metrics: [],
+         };
+         const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
+         // No Person node table, and NOT a Person label anywhere.
+         expect(ddl).not.toContain('AS Person');
+         expect(ddl).not.toContain('LABEL Person');
+         // Reported both as the KEY defect and as the omitted label.
+         expect(warnings.some(w => w.includes('empty KEY'))).toBe(true);
+         expect(warnings.some(
+                    w => w.includes(
+                        `the 'Person' label is omitted from 'Customer'`)))
+             .toBe(true);
+         // Person's `email` still flattened onto Customer (it physically exists).
+         expect(ddl).toContain('email');
+       });
 });

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.bigquery.golden.sql
@@ -1,0 +1,77 @@
+CREATE OR REPLACE PROPERTY GRAPH `sqlgen-testing.demo.people`
+NODE TABLES (
+  `sqlgen-testing.demo.person` AS Person
+    KEY(id)
+    OPTIONS(description="A human being")
+    PROPERTIES(
+      id,
+      full_name OPTIONS(description="Full Name"),
+      email,
+      MEASURE(COUNT(id)) AS total_people OPTIONS(description="Number of people")
+    ),
+  `sqlgen-testing.demo.customer` AS Customer
+    KEY(id)
+    PROPERTIES(
+      id,
+      loyalty_tier,
+      full_name OPTIONS(description="Full Name"),
+      email
+    )
+    LABEL Person
+    PROPERTIES(
+      id,
+      full_name OPTIONS(description="Full Name"),
+      email
+    ),
+  `sqlgen-testing.demo.employee` AS Employee
+    KEY(id)
+    PROPERTIES(
+      id,
+      department,
+      full_name OPTIONS(description="Full Name"),
+      email
+    )
+    LABEL Person
+    PROPERTIES(
+      id,
+      full_name OPTIONS(description="Full Name"),
+      email
+    ),
+  `sqlgen-testing.demo.manager` AS Manager
+    KEY(id)
+    PROPERTIES(
+      id,
+      team_size,
+      department,
+      full_name OPTIONS(description="Full Name"),
+      email
+    )
+    LABEL Employee
+    PROPERTIES(
+      id,
+      department,
+      full_name OPTIONS(description="Full Name"),
+      email
+    )
+    LABEL Person
+    PROPERTIES(
+      id,
+      full_name OPTIONS(description="Full Name"),
+      email
+    ),
+  `sqlgen-testing.demo.city` AS City
+    KEY(id)
+    PROPERTIES(
+      id,
+      city_name
+    )
+)
+EDGE TABLES (
+  `sqlgen-testing.demo.person` AS livesIn
+    KEY(id)
+    SOURCE KEY(id) REFERENCES Person(id)
+    DESTINATION KEY(city_id) REFERENCES City(id)
+);
+
+-- warnings --
+-- note: no 'BIGQUERY' dialect for one or more expressions; using the portable 'ANSI_SQL' dialect verbatim ('BIGQUERY' accepts the ANSI core subset — supply 'BIGQUERY' variants only for BIGQUERY-specific SQL)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.bigquery.golden.sql
@@ -2,15 +2,15 @@ CREATE OR REPLACE PROPERTY GRAPH `sqlgen-testing.demo.people`
 NODE TABLES (
   `sqlgen-testing.demo.person` AS Person
     KEY(id)
-    OPTIONS(description="A human being")
+    DEFAULT LABEL
     PROPERTIES(
       id,
       full_name OPTIONS(description="Full Name"),
-      email,
-      MEASURE(COUNT(id)) AS total_people OPTIONS(description="Number of people")
+      email
     ),
   `sqlgen-testing.demo.customer` AS Customer
     KEY(id)
+    DEFAULT LABEL
     PROPERTIES(
       id,
       loyalty_tier,
@@ -25,6 +25,7 @@ NODE TABLES (
     ),
   `sqlgen-testing.demo.employee` AS Employee
     KEY(id)
+    DEFAULT LABEL
     PROPERTIES(
       id,
       department,
@@ -39,6 +40,7 @@ NODE TABLES (
     ),
   `sqlgen-testing.demo.manager` AS Manager
     KEY(id)
+    DEFAULT LABEL
     PROPERTIES(
       id,
       team_size,
@@ -63,7 +65,8 @@ NODE TABLES (
     KEY(id)
     PROPERTIES(
       id,
-      city_name
+      city_name,
+      MEASURE(COUNT(id)) AS total_cities OPTIONS(description="Number of cities")
     )
 )
 EDGE TABLES (
@@ -75,3 +78,4 @@ EDGE TABLES (
 
 -- warnings --
 -- note: no 'BIGQUERY' dialect for one or more expressions; using the portable 'ANSI_SQL' dialect verbatim ('BIGQUERY' accepts the ANSI core subset — supply 'BIGQUERY' variants only for BIGQUERY-specific SQL)
+-- entity 'Person' is a supertype in a class hierarchy; its description/synonyms are dropped from the shared 'Person' label (BigQuery forbids OPTIONS on a label bound by multiple tables)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.yaml
@@ -1,0 +1,117 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# A bound class hierarchy exercising entity-level inheritance (`extends`) on the
+# BigQuery leg: labels mimic the hierarchy and supertype fields flatten down.
+#
+#   Person  (base)
+#     |- Customer   extends Person
+#     |- Employee   extends Person
+#           |- Manager   extends Employee   (transitive: also a Person)
+#
+# Every class here is CONCRETE (backed by a real table). A `livesIn` edge on
+# Person shows that edges do NOT inherit: Customer/Employee/Manager gain the
+# Person LABEL and its fields, but not its relationships. `extends` is a
+# deliberate superset of released OSI (see osi_schema.test.ts).
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: people
+    description: People and organizations, as a class hierarchy
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/people"]}'
+    datasets:
+      - name: Person
+        source: sqlgen-testing.demo.person
+        primary_key: [id]
+        description: A human being
+        fields:
+          - name: id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+          - name: full_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: full_name
+            label: Full Name
+          - name: email
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: email
+      - name: Customer
+        source: sqlgen-testing.demo.customer
+        primary_key: [id]
+        extends: [Person]
+        fields:
+          - name: id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+          - name: loyalty_tier
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: loyalty_tier
+      - name: Employee
+        source: sqlgen-testing.demo.employee
+        primary_key: [id]
+        extends: [Person]
+        fields:
+          - name: id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+          - name: department
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: department
+      - name: Manager
+        source: sqlgen-testing.demo.manager
+        primary_key: [id]
+        extends: [Employee]
+        fields:
+          - name: id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+          - name: team_size
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: team_size
+      - name: City
+        source: sqlgen-testing.demo.city
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: id
+          - name: city_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: city_name
+    relationships:
+      - name: livesIn
+        from: Person
+        to: City
+        from_columns: [city_id]
+        to_columns: [id]
+    metrics:
+      - name: total_people
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: COUNT(Person.id)
+        description: Number of people

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.yaml
@@ -109,9 +109,12 @@ semantic_model:
         from_columns: [city_id]
         to_columns: [id]
     metrics:
-      - name: total_people
+      # Targets City -- a leaf class. A metric on a SUPERTYPE (e.g. Person) is
+      # dropped with a warning: its label is shared across subclass tables and
+      # BigQuery cannot bind a MEASURE to a label carried by more than one table.
+      - name: total_cities
         expression:
           dialects:
             - dialect: ANSI_SQL
-              expression: COUNT(Person.id)
-        description: Number of people
+              expression: COUNT(City.id)
+        description: Number of cities

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
@@ -556,3 +556,42 @@ describe('relationships map to schema-join entry links', () => {
             .toBe(true);
       });
 });
+
+
+describe('abstract entities are skipped for Knowledge Catalog', () => {
+  // The KC leg does not model inheritance (that is BigQuery-only today), and an
+  // abstract entity has no physical table, so it must not be published as an
+  // entry with an empty linked resource. It is skipped with a warning; its
+  // concrete subtype is published normally.
+  function withAbstract(): SemanticModel {
+    return {
+      name: 'm',
+      entities: [
+        {name: 'Party', dataSource: '', keys: [], abstract: true,
+         fields: [{name: 'id', expression: 'id'}]},
+        {name: 'Person', dataSource: 'p.d.person', keys: ['id'],
+         extends: ['Party'], fields: [{name: 'id', expression: 'id'}]},
+      ],
+      relationships: [],
+      metrics: [],
+    };
+  }
+
+  test('an abstract entity produces no entry and warns', () => {
+    const {entries, warnings} = generateCatalogResources(withAbstract(), OPTS);
+    const names = entries.map(e => e.entrySource!.displayName ?? '');
+    expect(names).not.toContain('Party');
+    expect(warnings.some(
+               w => w.includes(`entity 'Party' is abstract`) &&
+                   w.includes('skipped for Knowledge Catalog')))
+        .toBe(true);
+  });
+
+  test('the concrete subtype is still published', () => {
+    const {entries} = generateCatalogResources(withAbstract(), OPTS);
+    const person =
+        entries.find(e => e.entryType.endsWith('/semantic-entity'));
+    expect(person).toBeDefined();
+    expect(person!.entrySource!.displayName).toBe('Person');
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/loader.test.ts
@@ -289,6 +289,42 @@ describe('relationships map onto the direct-FK IR convention', () => {
   });
 });
 
+describe('abstract datasets and their source constraint', () => {
+  test('a non-abstract dataset with no source is a hard error', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', primary_key: ['id'], fields: [] }],
+      }],
+    })).toThrow(/non-abstract dataset requires a source/);
+  });
+
+  test('an abstract dataset that also declares a source is a hard error', () => {
+    // abstract == no physical table; a source would be silently ignored by the
+    // BigQuery leg, dropping a table the author intended, so reject the combo.
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'Party', source: 'proj.ds.party', abstract: true,
+          primary_key: ['id'], fields: [],
+        }],
+      }],
+    })).toThrow(/an abstract dataset has no table/);
+  });
+
+  test('an abstract dataset with no source loads and is marked abstract', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'Party', abstract: true, fields: [] }],
+      }],
+    });
+    expect(models[0].entities[0].abstract).toBe(true);
+    expect(models[0].entities[0].dataSource).toBe('');
+  });
+});
+
 
 describe('metrics infer their referenced entities from the expression', () => {
   test('a single referenced entity becomes the metric attach entity', () => {

--- a/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
@@ -259,6 +259,26 @@ describe('serialize flags loader-invalid reconstructions', () => {
         .toBe(true);
   });
 
+  test('a non-abstract entity with no source warns it will not reload', () => {
+    // A lossy pull could drop an entity's binding without marking it abstract;
+    // the loader requires a source unless abstract, so flag it at write time.
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{
+        name: 'orphanEntity',
+        dataSource: '',
+        keys: ['id'],
+        fields: [{name: 'id', expression: 'id'}],
+      }],
+      relationships: [],
+      metrics: [],
+    };
+    const {warnings} = serializeModel(model);
+    expect(warnings.some(
+               w => /orphanEntity.*no source and is not abstract/i.test(w)))
+        .toBe(true);
+  });
+
   test(
       'an imported dialect colliding with the canonical label is relabeled',
       () => {

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -64,11 +64,16 @@ function onlyMissingExpression(errors: typeof validate.errors): boolean {
 // upstream OSI adopts `extends`, re-vendoring the schema makes this pass with no
 // special-casing and this tolerance can be removed.
 function onlyExtendsExtension(errors: typeof validate.errors): boolean {
+  // `extends` and `abstract` are the two deliberate dataset-level supersets of
+  // released OSI (OWL rdfs:subClassOf -> inheritance, and the abstract marker);
+  // tolerate exactly those additional properties and nothing else.
+  const allowed = new Set(['extends', 'abstract']);
   return !!errors && errors.length > 0 &&
     errors.every(
       e => e.keyword === 'additionalProperties' &&
-        (e.params as {additionalProperty?: string}).additionalProperty ===
-          'extends' &&
+        allowed.has(
+          (e.params as {additionalProperty?: string}).additionalProperty ??
+          '') &&
         /\/datasets\/\d+$/.test(e.instancePath));
 }
 
@@ -90,12 +95,14 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
             onlyMissingExpression(validate.errors)) {
           return;
         }
-        // A dataset `extends` is a deliberate superset of released OSI (OWL
-        // rdfs:subClassOf -> entity-level inheritance); tolerate exactly that
-        // extra property and nothing else, and only on the OWL import goldens
-        // (.osi.golden.yaml) that legitimately carry it -- so a stray `extends`
-        // slipping into any other fixture still fails this guardrail.
-        if (rel.endsWith('.osi.golden.yaml') &&
+        // A dataset `extends`/`abstract` is a deliberate superset of released
+        // OSI (OWL rdfs:subClassOf -> entity-level inheritance, plus the
+        // abstract marker); tolerate exactly those extra properties and nothing
+        // else, and only on the OWL import goldens (.osi.golden.yaml) and the
+        // hand-authored hierarchy fixture that legitimately carry them -- so a
+        // stray `extends` slipping into any other fixture still fails.
+        if ((rel.endsWith('.osi.golden.yaml') ||
+             rel === 'hierarchy_graph.yaml') &&
             onlyExtendsExtension(validate.errors)) {
           return;
         }

--- a/toolbox/mdcode/tests/libts/semantic/resolve_inheritance.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/resolve_inheritance.test.ts
@@ -1,0 +1,178 @@
+// Behavior specification for the inheritance-resolution pass
+// (src/libts/semantic/resolve_inheritance.ts): expanding `extends` to the full
+// transitive ancestor set and flattening supertype fields onto subclasses,
+// without mutating the input.
+
+import {describe, expect, test} from 'bun:test';
+
+import {Entity, Field, SemanticModel} from '../../../src/libts/semantic/ir';
+import {resolveInheritance} from '../../../src/libts/semantic/resolve_inheritance';
+
+// Minimal field/entity builders so a test reads as the hierarchy it describes.
+function field(name: string): Field {
+  return {name, expression: name};
+}
+function entity(
+    name: string, fieldNames: string[], extendsList?: string[],
+    extra: Partial<Entity> = {}): Entity {
+  return {
+    name,
+    dataSource: `proj.ds.${name}`,
+    keys: [`${name}_id`],
+    fields: fieldNames.map(field),
+    ...(extendsList ? {extends: extendsList} : {}),
+    ...extra,
+  };
+}
+function model(entities: Entity[], relationships: any[] = []): SemanticModel {
+  return {name: 'm', entities, relationships, metrics: []};
+}
+// The field names on the named resolved entity, in order.
+function fieldsOf(m: SemanticModel, name: string): string[] {
+  return m.entities.find(e => e.name === name)!.fields.map(f => f.name);
+}
+function entityOf(m: SemanticModel, name: string): Entity {
+  return m.entities.find(e => e.name === name)!;
+}
+
+
+describe('field flattening', () => {
+  test(
+      'a single parent flows its fields onto the child, own fields first',
+      () => {
+        const {model: r, warnings} = resolveInheritance(model([
+          entity('Person', ['id', 'fullName', 'email']),
+          entity('Customer', ['id', 'loyaltyTier'], ['Person']),
+        ]));
+        // Own fields lead (declared order), then the parent's not-yet-present
+        // ones; `id` is shared, so the child's `id` wins and the parent's is
+        // not appended.
+        expect(fieldsOf(r, 'Customer')).toEqual([
+          'id', 'loyaltyTier', 'fullName', 'email'
+        ]);
+        expect(warnings).toEqual([]);
+      });
+
+  test('a transitive chain flattens every ancestor, nearest-first', () => {
+    const {model: r} = resolveInheritance(model([
+      entity('Person', ['id', 'fullName']),
+      entity('Employee', ['id', 'department'], ['Person']),
+      entity('Manager', ['id', 'teamSize'], ['Employee']),
+    ]));
+    expect(fieldsOf(r, 'Manager')).toEqual([
+      'id', 'teamSize', 'department', 'fullName'
+    ]);
+    expect(fieldsOf(r, 'Employee')).toEqual(['id', 'department', 'fullName']);
+  });
+
+  test('a nearer definition of a field name wins over a farther one', () => {
+    const {model: r} = resolveInheritance(model([
+      entity('A', ['id', 'note']),
+      entity('B', ['id', 'note'], ['A']),  // B.note shadows A.note
+    ]));
+    const b = entityOf(r, 'B');
+    // The kept `note` is B's own (its expression), not A's.
+    const note = b.fields.find(f => f.name === 'note')!;
+    expect(note.expression).toBe('note');
+    expect(fieldsOf(r, 'B')).toEqual(['id', 'note']);
+  });
+
+  test('a diamond includes each ancestor and each field exactly once', () => {
+    // D -> {B, C} -> A. A is reached via both B and C but must appear once.
+    const {model: r} = resolveInheritance(model([
+      entity('A', ['id', 'base']),
+      entity('B', ['b'], ['A']),
+      entity('C', ['c'], ['A']),
+      entity('D', ['d'], ['B', 'C']),
+    ]));
+    expect(entityOf(r, 'D').extends).toEqual(['B', 'C', 'A']);
+    // Nearest-first: own (d), then direct parents B (b) and C (c), then the
+    // shared grandparent A (id, base) once.
+    expect(fieldsOf(r, 'D')).toEqual(['d', 'b', 'c', 'id', 'base']);
+  });
+});
+
+
+describe('extends expansion', () => {
+  test(
+      'extends becomes the full transitive ancestor set, nearest-first', () => {
+        const {model: r} = resolveInheritance(model([
+          entity('Person', ['id']),
+          entity('Employee', ['id'], ['Person']),
+          entity('Manager', ['id'], ['Employee']),
+        ]));
+        expect(entityOf(r, 'Manager').extends).toEqual(['Employee', 'Person']);
+        expect(entityOf(r, 'Person').extends).toBeUndefined();
+      });
+});
+
+
+describe('robustness', () => {
+  test('a cycle is warned and terminates (no infinite loop)', () => {
+    const {model: r, warnings} = resolveInheritance(model([
+      entity('A', ['a'], ['B']),
+      entity('B', ['b'], ['A']),
+    ]));
+    // Each still gets the other as an ancestor, but the back-edge is cut.
+    expect(entityOf(r, 'A').extends).toEqual(['B']);
+    expect(entityOf(r, 'B').extends).toEqual(['A']);
+    expect(warnings.some(w => w.includes('cycle'))).toBe(true);
+  });
+
+  test('an unknown parent is warned and excluded from the ancestor set', () => {
+    const {model: r, warnings} = resolveInheritance(model([
+      entity('Customer', ['id'], ['Ghost']),
+    ]));
+    expect(entityOf(r, 'Customer').extends).toBeUndefined();
+    expect(warnings.some(w => w.includes('unknown entity \'Ghost\'')))
+        .toBe(true);
+  });
+});
+
+
+describe('what does NOT flow down', () => {
+  test('keys are not inherited: each entity keeps its own KEY', () => {
+    const {model: r} = resolveInheritance(model([
+      entity('Person', ['id']),
+      entity('Customer', ['id'], ['Person']),
+    ]));
+    expect(entityOf(r, 'Customer').keys).toEqual(['Customer_id']);
+  });
+
+  test('relationships are untouched (edges do not inherit)', () => {
+    const rel = {
+      name: 'livesIn',
+      source: {entity: 'Person', columns: ['city_id']},
+      destination: {entity: 'City', columns: ['id']},
+    };
+    const {model: r} = resolveInheritance(model(
+        [
+          entity('Person', ['id']),
+          entity('City', ['id']),
+          entity('Customer', ['id'], ['Person']),
+        ],
+        [rel]));
+    expect(r.relationships).toEqual([rel]);
+  });
+});
+
+
+describe('non-mutation and identity', () => {
+  test('the input model is not mutated', () => {
+    const input = model([
+      entity('Person', ['id', 'fullName']),
+      entity('Customer', ['id'], ['Person']),
+    ]);
+    const before = JSON.stringify(input);
+    resolveInheritance(input);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+
+  test('a model with no extends resolves to an equivalent model', () => {
+    const input = model([entity('Person', ['id', 'fullName'])]);
+    const {model: r, warnings} = resolveInheritance(input);
+    expect(warnings).toEqual([]);
+    expect(r.entities[0].extends).toBeUndefined();
+    expect(fieldsOf(r, 'Person')).toEqual(['id', 'fullName']);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/resolve_inheritance.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/resolve_inheritance.test.ts
@@ -176,3 +176,40 @@ describe('non-mutation and identity', () => {
     expect(fieldsOf(r, 'Person')).toEqual(['id', 'fullName']);
   });
 });
+
+
+describe('inherited-expression localization', () => {
+  // A field written on the supertype as `<Supertype>.col` references the
+  // supertype's own table; inherited onto a subclass it must reference the
+  // subclass's local column, so its own-name qualifier is stripped on the
+  // flattened copy (the supertype's own field is left untouched). Without this,
+  // the subclass and supertype would render the same property differently and
+  // an emitter reusing one label across both tables would reject it.
+  test('a self-qualified inherited expression becomes table-local', () => {
+    const {model: r} = resolveInheritance(model([
+      entity('Person', [], undefined, {
+        fields: [{name: 'email', expression: 'Person.email'}],
+      }),
+      entity('Customer', ['id'], ['Person']),
+    ]));
+    const inherited =
+        entityOf(r, 'Customer').fields.find(f => f.name === 'email')!;
+    expect(inherited.expression).toBe('email');
+    // The supertype's own copy is unchanged.
+    const own = entityOf(r, 'Person').fields.find(f => f.name === 'email')!;
+    expect(own.expression).toBe('Person.email');
+  });
+
+  test('a qualifier that is not the defining entity is left intact', () => {
+    // `LOWER(email)` has no `<Person>.` qualifier, so nothing is stripped.
+    const {model: r} = resolveInheritance(model([
+      entity('Person', [], undefined, {
+        fields: [{name: 'email', expression: 'LOWER(email)'}],
+      }),
+      entity('Customer', ['id'], ['Person']),
+    ]));
+    const inherited =
+        entityOf(r, 'Customer').fields.find(f => f.name === 'email')!;
+    expect(inherited.expression).toBe('LOWER(email)');
+  });
+});


### PR DESCRIPTION
## What

Makes `Entity.extends` (from OWL `rdfs:subClassOf`, merged in #329) actually shape the BigQuery Graph push, so a class hierarchy is queryable.

Three mechanisms:

- **Labels mimic the hierarchy.** A subclass node table declares its own default label plus one `LABEL <Ancestor>` per transitive supertype, so `MATCH (:Person)` also matches `Customer`/`Manager` nodes.
- **Fields flow down (flattening); edges do not.** Supertype fields are copied onto subclasses (nearest-definition-wins), so each shared label's property signature matches — BigQuery requires an identical signature on every table that binds a shared label. Relationships are never inherited.
- **Abstract (table-less) superclasses.** An entity marked `abstract: true` has no physical table/source/key, produces no node table, and survives only as a `LABEL` on its concrete descendants (whose tables carry its flattened fields). An abstract class that is no concrete entity's ancestor is warned and dropped. `unbound:` remains a hard error, deliberately distinct from the explicit `abstract` marker (overloading it would silently drop an entity someone merely forgot to bind).

## Shared-label DDL constraints (discovered by live validation)

A label bound by more than one element table is a rigid contract in BigQuery. Live probing against `sqlgen-testing` pinned three rules the emitter now honors:

1. **No OPTIONS on a shared label.** A label carrying `OPTIONS(...)` "cannot be bound to another element table," so a supertype's own `DEFAULT LABEL` drops its description/synonyms (with a warning).
2. **Identical property signature everywhere.** Every table binding a shared label must list the same property set — which holds because supertype fields are flattened onto each subclass.
3. **No MEASURE on a shared label.** A measure cannot be replicated across the tables sharing a label ("defined as MEASURE, but there are other declarations with the same name"), so a metric targeting a supertype is skipped with a warning.

## Scope

- **BigQuery leg only.** Inheritance resolution lives in a new leg-agnostic pass (`resolve_inheritance.ts`) run only by the BigQuery generator; the Knowledge Catalog push output is unchanged.
- **No golden drift.** Existing corpus goldens are byte-for-byte unchanged (entities with no `extends` render identically).

## Example

A `Manager` (extends `Employee` extends `Person`) node table:

```
`…manager` AS Manager
  KEY(id)
  DEFAULT LABEL
  PROPERTIES(id, team_size, department, full_name OPTIONS(...), email)
  LABEL Employee PROPERTIES(id, department, full_name OPTIONS(...), email)
  LABEL Person   PROPERTIES(id, full_name OPTIONS(...), email)
```

## Tests

- `resolve_inheritance.test.ts` — single/multi/transitive parents, diamond dedup + ordering, child-override, cycle, unknown parent, edges-/keys-not-inherited.
- Abstract-elimination block in `bigquery.test.ts` — no node table for the abstract class, label + flattened fields on descendants, no-descendant warning.
- Supertype shared-label block in `bigquery.test.ts` — dropped label OPTIONS + skipped supertype metric, with a leaf metric still emitting.
- Bound `hierarchy_graph.yaml` fixture + `hierarchy_graph.bigquery.golden.sql` in the e2e corpus.
- Full suite: 443 pass, `tsc --noEmit` clean.

## Live validation

Pushed the full 5-class DDL to `sqlgen-testing` (accepted), then ran traversals:

- `MATCH (:Person)` → base + all three subclasses, inherited `full_name`/`email` resolve.
- `MATCH (:Employee)` → Employee + Manager (transitive).
- `MATCH (:Manager)` → Manager only, own `team_size` + inherited `department`/`full_name`.
- `livesIn` edge stays Person-only — edges are not inherited.

Scratch dataset cleaned up afterward.
