### PR TITLE
mdcode: carry OWL unqualified cardinality restrictions

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -12,13 +12,13 @@ datatype property → property, plus **class hierarchies** (`rdfs:subClassOf` �
 entity `extends`, see [Class hierarchies](#class-hierarchies-rdfssubclassof)).
 Constructs that have **no native home yet** — property inheritance
 (`rdfs:subPropertyOf`), the inverse / equivalence / disjointness cross-references,
-the property characteristics, and per-term annotations (`rdfs:seeAlso`,
+the property characteristics, the set-level disjointness / identity axioms,
+unqualified cardinality restrictions, and per-term annotations (`rdfs:seeAlso`,
 `owl:deprecated`, …) — are not dropped: they **ride along verbatim** as custom
 extensions, lossless and inert, until they earn a first-class concept (see
 [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)).
-Richer OWL still not read at all (SHACL, cardinality restrictions, the set-level
-disjointness / identity axioms, individuals) is listed in
-[Limitations](#limitations).
+Richer OWL still not read at all (SHACL, *qualified* cardinality restrictions,
+individuals) is listed in [Limitations](#limitations).
 
 ## 1. The OWL file
 
@@ -247,7 +247,7 @@ appears nowhere above.
 | `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; `expression` defaults to the property's local name (a valid column ref once bound) |
 | `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; join columns bound to the destination key when it has one, else `TODO_BIND` (see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
-| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, `owl:AllDisjointClasses`, `owl:AllDisjointProperties`, `owl:AllDifferent`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
+| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, `owl:AllDisjointClasses`, `owl:AllDisjointProperties`, `owl:AllDifferent`, unqualified cardinality restrictions (`owl:cardinality` / `owl:minCardinality` / `owl:maxCardinality` on an `owl:Restriction`), the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
 | `owl:hasKey ( ... )` | dataset `primary_key` | single or composite, in list order |
 | `owl:InverseFunctionalProperty` | dataset `unique_keys` | a uniquely-identifying property; omitted when it is already the `primary_key`; a lone one on a keyless class is promoted to `primary_key` instead |
@@ -363,10 +363,15 @@ the `Person` and `Customer` datasets come out as (`Customer` carrying
 ```
 
 Multiple superclasses are allowed (`extends: [Person, Employee]`, in document
-order). A `subClassOf` whose object is a blank-node axiom (`owl:Restriction` and
-similar) is not a named class, so it is ignored, as are the implicit universal
-superclasses `owl:Thing` / `rdfs:Resource` (every class subclasses them, so they
-carry no inheritance information).
+order). A `subClassOf` whose object is a blank-node axiom is not a named class,
+so it never becomes an `extends` — but an **unqualified cardinality
+`owl:Restriction`** reached this way is not simply dropped: its constraint rides
+along verbatim on the class (see [Constructs carried as custom
+extensions](#constructs-carried-as-custom-extensions-not-yet-native)). Any other
+blank-node class expression (`owl:intersectionOf`, a value restriction, …) is
+ignored, as are the implicit universal superclasses `owl:Thing` /
+`rdfs:Resource` (every class subclasses them, so they carry no inheritance
+information).
 
 Two boundaries to be clear about:
 
@@ -458,6 +463,7 @@ disjointness axioms stay two entries rather than merging into one flat list.
 | `owl:equivalentClass` | entity | `string[]` (equivalent class refs) | this class denotes the same set as another |
 | `owl:disjointWith` | entity | `string[]` (disjoint class refs) | no individual is in both classes |
 | `owl:oneOf` | entity | `string[]` (member refs; an enumeration is a **set** — deduped, order not significant) | the class is exactly this enumerated set of members |
+| `owl:Restriction` (unqualified cardinality, via `rdfs:subClassOf`) | entity | `object[]` — one record per restriction: `{ "owl:onProperty": ref, "owl:cardinality"? / "owl:minCardinality"? / "owl:maxCardinality"?: number }` (a compound, so a real object, not a flattened string) | how many values of the named property a class instance may have (the **qualified** forms are not read yet — see [Limitations](#limitations)) |
 | `rdfs:subPropertyOf` | field / relationship | `string[]` (super-property refs) | this property refines a broader one |
 | `owl:equivalentProperty` | field / relationship | `string[]` (equivalent property refs) | this property means the same as another |
 | `owl:propertyDisjointWith` | field / relationship | `string[]` (disjoint property refs) | the two properties never both hold |
@@ -618,10 +624,14 @@ IRI):
 | `owl:` | `http://www.w3.org/2002/07/owl#` |
 | `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` |
 
-Blank-node forms are **not** carried: an `owl:equivalentClass` (or
-`rdfs:subClassOf`) whose object is a class *expression* (`owl:intersectionOf`, an
-`owl:Restriction`, …) is a definition rather than a plain cross-reference, so it
-is out of scope (see [Limitations](#limitations)).
+Most blank-node forms are **not** carried: an `owl:equivalentClass` (or
+`rdfs:subClassOf`) whose object is a class *expression* (`owl:intersectionOf`, a
+value restriction, …) is a definition rather than a plain cross-reference, so it
+is out of scope (see [Limitations](#limitations)). The **one** blank-node shape
+that *is* read is an unqualified cardinality `owl:Restriction` reached through
+`rdfs:subClassOf`: its `owl:onProperty` + `owl:cardinality` / `owl:minCardinality`
+/ `owl:maxCardinality` ride on the class as an `owl:Restriction` record (see the
+table above).
 
 ## 4. Going from ontology to a running graph (binding)
 
@@ -707,21 +717,31 @@ import:
     (`owl:propertyChainAxiom`).
   - **Set-level axioms** — `owl:AllDisjointClasses`,
     `owl:AllDisjointProperties`, `owl:AllDifferent` (carried on the model).
+  - **Unqualified cardinality restrictions** — `owl:cardinality` /
+    `owl:minCardinality` / `owl:maxCardinality` on an anonymous `owl:Restriction`
+    reached through `rdfs:subClassOf` (carried on the class). The restriction
+    node must carry an explicit `a owl:Restriction` type triple (the shape the
+    reader targets); a bare blank node with `owl:onProperty` + a cardinality but
+    no `owl:Restriction` type is not recognized and is silently skipped.
   - **Per-term annotations** — `rdfs:seeAlso`, `rdfs:isDefinedBy`,
     `owl:deprecated`, `owl:versionInfo`.
 
-**Not read yet — the next candidate for carriage.** Cardinality
-(`owl:minCardinality` / `owl:maxCardinality`) lives on an anonymous
-`owl:Restriction` reached through `rdfs:subClassOf` — the last blank-node shape
-the converter does not yet read. Carrying it needs an `owl:Restriction` reader
-joined back to its class.
+**Not read yet — the next candidate for carriage.** *Qualified* cardinality
+(`owl:qualifiedCardinality` / `owl:minQualifiedCardinality` /
+`owl:maxQualifiedCardinality`) is the unqualified restriction now read plus an
+`owl:onClass` / `owl:onDataRange` naming the class or datatype the count ranges
+over. The reader already sees these markers and *skips* such a restriction rather
+than mis-carrying it as unqualified; carrying it in full means reading the extra
+`onClass` / `onDataRange` referent alongside the count.
 
 **Not read — out of scope.** Richer OWL/RDF beyond the schema-shaped subset this
 converter targets:
 
-- SHACL shapes, class expressions (`owl:unionOf` / `intersectionOf`, and any
-  blank-node `owl:equivalentClass` / `rdfs:subClassOf`), individuals (A-box
-  instances), and `owl:sameAs` / `owl:differentFrom` (which relate individuals).
+- SHACL shapes, class expressions (`owl:unionOf` / `intersectionOf`, value
+  restrictions, and any blank-node `owl:equivalentClass` / `rdfs:subClassOf`
+  *other than* the unqualified cardinality restriction read above), qualified
+  cardinality restrictions, individuals (A-box instances), and `owl:sameAs` /
+  `owl:differentFrom` (which relate individuals).
 - OWL serializations other than Turtle (`.ttl`), and the reverse direction —
   semantic model → OWL export. Import is one-way.
 

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -18,12 +18,15 @@
 // characteristics (symmetric / transitive / functional / reflexive /
 // irreflexive / asymmetric), per-term annotations (rdfs:seeAlso,
 // rdfs:isDefinedBy, owl:deprecated, owl:versionInfo), enumerations
-// (owl:oneOf), property chains (owl:propertyChainAxiom), and the set-level
+// (owl:oneOf), property chains (owl:propertyChainAxiom), the set-level
 // axioms that hang off an anonymous node rather than a named term
 // (owl:AllDisjointClasses, owl:AllDisjointProperties, owl:AllDifferent -> the
-// model). A carried cross-reference keeps the FULL referent IRI; the mapper
-// shortens it to a local name only when it lives in this ontology's own
-// namespace (see to_ir.refValue). Richer OWL still absent (SHACL, cardinality
+// model), and the UNqualified cardinality restrictions on an anonymous
+// owl:Restriction reached through rdfs:subClassOf (owl:cardinality /
+// owl:minCardinality / owl:maxCardinality -> the class). A carried
+// cross-reference keeps the FULL referent IRI; the mapper shortens it to a
+// local name only when it lives in this ontology's own namespace (see
+// to_ir.refValue). Richer OWL still absent (SHACL, QUALIFIED cardinality
 // restrictions, individuals); see the "What is not covered yet" note in the
 // guide.
 
@@ -49,6 +52,33 @@ export interface OwlCommonAnnotations {
   deprecated: boolean;
   // owl:versionInfo on the term itself (not the ontology header), if present.
   versionInfo?: string;
+}
+
+/**
+ * An UNqualified cardinality restriction on a class -- an anonymous
+ * `owl:Restriction` reached through `rdfs:subClassOf`, constraining how many
+ * values of one property an instance of the class may have.
+ *
+ * No native OSI home (OSI has no cardinality concept), so it is carried
+ * verbatim as a custom extension on the entity. Only the UNqualified forms are
+ * read; the qualified forms (`owl:qualifiedCardinality` and friends, which add
+ * `owl:onClass` / `owl:onDataRange`) are a separate blank-node shape, out of
+ * scope for now (see the user guide's "not read yet" note). A restriction with
+ * no cardinality (e.g. an `owl:someValuesFrom` value restriction) contributes
+ * no OwlRestriction -- only the cardinality shape is carried.
+ */
+export interface OwlRestriction {
+  // The restricted property's referent IRI (`owl:onProperty`). Full IRI -- the
+  // mapper shortens an in-namespace one to its local name (see to_ir.refValue).
+  onProperty: string;
+  // `owl:cardinality` -- the exact number of values. Undefined when not stated.
+  cardinality?: number;
+  // `owl:minCardinality` -- the minimum number of values. Undefined when not
+  // stated.
+  minCardinality?: number;
+  // `owl:maxCardinality` -- the maximum number of values. Undefined when not
+  // stated.
+  maxCardinality?: number;
 }
 
 /** An `owl:Class` -- becomes an OSI dataset (entity). */
@@ -97,6 +127,11 @@ export interface OwlClass extends OwlCommonAnnotations {
   // -- the mapper shortens an in-namespace one to its local name. Empty when
   // the class is not an enumeration.
   oneOf: string[];
+  // Unqualified cardinality restrictions on this class, in document order --
+  // each an anonymous `owl:Restriction` reached through `rdfs:subClassOf` (see
+  // OwlRestriction). No native OSI home; carried verbatim on the entity. Empty
+  // when the class declares none.
+  restrictions: OwlRestriction[];
 }
 
 /**

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/parse.ts
@@ -12,7 +12,7 @@
 
 import {Parser} from 'n3';
 
-import {OwlClass, OwlCommonAnnotations, OwlDatatypeProperty, OwlModel, OwlObjectProperty, OwlOntology,} from './model';
+import {OwlClass, OwlCommonAnnotations, OwlDatatypeProperty, OwlModel, OwlObjectProperty, OwlOntology, OwlRestriction,} from './model';
 
 // RDF/RDFS/OWL/SKOS/Dublin-Core term IRIs we recognize. Only these; anything
 // else is carried by neither the parser nor the model (see the user guide's
@@ -75,6 +75,28 @@ const OWL_ALL_DISJOINT_PROPERTIES = `${OWL}AllDisjointProperties`;
 const OWL_ALL_DIFFERENT = `${OWL}AllDifferent`;
 const OWL_MEMBERS = `${OWL}members`;
 const OWL_DISTINCT_MEMBERS = `${OWL}distinctMembers`;
+// Unqualified cardinality restrictions. Each is an ANONYMOUS owl:Restriction
+// node reached through `rdfs:subClassOf` from a named class, naming the
+// restricted property (owl:onProperty) and one or more of the three unqualified
+// cardinality predicates. Carried verbatim on the class (no native OSI home).
+// The QUALIFIED forms (owl:qualifiedCardinality and friends, marked by
+// owl:onClass / owl:onDataRange) are a separate shape, out of scope for now: a
+// node carrying either marker is skipped rather than mis-carried as
+// unqualified.
+const OWL_RESTRICTION = `${OWL}Restriction`;
+const OWL_ON_PROPERTY = `${OWL}onProperty`;
+const OWL_CARDINALITY = `${OWL}cardinality`;
+const OWL_MIN_CARDINALITY = `${OWL}minCardinality`;
+const OWL_MAX_CARDINALITY = `${OWL}maxCardinality`;
+const OWL_ON_CLASS = `${OWL}onClass`;
+const OWL_ON_DATA_RANGE = `${OWL}onDataRange`;
+// The predicates gathered off an owl:Restriction node in pass 2 (see
+// restrictionData). Restricting the pass-2 branch to these avoids allocating a
+// data record for an unrelated triple (e.g. an rdfs:comment) on a restriction.
+const RESTRICTION_PREDICATES = new Set([
+  OWL_ON_PROPERTY, OWL_CARDINALITY, OWL_MIN_CARDINALITY, OWL_MAX_CARDINALITY,
+  OWL_ON_CLASS, OWL_ON_DATA_RANGE
+]);
 
 const RDFS_LABEL = `${RDFS}label`;
 const RDFS_COMMENT = `${RDFS}comment`;
@@ -144,6 +166,21 @@ function ntriplesLiteral(
   return quoted;
 }
 
+// The non-negative integer value of a cardinality literal (owl:cardinality /
+// owl:minCardinality / owl:maxCardinality). OWL types these
+// xsd:nonNegativeInteger, but a plain Turtle integer (xsd:integer, e.g. a bare
+// `1`) is accepted too -- the datatype is not checked, only the lexical form.
+// Returns undefined for a non-literal or any value that is not a plain run of
+// decimal digits, so a malformed cardinality is ignored rather than carried.
+// The digits-only test (not Number()) is deliberate: Number() would coerce an
+// empty or whitespace-only literal to 0, and a hex ("0x1F") or exponent
+// ("1e2") string to a bogus integer, silently fabricating a cardinality.
+function cardinalityValue(term: {termType: string; value: string}): number|
+    undefined {
+  if (term.termType !== 'Literal') return undefined;
+  return /^[0-9]+$/.test(term.value) ? Number(term.value) : undefined;
+}
+
 // The most common namespace among a set of term IRIs -- the ontology's own
 // namespace. A tie (or a single term) resolves to the first in document order,
 // since `best` is only replaced on a STRICTLY greater count. Returns undefined
@@ -186,6 +223,7 @@ interface Annotations {
   keyListHeads: string[];          // owl:hasKey list heads (blank nodes)
   oneOfListHeads: string[];        // owl:oneOf list heads (blank nodes)
   chainListHeads: string[];        // owl:propertyChainAxiom list heads
+  restrictionHeads: string[];      // subClassOf owl:Restriction nodes (blanks)
   subClassOf: string[];            // local names (feed native `extends`)
   subPropertyOf: string[];         // full IRIs (named superproperties)
   equivalentClass: string[];       // full IRIs (named classes only)
@@ -207,6 +245,7 @@ function emptyAnnotations(): Annotations {
     keyListHeads: [],
     oneOfListHeads: [],
     chainListHeads: [],
+    restrictionHeads: [],
     subClassOf: [],
     subPropertyOf: [],
     equivalentClass: [],
@@ -280,6 +319,11 @@ export function parseOwl(turtle: string): OwlModel {
   const seenDisjointClasses = new Set<string>();
   const seenDisjointProperties = new Set<string>();
   const seenDifferent = new Set<string>();
+  // Anonymous owl:Restriction nodes (blank nodes), by id, so an rdfs:subClassOf
+  // whose object is one is recognized as a cardinality restriction rather than
+  // a named superclass. Their onProperty / cardinality fields are gathered in
+  // pass 2 (restrictionData).
+  const restrictionNodes = new Set<string>();
   let ontologyIri: string|undefined;
   for (const q of quads) {
     if (q.predicate.value !== RDF_TYPE) continue;
@@ -338,11 +382,34 @@ export function parseOwl(turtle: string): OwlModel {
       }
       continue;
     }
+    if (type === OWL_RESTRICTION) {
+      // An anonymous restriction is a BLANK node by definition. A named IRI
+      // typed owl:Restriction is not an anonymous restriction -- ignore the
+      // marker so it keeps whatever named kind (owl:Class, ...) it also carries
+      // rather than being pruned below and vanishing (it is never reached via a
+      // blank-node subClassOf, so it could not be carried as a restriction).
+      if (q.subject.termType === 'BlankNode') restrictionNodes.add(subject);
+      continue;
+    }
     const k = KIND_BY_TYPE[type];
     if (!k) continue;
     if (!kind.has(subject)) {
       kind.set(subject, k);
       order.push(subject);
+    }
+  }
+  // A blank node typed BOTH owl:Restriction and a named kind (owl:Class, an
+  // owl:*Property) -- legal but nonsensical RDF, and possible from a reasoner
+  // materialization -- must not also surface as a bogus entity/property named
+  // after a blank-node id. The restriction reading owns it. Prune it from the
+  // named-term maps here, after pass 1, so the outcome is independent of which
+  // type triple was seen first (a guard at registration would miss the case
+  // where the named type came before the owl:Restriction type). Pruning from
+  // `order` also keeps the blank-node id out of the dominantNamespace tally.
+  for (const node of restrictionNodes) {
+    if (kind.delete(node)) {
+      const i = order.indexOf(node);
+      if (i >= 0) order.splice(i, 1);
     }
   }
 
@@ -359,6 +426,28 @@ export function parseOwl(turtle: string): OwlModel {
   // owl:distinctMembers on an owl:AllDisjoint* node is ignored rather than
   // carried.
   const membersHead = new Map<string, string>();
+  // owl:Restriction field data, by restriction node id: the restricted property
+  // and any of the three unqualified cardinality values, plus a `qualified`
+  // flag set when the node carries owl:onClass / owl:onDataRange (a QUALIFIED
+  // restriction, out of scope for now) so build skips it rather than carrying
+  // its unqualified-looking parts. Resolved against each class's subClassOf
+  // restriction heads at build time.
+  interface RestrictionData {
+    onProperty?: string;
+    cardinality?: number;
+    minCardinality?: number;
+    maxCardinality?: number;
+    qualified: boolean;
+  }
+  const restrictionData = new Map<string, RestrictionData>();
+  const restrictionFor = (node: string): RestrictionData => {
+    let r = restrictionData.get(node);
+    if (!r) {
+      r = {qualified: false};
+      restrictionData.set(node, r);
+    }
+    return r;
+  };
   for (const q of quads) {
     if (q.predicate.value === RDF_FIRST)
       listFirst.set(q.subject.value, q.object.value);
@@ -370,6 +459,39 @@ export function parseOwl(turtle: string): OwlModel {
         q.predicate.value === OWL_DISTINCT_MEMBERS &&
         seenDifferent.has(q.subject.value) && !membersHead.has(q.subject.value))
       membersHead.set(q.subject.value, q.object.value);
+    else if (
+        RESTRICTION_PREDICATES.has(q.predicate.value) &&
+        restrictionNodes.has(q.subject.value)) {
+      const r = restrictionFor(q.subject.value);
+      switch (q.predicate.value) {
+        case OWL_ON_PROPERTY:
+          // Named property only; a blank-node property expression (an inverse
+          // property, ...) is out of scope.
+          if (q.object.termType === 'NamedNode') r.onProperty = q.object.value;
+          break;
+        case OWL_CARDINALITY: {
+          const n = cardinalityValue(q.object);
+          if (n !== undefined) r.cardinality = n;
+          break;
+        }
+        case OWL_MIN_CARDINALITY: {
+          const n = cardinalityValue(q.object);
+          if (n !== undefined) r.minCardinality = n;
+          break;
+        }
+        case OWL_MAX_CARDINALITY: {
+          const n = cardinalityValue(q.object);
+          if (n !== undefined) r.maxCardinality = n;
+          break;
+        }
+        case OWL_ON_CLASS:
+        case OWL_ON_DATA_RANGE:
+          r.qualified = true;
+          break;
+        default:
+          break;
+      }
+    }
   }
   // Resolves an RDF collection to its member IRIs, following rdf:rest to nil.
   // Defensive against a cycle or a missing link (stops at the first gap).
@@ -386,6 +508,27 @@ export function parseOwl(turtle: string): OwlModel {
     }
     return out;
   };
+  // Resolves a class's subClassOf restriction heads to its carried cardinality
+  // restrictions. A head contributes one OwlRestriction only when it names a
+  // property (owl:onProperty) AND states at least one unqualified cardinality;
+  // a qualified restriction (owl:onClass / owl:onDataRange), a value
+  // restriction (owl:someValuesFrom / allValuesFrom, no cardinality), or a
+  // malformed one contributes nothing. Member names are kept as full IRIs; the
+  // mapper shortens an in-namespace one.
+  const resolveRestrictions = (heads: string[]): OwlRestriction[] =>
+      heads.map(h => restrictionData.get(h))
+          .filter(
+              (r): r is RestrictionData => r !== undefined && !r.qualified &&
+                  r.onProperty !== undefined &&
+                  (r.cardinality !== undefined ||
+                   r.minCardinality !== undefined ||
+                   r.maxCardinality !== undefined))
+          .map(r => ({
+                 onProperty: r.onProperty!,
+                 cardinality: r.cardinality,
+                 minCardinality: r.minCardinality,
+                 maxCardinality: r.maxCardinality,
+               }));
 
   // Pass 3: accumulate annotations for each typed subject (and the ontology
   // header) in document order, so the first label is the primary and the rest
@@ -460,15 +603,25 @@ export function parseOwl(turtle: string): OwlModel {
         a.chainListHeads.push(q.object.value);
         break;
       case RDFS_SUBCLASS_OF:
-        // Class hierarchy -> the entity's `extends`. Named superclasses only:
-        // a blank-node object (an owl:Restriction and similar axioms) is not a
-        // named class, so it is ignored here (out of scope). The implicit
-        // universal superclasses (owl:Thing / rdfs:Resource) are ignored too --
-        // every class subclasses them, so they carry no inheritance
-        // information.
-        if (q.object.termType === 'NamedNode' &&
-            !TOP_CLASS_IRIS.has(q.object.value))
-          a.subClassOf.push(localName(q.object.value));
+        // Class hierarchy. A NAMED superclass feeds the entity's `extends`
+        // (except the implicit universal superclasses owl:Thing /
+        // rdfs:Resource, which every class trivially subclasses, so they carry
+        // no inheritance information). A BLANK-NODE object typed
+        // owl:Restriction is a cardinality restriction -- recorded here as a
+        // restriction head for carriage on the class (see restrictionData); its
+        // unqualified cardinality is resolved at build time. Any other
+        // blank-node axiom (a class expression: owl:intersectionOf, a value
+        // restriction, ...) is out of scope and ignored. `includes` dedupes a
+        // subClassOf triple that names the same restriction node twice.
+        if (q.object.termType === 'NamedNode') {
+          if (!TOP_CLASS_IRIS.has(q.object.value))
+            a.subClassOf.push(localName(q.object.value));
+        } else if (
+            q.object.termType === 'BlankNode' &&
+            restrictionNodes.has(q.object.value) &&
+            !a.restrictionHeads.includes(q.object.value)) {
+          a.restrictionHeads.push(q.object.value);
+        }
         break;
       case RDFS_SUBPROPERTY_OF:
         // Property hierarchy -> no native OSI home; carried verbatim by the
@@ -576,6 +729,7 @@ export function parseOwl(turtle: string): OwlModel {
           // members across every oneOf head -- an enumeration is a set, so the
           // mapper dedupes and order does not matter (contrast propertyChain).
           oneOf: a.oneOfListHeads.flatMap(resolveList),
+          restrictions: resolveRestrictions(a.restrictionHeads),
           ...commonAnnotations(a),
         });
         break;

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -32,6 +32,7 @@
 //   owl:propertyDisjointWith -> field / relationship
 //   property characteristics -> relationship (symmetric, transitive, ...)
 //   owl:oneOf -> entity (enumerated class members)
+//   owl:Restriction -> entity (unqualified cardinality on a class's property)
 //   owl:propertyChainAxiom -> relationship (ordered property composition)
 //   owl:AllDisjointClasses -> model (a set of pairwise-disjoint classes)
 //   owl:AllDisjointProperties -> model (pairwise-disjoint properties)
@@ -52,7 +53,7 @@
 
 import {AiContext, CustomExtension, Entity, Field, Relationship, SemanticModel,} from '../../ir';
 
-import {OwlCommonAnnotations, OwlModel, OwlOntology} from './model';
+import {OwlCommonAnnotations, OwlModel, OwlOntology, OwlRestriction} from './model';
 import {localName, namespace} from './parse';
 
 export interface ToIrResult {
@@ -340,20 +341,40 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
   // than once (its shortened form is identical), so a repeated identical triple
   // never looks like a conflict.
   let shortenedRef = false;
-  const refs = (iris: string[]): string[] => dedupe(iris.map(iri => {
+  // Shortens ONE referent IRI to its in-namespace local name (see refValue),
+  // recording whether it was actually shortened so owl:baseIri is carried on
+  // the model whenever any reference is (below). The single building block the
+  // list-shortening helpers -- and the single-IRI owl:onProperty on a
+  // restriction -- are all built from.
+  const ref1 = (iri: string): string => {
     const v = refValue(iri, owl.baseIri);
     if (v !== iri) shortenedRef = true;
     return v;
-  }));
+  };
+  // refValue over a list, deduped. Mapping before dedupe collapses a referent
+  // stated more than once (its shortened form is identical), so a repeated
+  // identical triple never looks like a conflict.
+  const refs = (iris: string[]): string[] => dedupe(iris.map(ref1));
 
   // Like refs(), but preserves order AND duplicates -- for an ORDERED construct
   // (a property chain) where a repeated referent is meaningful (e.g.
   // hasParent/hasParent == grandparent), so deduping would silently corrupt it.
-  const refSeq = (iris: string[]): string[] => iris.map(iri => {
-    const v = refValue(iri, owl.baseIri);
-    if (v !== iri) shortenedRef = true;
-    return v;
-  });
+  const refSeq = (iris: string[]): string[] => iris.map(ref1);
+
+  // One carried owl:Restriction record: the restricted property (shortened when
+  // in-namespace) followed by whichever unqualified cardinalities were stated,
+  // in a fixed key order (exact, then min, then max) so the emitted block is
+  // stable. The value mirrors the construct faithfully -- a compound is a real
+  // object, not a flattened string -- matching the carriage convention.
+  const restrictionTerm = (r: OwlRestriction): Record<string, unknown> => {
+    const rec: Record<string, unknown> = {'owl:onProperty': ref1(r.onProperty)};
+    if (r.cardinality !== undefined) rec['owl:cardinality'] = r.cardinality;
+    if (r.minCardinality !== undefined)
+      rec['owl:minCardinality'] = r.minCardinality;
+    if (r.maxCardinality !== undefined)
+      rec['owl:maxCardinality'] = r.maxCardinality;
+    return rec;
+  };
 
   // Entities, one per class, in class-declaration order. Fields are attached in
   // datatype-property-declaration order below. Two classes can share a local
@@ -405,14 +426,22 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     // individuals, which are not modeled, so only the names are kept) -- an
     // enumeration is a set, so refs() (which dedupes) is correct here, unlike
     // the ordered propertyChainAxiom which uses refSeq; blank-node class
-    // expressions were dropped in the parser. commonTerms adds any per-term
-    // annotations (seeAlso, deprecated, ...).
+    // expressions were dropped in the parser. owl:Restriction carries this
+    // class's unqualified cardinality restrictions (reached via
+    // rdfs:subClassOf). commonTerms adds any per-term annotations (seeAlso,
+    // deprecated, ...).
     const entityTerms: Record<string, unknown> = {};
     if (c.equivalentClass.length)
       entityTerms['owl:equivalentClass'] = refs(c.equivalentClass);
     if (c.disjointWith.length)
       entityTerms['owl:disjointWith'] = refs(c.disjointWith);
     if (c.oneOf.length) entityTerms['owl:oneOf'] = refs(c.oneOf);
+    // Unqualified cardinality restrictions (owl:Restriction reached via
+    // rdfs:subClassOf) -> a list of records, one per restriction, each naming
+    // the restricted property and its stated cardinalities. No native OSI home
+    // (OSI has no cardinality concept), so carried verbatim on the entity.
+    if (c.restrictions.length)
+      entityTerms['owl:Restriction'] = c.restrictions.map(restrictionTerm);
     Object.assign(entityTerms, commonTerms(c));
     attachOntology(entity, entityTerms);
     entitiesByName.set(c.localName, entity);

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
@@ -79,6 +79,13 @@ semantic_model:
                 "owl:disjointWith": [
                   "Robot"
                 ],
+                "owl:Restriction": [
+                  {
+                    "owl:onProperty": "name",
+                    "owl:minCardinality": 1,
+                    "owl:maxCardinality": 1
+                  }
+                ],
                 "rdfs:seeAlso": [
                   "<https://schema.org/Person>"
                 ],

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.owl.ttl
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.owl.ttl
@@ -13,6 +13,8 @@
 #     transitive / asymmetric characteristics on an object property ->
 #     relationship extension
 #   - owl:oneOf on a class (an enumeration) -> entity extension
+#   - an unqualified cardinality owl:Restriction (reached via rdfs:subClassOf)
+#     -> entity extension
 #   - owl:AllDisjointClasses / owl:AllDisjointProperties / owl:AllDifferent,
 #     each asserted on an ANONYMOUS node about a SET of terms (belonging to no
 #     single class/property) -> model extension
@@ -41,11 +43,20 @@
 
 # Person is equivalent to the EXTERNAL foaf:Person (carried as a full IRI) and
 # disjoint with the IN-NAMESPACE ex:Robot (carried as the local name "Robot").
-# rdfs:seeAlso / rdfs:isDefinedBy point outside the model, so they ride verbatim.
+# It also carries an unqualified cardinality restriction: every person has
+# exactly one name (owl:minCardinality/owl:maxCardinality 1 on the in-namespace
+# ex:name, reached via an anonymous owl:Restriction under rdfs:subClassOf -- the
+# restriction is not a named superclass, so it adds no `extends`, only the
+# carried restriction). rdfs:seeAlso / rdfs:isDefinedBy point outside the model,
+# so they ride verbatim.
 ex:Person a owl:Class ;
     rdfs:comment "A human being." ;
     owl:equivalentClass foaf:Person ;
     owl:disjointWith ex:Robot ;
+    rdfs:subClassOf [ a owl:Restriction ;
+                      owl:onProperty ex:name ;
+                      owl:minCardinality 1 ;
+                      owl:maxCardinality 1 ] ;
     rdfs:seeAlso <https://schema.org/Person> ;
     rdfs:isDefinedBy <http://example.com/people> ;
     owl:hasKey ( ex:personId ) .

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
@@ -61,6 +61,17 @@ semantic_model:
           - Person
           - Employee
         description: An employee who manages others.
+        custom_extensions:
+          - vendor_name: GOOGLE
+            data: |-
+              {
+                "owl:Restriction": [
+                  {
+                    "owl:onProperty": "employeeId",
+                    "owl:minCardinality": 1
+                  }
+                ]
+              }
     relationships:
       - name: managedBy
         from: Employee

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -278,6 +278,23 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
         expect(byName['Employee'].extends).toBeUndefined();
       });
 
+  test(
+      'a subClassOf cardinality owl:Restriction is carried on the class',
+      () => {
+        // Manager rdfs:subClassOf an anonymous owl:Restriction (onProperty
+        // employeeId, minCardinality 1). The restriction is not a named
+        // superclass, so it adds no `extends`; its unqualified cardinality is
+        // carried verbatim on the entity instead.
+        const model =
+            loadModels(convertOwlToOsi(ttl, 'hierarchy').yaml).models[0];
+        const manager = model.entities.find(e => e.name === 'Manager')!;
+        expect(manager.extends).toEqual(['Person', 'Employee']);
+        expect(ontologyTerms(manager.customExtensions)).toEqual({
+          'owl:Restriction':
+              [{'owl:onProperty': 'employeeId', 'owl:minCardinality': 1}]
+        });
+      });
+
   test('inheritance is recorded, not flattened (no fields copied down)', () => {
     // This cut only RECORDS the hierarchy; it does not resolve it. A subclass
     // keeps exactly its own fields -- Person's fullName does NOT appear on
@@ -1297,6 +1314,230 @@ describe('OWL constructs carried as custom extensions', () => {
           'owl:baseIri': 'http://example.com/x#',
         });
       });
+
+  // --- Unqualified cardinality restrictions (carried on the class). ---------
+  // An anonymous owl:Restriction reached via rdfs:subClassOf, naming a property
+  // and one or more of owl:cardinality / owl:minCardinality /
+  // owl:maxCardinality. No native OSI home, so it rides on the entity as a list
+  // of records. The QUALIFIED forms (owl:onClass / owl:qualifiedCardinality)
+  // are out of scope.
+
+  test('owl:cardinality (exact) on a subClassOf restriction -> entity', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:ssn ;
+                            owl:cardinality 1 ] .
+      ex:ssn a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .`;
+    const model = loadOwl(ttl);
+    const person = model.entities.find(e => e.name === 'Person')!;
+    // The restriction rides on the entity; owl:baseIri (the in-namespace ssn
+    // was shortened) rides on the model, as for every other shortened ref.
+    expect(ontologyTerms(person.customExtensions)).toEqual({
+      'owl:Restriction': [{'owl:onProperty': 'ssn', 'owl:cardinality': 1}],
+    });
+    expect(ontologyTerms(model.customExtensions)).toEqual({
+      'owl:baseIri': 'http://example.com/x#',
+    });
+  });
+
+  test('owl:minCardinality and owl:maxCardinality are carried together', () => {
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:name ;
+                            owl:minCardinality 1 ;
+                            owl:maxCardinality 3 ] .`;
+    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
+    // Fixed key order: onProperty, cardinality, min, max.
+    const carried = JSON.parse(person.customExtensions![0].data);
+    expect(Object.keys(carried['owl:Restriction'][0])).toEqual([
+      'owl:onProperty', 'owl:minCardinality', 'owl:maxCardinality'
+    ]);
+    expect(carried['owl:Restriction']).toEqual([{
+      'owl:onProperty': 'name',
+      'owl:minCardinality': 1,
+      'owl:maxCardinality': 3
+    }]);
+  });
+
+  test(
+      'multiple cardinality restrictions on one class are each carried', () => {
+        const ttl = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:ssn ; owl:cardinality 1 ] ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:phone ; owl:minCardinality 1 ] .`;
+        const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
+        expect(ontologyTerms(person.customExtensions)!['owl:Restriction'])
+            .toEqual([
+              {'owl:onProperty': 'ssn', 'owl:cardinality': 1},
+              {'owl:onProperty': 'phone', 'owl:minCardinality': 1},
+            ]);
+      });
+
+  test(
+      'the restricted property shortens in-namespace, full IRI cross-ns',
+      () => {
+        // ex:name shortens to "name" (and the model carries owl:baseIri); the
+        // cross-namespace foaf:age keeps its full IRI (nothing to shorten
+        // there).
+        const inNs = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:name ; owl:cardinality 1 ] .`;
+        const crossNs = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty foaf:age ; owl:cardinality 1 ] .`;
+        expect(ontologyTerms(loadOwl(inNs).entities[0].customExtensions))
+            .toEqual({
+              'owl:Restriction':
+                  [{'owl:onProperty': 'name', 'owl:cardinality': 1}],
+            });
+        expect(ontologyTerms(loadOwl(crossNs).entities[0].customExtensions))
+            .toEqual({
+              'owl:Restriction': [{
+                'owl:onProperty': 'http://xmlns.com/foaf/0.1/age',
+                'owl:cardinality': 1
+              }]
+            });
+      });
+
+  test('a value restriction (no cardinality) is not carried', () => {
+    // owl:someValuesFrom is a different restriction shape with no cardinality;
+    // it contributes no owl:Restriction (and no empty block).
+    const ttl = `${PREFIXES}
+      ex:Parent a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:hasChild ;
+                            owl:someValuesFrom ex:Person ] .
+      ex:Person a owl:Class .`;
+    const parent = loadOwl(ttl).entities.find(e => e.name === 'Parent')!;
+    expect(ontologyTerms(parent.customExtensions)).toBeUndefined();
+  });
+
+  test(
+      'a qualified cardinality restriction is not carried yet (Stage 4)',
+      () => {
+        // owl:onClass marks a QUALIFIED restriction; it is a separate
+        // blank-node shape, out of scope for now, so nothing is carried.
+        const ttl = `${PREFIXES}
+      ex:Parent a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:hasChild ;
+                            owl:onClass ex:Person ;
+                            owl:qualifiedCardinality 2 ] .
+      ex:Person a owl:Class .`;
+        const parent = loadOwl(ttl).entities.find(e => e.name === 'Parent')!;
+        expect(ontologyTerms(parent.customExtensions)).toBeUndefined();
+      });
+
+  test('a restriction reached via owl:equivalentClass is not carried', () => {
+    // Only rdfs:subClassOf feeds the restriction reader; a restriction under
+    // owl:equivalentClass is a class definition, out of scope (see the
+    // blank-node equivalentClass test above).
+    const ttl = `${PREFIXES}
+      ex:Parent a owl:Class ;
+          owl:equivalentClass [ a owl:Restriction ;
+                                owl:onProperty ex:hasChild ;
+                                owl:minCardinality 1 ] .
+      ex:hasChild a owl:ObjectProperty ; rdfs:domain ex:Parent ; rdfs:range ex:Parent .`;
+    const parent = loadOwl(ttl).entities.find(e => e.name === 'Parent')!;
+    expect(ontologyTerms(parent.customExtensions)).toBeUndefined();
+  });
+
+  test('a malformed cardinality value is ignored, valid siblings kept', () => {
+    // A non-integer max is dropped; a valid min on the same restriction still
+    // rides. (A negative value is likewise rejected.)
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:name ;
+                            owl:minCardinality 1 ;
+                            owl:maxCardinality "many" ] .`;
+    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
+    expect(ontologyTerms(person.customExtensions)!['owl:Restriction']).toEqual([
+      {'owl:onProperty': 'name', 'owl:minCardinality': 1}
+    ]);
+  });
+
+  test(
+      'a cardinality that only Number()-coerces (empty/hex/exponent) is ignored',
+      () => {
+        // Values that are not a plain run of decimal digits must be dropped,
+        // not silently coerced: Number("") / Number(" ") are 0, Number("0x1F")
+        // is 31, Number("1e2") is 100 -- each would fabricate a cardinality. A
+        // valid sibling on the same restriction still rides.
+        const ttl = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:name ;
+                            owl:minCardinality 1 ;
+                            owl:cardinality "" ;
+                            owl:maxCardinality "1e2" ] .`;
+        const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
+        expect(ontologyTerms(person.customExtensions)!['owl:Restriction'])
+            .toEqual([{'owl:onProperty': 'name', 'owl:minCardinality': 1}]);
+      });
+
+  test(
+      'a blank node typed both owl:Restriction and owl:Class is not an entity',
+      () => {
+        // Nonsensical but legal RDF (and possible from a reasoner dump): the
+        // node is a cardinality restriction on Person, never a class named
+        // after a blank-node id. Only Person surfaces; the restriction rides on
+        // it.
+        const ttl = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Class, owl:Restriction ;
+                            owl:onProperty ex:name ;
+                            owl:minCardinality 1 ] .`;
+        const model = loadOwl(ttl);
+        expect(model.entities.map(e => e.name)).toEqual(['Person']);
+        expect(ontologyTerms(
+                   model.entities[0].customExtensions)!['owl:Restriction'])
+            .toEqual([{'owl:onProperty': 'name', 'owl:minCardinality': 1}]);
+      });
+
+  test(
+      'a NAMED class also typed owl:Restriction stays an entity (not pruned)',
+      () => {
+        // Only ANONYMOUS (blank-node) restrictions are restriction nodes. A
+        // named IRI typed owl:Restriction keeps its owl:Class identity -- the
+        // prune that drops dual-typed blank nodes must not touch it.
+        const ttl = `${PREFIXES}
+      ex:Weird a owl:Class, owl:Restriction ;
+          rdfs:comment "Still a class." .`;
+        const model = loadOwl(ttl);
+        expect(model.entities.map(e => e.name)).toEqual(['Weird']);
+        expect(model.entities[0].description).toBe('Still a class.');
+      });
+
+  test(
+      'owl:cardinality accepts xsd:nonNegativeInteger and a bare integer',
+      () => {
+        const typed = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ;
+                            owl:onProperty ex:name ;
+                            owl:cardinality "1"^^xsd:nonNegativeInteger ] .`;
+        expect(ontologyTerms(loadOwl(typed)
+                                 .entities[0]
+                                 .customExtensions)!['owl:Restriction'])
+            .toEqual([{'owl:onProperty': 'name', 'owl:cardinality': 1}]);
+      });
+
+  test('a restriction with no owl:onProperty is dropped', () => {
+    // A cardinality with nothing to constrain is meaningless; drop it (no
+    // empty block).
+    const ttl = `${PREFIXES}
+      ex:Person a owl:Class ;
+          rdfs:subClassOf [ a owl:Restriction ; owl:cardinality 1 ] .`;
+    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
+    expect(ontologyTerms(person.customExtensions)).toBeUndefined();
+  });
 
   test(
       'reflexive / irreflexive / asymmetric characteristics -> relationship',


### PR DESCRIPTION
## What

Stage 3 of the OWL→OSI converter: read an anonymous `owl:Restriction` reached through `rdfs:subClassOf` from a named class — naming a property (`owl:onProperty`) and one or more of the **unqualified** cardinality predicates (`owl:cardinality` / `owl:minCardinality` / `owl:maxCardinality`) — and carry it verbatim on the entity as a `GOOGLE` custom extension.

Carriage is inert on push and lossless on the OSI round-trip (promotable later). OSI has no cardinality concept, so **entity-level** carriage is used: the restriction rides even when the restricted property has no field on that class (e.g. inherited).

## Scope / exclusions

- **Qualified** cardinality (`owl:onClass` / `owl:onDataRange` + qualified predicates) is detected and **skipped** — deferred to a later stage.
- A value restriction (`owl:someValuesFrom`, no cardinality) and a malformed cardinality contribute nothing (no empty block).
- Cardinality literals are parsed **digits-only**, so an empty / hex / exponent string is ignored rather than coerced to a bogus number.
- A blank node typed both `owl:Restriction` and a named kind is pruned from the named-term maps so it does not surface as a bogus entity; a **named** IRI typed `owl:Restriction` keeps its class identity.

## Tests

Full `bun test` suite green (510 pass / 0 fail). Adds targeted tests for the carried shapes (exact / min+max / multiple / in- vs cross-namespace `onProperty`), the exclusions (qualified, value restriction, via `equivalentClass`, no `onProperty`), and edge cases (malformed/coercible literals, dual-typed blank node, named dual-typed class). Docs (`owl-import.md`) and fixtures updated.