### PR TITLE
mdcode: carry non-native OWL constructs as custom extensions

### DIFF
--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -481,14 +481,18 @@ does not learn a second format — it **converts OWL into a semantic model** onc
 then the ontology rides the normal `kcmd push` / `kcmd pull` above. The semantic
 model stays the single canonical form.
 
-This first cut converts the OWL constructs that have a clean BigQuery Graph
-shape (class → node, object property → edge, datatype property → property), plus
-**class hierarchies** (`rdfs:subClassOf` → entity `extends`, see
-[Class hierarchies](#class-hierarchies-rdfssubclassof)). Everything the converter
-reads maps to a **native** semantic-model field — no custom extensions, no IRIs
-to carry. Richer OWL that has no native home yet (`inverseOf`,
-`rdfs:subPropertyOf`, SHACL, cardinality, individuals) is not read yet — see
-[What is not covered yet](#what-is-not-covered-yet).
+The converter maps the OWL constructs that have a clean BigQuery Graph shape to
+**native** semantic-model fields — class → node, object property → edge,
+datatype property → property, plus **class hierarchies** (`rdfs:subClassOf` →
+entity `extends`, see [Class hierarchies](#class-hierarchies-rdfssubclassof)).
+Constructs that have **no native home yet** (`rdfs:subPropertyOf`,
+`owl:inverseOf`, `owl:equivalentClass`, and the symmetric / transitive /
+functional property characteristics) are not dropped — they **ride along
+verbatim** as custom extensions, lossless and inert, until they earn a
+first-class concept (see
+[Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)).
+Richer OWL still not read at all (SHACL, cardinality restrictions, `owl:oneOf`,
+individuals) is listed in [What is not covered yet](#what-is-not-covered-yet).
 
 ### 1. The OWL file
 
@@ -701,6 +705,7 @@ in the model `description` as provenance.
 | `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; `expression` defaults to the property's local name (a valid column ref once bound) |
 | `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; join columns bound to the destination key when it has one, else `TODO_BIND` (see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
+| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:Symmetric`/`Transitive`/`FunctionalProperty` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
 | `owl:hasKey ( ... )` | dataset `primary_key` | single or composite, in list order |
 | `owl:InverseFunctionalProperty` | dataset `unique_keys` | a uniquely-identifying property; omitted when it is already the `primary_key`; a lone one on a keyless class is promoted to `primary_key` instead |
@@ -814,11 +819,118 @@ Two boundaries to be clear about:
   labels)](#class-hierarchies-extends--labels). The **Knowledge Catalog** push is
   unchanged: it still publishes each entry with exactly the fields it declares
   (KC-side inheritance is a separate, later opt-in).
-- **Inheritance is entity-level only.** `extends` lives on `datasets`, never on
-  relationships — the boundary is structural. `rdfs:subPropertyOf` (property /
-  relationship inheritance) is **not supported**: the field or relationship is
-  still imported, but the `subPropertyOf` link is **dropped with a warning**. See
-  [What is not covered yet](#what-is-not-covered-yet).
+- **Native inheritance is entity-level only.** `extends` lives on `datasets`,
+  never on relationships — the boundary is structural. `rdfs:subPropertyOf`
+  (property / relationship inheritance) has no such native slot, so it is **not
+  dropped but carried verbatim** as a custom extension on the field or
+  relationship (see [Constructs carried as custom
+  extensions](#constructs-carried-as-custom-extensions-not-yet-native)).
+
+#### Constructs carried as custom extensions (not yet native)
+
+Some OWL constructs have no native slot in the semantic model — a class is one
+entity, so it has nowhere to record that it *equals* another class; an edge is
+directed, so it has nowhere to record its *inverse*. Rather than drop these, the
+converter **carries them verbatim** in a `GOOGLE` custom extension on the object
+they describe. Carriage is a holding pattern with three deliberate properties:
+
+- **Lossless.** Nothing the converter reads is thrown away; `kcmd pull` recovers
+  every carried fact exactly as imported.
+- **Inert.** A carried fact changes **nothing** downstream — the BigQuery Graph
+  push and the Knowledge Catalog push read none of it, so it never alters a node,
+  an edge, or a query. (Contrast `extends`, which *does* change the graph by
+  adding node labels — that is why it earned a native slot and these have not.)
+- **Promotable.** When a construct proves it needs to be first-class, it moves
+  out of carriage into a native concept; the extension is the seam where that
+  happens.
+
+**The shape.** Each carried construct is one key in a flat JSON object under the
+`GOOGLE` vendor. **The key *is* the source construct, prefixed with its
+vocabulary** (`owl:` or `rdfs:`); the value mirrors the construct faithfully:
+
+```yaml
+custom_extensions:
+  - vendor_name: GOOGLE
+    data: '{"rdfs:subPropertyOf":["name"],"owl:FunctionalProperty":true}'
+```
+
+The prefix carries the namespace, which does two jobs: it keeps a carried fact
+from colliding with Google's own keys in the same block (a deployment target is
+`deploymentTargets`, unprefixed), and it disambiguates a short name that means
+different things in different standards (`subPropertyOf` is RDFS; `inverseOf` is
+OWL). A reader treats **any key containing a `:`** as a carried ontology fact.
+Values are mirrored, not invented — a symmetric property is `"owl:SymmetricProperty":
+true`, not a synthesized `characteristics` list — so no information about the
+original construct is lost in translation.
+
+**What is carried, and where it attaches:**
+
+| OWL construct | Key | Attaches to | Value | Meaning |
+|---|---|---|---|---|
+| `rdfs:subPropertyOf` | `rdfs:subPropertyOf` | field / relationship | `string[]` (super-property names) | this property refines a broader one |
+| `owl:inverseOf` | `owl:inverseOf` | relationship | `string` (the inverse edge's name) | the same edge read the other way |
+| `owl:equivalentClass` | `owl:equivalentClass` | entity | `string[]` (equivalent class names) | this class denotes the same set as another |
+| `owl:SymmetricProperty` | `owl:SymmetricProperty` | relationship | `true` | the edge holds both ways (`a→b` ⇒ `b→a`) |
+| `owl:TransitiveProperty` | `owl:TransitiveProperty` | relationship | `true` | the edge chains (`a→b`, `b→c` ⇒ `a→c`) |
+| `owl:FunctionalProperty` | `owl:FunctionalProperty` | field / relationship | `true` | at most one value / destination per subject |
+
+When more than one fact applies to the same object they share **one** block, in a
+fixed key order (`rdfs:subPropertyOf`, then `owl:inverseOf`, then the
+characteristics) so the output is stable. A carried name is the referent's plain
+local name, verbatim — it is **not** validated against the model (the referent
+may live in another ontology), which is exactly why it is a fact-to-carry and not
+a resolved link.
+
+**Example.** Given this ontology:
+
+```turtle
+ex:Person a owl:Class ;
+    owl:equivalentClass ex:Human ;
+    owl:hasKey ( ex:personId ) .
+
+ex:legalName a owl:DatatypeProperty, owl:FunctionalProperty ;
+    rdfs:domain ex:Person ; rdfs:range xsd:string ;
+    rdfs:subPropertyOf ex:name .
+
+ex:ancestorOf a owl:ObjectProperty, owl:TransitiveProperty ;
+    rdfs:domain ex:Person ; rdfs:range ex:Person ;
+    rdfs:subPropertyOf ex:relatedTo ;
+    owl:inverseOf ex:descendantOf .
+```
+
+the equivalence lands on the `Person` entity, the super-property and
+single-valued flag on the `legalName` field, and the inverse / super-property /
+transitivity together on the `ancestorOf` relationship:
+
+```yaml
+  - name: Person
+    # ... fields ...
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"owl:equivalentClass":["Human"]}'
+# ... on the legalName field ...
+        custom_extensions:
+          - vendor_name: GOOGLE
+            data: '{"rdfs:subPropertyOf":["name"],"owl:FunctionalProperty":true}'
+  relationships:
+    - name: ancestorOf
+      # ... endpoints ...
+      custom_extensions:
+        - vendor_name: GOOGLE
+          data: '{"rdfs:subPropertyOf":["relatedTo"],"owl:inverseOf":"descendantOf","owl:TransitiveProperty":true}'
+```
+
+**Prefix → namespace** (for reconstructing the full IRI, `<namespace><name>`):
+
+| Prefix | Namespace IRI |
+|---|---|
+| `owl:` | `http://www.w3.org/2002/07/owl#` |
+| `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` |
+
+Blank-node forms are **not** carried: an `owl:equivalentClass` (or
+`rdfs:subClassOf`) whose object is a class *expression* (`owl:intersectionOf`, an
+`owl:Restriction`, …) is a definition rather than a plain cross-reference, so it
+is out of scope (see [What is not covered yet](#what-is-not-covered-yet)).
 
 ### 4. Going from ontology to a running graph (binding)
 
@@ -871,18 +983,20 @@ in this first cut.
   labels)](#class-hierarchies-extends--labels)). Resolving the same inheritance
   into **Knowledge Catalog** entries is still a follow-on; the KC push publishes
   each entry with only its own fields.
-- `owl:inverseOf`, `rdfs:subPropertyOf` (property / relationship inheritance),
-  `owl:equivalentClass` — not supported. A `subPropertyOf` link is dropped with a
-  warning (the field or relationship itself is still imported); only entity-level
-  inheritance exists. When richer constructs are added, they will land in a
-  GOOGLE `custom_extensions` block (under a `data.ontology` key), which is also
-  where the base IRI + prefixes would come back (needed to expand parent-property
-  references).
-- Cardinality / required (`owl:FunctionalProperty`, `owl:minCardinality`,
-  restrictions), enumerations (`owl:oneOf`), and property characteristics
-  (symmetric / transitive) — to be carried later via `custom_extensions`.
-- SHACL shapes, class expressions (`owl:unionOf` / `intersectionOf`), and
-  individuals (A-box instances) — not read.
+- `rdfs:subPropertyOf` (property / relationship inheritance), `owl:inverseOf`,
+  `owl:equivalentClass`, and the symmetric / transitive / functional property
+  characteristics **are** read now — they have no native slot, so they are
+  **carried verbatim** as `custom_extensions` rather than dropped (see
+  [Constructs carried as custom
+  extensions](#constructs-carried-as-custom-extensions-not-yet-native)). They are
+  inert on push; promoting any of them to a native concept is a later step.
+- Cardinality / required (`owl:minCardinality` / `owl:maxCardinality`
+  restrictions) and enumerations (`owl:oneOf`) — **not read yet.** Both are
+  stated as blank-node axioms, which the parser does not walk today; they are the
+  next carriage candidates.
+- SHACL shapes, class expressions (`owl:unionOf` / `intersectionOf`, and any
+  blank-node `owl:equivalentClass` / `rdfs:subClassOf`), and individuals (A-box
+  instances) — not read.
 - Semantic model → OWL export (reverse) — not built; import is one-way.
 - OWL serializations other than Turtle (`.ttl`) — not read.
 

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -9,9 +9,13 @@
 // Scope: the OWL constructs the converter maps to native OSI today -- classes,
 // datatype/object properties, their human annotations (rdfs:label / comment,
 // skos labels / definition / example, dcterms/dc description), datatype ranges,
-// keys (owl:hasKey, owl:InverseFunctionalProperty), and ontology-header
-// metadata. Richer OWL (subClassOf, inverseOf, SHACL, cardinality, individuals)
-// is intentionally absent; see the "What is not covered yet" note in the guide.
+// keys (owl:hasKey, owl:InverseFunctionalProperty), class hierarchy
+// (rdfs:subClassOf -> extends), and ontology-header metadata -- PLUS the
+// constructs with no native home that ride along verbatim as custom extensions
+// (rdfs:subPropertyOf, owl:inverseOf, owl:equivalentClass, and the
+// symmetric/transitive/functional property characteristics). Richer OWL still
+// absent (SHACL, cardinality restrictions, owl:oneOf, individuals); see the
+// "What is not covered yet" note in the guide.
 
 /** An `owl:Class` -- becomes an OSI dataset (entity). */
 export interface OwlClass {
@@ -36,6 +40,12 @@ export interface OwlClass {
   // entity's `extends` (entity-level inheritance). Named superclasses only;
   // blank-node axioms (owl:Restriction, ...) are not recorded. Empty when none.
   subClassOf: string[];
+  // Local names of `owl:equivalentClass` classes, in document order. No native
+  // OSI home (a class is one entity; equivalence is a fact ABOUT it, not a
+  // structural link), so it is carried verbatim as a custom extension. Named
+  // classes only; a blank-node class expression (owl:intersectionOf, ...) is
+  // not recorded (out of scope, Tier 3). Empty when none.
+  equivalentClass: string[];
 }
 
 /**
@@ -59,9 +69,14 @@ export interface OwlDatatypeProperty {
   // uniquely identifies its subject, so it maps to a unique_keys constraint on
   // each domain entity.
   inverseFunctional: boolean;
+  // True when the property is also an owl:FunctionalProperty -- it has at most
+  // one value per subject. No native OSI home (OSI has no single-valued flag),
+  // so it is carried verbatim as a field custom extension.
+  functional: boolean;
   // Local names of `rdfs:subPropertyOf` superproperties, if any. Property
-  // inheritance is NOT supported (only entity-level `rdfs:subClassOf`); this is
-  // recorded solely so the mapper can warn and drop it. Empty when none.
+  // inheritance has no native OSI home (only entity-level `rdfs:subClassOf` ->
+  // `extends`); it is carried verbatim as a field custom extension. Empty when
+  // none.
   subPropertyOf: string[];
 }
 
@@ -84,9 +99,25 @@ export interface OwlObjectProperty {
   synonyms: string[];
   examples: string[];
   // Local names of `rdfs:subPropertyOf` superproperties, if any. Relationship
-  // inheritance is NOT supported (only entity-level `rdfs:subClassOf`); this is
-  // recorded solely so the mapper can warn and drop it. Empty when none.
+  // inheritance has no native OSI home (only entity-level `rdfs:subClassOf` ->
+  // `extends`); it is carried verbatim as a relationship custom extension.
+  // Empty when none.
   subPropertyOf: string[];
+  // Local names of `owl:inverseOf` properties (the edge read the other way),
+  // in document order. No native OSI home (an edge is directed; the inverse is
+  // a separate fact), so it is carried verbatim. Usually one; more than one is
+  // kept here and reconciled by the mapper (first wins, rest warned). Empty
+  // when none.
+  inverseOf: string[];
+  // owl:SymmetricProperty -- the edge holds both ways (`a rel b` implies
+  // `b rel a`). Carried verbatim; no native OSI home.
+  symmetric: boolean;
+  // owl:TransitiveProperty -- the edge chains (`a rel b` and `b rel c` imply
+  // `a rel c`). Carried verbatim; no native OSI home.
+  transitive: boolean;
+  // owl:FunctionalProperty -- at most one destination per source. Carried
+  // verbatim; no native OSI home.
+  functional: boolean;
 }
 
 /**

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -34,8 +34,15 @@ const OWL_CLASS = `${OWL}Class`;
 const OWL_DATATYPE_PROPERTY = `${OWL}DatatypeProperty`;
 const OWL_OBJECT_PROPERTY = `${OWL}ObjectProperty`;
 const OWL_INVERSE_FUNCTIONAL_PROPERTY = `${OWL}InverseFunctionalProperty`;
+// Property characteristics carried verbatim (no native OSI home). Recognized by
+// their rdf:type, like owl:InverseFunctionalProperty, and collected as
+// typed-subject sets.
+const OWL_SYMMETRIC_PROPERTY = `${OWL}SymmetricProperty`;
+const OWL_TRANSITIVE_PROPERTY = `${OWL}TransitiveProperty`;
+const OWL_FUNCTIONAL_PROPERTY = `${OWL}FunctionalProperty`;
 const OWL_ONTOLOGY = `${OWL}Ontology`;
 const OWL_HAS_KEY = `${OWL}hasKey`;
+const OWL_INVERSE_OF = `${OWL}inverseOf`;
 const OWL_VERSION_INFO = `${OWL}versionInfo`;
 const OWL_THING = `${OWL}Thing`;
 
@@ -45,6 +52,7 @@ const RDFS_DOMAIN = `${RDFS}domain`;
 const RDFS_RANGE = `${RDFS}range`;
 const RDFS_SUBCLASS_OF = `${RDFS}subClassOf`;
 const RDFS_SUBPROPERTY_OF = `${RDFS}subPropertyOf`;
+const OWL_EQUIVALENT_CLASS = `${OWL}equivalentClass`;
 const RDFS_RESOURCE = `${RDFS}Resource`;
 // The implicit universal superclasses: every class is trivially a subclass of
 // owl:Thing / rdfs:Resource, so an explicit `rdfs:subClassOf` naming one
@@ -104,6 +112,8 @@ interface Annotations {
   keyListHeads: string[];  // owl:hasKey list heads (blank nodes)
   subClassOf: string[];
   subPropertyOf: string[];
+  equivalentClass: string[];  // owl:equivalentClass (named classes only)
+  inverseOf: string[];        // owl:inverseOf (named object properties only)
 }
 
 function emptyAnnotations(): Annotations {
@@ -114,7 +124,9 @@ function emptyAnnotations(): Annotations {
     ranges: [],
     keyListHeads: [],
     subClassOf: [],
-    subPropertyOf: []
+    subPropertyOf: [],
+    equivalentClass: [],
+    inverseOf: []
   };
 }
 
@@ -144,6 +156,14 @@ export function parseOwl(turtle: string): OwlModel {
   const order: string[] = [];
   const kind = new Map<string, OwlKind>();
   const inverseFunctional = new Set<string>();
+  // Property characteristics carried verbatim, each a set of the subjects typed
+  // with it. A property is commonly typed with several types (e.g.
+  // `a owl:ObjectProperty, owl:SymmetricProperty`), so a characteristic type is
+  // recorded here and does not compete with the kind that routes it to a
+  // class/property.
+  const symmetric = new Set<string>();
+  const transitive = new Set<string>();
+  const functional = new Set<string>();
   let ontologyIri: string|undefined;
   for (const q of quads) {
     if (q.predicate.value !== RDF_TYPE) continue;
@@ -151,6 +171,18 @@ export function parseOwl(turtle: string): OwlModel {
     const subject = q.subject.value;
     if (type === OWL_INVERSE_FUNCTIONAL_PROPERTY) {
       inverseFunctional.add(subject);
+      continue;
+    }
+    if (type === OWL_SYMMETRIC_PROPERTY) {
+      symmetric.add(subject);
+      continue;
+    }
+    if (type === OWL_TRANSITIVE_PROPERTY) {
+      transitive.add(subject);
+      continue;
+    }
+    if (type === OWL_FUNCTIONAL_PROPERTY) {
+      functional.add(subject);
       continue;
     }
     if (type === OWL_ONTOLOGY) {
@@ -262,11 +294,25 @@ export function parseOwl(turtle: string): OwlModel {
           a.subClassOf.push(localName(q.object.value));
         break;
       case RDFS_SUBPROPERTY_OF:
-        // Property hierarchy -> NOT supported (entity-level inheritance only).
-        // Recorded so the mapper can warn and drop it; named superproperties
-        // only.
+        // Property hierarchy -> no native OSI home; carried verbatim by the
+        // mapper as a custom extension. Named superproperties only (a
+        // blank-node property expression is out of scope).
         if (q.object.termType === 'NamedNode')
           a.subPropertyOf.push(localName(q.object.value));
+        break;
+      case OWL_EQUIVALENT_CLASS:
+        // Class equivalence -> no native OSI home; carried verbatim. Named
+        // classes only; a blank-node class expression (owl:intersectionOf, ...)
+        // is a class definition, not a plain cross-reference, so it is ignored
+        // (out of scope, like a blank-node subClassOf).
+        if (q.object.termType === 'NamedNode')
+          a.equivalentClass.push(localName(q.object.value));
+        break;
+      case OWL_INVERSE_OF:
+        // Inverse edge -> no native OSI home; carried verbatim. Named object
+        // properties only.
+        if (q.object.termType === 'NamedNode')
+          a.inverseOf.push(localName(q.object.value));
         break;
       default:
         break;
@@ -291,6 +337,7 @@ export function parseOwl(turtle: string): OwlModel {
           examples: a.examples,
           keys: a.keyListHeads.flatMap(resolveList).map(localName),
           subClassOf: a.subClassOf,
+          equivalentClass: a.equivalentClass,
         });
         break;
       case 'datatypeProperty':
@@ -303,6 +350,7 @@ export function parseOwl(turtle: string): OwlModel {
           synonyms: a.synonyms,
           examples: a.examples,
           inverseFunctional: inverseFunctional.has(iri),
+          functional: functional.has(iri),
           subPropertyOf: a.subPropertyOf,
         });
         break;
@@ -319,6 +367,10 @@ export function parseOwl(turtle: string): OwlModel {
           synonyms: a.synonyms,
           examples: a.examples,
           subPropertyOf: a.subPropertyOf,
+          inverseOf: a.inverseOf,
+          symmetric: symmetric.has(iri),
+          transitive: transitive.has(iri),
+          functional: functional.has(iri),
         });
         break;
       default:

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -12,10 +12,18 @@
 //   rdfs:range xsd:*              -> field datatype (see XSD_DATATYPES)
 //   owl:hasKey                    -> dataset primary_key
 //   owl:InverseFunctionalProperty -> dataset unique_keys (or primary_key)
+//   rdfs:subClassOf               -> dataset extends (entity inheritance)
 //   rdfs:label                    -> field label / synonym (no label slot)
 //   rdfs:comment/skos:definition/dcterms:/dc: -> description
 //   skos:example                  -> ai_context.examples
 //   owl:Ontology header           -> model description / ai_context
+//
+// Constructs with no native OSI home ride along verbatim in a GOOGLE custom
+// extension (see googleOntologyExtension), inert on push and lossless on pull:
+//   rdfs:subPropertyOf            -> field / relationship (property
+//   inheritance) owl:inverseOf                 -> relationship (the edge,
+//   reversed) owl:equivalentClass           -> entity (class equivalence)
+//   owl:Symmetric/Transitive/FunctionalProperty -> relationship / field
 //
 // The result is UNBOUND: entities carry an `unbound:<Name>` source placeholder
 // and relationships carry `TODO_BIND` join columns, because an ontology has no
@@ -45,30 +53,55 @@ export interface ToIrResult {
 
 // --- Seams: the isolated change-points for later work. ----------------------
 
-// The GOOGLE custom-extensions vendor name. Ontology data that OSI can't yet
-// express natively (subClassOf, inverseOf, base IRI, ...) will ride in this
-// vendor's block under a `data.ontology` key -- Google's choice to support OWL,
-// so it sits in the GOOGLE block alongside deployment targets, not a new "OWL"
-// vendor. See deploy_bigquery.googleDeploymentTargets, which safely ignores a
-// GOOGLE block that carries no deploymentTargets.
+// The GOOGLE custom-extensions vendor name. OWL constructs OSI can't express
+// natively (rdfs:subPropertyOf, owl:inverseOf, owl:equivalentClass, property
+// characteristics) ride in this vendor's block -- Google's choice to support
+// OWL, so it sits in the GOOGLE block alongside deployment targets, not a new
+// "OWL" vendor. See deploy_bigquery.googleDeploymentTargets, which safely
+// ignores a GOOGLE block that carries no deploymentTargets.
 const GOOGLE_VENDOR = 'GOOGLE';
 
 /**
- * Builds the GOOGLE custom-extension block that carries OWL constructs OSI
- * cannot express natively, under `data.ontology`.
+ * Builds a GOOGLE custom-extension block carrying OWL constructs that have no
+ * native OSI home, verbatim.
  *
- * This is the promotion seam: when subClassOf / inverseOf / base-IRI carriage
- * lands, it is emitted here (and, later, promoted to native OSI fields by
- * changing only this function and its callers). The current cut maps everything
- * it reads to native OSI, so nothing calls this yet -- it is defined, tested
- * for shape, and left unused until the richer constructs arrive.
+ * The payload is a FLAT object whose keys ARE the source constructs, prefixed
+ * with their vocabulary (`owl:inverseOf`, `rdfs:subPropertyOf`, ...): the
+ * prefix carries the namespace, so the same short name from a different
+ * standard can't collide and the reader always knows which vocabulary a fact
+ * came from. This is the deliberate mirror of the deployment-target block,
+ * whose own keys are Google's (`deploymentTargets`, unprefixed) -- the two
+ * kinds of key coexist in one GOOGLE block without clashing, and a consumer
+ * reads "any key with a `:`" as a carried ontology fact.
+ *
+ * The values mirror the construct faithfully rather than inventing a shape:
+ * `owl:SymmetricProperty: true` (not a synthesized `characteristics` list), the
+ * raw superproperty names for `rdfs:subPropertyOf`, and so on. Carriage is
+ * inert on push (the BigQuery / KC legs read none of it) and round-trips
+ * losslessly through pull; promoting a construct to a native OSI concept later
+ * means changing this seam and its callers, nothing downstream.
+ *
+ * Returns undefined when `terms` is empty, so a caller can attach the result
+ * unconditionally without emitting an empty block.
  */
-export function googleOntologyExtension(ontology: Record<string, unknown>):
-    CustomExtension {
+export function googleOntologyExtension(terms: Record<string, unknown>):
+    CustomExtension|undefined {
+  if (!Object.keys(terms).length) return undefined;
   return {
     vendorName: GOOGLE_VENDOR,
-    data: JSON.stringify({data: {ontology}}),
+    data: JSON.stringify(terms),
   };
+}
+
+// Appends a carried-ontology GOOGLE block to an IR object (entity / field /
+// relationship), leaving any existing custom extensions in place. A no-op when
+// there is nothing to carry, so callers can attach unconditionally.
+function attachOntology(
+    target: {customExtensions?: CustomExtension[]},
+    terms: Record<string, unknown>): void {
+  const ext = googleOntologyExtension(terms);
+  if (!ext) return;
+  (target.customExtensions ??= []).push(ext);
 }
 
 // The placeholder source for an unbound entity: an ontology class has no
@@ -291,6 +324,14 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
             `ontology).`);
       }
     }
+    // owl:equivalentClass -> carried verbatim (no native OSI home: a class is
+    // one entity, so equivalence is a fact ABOUT it, not a structural link).
+    // Named classes only; blank-node class expressions were dropped in the
+    // parser.
+    if (c.equivalentClass.length) {
+      attachOntology(
+          entity, {'owl:equivalentClass': dedupe(c.equivalentClass)});
+    }
     entitiesByName.set(c.localName, entity);
     entities.push(entity);
   }
@@ -305,16 +346,15 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `(a field must belong to a class).`);
       continue;
     }
-    if (p.subPropertyOf.length) {
-      // Property inheritance is not supported (only entity-level
-      // rdfs:subClassOf -> extends). The field is still imported on each
-      // domain; only the subPropertyOf link is dropped.
-      warnings.push(
-          `datatype property '${p.localName}' declares rdfs:subPropertyOf ` +
-          `(${p.subPropertyOf.join(', ')}); property inheritance is not ` +
-          `supported, so the subPropertyOf link is dropped (the field itself ` +
-          `is still imported).`);
-    }
+    // OWL facts with no native OSI home, carried verbatim on the field. Built
+    // once and attached to the field on each domain (the facts are the
+    // property's, independent of which class it lands on). rdfs:subPropertyOf
+    // -> property inheritance (no entity-style flattening; the link is kept as
+    // a fact); owl:FunctionalProperty -> single-valued.
+    const fieldTerms: Record<string, unknown> = {};
+    if (p.subPropertyOf.length)
+      fieldTerms['rdfs:subPropertyOf'] = dedupe(p.subPropertyOf);
+    if (p.functional) fieldTerms['owl:FunctionalProperty'] = true;
     // A property counts as converted once if it produces at least one field,
     // regardless of how many domains it lands on.
     let produced = false;
@@ -346,6 +386,7 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
         description: p.comment,
         aiContext: fieldAiContext(p.synonyms, p.localName, p.examples),
       };
+      attachOntology(field, fieldTerms);
       entity.fields.push(field);
       produced = true;
       // An inverse-functional property uniquely identifies its subject -> a
@@ -436,19 +477,34 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `name; skipped (relationship names must be unique).`);
       continue;
     }
-    if (p.subPropertyOf.length) {
-      // Relationship inheritance is not supported (only entity-level
-      // rdfs:subClassOf -> extends). The relationship is still imported; only
-      // the subPropertyOf link is dropped.
-      warnings.push(
-          `object property '${p.localName}' declares rdfs:subPropertyOf ` +
-          `(${p.subPropertyOf.join(', ')}); relationship inheritance is not ` +
-          `supported, so the subPropertyOf link is dropped (the relationship ` +
-          `itself is still imported).`);
+    // OWL facts with no native OSI home, carried verbatim on the relationship,
+    // in a fixed key order so the emitted block is stable. rdfs:subPropertyOf
+    // -> relationship inheritance (kept as a fact, no flattening);
+    // owl:inverseOf -> the edge read the other way;
+    // owl:Symmetric/Transitive/FunctionalProperty
+    // -> the edge's characteristics.
+    const relTerms: Record<string, unknown> = {};
+    if (p.subPropertyOf.length)
+      relTerms['rdfs:subPropertyOf'] = dedupe(p.subPropertyOf);
+    if (p.inverseOf.length) {
+      // owl:inverseOf pairs two properties; one statement is the norm. If more
+      // than one is declared, carry the first and say what was dropped rather
+      // than emitting an array the reader would have to disambiguate.
+      relTerms['owl:inverseOf'] = p.inverseOf[0];
+      if (p.inverseOf.length > 1) {
+        warnings.push(
+            `object property '${p.localName}' declares owl:inverseOf more ` +
+            `than once (${p.inverseOf.join(', ')}); a relationship has one ` +
+            `inverse, so only '${p.inverseOf[0]}' is carried.`);
+      }
     }
+    if (p.symmetric) relTerms['owl:SymmetricProperty'] = true;
+    if (p.transitive) relTerms['owl:TransitiveProperty'] = true;
+    if (p.functional) relTerms['owl:FunctionalProperty'] = true;
+
     const destKeys = entitiesByName.get(range)?.keys ?? [];
     const bound = destKeys.length > 0;
-    relationships.push({
+    const relationship: Relationship = {
       name: p.localName,
       // Source FK columns are unknown until binding; keep the count aligned
       // with the destination key so the positional join is well-formed.
@@ -466,7 +522,9 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       // rides in ai_context.instructions (see relationshipAiContext).
       aiContext: relationshipAiContext(
           p.label, p.localName, p.synonyms, p.comment, p.examples),
-    });
+    };
+    attachOntology(relationship, relTerms);
+    relationships.push(relationship);
   }
 
   const model: SemanticModel = {

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -487,15 +487,18 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     if (p.subPropertyOf.length)
       relTerms['rdfs:subPropertyOf'] = dedupe(p.subPropertyOf);
     if (p.inverseOf.length) {
-      // owl:inverseOf pairs two properties; one statement is the norm. If more
-      // than one is declared, carry the first and say what was dropped rather
-      // than emitting an array the reader would have to disambiguate.
-      relTerms['owl:inverseOf'] = p.inverseOf[0];
-      if (p.inverseOf.length > 1) {
+      // owl:inverseOf pairs two properties; one DISTINCT statement is the norm.
+      // Dedupe first (as subPropertyOf/equivalentClass do) so a repeated
+      // identical triple isn't mistaken for a genuine conflict. If more than
+      // one distinct inverse remains, carry the first and say what was dropped
+      // rather than emitting an array the reader would have to disambiguate.
+      const inverses = dedupe(p.inverseOf);
+      relTerms['owl:inverseOf'] = inverses[0];
+      if (inverses.length > 1) {
         warnings.push(
             `object property '${p.localName}' declares owl:inverseOf more ` +
-            `than once (${p.inverseOf.join(', ')}); a relationship has one ` +
-            `inverse, so only '${p.inverseOf[0]}' is carried.`);
+            `than once (${inverses.join(', ')}); a relationship has one ` +
+            `inverse, so only '${inverses[0]}' is carried.`);
       }
     }
     if (p.symmetric) relTerms['owl:SymmetricProperty'] = true;

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
@@ -1,0 +1,59 @@
+version: 0.2.0.dev0
+semantic_model:
+  - name: carriage
+    description: Imported from OWL ontology http://example.com/people#
+    datasets:
+      - name: Person
+        source: unbound:Person
+        primary_key:
+          - personId
+        description: A human being.
+        fields:
+          - name: personId
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: personId
+            datatype: String
+          - name: name
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: name
+            datatype: String
+          - name: legalName
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: legalName
+            datatype: String
+            custom_extensions:
+              - vendor_name: GOOGLE
+                data: '{"rdfs:subPropertyOf":["name"],"owl:FunctionalProperty":true}'
+        custom_extensions:
+          - vendor_name: GOOGLE
+            data: '{"owl:equivalentClass":["Human"]}'
+      - name: Human
+        source: unbound:Human
+        description: Synonym class for Person.
+    relationships:
+      - name: ancestorOf
+        from: Person
+        to: Person
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - personId
+        custom_extensions:
+          - vendor_name: GOOGLE
+            data: '{"rdfs:subPropertyOf":["relatedTo"],"owl:inverseOf":"descendantOf","owl:TransitiveProperty":true}'
+      - name: relatedTo
+        from: Person
+        to: Person
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - personId
+        custom_extensions:
+          - vendor_name: GOOGLE
+            data: '{"owl:SymmetricProperty":true}'

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.owl.ttl
@@ -1,0 +1,48 @@
+# An ontology exercising the OWL constructs that have no native OSI home and so
+# ride along verbatim as GOOGLE custom extensions (see the user guide's
+# "Constructs carried as custom extensions (not yet native)"):
+#   - owl:equivalentClass on a class          -> entity extension
+#   - rdfs:subPropertyOf on a datatype prop   -> field extension
+#   - owl:FunctionalProperty on a datatype prop -> field extension
+#   - rdfs:subPropertyOf on an object prop     -> relationship extension
+#   - owl:inverseOf on an object prop          -> relationship extension
+#   - owl:Symmetric/TransitiveProperty         -> relationship extension
+# Each is carried under the GOOGLE vendor with the source construct AS the key
+# (prefixed with its vocabulary), the value mirroring the construct faithfully.
+# Carriage is inert on push and lossless on pull; it does not change the graph.
+
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <http://example.com/people#> .
+
+# A class equivalent to another (owl:equivalentClass) -> carried on the entity.
+ex:Person a owl:Class ;
+    rdfs:comment "A human being." ;
+    owl:equivalentClass ex:Human ;
+    owl:hasKey ( ex:personId ) .
+ex:Human a owl:Class ;
+    rdfs:comment "Synonym class for Person." .
+
+ex:personId a owl:DatatypeProperty ;
+    rdfs:domain ex:Person ; rdfs:range xsd:string .
+
+# A super-property (rdfs:subPropertyOf) and a single-valued flag
+# (owl:FunctionalProperty) on a datatype property -> carried on the field.
+ex:name a owl:DatatypeProperty ;
+    rdfs:domain ex:Person ; rdfs:range xsd:string .
+ex:legalName a owl:DatatypeProperty, owl:FunctionalProperty ;
+    rdfs:domain ex:Person ; rdfs:range xsd:string ;
+    rdfs:subPropertyOf ex:name .
+
+# An object property that is its own inverse's counterpart (owl:inverseOf), is
+# symmetric and transitive, and refines a base property (rdfs:subPropertyOf) ->
+# all carried on the one relationship, in a single ordered block.
+ex:ancestorOf a owl:ObjectProperty, owl:TransitiveProperty ;
+    rdfs:domain ex:Person ; rdfs:range ex:Person ;
+    rdfs:subPropertyOf ex:relatedTo ;
+    owl:inverseOf ex:descendantOf .
+
+# A symmetric object property (owl:SymmetricProperty): the edge holds both ways.
+ex:relatedTo a owl:ObjectProperty, owl:SymmetricProperty ;
+    rdfs:domain ex:Person ; rdfs:range ex:Person .

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
@@ -29,6 +29,9 @@ semantic_model:
                 - dialect: BIGQUERY
                   expression: legalName
             datatype: String
+            custom_extensions:
+              - vendor_name: GOOGLE
+                data: '{"rdfs:subPropertyOf":["fullName"]}'
       - name: Customer
         source: unbound:Customer
         extends:
@@ -55,6 +58,9 @@ semantic_model:
           - TODO_BIND
         to_columns:
           - TODO_BIND
+        custom_extensions:
+          - vendor_name: GOOGLE
+            data: '{"rdfs:subPropertyOf":["worksWith"]}'
       - name: worksWith
         from: Employee
         to: Employee

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.owl.ttl
@@ -5,10 +5,10 @@
 #     parents are recorded in document order;
 #   - a subclass of a blank-node axiom (owl:Restriction), which is NOT a named
 #     class and so is ignored (only named superclasses become `extends`);
-#   - a datatype property with rdfs:subPropertyOf (property inheritance, NOT
-#     supported: warned and dropped, the field is still imported);
-#   - an object property with rdfs:subPropertyOf (relationship inheritance, NOT
-#     supported: warned and dropped, the relationship is still imported).
+#   - a datatype property with rdfs:subPropertyOf (property inheritance: no
+#     native OSI home, carried verbatim as a field custom extension);
+#   - an object property with rdfs:subPropertyOf (relationship inheritance: no
+#     native OSI home, carried verbatim as a relationship custom extension).
 # Class inheritance is recorded as the entity's `extends`; it is NOT flattened
 # (fields are not copied down) -- see the user guide.
 
@@ -47,16 +47,16 @@ ex:Manager a owl:Class ;
                       owl:minCardinality 1 ] ;
     rdfs:comment "An employee who manages others." .
 
-# A datatype property with rdfs:subPropertyOf: property inheritance is not
-# supported, so the subPropertyOf link is warned and dropped -- but the field is
-# still imported onto Employee.
+# A datatype property with rdfs:subPropertyOf: property inheritance has no native
+# OSI home, so the subPropertyOf link is carried verbatim as a field custom
+# extension; the field is imported onto Employee.
 ex:legalName a owl:DatatypeProperty ;
     rdfs:domain ex:Employee ; rdfs:range xsd:string ;
     rdfs:subPropertyOf ex:fullName .
 
-# An object property with rdfs:subPropertyOf: relationship inheritance is not
-# supported, so the subPropertyOf link is warned and dropped -- but the
-# relationship is still imported.
+# An object property with rdfs:subPropertyOf: relationship inheritance has no
+# native OSI home, so the subPropertyOf link is carried verbatim as a
+# relationship custom extension; the relationship is imported.
 ex:managedBy a owl:ObjectProperty ;
     rdfs:domain ex:Employee ; rdfs:range ex:Manager ;
     rdfs:subPropertyOf ex:worksWith .

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -31,6 +31,16 @@ function loadOwl(ttl: string) {
   return loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
 }
 
+// The carried OWL facts on an IR object: the parsed payload of its single
+// GOOGLE custom extension (the flat, prefixed-key block the converter emits).
+// Returns undefined when there is no GOOGLE block, so a test can assert
+// "nothing carried" too.
+function ontologyTerms(exts: {vendorName: string; data: string}[]|undefined):
+    Record<string, unknown>|undefined {
+  const google = exts?.find(e => e.vendorName === 'GOOGLE');
+  return google ? JSON.parse(google.data) : undefined;
+}
+
 const PREFIXES = `
   @prefix owl:  <http://www.w3.org/2002/07/owl#> .
   @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -208,25 +218,30 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
   });
 
   test(
-      'property inheritance (rdfs:subPropertyOf) is warned and dropped', () => {
-        // Only entity-level inheritance is supported. A datatype/object
-        // property's rdfs:subPropertyOf is dropped with a warning, but the
-        // field/relationship itself is still imported.
-        const {yaml, warnings} = convertOwlToOsi(ttl, 'hierarchy');
-        expect(warnings).toHaveLength(2);
-        expect(warnings.some(
-                   w => w.includes('legalName') && w.includes('subPropertyOf')))
-            .toBe(true);
-        expect(warnings.some(
-                   w => w.includes('managedBy') && w.includes('subPropertyOf')))
-            .toBe(true);
-        // The field and relationship survive despite the dropped subPropertyOf
-        // link.
-        const model = loadModels(yaml).models[0];
+      'property inheritance (rdfs:subPropertyOf) is carried verbatim, not dropped',
+      () => {
+        // Only entity-level inheritance (rdfs:subClassOf -> extends) is native.
+        // A datatype/object property's rdfs:subPropertyOf has no native OSI
+        // home, so it rides along verbatim as a GOOGLE custom extension -- no
+        // warning, nothing lost.
+        const {warnings} = convertOwlToOsi(ttl, 'hierarchy');
+        expect(warnings).toEqual([]);
+        const model =
+            loadModels(convertOwlToOsi(ttl, 'hierarchy').yaml).models[0];
+
+        // The field survives AND carries its superproperty as a fact.
         const employee = model.entities.find(e => e.name === 'Employee')!;
-        expect(employee.fields.some(f => f.name === 'legalName')).toBe(true);
-        expect(model.relationships.some(r => r.name === 'managedBy'))
-            .toBe(true);
+        const legalName = employee.fields.find(f => f.name === 'legalName')!;
+        expect(ontologyTerms(legalName.customExtensions)).toEqual({
+          'rdfs:subPropertyOf': ['fullName']
+        });
+
+        // The relationship survives AND carries its superproperty as a fact.
+        const managedBy =
+            model.relationships.find(r => r.name === 'managedBy')!;
+        expect(ontologyTerms(managedBy.customExtensions)).toEqual({
+          'rdfs:subPropertyOf': ['worksWith']
+        });
       });
 
   test('an extends parent that is not a class is recorded but warned', () => {
@@ -773,25 +788,163 @@ describe('mapping table rules (labels, comments, skips)', () => {
 });
 
 
-// The GOOGLE data.ontology extension is the promotion seam for OWL constructs
-// OSI cannot yet express natively (subClassOf, inverseOf, ...). It is defined
-// and shape-tested but unused by the current cut, which maps everything it
-// reads to native OSI -- see to_ir.ts.
-describe('the GOOGLE ontology extension seam (defined-but-unused)', () => {
+// The GOOGLE ontology extension carries OWL constructs OSI has no native home
+// for. The payload is FLAT, its keys the prefixed source constructs -- the
+// prefix is the namespace, so a carried fact never collides with Google's own
+// keys (deploymentTargets) or with a same-named construct from another
+// vocabulary.
+describe('the GOOGLE ontology extension seam', () => {
+  test('emits a flat, prefixed-key GOOGLE block', () => {
+    const ext = googleOntologyExtension(
+        {'owl:inverseOf': 'hasChild', 'owl:SymmetricProperty': true})!;
+    expect(ext.vendorName).toBe('GOOGLE');
+    // No `data`/`ontology` wrapper: the keys ARE the constructs, verbatim.
+    expect(JSON.parse(ext.data))
+        .toEqual({'owl:inverseOf': 'hasChild', 'owl:SymmetricProperty': true});
+  });
+
+  test('returns undefined for an empty term set (nothing to carry)', () => {
+    expect(googleOntologyExtension({})).toBeUndefined();
+  });
+
   test(
-      'wraps its payload as a GOOGLE custom extension under data.ontology',
+      'is not emitted by the sales example (every construct maps natively)',
       () => {
-        const ext =
-            googleOntologyExtension({subClassOf: {Manager: 'Employee'}});
-        expect(ext.vendorName).toBe('GOOGLE');
-        expect(JSON.parse(ext.data)).toEqual({
-          data: {ontology: {subClassOf: {Manager: 'Employee'}}}
+        const {yaml} = convertOwlToOsi(readFixture('sales.owl.ttl'), 'sales');
+        expect(yaml).not.toContain('custom_extensions');
+        expect(yaml).not.toContain('GOOGLE');
+      });
+});
+
+
+// Tier 2 carriage: constructs with no native OSI home ride along verbatim in a
+// GOOGLE custom extension. They are inert on push and lossless on round-trip;
+// each is pinned here at the level it attaches to.
+describe('OWL constructs carried as custom extensions', () => {
+  // The showcase fixture used verbatim in the user guide: every carried
+  // construct, at each level it attaches to. Golden-tested so the documented
+  // YAML cannot drift from what the converter emits.
+  test(
+      'the carriage fixture produces exactly the documented OSI (golden)',
+      () => {
+        const {yaml, warnings, stats} =
+            convertOwlToOsi(readFixture('carriage.owl.ttl'), 'carriage');
+        expect(yaml).toEqual(readFixture('carriage.osi.golden.yaml'));
+        // Carriage is never a warning -- nothing is dropped.
+        expect(warnings).toEqual([]);
+        expect(stats).toEqual(
+            {classes: 2, datatypeProperties: 3, objectProperties: 2});
+        // And the result stays loadable (KC-pushable) with the blocks attached.
+        expect(() => loadModels(yaml)).not.toThrow();
+      });
+
+  test('owl:inverseOf on an object property -> relationship', () => {
+    const ttl = `${PREFIXES}
+      ex:Parent a owl:Class ; owl:hasKey ( ex:pid ) .
+      ex:pid a owl:DatatypeProperty ; rdfs:domain ex:Parent ; rdfs:range xsd:string .
+      ex:hasChild a owl:ObjectProperty ;
+          rdfs:domain ex:Parent ; rdfs:range ex:Parent ;
+          owl:inverseOf ex:hasParent .`;
+    const rel = loadOwl(ttl).relationships.find(r => r.name === 'hasChild')!;
+    expect(ontologyTerms(rel.customExtensions)).toEqual({
+      'owl:inverseOf': 'hasParent'
+    });
+  });
+
+  test('multiple owl:inverseOf keeps the first and warns', () => {
+    const ttl = `${PREFIXES}
+      ex:A a owl:Class . ex:B a owl:Class .
+      ex:rel a owl:ObjectProperty ;
+          rdfs:domain ex:A ; rdfs:range ex:B ;
+          owl:inverseOf ex:inv1 ; owl:inverseOf ex:inv2 .`;
+    const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
+    expect(warnings.some(w => w.includes('inverseOf') && w.includes('inv1')))
+        .toBe(true);
+    const rel = loadModels(yaml).models[0].relationships[0];
+    expect(ontologyTerms(rel.customExtensions)).toEqual({
+      'owl:inverseOf': 'inv1'
+    });
+  });
+
+  test(
+      'property characteristics -> relationship, faithful boolean keys', () => {
+        const ttl = `${PREFIXES}
+      ex:A a owl:Class . ex:B a owl:Class .
+      ex:knows a owl:ObjectProperty, owl:SymmetricProperty, owl:TransitiveProperty ;
+          rdfs:domain ex:A ; rdfs:range ex:B .`;
+        const rel = loadOwl(ttl).relationships.find(r => r.name === 'knows')!;
+        // The construct is mirrored (SymmetricProperty: true), not folded into
+        // an invented `characteristics` list.
+        expect(ontologyTerms(rel.customExtensions)).toEqual({
+          'owl:SymmetricProperty': true,
+          'owl:TransitiveProperty': true,
         });
       });
 
-  test('is not exercised by the sales example (nothing to promote yet)', () => {
-    const {yaml} = convertOwlToOsi(readFixture('sales.owl.ttl'), 'sales');
-    expect(yaml).not.toContain('custom_extensions');
-    expect(yaml).not.toContain('GOOGLE');
+  test('owl:FunctionalProperty on a datatype property -> field', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      ex:ssn a owl:DatatypeProperty, owl:FunctionalProperty ;
+          rdfs:domain ex:Person ; rdfs:range xsd:string .`;
+    const field = loadOwl(ttl).entities[0].fields.find(f => f.name === 'ssn')!;
+    expect(ontologyTerms(field.customExtensions)).toEqual({
+      'owl:FunctionalProperty': true
+    });
+  });
+
+  test('owl:equivalentClass -> entity (named classes only)', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ; owl:equivalentClass ex:Human .
+      ex:Human a owl:Class .`;
+    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
+    expect(ontologyTerms(person.customExtensions)).toEqual({
+      'owl:equivalentClass': ['Human']
+    });
+  });
+
+  test('a blank-node owl:equivalentClass expression is not carried', () => {
+    // An equivalentClass to a class expression (owl:intersectionOf, ...) is a
+    // class definition, not a plain cross-reference -- out of scope, so nothing
+    // is carried (no empty block either).
+    const ttl = `${PREFIXES}
+      ex:Parent a owl:Class ;
+          owl:equivalentClass [ a owl:Restriction ;
+                                owl:onProperty ex:hasChild ;
+                                owl:minCardinality 1 ] .
+      ex:hasChild a owl:ObjectProperty ; rdfs:domain ex:Parent ; rdfs:range ex:Parent .`;
+    const parent = loadOwl(ttl).entities.find(e => e.name === 'Parent')!;
+    expect(ontologyTerms(parent.customExtensions)).toBeUndefined();
+  });
+
+  test('several facts on one relationship share a single ordered block', () => {
+    const ttl = `${PREFIXES}
+      ex:A a owl:Class . ex:B a owl:Class .
+      ex:rel a owl:ObjectProperty, owl:SymmetricProperty ;
+          rdfs:domain ex:A ; rdfs:range ex:B ;
+          rdfs:subPropertyOf ex:base ;
+          owl:inverseOf ex:invRel .`;
+    const rel = loadOwl(ttl).relationships[0];
+    // One GOOGLE block carries every fact; key order is fixed for a stable
+    // golden (subPropertyOf, inverseOf, then characteristics).
+    expect(rel.customExtensions).toHaveLength(1);
+    expect(JSON.parse(rel.customExtensions![0].data)).toEqual({
+      'rdfs:subPropertyOf': ['base'],
+      'owl:inverseOf': 'invRel',
+      'owl:SymmetricProperty': true,
+    });
+  });
+
+  test('carriage round-trips losslessly through the loader', () => {
+    // The generated YAML re-parses to the same carried facts -- the guarantee
+    // that pull recovers what import carried.
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ; owl:equivalentClass ex:Human .
+      ex:Human a owl:Class .`;
+    const yaml = convertOwlToOsi(ttl, 'x').yaml;
+    const reloaded = loadModels(yaml).models[0];
+    const person = reloaded.entities.find(e => e.name === 'Person')!;
+    expect(ontologyTerms(person.customExtensions)).toEqual({
+      'owl:equivalentClass': ['Human']
+    });
   });
 });

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -866,6 +866,22 @@ describe('OWL constructs carried as custom extensions', () => {
     });
   });
 
+  test('a repeated identical owl:inverseOf is not a conflict', () => {
+    // The same inverse stated twice is one distinct fact, not a genuine
+    // multi-inverse conflict: dedupe before counting so no spurious warning.
+    const ttl = `${PREFIXES}
+      ex:A a owl:Class . ex:B a owl:Class .
+      ex:rel a owl:ObjectProperty ;
+          rdfs:domain ex:A ; rdfs:range ex:B ;
+          owl:inverseOf ex:inv ; owl:inverseOf ex:inv .`;
+    const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
+    expect(warnings.some(w => w.includes('inverseOf'))).toBe(false);
+    const rel = loadModels(yaml).models[0].relationships[0];
+    expect(ontologyTerms(rel.customExtensions)).toEqual({
+      'owl:inverseOf': 'inv'
+    });
+  });
+
   test(
       'property characteristics -> relationship, faithful boolean keys', () => {
         const ttl = `${PREFIXES}
@@ -925,9 +941,15 @@ describe('OWL constructs carried as custom extensions', () => {
           owl:inverseOf ex:invRel .`;
     const rel = loadOwl(ttl).relationships[0];
     // One GOOGLE block carries every fact; key order is fixed for a stable
-    // golden (subPropertyOf, inverseOf, then characteristics).
+    // golden (subPropertyOf, inverseOf, then characteristics). Assert the order
+    // explicitly -- toEqual on the parsed object is order-insensitive, so only
+    // Object.keys (insertion order, mirroring the serialized JSON) pins it.
     expect(rel.customExtensions).toHaveLength(1);
-    expect(JSON.parse(rel.customExtensions![0].data)).toEqual({
+    const carried = JSON.parse(rel.customExtensions![0].data);
+    expect(Object.keys(carried)).toEqual([
+      'rdfs:subPropertyOf', 'owl:inverseOf', 'owl:SymmetricProperty'
+    ]);
+    expect(carried).toEqual({
       'rdfs:subPropertyOf': ['base'],
       'owl:inverseOf': 'invRel',
       'owl:SymmetricProperty': true,


### PR DESCRIPTION
## What

The OWL importer mapped every construct it read to a **native** semantic-model slot and dropped the rest with a warning. This carries the four constructs that have no native slot **verbatim** instead of dropping them:

| Construct | Attaches to | Meaning |
|---|---|---|
| `rdfs:subPropertyOf` | field / relationship | property inheritance |
| `owl:inverseOf` | relationship | the edge, reversed |
| `owl:equivalentClass` | entity | class equivalence |
| `owl:Symmetric` / `Transitive` / `FunctionalProperty` | relationship / field | property characteristics |

## Shape

Each rides in a `GOOGLE` `custom_extensions` block whose keys **are** the source constructs, prefixed with their vocabulary:

```yaml
custom_extensions:
  - vendor_name: GOOGLE
    data: '{"rdfs:subPropertyOf":["name"],"owl:FunctionalProperty":true}'
```

- **Prefix = namespace.** A carried fact never collides with Google's own unprefixed keys (`deploymentTargets`) or a same-named construct from another standard (`subPropertyOf` is RDFS, `inverseOf` is OWL). A reader treats "any key with a `:`" as a carried ontology fact.
- **Faithful, not invented.** A symmetric property is `"owl:SymmetricProperty": true`, not a synthesized `characteristics` list. Flat payload — no `data`/`ontology` wrapper.

## Properties

- **Lossless** — `kcmd pull` recovers every carried fact (round-trip test).
- **Inert on push** — neither the BigQuery Graph nor the Knowledge Catalog leg reads it, so it changes no node, edge, or query. `extends` stays the only construct that reshapes the graph.
- **Promotable** — the extension is the seam where a construct graduates to a first-class concept.

## Still unread

Blank-node axioms (`owl:oneOf`, `owl:Restriction` cardinality, class expressions) need a blank-node walker and remain unread — the next carriage candidates.

## Tests / docs

- New `carriage.owl.ttl` showcase fixture + golden, used verbatim in the guide (so the doc example can't drift).
- Enriched `hierarchy` fixture: `subPropertyOf` now carried, not dropped.
- New user-guide subsection "Constructs carried as custom extensions (not yet native)": shape, attach-point table, worked example, prefix→IRI map.
- Full suite green (466 pass), `tsc` clean.