### PR TITLE
mdcode: carry owl:oneOf and owl:propertyChainAxiom as custom extensions

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -16,8 +16,9 @@ the property characteristics, and per-term annotations (`rdfs:seeAlso`,
 `owl:deprecated`, …) — are not dropped: they **ride along verbatim** as custom
 extensions, lossless and inert, until they earn a first-class concept (see
 [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)).
-Richer OWL still not read at all (SHACL, cardinality restrictions, `owl:oneOf`,
-individuals) is listed in [Limitations](#limitations).
+Richer OWL still not read at all (SHACL, cardinality restrictions, the set-level
+disjointness / identity axioms, individuals) is listed in
+[Limitations](#limitations).
 
 ## 1. The OWL file
 
@@ -246,7 +247,7 @@ appears nowhere above.
 | `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; `expression` defaults to the property's local name (a valid column ref once bound) |
 | `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; join columns bound to the destination key when it has one, else `TODO_BIND` (see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
-| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
+| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
 | `owl:hasKey ( ... )` | dataset `primary_key` | single or composite, in list order |
 | `owl:InverseFunctionalProperty` | dataset `unique_keys` | a uniquely-identifying property; omitted when it is already the `primary_key`; a lone one on a keyless class is promoted to `primary_key` instead |
@@ -449,6 +450,8 @@ repeated as its own column. Rows are grouped by what they attach to.
 |---|---|---|---|
 | `owl:equivalentClass` | entity | `string[]` (equivalent class refs) | this class denotes the same set as another |
 | `owl:disjointWith` | entity | `string[]` (disjoint class refs) | no individual is in both classes |
+| `owl:oneOf` | entity | `string[]` (member refs, in list order) | the class is exactly this enumerated set of members |
+| `owl:propertyChainAxiom` | relationship | `string[]` (property refs, **in chain order, duplicates kept**) | this edge is the ordered composition of the listed ones (`hasParent` then `hasBrother` ⇒ `hasUncle`) |
 | `rdfs:subPropertyOf` | field / relationship | `string[]` (super-property refs) | this property refines a broader one |
 | `owl:equivalentProperty` | field / relationship | `string[]` (equivalent property refs) | this property means the same as another |
 | `owl:propertyDisjointWith` | field / relationship | `string[]` (disjoint property refs) | the two properties never both hold |
@@ -692,16 +695,21 @@ import:
   extensions](#constructs-carried-as-custom-extensions-not-yet-native)). They are
   inert on push; promoting any to a native concept is the follow-on.
 
-**Not read yet — the next candidates for carriage.** Each is stated as a
-blank-node axiom (an RDF list or an anonymous node) whose predicates the
-converter does not recognize today; the RDF-list walker itself already exists (it
-reads `owl:hasKey`), so these are within reach:
+**Not read yet — the next candidates for carriage.** Each is stated as an
+anonymous axiom node (a blank node, sometimes carrying an RDF list) whose
+predicates the converter does not recognize today; the RDF-list walker itself
+already exists (it reads `owl:hasKey`, `owl:oneOf`, and `owl:propertyChainAxiom`),
+so these are within reach:
 
 - Cardinality / required (`owl:minCardinality` / `owl:maxCardinality`
-  restrictions), enumerations (`owl:oneOf`), and the *set* disjointness / identity
-  axioms (`owl:AllDisjointClasses` / `AllDisjointProperties` / `AllDifferent`,
-  `owl:propertyChainAxiom`). (Pairwise `owl:disjointWith` /
-  `owl:propertyDisjointWith`, which name a term directly, *are* carried.)
+  restrictions) and the *set* disjointness / identity axioms
+  (`owl:AllDisjointClasses` / `AllDisjointProperties` / `AllDifferent`). Unlike
+  the carried axioms above, none hangs off a named term: a cardinality lives on an
+  anonymous `owl:Restriction` reached through `rdfs:subClassOf`, and the set
+  axioms are free-standing anonymous nodes — so reaching them needs a new scan,
+  not just the list walker. (Pairwise `owl:disjointWith` /
+  `owl:propertyDisjointWith` and the enumeration `owl:oneOf` / chain
+  `owl:propertyChainAxiom`, which hang off a named term, *are* carried.)
 
 **Not read — out of scope.** Richer OWL/RDF beyond the schema-shaped subset this
 converter targets:

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -450,8 +450,8 @@ repeated as its own column. Rows are grouped by what they attach to.
 |---|---|---|---|
 | `owl:equivalentClass` | entity | `string[]` (equivalent class refs) | this class denotes the same set as another |
 | `owl:disjointWith` | entity | `string[]` (disjoint class refs) | no individual is in both classes |
-| `owl:oneOf` | entity | `string[]` (member refs, in list order) | the class is exactly this enumerated set of members |
-| `owl:propertyChainAxiom` | relationship | `string[]` (property refs, **in chain order, duplicates kept**) | this edge is the ordered composition of the listed ones (`hasParent` then `hasBrother` ⇒ `hasUncle`) |
+| `owl:oneOf` | entity | `string[]` (member refs; an enumeration is a **set** — deduped, order not significant) | the class is exactly this enumerated set of members |
+| `owl:propertyChainAxiom` | relationship | `string[][]` (one ordered chain per axiom — **in chain order, duplicates kept**; a property may carry several chain axioms) | this edge is the ordered composition of the listed ones (`hasParent` then `hasBrother` ⇒ `hasUncle`) |
 | `rdfs:subPropertyOf` | field / relationship | `string[]` (super-property refs) | this property refines a broader one |
 | `owl:equivalentProperty` | field / relationship | `string[]` (equivalent property refs) | this property means the same as another |
 | `owl:propertyDisjointWith` | field / relationship | `string[]` (disjoint property refs) | the two properties never both hold |

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -451,11 +451,11 @@ repeated as its own column. Rows are grouped by what they attach to.
 | `owl:equivalentClass` | entity | `string[]` (equivalent class refs) | this class denotes the same set as another |
 | `owl:disjointWith` | entity | `string[]` (disjoint class refs) | no individual is in both classes |
 | `owl:oneOf` | entity | `string[]` (member refs; an enumeration is a **set** — deduped, order not significant) | the class is exactly this enumerated set of members |
-| `owl:propertyChainAxiom` | relationship | `string[][]` (one ordered chain per axiom — **in chain order, duplicates kept**; a property may carry several chain axioms) | this edge is the ordered composition of the listed ones (`hasParent` then `hasBrother` ⇒ `hasUncle`) |
 | `rdfs:subPropertyOf` | field / relationship | `string[]` (super-property refs) | this property refines a broader one |
 | `owl:equivalentProperty` | field / relationship | `string[]` (equivalent property refs) | this property means the same as another |
 | `owl:propertyDisjointWith` | field / relationship | `string[]` (disjoint property refs) | the two properties never both hold |
 | `owl:FunctionalProperty` | field / relationship | `true` | at most one value / destination per subject |
+| `owl:propertyChainAxiom` | relationship | `string[][]` (one ordered chain per axiom — **in chain order, duplicates kept**; a property may carry several chain axioms) | this edge is the ordered composition of the listed ones (`hasParent` then `hasBrother` ⇒ `hasUncle`) |
 | `owl:inverseOf` | relationship | `string` (the inverse edge's ref) | the same edge read the other way |
 | `owl:SymmetricProperty` | relationship | `true` | the edge holds both ways (`a→b` ⇒ `b→a`) |
 | `owl:TransitiveProperty` | relationship | `true` | the edge chains (`a→b`, `b→c` ⇒ `a→c`) |

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -16,12 +16,14 @@
 // cross-references (owl:inverseOf, owl:equivalentClass, owl:disjointWith,
 // owl:equivalentProperty, owl:propertyDisjointWith), the full set of property
 // characteristics (symmetric / transitive / functional / reflexive /
-// irreflexive / asymmetric), and per-term annotations (rdfs:seeAlso,
-// rdfs:isDefinedBy, owl:deprecated, owl:versionInfo). A carried cross-reference
-// keeps the FULL referent IRI; the mapper shortens it to a local name only when
-// it lives in this ontology's own namespace (see to_ir.refValue). Richer OWL
-// still absent (SHACL, cardinality restrictions, owl:oneOf, individuals); see
-// the "What is not covered yet" note in the guide.
+// irreflexive / asymmetric), per-term annotations (rdfs:seeAlso,
+// rdfs:isDefinedBy, owl:deprecated, owl:versionInfo), enumerations
+// (owl:oneOf), and property chains (owl:propertyChainAxiom). A carried
+// cross-reference keeps the FULL referent IRI; the mapper shortens it to a
+// local name only when it lives in this ontology's own namespace (see
+// to_ir.refValue). Richer OWL still absent (SHACL, cardinality restrictions,
+// the set-level disjointness/identity axioms, individuals); see the "What is
+// not covered yet" note in the guide.
 
 /**
  * Per-term annotations carried verbatim on any class or property -- links to
@@ -82,6 +84,13 @@ export interface OwlClass extends OwlCommonAnnotations {
   // expression is out of scope). Full IRIs (see equivalentClass). Empty when
   // none.
   disjointWith: string[];
+  // Referent IRIs of the members of an `owl:oneOf` enumeration (the class is
+  // defined by listing its members), in list order. No native OSI home -- the
+  // members are usually individuals, which the converter does not model -- so
+  // the enumeration is carried verbatim as a custom extension, keeping the
+  // member names. Full IRIs -- the mapper shortens an in-namespace one to its
+  // local name. Empty when the class is not an enumeration.
+  oneOf: string[];
 }
 
 /**
@@ -163,6 +172,15 @@ export interface OwlObjectProperty extends OwlCommonAnnotations {
   // No native OSI home; carried verbatim. Named properties only. Full IRIs.
   // Empty when none.
   propertyDisjointWith: string[];
+  // Referent IRIs of the properties in an `owl:propertyChainAxiom` (this
+  // property is the composition of the listed ones, e.g. hasParent then
+  // hasBrother == hasUncle), in chain order. No native OSI home, so it is
+  // carried verbatim. Order is significant AND repetition is meaningful (a
+  // chain may name the same property twice, e.g. hasParent/hasParent for a
+  // grandparent), so it is neither reordered nor deduped. Full IRIs -- the
+  // mapper shortens an in-namespace one to its local name. Empty when the
+  // property is not a chain.
+  propertyChain: string[];
   // owl:SymmetricProperty -- the edge holds both ways (`a rel b` implies
   // `b rel a`). Carried verbatim; no native OSI home.
   symmetric: boolean;

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -85,11 +85,15 @@ export interface OwlClass extends OwlCommonAnnotations {
   // none.
   disjointWith: string[];
   // Referent IRIs of the members of an `owl:oneOf` enumeration (the class is
-  // defined by listing its members), in list order. No native OSI home -- the
-  // members are usually individuals, which the converter does not model -- so
-  // the enumeration is carried verbatim as a custom extension, keeping the
-  // member names. Full IRIs -- the mapper shortens an in-namespace one to its
-  // local name. Empty when the class is not an enumeration.
+  // defined by listing its members). An enumeration is an unordered SET, so the
+  // members are deduped and -- in the non-standard case of a class carrying
+  // more than one oneOf axiom -- unioned; unlike a property chain, neither
+  // order nor repetition is meaningful. No native OSI home -- the members are
+  // usually individuals, which the converter does not model -- so the
+  // enumeration is carried verbatim as a custom extension, keeping the member
+  // names. Full IRIs
+  // -- the mapper shortens an in-namespace one to its local name. Empty when
+  // the class is not an enumeration.
   oneOf: string[];
 }
 
@@ -172,15 +176,18 @@ export interface OwlObjectProperty extends OwlCommonAnnotations {
   // No native OSI home; carried verbatim. Named properties only. Full IRIs.
   // Empty when none.
   propertyDisjointWith: string[];
-  // Referent IRIs of the properties in an `owl:propertyChainAxiom` (this
-  // property is the composition of the listed ones, e.g. hasParent then
-  // hasBrother == hasUncle), in chain order. No native OSI home, so it is
-  // carried verbatim. Order is significant AND repetition is meaningful (a
-  // chain may name the same property twice, e.g. hasParent/hasParent for a
-  // grandparent), so it is neither reordered nor deduped. Full IRIs -- the
-  // mapper shortens an in-namespace one to its local name. Empty when the
-  // property is not a chain.
-  propertyChain: string[];
+  // One entry per `owl:propertyChainAxiom` on this property, each the ordered
+  // list of properties it composes (e.g. hasParent then hasBrother ==
+  // hasUncle). OWL 2 allows a property to carry MORE THAN ONE chain axiom (e.g.
+  // uncleOf as fatherOf/brotherOf and as motherOf/brotherOf), so the chains are
+  // kept separate -- flattening them into one list would fuse the axiom
+  // boundaries and be indistinguishable from a single longer chain. No native
+  // OSI home, so each is carried verbatim. Within a chain, order is significant
+  // AND repetition is meaningful (a chain may name the same property twice,
+  // e.g. hasParent/hasParent for a grandparent), so it is neither reordered nor
+  // deduped. Full IRIs -- the mapper shortens an in-namespace one to its local
+  // name. Empty when the property is not a chain.
+  propertyChain: string[][];
   // owl:SymmetricProperty -- the edge holds both ways (`a rel b` implies
   // `b rel a`). Carried verbatim; no native OSI home.
   symmetric: boolean;

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -392,9 +392,10 @@ export function parseOwl(turtle: string): OwlModel {
       case OWL_ONE_OF:
         // Enumerated class -> no native OSI home; carried verbatim. The object
         // is an RDF collection head; the members (usually individuals) are
-        // resolved with the list walker at build time. On a subject that is not
-        // a class (e.g. a datatype-defining node) this never runs -- only typed
-        // classes/properties are annotated.
+        // resolved with the list walker at build time. This is recorded for any
+        // annotated subject, but only the class build reads it -- if the
+        // subject is typed a property instead, the heads are collected here and
+        // then dropped (an owl:oneOf on a property is not meaningful).
         a.oneOfListHeads.push(q.object.value);
         break;
       case OWL_PROPERTY_CHAIN_AXIOM:
@@ -514,8 +515,10 @@ export function parseOwl(turtle: string): OwlModel {
           subClassOf: a.subClassOf,
           equivalentClass: a.equivalentClass,
           disjointWith: a.disjointWith,
-          // Full member IRIs (a carried cross-reference); the mapper shortens
-          // an in-namespace one. flatMap over resolveList keeps list order.
+          // Full member IRIs of the enumeration set (a carried cross-reference;
+          // the mapper shortens an in-namespace one). flatMap unions the
+          // members across every oneOf head -- an enumeration is a set, so the
+          // mapper dedupes and order does not matter (contrast propertyChain).
           oneOf: a.oneOfListHeads.flatMap(resolveList),
           ...commonAnnotations(a),
         });
@@ -553,9 +556,15 @@ export function parseOwl(turtle: string): OwlModel {
           inverseOf: a.inverseOf,
           equivalentProperty: a.equivalentProperty,
           propertyDisjointWith: a.propertyDisjointWith,
-          // Full property IRIs in chain order (the mapper shortens in-namespace
-          // ones); order and repetition are preserved, so no dedupe here.
-          propertyChain: a.chainListHeads.flatMap(resolveList),
+          // One resolved chain per owl:propertyChainAxiom (map, NOT flatMap):
+          // OWL 2 permits several chain axioms on one property, and fusing them
+          // would be indistinguishable from a single longer chain. Full
+          // property IRIs in chain order (the mapper shortens in-namespace
+          // ones); within a chain order and repetition are preserved, so no
+          // dedupe. An empty chain (a broken/gapped list) is dropped rather
+          // than carried as [].
+          propertyChain:
+              a.chainListHeads.map(resolveList).filter(c => c.length),
           symmetric: symmetric.has(iri),
           transitive: transitive.has(iri),
           functional: functional.has(iri),

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -52,6 +52,12 @@ const OWL_IRREFLEXIVE_PROPERTY = `${OWL}IrreflexiveProperty`;
 const OWL_ASYMMETRIC_PROPERTY = `${OWL}AsymmetricProperty`;
 const OWL_ONTOLOGY = `${OWL}Ontology`;
 const OWL_HAS_KEY = `${OWL}hasKey`;
+// List-valued constructs whose object is an RDF collection head (a blank node),
+// resolved with the same list walker as owl:hasKey. owl:oneOf enumerates a
+// class's members; owl:propertyChainAxiom composes a property from a sequence
+// of others. Both are carried verbatim (no native OSI home).
+const OWL_ONE_OF = `${OWL}oneOf`;
+const OWL_PROPERTY_CHAIN_AXIOM = `${OWL}propertyChainAxiom`;
 const OWL_INVERSE_OF = `${OWL}inverseOf`;
 const OWL_EQUIVALENT_PROPERTY = `${OWL}equivalentProperty`;
 const OWL_PROPERTY_DISJOINT_WITH = `${OWL}propertyDisjointWith`;
@@ -168,6 +174,8 @@ interface Annotations {
   ranges: string[];  // raw range IRIs; the mapper maps xsd:* -> datatype
   versionInfo?: string;
   keyListHeads: string[];          // owl:hasKey list heads (blank nodes)
+  oneOfListHeads: string[];        // owl:oneOf list heads (blank nodes)
+  chainListHeads: string[];        // owl:propertyChainAxiom list heads
   subClassOf: string[];            // local names (feed native `extends`)
   subPropertyOf: string[];         // full IRIs (named superproperties)
   equivalentClass: string[];       // full IRIs (named classes only)
@@ -187,6 +195,8 @@ function emptyAnnotations(): Annotations {
     domains: [],
     ranges: [],
     keyListHeads: [],
+    oneOfListHeads: [],
+    chainListHeads: [],
     subClassOf: [],
     subPropertyOf: [],
     equivalentClass: [],
@@ -379,6 +389,19 @@ export function parseOwl(turtle: string): OwlModel {
       case OWL_HAS_KEY:
         a.keyListHeads.push(q.object.value);
         break;
+      case OWL_ONE_OF:
+        // Enumerated class -> no native OSI home; carried verbatim. The object
+        // is an RDF collection head; the members (usually individuals) are
+        // resolved with the list walker at build time. On a subject that is not
+        // a class (e.g. a datatype-defining node) this never runs -- only typed
+        // classes/properties are annotated.
+        a.oneOfListHeads.push(q.object.value);
+        break;
+      case OWL_PROPERTY_CHAIN_AXIOM:
+        // Property chain -> no native OSI home; carried verbatim. The object is
+        // an RDF collection head naming the composed properties, in order.
+        a.chainListHeads.push(q.object.value);
+        break;
       case RDFS_SUBCLASS_OF:
         // Class hierarchy -> the entity's `extends`. Named superclasses only:
         // a blank-node object (an owl:Restriction and similar axioms) is not a
@@ -491,6 +514,9 @@ export function parseOwl(turtle: string): OwlModel {
           subClassOf: a.subClassOf,
           equivalentClass: a.equivalentClass,
           disjointWith: a.disjointWith,
+          // Full member IRIs (a carried cross-reference); the mapper shortens
+          // an in-namespace one. flatMap over resolveList keeps list order.
+          oneOf: a.oneOfListHeads.flatMap(resolveList),
           ...commonAnnotations(a),
         });
         break;
@@ -527,6 +553,9 @@ export function parseOwl(turtle: string): OwlModel {
           inverseOf: a.inverseOf,
           equivalentProperty: a.equivalentProperty,
           propertyDisjointWith: a.propertyDisjointWith,
+          // Full property IRIs in chain order (the mapper shortens in-namespace
+          // ones); order and repetition are preserved, so no dedupe here.
+          propertyChain: a.chainListHeads.flatMap(resolveList),
           symmetric: symmetric.has(iri),
           transitive: transitive.has(iri),
           functional: functional.has(iri),

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -31,6 +31,8 @@
 //   owl:equivalentProperty -> field / relationship
 //   owl:propertyDisjointWith -> field / relationship
 //   property characteristics -> relationship (symmetric, transitive, ...)
+//   owl:oneOf -> entity (enumerated class members)
+//   owl:propertyChainAxiom -> relationship (ordered property composition)
 //   rdfs:seeAlso, rdfs:isDefinedBy -> any (external pointers, verbatim)
 //   owl:deprecated, owl:versionInfo -> any (lifecycle metadata)
 //
@@ -341,6 +343,15 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     return v;
   }));
 
+  // Like refs(), but preserves order AND duplicates -- for an ORDERED construct
+  // (a property chain) where a repeated referent is meaningful (e.g.
+  // hasParent/hasParent == grandparent), so deduping would silently corrupt it.
+  const refSeq = (iris: string[]): string[] => iris.map(iri => {
+    const v = refValue(iri, owl.baseIri);
+    if (v !== iri) shortenedRef = true;
+    return v;
+  });
+
   // Entities, one per class, in class-declaration order. Fields are attached in
   // datatype-property-declaration order below. Two classes can share a local
   // name (e.g. same name in different namespaces); OSI dataset names must be
@@ -387,14 +398,16 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     // OWL facts with no native OSI home, carried verbatim on the entity, in a
     // fixed key order. owl:equivalentClass / owl:disjointWith are class
     // cross-references (a class is one entity, so these are facts ABOUT it, not
-    // structural links); blank-node class expressions were dropped in the
-    // parser. commonTerms adds any per-term annotations (seeAlso, deprecated,
-    // ...).
+    // structural links); owl:oneOf enumerates the class's members (usually
+    // individuals, which are not modeled, so only the names are kept);
+    // blank-node class expressions were dropped in the parser. commonTerms adds
+    // any per-term annotations (seeAlso, deprecated, ...).
     const entityTerms: Record<string, unknown> = {};
     if (c.equivalentClass.length)
       entityTerms['owl:equivalentClass'] = refs(c.equivalentClass);
     if (c.disjointWith.length)
       entityTerms['owl:disjointWith'] = refs(c.disjointWith);
+    if (c.oneOf.length) entityTerms['owl:oneOf'] = refs(c.oneOf);
     Object.assign(entityTerms, commonTerms(c));
     attachOntology(entity, entityTerms);
     entitiesByName.set(c.localName, entity);
@@ -554,13 +567,19 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     // OWL facts with no native OSI home, carried verbatim on the relationship,
     // in a fixed key order so the emitted block is stable. rdfs:subPropertyOf
     // -> relationship inheritance (kept as a fact, no flattening);
-    // owl:inverseOf -> the edge read the other way; owl:equivalentProperty /
-    // propertyDisjointWith -> property cross-references; then the edge's
-    // characteristics (symmetric / transitive / functional / reflexive /
-    // irreflexive / asymmetric); commonTerms adds any per-term annotations.
+    // owl:propertyChainAxiom -> this edge as an ordered composition of other
+    // properties; owl:inverseOf -> the edge read the other way;
+    // owl:equivalentProperty / propertyDisjointWith -> property
+    // cross-references; then the edge's characteristics (symmetric / transitive
+    // / functional / reflexive / irreflexive / asymmetric); commonTerms adds
+    // any per-term annotations.
     const relTerms: Record<string, unknown> = {};
     if (p.subPropertyOf.length)
       relTerms['rdfs:subPropertyOf'] = refs(p.subPropertyOf);
+    // Ordered and repetition-sensitive, so refSeq (not refs): a chain may name
+    // the same property twice (e.g. hasParent/hasParent for a grandparent).
+    if (p.propertyChain.length)
+      relTerms['owl:propertyChainAxiom'] = refSeq(p.propertyChain);
     if (p.inverseOf.length) {
       // owl:inverseOf pairs two properties; one DISTINCT statement is the norm.
       // refs() shortens and dedupes first, so a repeated identical triple isn't

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -399,9 +399,11 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     // fixed key order. owl:equivalentClass / owl:disjointWith are class
     // cross-references (a class is one entity, so these are facts ABOUT it, not
     // structural links); owl:oneOf enumerates the class's members (usually
-    // individuals, which are not modeled, so only the names are kept);
-    // blank-node class expressions were dropped in the parser. commonTerms adds
-    // any per-term annotations (seeAlso, deprecated, ...).
+    // individuals, which are not modeled, so only the names are kept) -- an
+    // enumeration is a set, so refs() (which dedupes) is correct here, unlike
+    // the ordered propertyChainAxiom which uses refSeq; blank-node class
+    // expressions were dropped in the parser. commonTerms adds any per-term
+    // annotations (seeAlso, deprecated, ...).
     const entityTerms: Record<string, unknown> = {};
     if (c.equivalentClass.length)
       entityTerms['owl:equivalentClass'] = refs(c.equivalentClass);
@@ -576,10 +578,12 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     const relTerms: Record<string, unknown> = {};
     if (p.subPropertyOf.length)
       relTerms['rdfs:subPropertyOf'] = refs(p.subPropertyOf);
-    // Ordered and repetition-sensitive, so refSeq (not refs): a chain may name
-    // the same property twice (e.g. hasParent/hasParent for a grandparent).
+    // One list per chain axiom (a property may carry several). Each is ordered
+    // and repetition-sensitive, so refSeq (not refs): a chain may name the same
+    // property twice (e.g. hasParent/hasParent for a grandparent). Emitted as a
+    // list of chains so distinct axioms are not fused into one flat sequence.
     if (p.propertyChain.length)
-      relTerms['owl:propertyChainAxiom'] = refSeq(p.propertyChain);
+      relTerms['owl:propertyChainAxiom'] = p.propertyChain.map(refSeq);
     if (p.inverseOf.length) {
       // owl:inverseOf pairs two properties; one DISTINCT statement is the norm.
       // refs() shortens and dedupes first, so a repeated identical triple isn't

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
@@ -136,7 +136,9 @@ semantic_model:
             data: |-
               {
                 "owl:propertyChainAxiom": [
-                  "ancestorOf",
-                  "relatedTo"
+                  [
+                    "ancestorOf",
+                    "relatedTo"
+                  ]
                 ]
               }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
@@ -70,6 +70,17 @@ semantic_model:
       - name: Robot
         source: unbound:Robot
         description: A machine, never a person.
+      - name: LifeStage
+        source: unbound:LifeStage
+        custom_extensions:
+          - vendor_name: GOOGLE
+            data: |-
+              {
+                "owl:oneOf": [
+                  "Infant",
+                  "Adult"
+                ]
+              }
     relationships:
       - name: ancestorOf
         from: Person
@@ -112,4 +123,20 @@ semantic_model:
                 ],
                 "owl:SymmetricProperty": true,
                 "owl:ReflexiveProperty": true
+              }
+      - name: uncleOf
+        from: Person
+        to: Person
+        from_columns:
+          - TODO_BIND
+        to_columns:
+          - personId
+        custom_extensions:
+          - vendor_name: GOOGLE
+            data: |-
+              {
+                "owl:propertyChainAxiom": [
+                  "ancestorOf",
+                  "relatedTo"
+                ]
               }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.owl.ttl
@@ -8,9 +8,11 @@
 #   - rdfs:subPropertyOf / owl:equivalentProperty / owl:FunctionalProperty and
 #     the rdfs:seeAlso / owl:deprecated / owl:versionInfo annotations on a
 #     datatype property -> field extension
-#   - rdfs:subPropertyOf / owl:inverseOf / owl:propertyDisjointWith and the
-#     reflexive / irreflexive / symmetric / transitive / asymmetric
-#     characteristics on an object property -> relationship extension
+#   - rdfs:subPropertyOf / owl:inverseOf / owl:propertyDisjointWith /
+#     owl:propertyChainAxiom and the reflexive / irreflexive / symmetric /
+#     transitive / asymmetric characteristics on an object property ->
+#     relationship extension
+#   - owl:oneOf on a class (an enumeration) -> entity extension
 #
 # Namespace handling: this ontology's base namespace is
 # http://example.com/people# (ex:); it also references the external FOAF and
@@ -47,6 +49,12 @@ ex:Person a owl:Class ;
 ex:Robot a owl:Class ;
     rdfs:comment "A machine, never a person." .
 
+# LifeStage is an ENUMERATION: it is exactly these members (owl:oneOf). The
+# members are individuals (which the converter does not model), so the list is
+# carried verbatim, keeping the in-namespace member names in list order.
+ex:LifeStage a owl:Class ;
+    owl:oneOf ( ex:Infant ex:Adult ) .
+
 ex:personId a owl:DatatypeProperty ;
     rdfs:domain ex:Person ; rdfs:range xsd:string .
 
@@ -81,3 +89,9 @@ ex:ancestorOf a owl:ObjectProperty, owl:TransitiveProperty,
 ex:relatedTo a owl:ObjectProperty, owl:SymmetricProperty, owl:ReflexiveProperty ;
     rdfs:domain ex:Person ; rdfs:range ex:Person ;
     owl:equivalentProperty foaf:knows .
+
+# uncleOf is the COMPOSITION ancestorOf then relatedTo (owl:propertyChainAxiom):
+# an ordered chain of in-namespace properties, kept in order and never deduped.
+ex:uncleOf a owl:ObjectProperty ;
+    rdfs:domain ex:Person ; rdfs:range ex:Person ;
+    owl:propertyChainAxiom ( ex:ancestorOf ex:relatedTo ) .

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -907,7 +907,7 @@ describe('OWL constructs carried as custom extensions', () => {
         // Carriage is never a warning -- nothing is dropped.
         expect(warnings).toEqual([]);
         expect(stats).toEqual(
-            {classes: 2, datatypeProperties: 3, objectProperties: 2});
+            {classes: 3, datatypeProperties: 3, objectProperties: 3});
         // And the result stays schema-valid and loadable with the blocks
         // attached (loadable, not yet pushable -- sources are still unbound).
         expect(() => loadModels(yaml)).not.toThrow();
@@ -1109,6 +1109,54 @@ describe('OWL constructs carried as custom extensions', () => {
     const rel = loadOwl(ttl).relationships[0];
     expect(ontologyTerms(rel.customExtensions)).toEqual({
       'owl:propertyDisjointWith': ['other']
+    });
+  });
+
+  // --- List-valued axioms on a named term (reuse the RDF-list walker). -------
+
+  test('owl:oneOf on a named class -> entity (enumerated members)', () => {
+    // The class is defined by listing its members. The members are individuals
+    // (which the converter does not model), so the enumeration rides along
+    // verbatim, keeping the member names in list order.
+    const ttl = `${PREFIXES}
+      ex:Suit a owl:Class ;
+          owl:oneOf ( ex:Hearts ex:Diamonds ex:Clubs ex:Spades ) .`;
+    const suit = loadOwl(ttl).entities.find(e => e.name === 'Suit')!;
+    expect(ontologyTerms(suit.customExtensions)).toEqual({
+      'owl:oneOf': ['Hearts', 'Diamonds', 'Clubs', 'Spades']
+    });
+  });
+
+  test('owl:propertyChainAxiom -> relationship (ordered composition)', () => {
+    // hasUncle == hasParent then hasBrother. Chain order is significant, so the
+    // members are kept in document order.
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      ex:hasParent a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
+      ex:hasBrother a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
+      ex:hasUncle a owl:ObjectProperty ;
+          rdfs:domain ex:Person ; rdfs:range ex:Person ;
+          owl:propertyChainAxiom ( ex:hasParent ex:hasBrother ) .`;
+    const rel = loadOwl(ttl).relationships.find(r => r.name === 'hasUncle')!;
+    expect(ontologyTerms(rel.customExtensions)).toEqual({
+      'owl:propertyChainAxiom': ['hasParent', 'hasBrother']
+    });
+  });
+
+  test('owl:propertyChainAxiom keeps a repeated member (not deduped)', () => {
+    // hasGrandparent == hasParent then hasParent. Repetition is meaningful, so
+    // unlike a set-valued cross-reference the chain is neither reordered nor
+    // deduped -- refSeq, not refs.
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      ex:hasParent a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
+      ex:hasGrandparent a owl:ObjectProperty ;
+          rdfs:domain ex:Person ; rdfs:range ex:Person ;
+          owl:propertyChainAxiom ( ex:hasParent ex:hasParent ) .`;
+    const rel =
+        loadOwl(ttl).relationships.find(r => r.name === 'hasGrandparent')!;
+    expect(ontologyTerms(rel.customExtensions)).toEqual({
+      'owl:propertyChainAxiom': ['hasParent', 'hasParent']
     });
   });
 

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -1129,7 +1129,9 @@ describe('OWL constructs carried as custom extensions', () => {
 
   test('owl:propertyChainAxiom -> relationship (ordered composition)', () => {
     // hasUncle == hasParent then hasBrother. Chain order is significant, so the
-    // members are kept in document order.
+    // members are kept in document order. A single axiom is carried as a list
+    // of one chain (a chain is itself a list), so the shape is stable whether a
+    // property has one axiom or several.
     const ttl = `${PREFIXES}
       ex:Person a owl:Class .
       ex:hasParent a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
@@ -1139,7 +1141,7 @@ describe('OWL constructs carried as custom extensions', () => {
           owl:propertyChainAxiom ( ex:hasParent ex:hasBrother ) .`;
     const rel = loadOwl(ttl).relationships.find(r => r.name === 'hasUncle')!;
     expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:propertyChainAxiom': ['hasParent', 'hasBrother']
+      'owl:propertyChainAxiom': [['hasParent', 'hasBrother']]
     });
   });
 
@@ -1156,7 +1158,28 @@ describe('OWL constructs carried as custom extensions', () => {
     const rel =
         loadOwl(ttl).relationships.find(r => r.name === 'hasGrandparent')!;
     expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:propertyChainAxiom': ['hasParent', 'hasParent']
+      'owl:propertyChainAxiom': [['hasParent', 'hasParent']]
+    });
+  });
+
+  test('multiple owl:propertyChainAxiom axioms are kept separate', () => {
+    // OWL 2 lets one property carry several chain axioms: an uncle is a
+    // father's brother OR a mother's brother. The two chains must not be fused
+    // into one flat list (that would be indistinguishable from a single 4-link
+    // chain), so each rides as its own ordered chain, in declaration order.
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      ex:hasFather a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
+      ex:hasMother a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
+      ex:hasBrother a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
+      ex:hasUncle a owl:ObjectProperty ;
+          rdfs:domain ex:Person ; rdfs:range ex:Person ;
+          owl:propertyChainAxiom ( ex:hasFather ex:hasBrother ) ;
+          owl:propertyChainAxiom ( ex:hasMother ex:hasBrother ) .`;
+    const rel = loadOwl(ttl).relationships.find(r => r.name === 'hasUncle')!;
+    expect(ontologyTerms(rel.customExtensions)).toEqual({
+      'owl:propertyChainAxiom':
+          [['hasFather', 'hasBrother'], ['hasMother', 'hasBrother']]
     });
   });
 


### PR DESCRIPTION
## What

Two more OWL constructs now ride along verbatim in the `GOOGLE` custom-extension block instead of being dropped:

- **`owl:oneOf`** on a class → entity. The class is defined by enumerating its members; the members (usually individuals, which the converter does not model) are kept as names in list order.
- **`owl:propertyChainAxiom`** on an object property → relationship. The edge is the ordered composition of the listed properties (`hasParent` then `hasBrother` ⇒ `hasUncle`).

## Why these two, now

Both list-valued axioms **hang off a named term**, so they reuse the existing RDF-list walker (the one that already reads `owl:hasKey`) — no new scan needed. That makes them the cheapest of the remaining carriage candidates. Neither has a native OSI home, so each is carried like the other cross-references: lossless, inert on push, promotable later.

The still-uncarried candidates (cardinality restrictions, the set-level `owl:AllDisjoint*` / `owl:AllDifferent` axioms) hang off an *anonymous* node and need a new scan, not just the list walker — the doc now draws that line explicitly.

## Ordering / dedup nuance

A property chain is **ordered and repetition-sensitive** (`hasParent`/`hasParent` == grandparent), so it is emitted with a new `refSeq` helper that preserves order **and** duplicates — unlike `refs()`, whose dedupe would silently corrupt a chain. `owl:oneOf` keeps set semantics (`refs`).

## Tests / docs

- Extends the exhaustive `carriage` fixture + golden with an enumerated class and a chain property (both exercising in-namespace shortening).
- Adds focused unit tests, including the duplicate-preservation case.
- `owl-import.md`: both move from "next candidates" to the carried table; the mapping summary and limitations notes are updated.

All 477 semantic tests pass (`bun test ./tests/libts/semantic/`).