### PR TITLE
mdcode: carry OWL set-level axioms (AllDisjoint*/AllDifferent)

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -688,25 +688,27 @@ importer handles them today, and the remaining work is a later step, not in the
 import:
 
 - **Class hierarchy** (`rdfs:subClassOf`) maps to dataset `extends` (see
-  [Class hierarchies](#class-hierarchies-rdfssubclassof)); a **BigQuery** push
-  resolves it into node-table labels with inherited fields flattened down (see
-  [Class hierarchies (`extends` →
-  labels)](reference.md#class-hierarchies-extends--labels)). Resolving the same
-  inheritance into **Knowledge Catalog** entries is the follow-on — KC push still
-  publishes each entry with only its own fields.
-- **Constructs with no native home** — property inheritance
-  (`rdfs:subPropertyOf`), the cross-references (`owl:inverseOf`,
-  `owl:equivalentClass`, `owl:disjointWith`, `owl:equivalentProperty`,
-  `owl:propertyDisjointWith`), every property characteristic (symmetric /
-  transitive / functional / reflexive / irreflexive / asymmetric), enumerations
-  (`owl:oneOf`) and property chains (`owl:propertyChainAxiom`), the set-level
-  axioms (`owl:AllDisjointClasses`, `owl:AllDisjointProperties`,
-  `owl:AllDifferent` — carried on the model), and the per-term annotations
-  (`rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo`) are
-  **carried verbatim** as `custom_extensions` rather than dropped (see
-  [Constructs carried as custom
-  extensions](#constructs-carried-as-custom-extensions-not-yet-native)). They are
-  inert on push; promoting any to a native concept is the follow-on.
+  [Class hierarchies](#class-hierarchies-rdfssubclassof)). Downstream:
+  - **BigQuery** push resolves it into node-table labels, inherited fields
+    flattened down (see [Class hierarchies (`extends` →
+    labels)](reference.md#class-hierarchies-extends--labels)).
+  - **Knowledge Catalog** is the follow-on — KC push still publishes each entry
+    with only its own fields.
+- **Constructs with no native home** are **carried verbatim** as
+  `custom_extensions` rather than dropped — inert on push, and promoting any to a
+  native concept is the follow-on (see [Constructs carried as custom
+  extensions](#constructs-carried-as-custom-extensions-not-yet-native)):
+  - **Property inheritance** — `rdfs:subPropertyOf`.
+  - **Cross-references** — `owl:inverseOf`, `owl:equivalentClass`,
+    `owl:disjointWith`, `owl:equivalentProperty`, `owl:propertyDisjointWith`.
+  - **Property characteristics** — symmetric / transitive / functional /
+    reflexive / irreflexive / asymmetric.
+  - **Enumerations** (`owl:oneOf`) and **property chains**
+    (`owl:propertyChainAxiom`).
+  - **Set-level axioms** — `owl:AllDisjointClasses`,
+    `owl:AllDisjointProperties`, `owl:AllDifferent` (carried on the model).
+  - **Per-term annotations** — `rdfs:seeAlso`, `rdfs:isDefinedBy`,
+    `owl:deprecated`, `owl:versionInfo`.
 
 **Not read yet — the next candidate for carriage.** Cardinality
 (`owl:minCardinality` / `owl:maxCardinality`) lives on an anonymous

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -247,7 +247,7 @@ appears nowhere above.
 | `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; `expression` defaults to the property's local name (a valid column ref once bound) |
 | `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; join columns bound to the destination key when it has one, else `TODO_BIND` (see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
-| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
+| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, `owl:AllDisjointClasses`, `owl:AllDisjointProperties`, `owl:AllDifferent`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
 | `owl:hasKey ( ... )` | dataset `primary_key` | single or composite, in list order |
 | `owl:InverseFunctionalProperty` | dataset `unique_keys` | a uniquely-identifying property; omitted when it is already the `primary_key`; a lone one on a keyless class is promoted to `primary_key` instead |
@@ -444,7 +444,14 @@ original construct is lost in translation.
 **What is carried, and where it attaches:**
 
 The JSON key is the OWL construct itself (see **The shape** above), so it is not
-repeated as its own column. Rows are grouped by what they attach to.
+repeated as its own column. Rows are grouped by what they attach to. Most attach
+to the term they describe (an entity, a field, a relationship, or *any* term);
+the **set-level axioms** are the exception — `owl:AllDisjointClasses`,
+`owl:AllDisjointProperties`, and `owl:AllDifferent` are each asserted on an
+anonymous node about a *set* of terms, belonging to no single class or property,
+so they attach to the **model** (the top-level `custom_extensions`, beside
+`owl:baseIri`). Each is an array of member sets — one per axiom — so two separate
+disjointness axioms stay two entries rather than merging into one flat list.
 
 | OWL construct | Attaches to | Value | Meaning |
 |---|---|---|---|
@@ -462,6 +469,9 @@ repeated as its own column. Rows are grouped by what they attach to.
 | `owl:ReflexiveProperty` | relationship | `true` | every subject relates to itself (`a→a`) |
 | `owl:IrreflexiveProperty` | relationship | `true` | no subject relates to itself |
 | `owl:AsymmetricProperty` | relationship | `true` | `a→b` rules out `b→a` |
+| `owl:AllDisjointClasses` | model | `string[][]` (one member **set** per axiom — deduped, order not significant) | the listed classes are pairwise disjoint |
+| `owl:AllDisjointProperties` | model | `string[][]` (one member set per axiom) | the listed properties are pairwise disjoint |
+| `owl:AllDifferent` | model | `string[][]` (one member set per axiom; members are individuals, names only, like `owl:oneOf`) | the listed individuals are pairwise distinct |
 | `rdfs:seeAlso` | any | `string[]` of N-Triples terms — an IRI as `<iri>`, a literal as `"text"` (with any `@lang` / `^^<datatype>` preserved) | pointer to further information (kept distinguishable, see below) |
 | `rdfs:isDefinedBy` | any | `string[]` (IRIs, verbatim) | the resource that defines this term |
 | `owl:deprecated` | any | `true` | the term is deprecated (carried only when true) |
@@ -688,28 +698,28 @@ import:
   (`rdfs:subPropertyOf`), the cross-references (`owl:inverseOf`,
   `owl:equivalentClass`, `owl:disjointWith`, `owl:equivalentProperty`,
   `owl:propertyDisjointWith`), every property characteristic (symmetric /
-  transitive / functional / reflexive / irreflexive / asymmetric), and the
-  per-term annotations (`rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`,
-  `owl:versionInfo`) are **carried verbatim** as `custom_extensions` rather than
-  dropped (see [Constructs carried as custom
+  transitive / functional / reflexive / irreflexive / asymmetric), enumerations
+  (`owl:oneOf`) and property chains (`owl:propertyChainAxiom`), the set-level
+  axioms (`owl:AllDisjointClasses`, `owl:AllDisjointProperties`,
+  `owl:AllDifferent` — carried on the model), and the per-term annotations
+  (`rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo`) are
+  **carried verbatim** as `custom_extensions` rather than dropped (see
+  [Constructs carried as custom
   extensions](#constructs-carried-as-custom-extensions-not-yet-native)). They are
   inert on push; promoting any to a native concept is the follow-on.
 
-**Not read yet — the next candidates for carriage.** Each is stated as an
-anonymous axiom node (a blank node, sometimes carrying an RDF list) whose
-predicates the converter does not recognize today; the RDF-list walker itself
-already exists (it reads `owl:hasKey`, `owl:oneOf`, and `owl:propertyChainAxiom`),
-so these are within reach:
+**Not read yet — the next candidate for carriage.** Stated as an anonymous
+axiom node whose predicates the converter does not recognize today:
 
 - Cardinality / required (`owl:minCardinality` / `owl:maxCardinality`
-  restrictions) and the *set* disjointness / identity axioms
-  (`owl:AllDisjointClasses` / `AllDisjointProperties` / `AllDifferent`). Unlike
-  the carried axioms above, none hangs off a named term: a cardinality lives on an
-  anonymous `owl:Restriction` reached through `rdfs:subClassOf`, and the set
-  axioms are free-standing anonymous nodes — so reaching them needs a new scan,
-  not just the list walker. (Pairwise `owl:disjointWith` /
-  `owl:propertyDisjointWith` and the enumeration `owl:oneOf` / chain
-  `owl:propertyChainAxiom`, which hang off a named term, *are* carried.)
+  restrictions). A cardinality lives on an anonymous `owl:Restriction` reached
+  through `rdfs:subClassOf`, so reaching it needs a `owl:Restriction` reader
+  joined back to its class — the last blank-node shape the converter does not yet
+  read. (The set-level axioms `owl:AllDisjointClasses` / `AllDisjointProperties`
+  / `AllDifferent`, also free-standing anonymous nodes, *are* now carried on the
+  model; the pairwise `owl:disjointWith` / `owl:propertyDisjointWith`, the
+  enumeration `owl:oneOf`, and the chain `owl:propertyChainAxiom`, which hang off
+  a named term, are carried too.)
 
 **Not read — out of scope.** Richer OWL/RDF beyond the schema-shaped subset this
 converter targets:

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -708,18 +708,11 @@ import:
   extensions](#constructs-carried-as-custom-extensions-not-yet-native)). They are
   inert on push; promoting any to a native concept is the follow-on.
 
-**Not read yet — the next candidate for carriage.** Stated as an anonymous
-axiom node whose predicates the converter does not recognize today:
-
-- Cardinality / required (`owl:minCardinality` / `owl:maxCardinality`
-  restrictions). A cardinality lives on an anonymous `owl:Restriction` reached
-  through `rdfs:subClassOf`, so reaching it needs a `owl:Restriction` reader
-  joined back to its class — the last blank-node shape the converter does not yet
-  read. (The set-level axioms `owl:AllDisjointClasses` / `AllDisjointProperties`
-  / `AllDifferent`, also free-standing anonymous nodes, *are* now carried on the
-  model; the pairwise `owl:disjointWith` / `owl:propertyDisjointWith`, the
-  enumeration `owl:oneOf`, and the chain `owl:propertyChainAxiom`, which hang off
-  a named term, are carried too.)
+**Not read yet — the next candidate for carriage.** Cardinality
+(`owl:minCardinality` / `owl:maxCardinality`) lives on an anonymous
+`owl:Restriction` reached through `rdfs:subClassOf` — the last blank-node shape
+the converter does not yet read. Carrying it needs an `owl:Restriction` reader
+joined back to its class.
 
 **Not read — out of scope.** Richer OWL/RDF beyond the schema-shaped subset this
 converter targets:

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -18,12 +18,14 @@
 // characteristics (symmetric / transitive / functional / reflexive /
 // irreflexive / asymmetric), per-term annotations (rdfs:seeAlso,
 // rdfs:isDefinedBy, owl:deprecated, owl:versionInfo), enumerations
-// (owl:oneOf), and property chains (owl:propertyChainAxiom). A carried
-// cross-reference keeps the FULL referent IRI; the mapper shortens it to a
-// local name only when it lives in this ontology's own namespace (see
-// to_ir.refValue). Richer OWL still absent (SHACL, cardinality restrictions,
-// the set-level disjointness/identity axioms, individuals); see the "What is
-// not covered yet" note in the guide.
+// (owl:oneOf), property chains (owl:propertyChainAxiom), and the set-level
+// axioms that hang off an anonymous node rather than a named term
+// (owl:AllDisjointClasses, owl:AllDisjointProperties, owl:AllDifferent -> the
+// model). A carried cross-reference keeps the FULL referent IRI; the mapper
+// shortens it to a local name only when it lives in this ontology's own
+// namespace (see to_ir.refValue). Richer OWL still absent (SHACL, cardinality
+// restrictions, individuals); see the "What is not covered yet" note in the
+// guide.
 
 /**
  * Per-term annotations carried verbatim on any class or property -- links to
@@ -245,4 +247,21 @@ export interface OwlModel {
   classes: OwlClass[];
   datatypeProperties: OwlDatatypeProperty[];
   objectProperties: OwlObjectProperty[];
+  // Set-level axioms carried at the MODEL level (unlike every other carried
+  // construct, these are asserted on an anonymous node and are ABOUT a set of
+  // terms, not any one named class/property, so they have no entity/field/
+  // relationship to ride on). Each is a list of axioms, and each axiom is the
+  // set of member referent IRIs named by its `owl:members` list -- a set, so
+  // the mapper dedupes and order is not significant (contrast propertyChain).
+  // Full IRIs; the mapper shortens an in-namespace one. Empty when none.
+  //
+  // owl:AllDisjointClasses -- the listed classes are pairwise disjoint.
+  allDisjointClasses: string[][];
+  // owl:AllDisjointProperties -- the listed properties are pairwise disjoint.
+  allDisjointProperties: string[][];
+  // owl:AllDifferent -- the listed individuals are pairwise distinct. Members
+  // are individuals (which the converter does not model), so only the names are
+  // kept, exactly like owl:oneOf. Both the OWL 2 `owl:members` and the legacy
+  // OWL 1 `owl:distinctMembers` spelling of the list are accepted.
+  allDifferent: string[][];
 }

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -65,6 +65,16 @@ const OWL_DISJOINT_WITH = `${OWL}disjointWith`;
 const OWL_DEPRECATED = `${OWL}deprecated`;
 const OWL_VERSION_INFO = `${OWL}versionInfo`;
 const OWL_THING = `${OWL}Thing`;
+// Set-level axioms. Each is asserted on an ANONYMOUS node (not a named term)
+// typed with one of these, whose `owl:members` list names the set the axiom
+// constrains. owl:AllDifferent also accepts the legacy OWL 1
+// `owl:distinctMembers` spelling. Carried verbatim at the model level (no
+// native OSI home).
+const OWL_ALL_DISJOINT_CLASSES = `${OWL}AllDisjointClasses`;
+const OWL_ALL_DISJOINT_PROPERTIES = `${OWL}AllDisjointProperties`;
+const OWL_ALL_DIFFERENT = `${OWL}AllDifferent`;
+const OWL_MEMBERS = `${OWL}members`;
+const OWL_DISTINCT_MEMBERS = `${OWL}distinctMembers`;
 
 const RDFS_LABEL = `${RDFS}label`;
 const RDFS_COMMENT = `${RDFS}comment`;
@@ -259,6 +269,13 @@ export function parseOwl(turtle: string): OwlModel {
   const reflexive = new Set<string>();
   const irreflexive = new Set<string>();
   const asymmetric = new Set<string>();
+  // Anonymous set-level-axiom nodes, in document order, deduped by node id (a
+  // node carries exactly one of these types, so one shared seen-set suffices).
+  // Their `owl:members` list is resolved after the list structure is known.
+  const allDisjointClassesNodes: string[] = [];
+  const allDisjointPropertiesNodes: string[] = [];
+  const allDifferentNodes: string[] = [];
+  const seenAxiomNode = new Set<string>();
   let ontologyIri: string|undefined;
   for (const q of quads) {
     if (q.predicate.value !== RDF_TYPE) continue;
@@ -296,6 +313,27 @@ export function parseOwl(turtle: string): OwlModel {
       if (ontologyIri === undefined) ontologyIri = subject;
       continue;
     }
+    if (type === OWL_ALL_DISJOINT_CLASSES) {
+      if (!seenAxiomNode.has(subject)) {
+        seenAxiomNode.add(subject);
+        allDisjointClassesNodes.push(subject);
+      }
+      continue;
+    }
+    if (type === OWL_ALL_DISJOINT_PROPERTIES) {
+      if (!seenAxiomNode.has(subject)) {
+        seenAxiomNode.add(subject);
+        allDisjointPropertiesNodes.push(subject);
+      }
+      continue;
+    }
+    if (type === OWL_ALL_DIFFERENT) {
+      if (!seenAxiomNode.has(subject)) {
+        seenAxiomNode.add(subject);
+        allDifferentNodes.push(subject);
+      }
+      continue;
+    }
     const k = KIND_BY_TYPE[type];
     if (!k) continue;
     if (!kind.has(subject)) {
@@ -309,11 +347,21 @@ export function parseOwl(turtle: string): OwlModel {
   // unrelated to the typed subjects, so they are collected separately.
   const listFirst = new Map<string, string>();
   const listRest = new Map<string, string>();
+  // The `owl:members` list head of each set-level-axiom node. owl:members (OWL
+  // 2) wins over the legacy owl:distinctMembers (OWL 1, owl:AllDifferent only)
+  // when a node carries both, regardless of the order the two triples appear.
+  const membersHead = new Map<string, string>();
   for (const q of quads) {
     if (q.predicate.value === RDF_FIRST)
       listFirst.set(q.subject.value, q.object.value);
     else if (q.predicate.value === RDF_REST)
       listRest.set(q.subject.value, q.object.value);
+    else if (q.predicate.value === OWL_MEMBERS)
+      membersHead.set(q.subject.value, q.object.value);
+    else if (
+        q.predicate.value === OWL_DISTINCT_MEMBERS &&
+        !membersHead.has(q.subject.value))
+      membersHead.set(q.subject.value, q.object.value);
   }
   // Resolves an RDF collection to its member IRIs, following rdf:rest to nil.
   // Defensive against a cycle or a missing link (stops at the first gap).
@@ -597,7 +645,26 @@ export function parseOwl(turtle: string): OwlModel {
     baseIri = baseIri ?? ontologyBaseIri(ontologyIri);
   }
 
-  return {baseIri, ontology, classes, datatypeProperties, objectProperties};
+  // Resolve each set-level-axiom node's `owl:members` list to its member IRIs.
+  // A node with no members list, or one whose list is broken/empty, contributes
+  // nothing (an axiom over no members is meaningless). Member names are kept as
+  // full IRIs; the mapper shortens an in-namespace one.
+  const resolveMembers = (nodes: string[]): string[][] =>
+      nodes.map(n => membersHead.get(n))
+          .filter((h): h is string => h !== undefined)
+          .map(resolveList)
+          .filter(members => members.length > 0);
+
+  return {
+    baseIri,
+    ontology,
+    classes,
+    datatypeProperties,
+    objectProperties,
+    allDisjointClasses: resolveMembers(allDisjointClassesNodes),
+    allDisjointProperties: resolveMembers(allDisjointPropertiesNodes),
+    allDifferent: resolveMembers(allDifferentNodes),
+  };
 }
 
 // The base namespace an ontology IRI stands for. An owl:Ontology is commonly

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -269,13 +269,17 @@ export function parseOwl(turtle: string): OwlModel {
   const reflexive = new Set<string>();
   const irreflexive = new Set<string>();
   const asymmetric = new Set<string>();
-  // Anonymous set-level-axiom nodes, in document order, deduped by node id (a
-  // node carries exactly one of these types, so one shared seen-set suffices).
-  // Their `owl:members` list is resolved after the list structure is known.
+  // Anonymous set-level-axiom nodes, in document order, deduped by node id
+  // within each kind (a duplicate type triple must not list the node twice). A
+  // node typed as two different kinds -- legal, if unusual, RDF -- is recorded
+  // under each, so the dedup is per-kind rather than one shared seen-set. Their
+  // `owl:members` list is resolved after the list structure is known.
   const allDisjointClassesNodes: string[] = [];
   const allDisjointPropertiesNodes: string[] = [];
   const allDifferentNodes: string[] = [];
-  const seenAxiomNode = new Set<string>();
+  const seenDisjointClasses = new Set<string>();
+  const seenDisjointProperties = new Set<string>();
+  const seenDifferent = new Set<string>();
   let ontologyIri: string|undefined;
   for (const q of quads) {
     if (q.predicate.value !== RDF_TYPE) continue;
@@ -314,22 +318,22 @@ export function parseOwl(turtle: string): OwlModel {
       continue;
     }
     if (type === OWL_ALL_DISJOINT_CLASSES) {
-      if (!seenAxiomNode.has(subject)) {
-        seenAxiomNode.add(subject);
+      if (!seenDisjointClasses.has(subject)) {
+        seenDisjointClasses.add(subject);
         allDisjointClassesNodes.push(subject);
       }
       continue;
     }
     if (type === OWL_ALL_DISJOINT_PROPERTIES) {
-      if (!seenAxiomNode.has(subject)) {
-        seenAxiomNode.add(subject);
+      if (!seenDisjointProperties.has(subject)) {
+        seenDisjointProperties.add(subject);
         allDisjointPropertiesNodes.push(subject);
       }
       continue;
     }
     if (type === OWL_ALL_DIFFERENT) {
-      if (!seenAxiomNode.has(subject)) {
-        seenAxiomNode.add(subject);
+      if (!seenDifferent.has(subject)) {
+        seenDifferent.add(subject);
         allDifferentNodes.push(subject);
       }
       continue;
@@ -350,6 +354,10 @@ export function parseOwl(turtle: string): OwlModel {
   // The `owl:members` list head of each set-level-axiom node. owl:members (OWL
   // 2) wins over the legacy owl:distinctMembers (OWL 1, owl:AllDifferent only)
   // when a node carries both, regardless of the order the two triples appear.
+  // owl:distinctMembers is honored ONLY on an owl:AllDifferent node, matching
+  // the OWL spec (it has no meaning on the disjointness axioms), so a stray
+  // owl:distinctMembers on an owl:AllDisjoint* node is ignored rather than
+  // carried.
   const membersHead = new Map<string, string>();
   for (const q of quads) {
     if (q.predicate.value === RDF_FIRST)
@@ -360,7 +368,7 @@ export function parseOwl(turtle: string): OwlModel {
       membersHead.set(q.subject.value, q.object.value);
     else if (
         q.predicate.value === OWL_DISTINCT_MEMBERS &&
-        !membersHead.has(q.subject.value))
+        seenDifferent.has(q.subject.value) && !membersHead.has(q.subject.value))
       membersHead.set(q.subject.value, q.object.value);
   }
   // Resolves an RDF collection to its member IRIs, following rdf:rest to nil.

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -33,6 +33,9 @@
 //   property characteristics -> relationship (symmetric, transitive, ...)
 //   owl:oneOf -> entity (enumerated class members)
 //   owl:propertyChainAxiom -> relationship (ordered property composition)
+//   owl:AllDisjointClasses -> model (a set of pairwise-disjoint classes)
+//   owl:AllDisjointProperties -> model (pairwise-disjoint properties)
+//   owl:AllDifferent -> model (a set of distinct individuals)
 //   rdfs:seeAlso, rdfs:isDefinedBy -> any (external pointers, verbatim)
 //   owl:deprecated, owl:versionInfo -> any (lifecycle metadata)
 //
@@ -644,13 +647,25 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     relationships,
     metrics: [],
   };
-  // Carry the base IRI as structured metadata WHENEVER a cross-reference was
-  // shortened to a local name (refValue), so a consumer can rebuild the full
-  // IRI as `<baseIri><localName>` mechanically instead of parsing it out of the
-  // prose description. Only emitted when it is actually needed for that
-  // reconstruction, so a model with no shortened reference stays clean.
-  if (shortenedRef && owl.baseIri)
-    attachOntology(model, {'owl:baseIri': owl.baseIri});
+  // Model-level carried facts, in a fixed key order so the block is stable. The
+  // set-level axioms come first (each an array of member SETS -- one per axiom
+  // -- so refs() per set, which dedupes; order within a set is not meaningful).
+  // owl:baseIri comes last and only WHEN a cross-reference was shortened to a
+  // local name (refValue), so a consumer can rebuild the full IRI as
+  // `<baseIri><localName>` mechanically instead of parsing it from the prose
+  // description; a model with no shortened reference stays clean. The set-level
+  // members are shortened through refs() too, so they alone can require the
+  // base IRI -- computed before the check below relies on that side effect.
+  const modelTerms: Record<string, unknown> = {};
+  if (owl.allDisjointClasses.length)
+    modelTerms['owl:AllDisjointClasses'] = owl.allDisjointClasses.map(refs);
+  if (owl.allDisjointProperties.length)
+    modelTerms['owl:AllDisjointProperties'] =
+        owl.allDisjointProperties.map(refs);
+  if (owl.allDifferent.length)
+    modelTerms['owl:AllDifferent'] = owl.allDifferent.map(refs);
+  if (shortenedRef && owl.baseIri) modelTerms['owl:baseIri'] = owl.baseIri;
+  attachOntology(model, modelTerms);
 
   return {
     model,

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -658,12 +658,13 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
   // base IRI -- computed before the check below relies on that side effect.
   const modelTerms: Record<string, unknown> = {};
   if (owl.allDisjointClasses.length)
-    modelTerms['owl:AllDisjointClasses'] = owl.allDisjointClasses.map(refs);
+    modelTerms['owl:AllDisjointClasses'] =
+        owl.allDisjointClasses.map(set => refs(set));
   if (owl.allDisjointProperties.length)
     modelTerms['owl:AllDisjointProperties'] =
-        owl.allDisjointProperties.map(refs);
+        owl.allDisjointProperties.map(set => refs(set));
   if (owl.allDifferent.length)
-    modelTerms['owl:AllDifferent'] = owl.allDifferent.map(refs);
+    modelTerms['owl:AllDifferent'] = owl.allDifferent.map(set => refs(set));
   if (shortenedRef && owl.baseIri) modelTerms['owl:baseIri'] = owl.baseIri;
   attachOntology(model, modelTerms);
 

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
@@ -6,6 +6,25 @@ semantic_model:
       - vendor_name: GOOGLE
         data: |-
           {
+            "owl:AllDisjointClasses": [
+              [
+                "Person",
+                "Robot",
+                "LifeStage"
+              ]
+            ],
+            "owl:AllDisjointProperties": [
+              [
+                "personId",
+                "name"
+              ]
+            ],
+            "owl:AllDifferent": [
+              [
+                "Infant",
+                "Adult"
+              ]
+            ],
             "owl:baseIri": "http://example.com/people#"
           }
     datasets:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.owl.ttl
@@ -13,6 +13,9 @@
 #     transitive / asymmetric characteristics on an object property ->
 #     relationship extension
 #   - owl:oneOf on a class (an enumeration) -> entity extension
+#   - owl:AllDisjointClasses / owl:AllDisjointProperties / owl:AllDifferent,
+#     each asserted on an ANONYMOUS node about a SET of terms (belonging to no
+#     single class/property) -> model extension
 #
 # Namespace handling: this ontology's base namespace is
 # http://example.com/people# (ex:); it also references the external FOAF and
@@ -95,3 +98,15 @@ ex:relatedTo a owl:ObjectProperty, owl:SymmetricProperty, owl:ReflexiveProperty 
 ex:uncleOf a owl:ObjectProperty ;
     rdfs:domain ex:Person ; rdfs:range ex:Person ;
     owl:propertyChainAxiom ( ex:ancestorOf ex:relatedTo ) .
+
+# Set-level axioms: each hangs off an ANONYMOUS node and is ABOUT a set of
+# terms, so it rides on the MODEL, not any one class/property. Members are
+# in-namespace, so they shorten to local names (reversible via owl:baseIri).
+# The three classes are mutually exclusive kinds; personId and name are disjoint
+# data properties; the two LifeStage individuals are distinct.
+[] a owl:AllDisjointClasses ;
+    owl:members ( ex:Person ex:Robot ex:LifeStage ) .
+[] a owl:AllDisjointProperties ;
+    owl:members ( ex:personId ex:name ) .
+[] a owl:AllDifferent ;
+    owl:members ( ex:Infant ex:Adult ) .

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -1183,6 +1183,93 @@ describe('OWL constructs carried as custom extensions', () => {
     });
   });
 
+  // --- Set-level axioms (carried at the MODEL level). -----------------------
+  // These hang off an anonymous node and are ABOUT a set of terms, not any one
+  // named class/property, so they ride on the model rather than an
+  // entity/field/ relationship. Each is an array of member SETS (one per
+  // axiom).
+
+  test('owl:AllDisjointClasses -> model (a set of disjoint classes)', () => {
+    // The three classes are pairwise disjoint. In-namespace members shorten to
+    // local names, so the model carries owl:baseIri to make that reversible.
+    const ttl = `${PREFIXES}
+      ex:Cat a owl:Class .
+      ex:Dog a owl:Class .
+      ex:Fish a owl:Class .
+      [] a owl:AllDisjointClasses ; owl:members ( ex:Cat ex:Dog ex:Fish ) .`;
+    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
+      'owl:AllDisjointClasses': [['Cat', 'Dog', 'Fish']],
+      'owl:baseIri': 'http://example.com/x#',
+    });
+  });
+
+  test('owl:AllDisjointProperties -> model (a set of disjoint props)', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      ex:homePhone a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
+      ex:workPhone a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
+      [] a owl:AllDisjointProperties ; owl:members ( ex:homePhone ex:workPhone ) .`;
+    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
+      'owl:AllDisjointProperties': [['homePhone', 'workPhone']],
+      'owl:baseIri': 'http://example.com/x#',
+    });
+  });
+
+  test('owl:AllDifferent -> model (distinct individuals, owl:members)', () => {
+    // Members are individuals (not modeled), so only the names are kept -- like
+    // owl:oneOf. ex:Person merely anchors the base namespace so the individual
+    // names shorten.
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      [] a owl:AllDifferent ; owl:members ( ex:Alice ex:Bob ) .`;
+    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
+      'owl:AllDifferent': [['Alice', 'Bob']],
+      'owl:baseIri': 'http://example.com/x#',
+    });
+  });
+
+  test('owl:AllDifferent accepts the legacy owl:distinctMembers list', () => {
+    // OWL 1 spelled the list owl:distinctMembers; it must resolve identically.
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class .
+      [] a owl:AllDifferent ; owl:distinctMembers ( ex:Alice ex:Bob ) .`;
+    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
+      'owl:AllDifferent': [['Alice', 'Bob']],
+      'owl:baseIri': 'http://example.com/x#',
+    });
+  });
+
+  test('multiple set-level axioms of one kind are kept separate', () => {
+    // Each owl:AllDisjointClasses is its own set; they must not be merged into
+    // one flat list. Kept in document order.
+    const ttl = `${PREFIXES}
+      ex:Cat a owl:Class . ex:Dog a owl:Class .
+      ex:Car a owl:Class . ex:Truck a owl:Class .
+      [] a owl:AllDisjointClasses ; owl:members ( ex:Cat ex:Dog ) .
+      [] a owl:AllDisjointClasses ; owl:members ( ex:Car ex:Truck ) .`;
+    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
+      'owl:AllDisjointClasses': [['Cat', 'Dog'], ['Car', 'Truck']],
+      'owl:baseIri': 'http://example.com/x#',
+    });
+  });
+
+  test(
+      'set-level members outside the namespace stay full IRIs (no baseIri)',
+      () => {
+        // Cross-namespace members are not shortened, so nothing is shortened
+        // and the model carries no owl:baseIri (ex:Anchor only anchors the base
+        // namespace; it names no cross-reference).
+        const ttl = `${PREFIXES}
+      ex:Anchor a owl:Class .
+      [] a owl:AllDisjointClasses ; owl:members ( foaf:Person foaf:Agent ) .`;
+        expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
+          'owl:AllDisjointClasses': [[
+            'http://xmlns.com/foaf/0.1/Person',
+            'http://xmlns.com/foaf/0.1/Agent',
+          ]],
+        });
+      });
+
   test(
       'reflexive / irreflexive / asymmetric characteristics -> relationship',
       () => {

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -1270,6 +1270,34 @@ describe('OWL constructs carried as custom extensions', () => {
         });
       });
 
+  test('owl:distinctMembers is ignored on a non-AllDifferent axiom', () => {
+    // owl:distinctMembers is the legacy OWL 1 spelling for owl:AllDifferent
+    // only; it has no meaning on owl:AllDisjointClasses. A node that carries it
+    // there (and no owl:members) contributes no member set, so nothing is
+    // carried at all (no shortened reference, hence no owl:baseIri either).
+    const ttl = `${PREFIXES}
+      ex:Cat a owl:Class . ex:Dog a owl:Class .
+      [] a owl:AllDisjointClasses ; owl:distinctMembers ( ex:Cat ex:Dog ) .`;
+    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toBeUndefined();
+  });
+
+  test(
+      'an anonymous node typed as two axiom kinds is carried under both',
+      () => {
+        // A single blank node typed as both owl:AllDisjointClasses and
+        // owl:AllDifferent is unusual but legal RDF; its one owl:members list
+        // must surface under each kind, not be dropped for the second.
+        const ttl = `${PREFIXES}
+      ex:Cat a owl:Class . ex:Dog a owl:Class .
+      [] a owl:AllDisjointClasses, owl:AllDifferent ;
+         owl:members ( ex:Cat ex:Dog ) .`;
+        expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
+          'owl:AllDisjointClasses': [['Cat', 'Dog']],
+          'owl:AllDifferent': [['Cat', 'Dog']],
+          'owl:baseIri': 'http://example.com/x#',
+        });
+      });
+
   test(
       'reflexive / irreflexive / asymmetric characteristics -> relationship',
       () => {


### PR DESCRIPTION
## What

Tier 2 follow-on to #341 (which carried `owl:oneOf` and `owl:propertyChainAxiom`). Carries the three OWL **set-level axioms** that hang off an *anonymous* node rather than a named term:

- `owl:AllDisjointClasses` — the listed classes are pairwise disjoint
- `owl:AllDisjointProperties` — the listed properties are pairwise disjoint
- `owl:AllDifferent` — the listed individuals are pairwise distinct

Because each is *about a set of terms* and belongs to no single class/property, they ride on the **model** level of the `GOOGLE` custom-extension block (beside `owl:baseIri`), not an entity/field/relationship.

## How

- **Parser** (`parse.ts`): a blank-node scan in Pass 1 collects the anonymous axiom nodes in document order (deduped), and Pass 2 captures each node's `owl:members` list head — falling back to the legacy OWL 1 `owl:distinctMembers` spelling for `owl:AllDifferent`, with `owl:members` winning if both are present regardless of triple order. Members resolve through the existing `resolveList` walker.
- **Shape**: each construct is an **array of member sets** (`string[][]`) — one entry per axiom — so two disjointness axioms of the same kind stay separate rather than fusing into one flat list. Members are sets, so they're deduped; order is not significant (contrast `propertyChainAxiom`).
- **Mapper** (`to_ir.ts`): the three keys are built into a single model-level terms object via `refs` (in-namespace shortening) and attached once, followed by `owl:baseIri` when any reference was shortened. A model with no set-level axioms is byte-for-byte unchanged.

## Tests / docs

- Extends the exhaustive `carriage` fixture + golden, **reusing existing terms** so conversion stats stay `3/3/3`.
- 6 new unit tests (each construct; multiple axioms kept separate; the legacy `owl:distinctMembers` form; cross-namespace members staying full IRIs with no `owl:baseIri`).
- Guide updated: mapping summary, carried-constructs table (new `model` row group + a note on the model-level attach point), and the "not covered yet" list narrowed to cardinality restrictions (the last blank-node shape).

**494 tests pass** (`bun test`). `tsc` is airlock-blocked in this environment, so the change was type-checked via `bun`; the one type-level change (`OwlModel` gains three required fields) is constructed only in `parse.ts`.

Carriage remains inert on push and lossless on the OSI-document round-trip; it is not yet persisted to Knowledge Catalog.