### PR TITLE
mdcode: support actions in the semantic model (prototype)

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -46,6 +46,7 @@ example that carries one model through the whole lifecycle, see the
 | [Binding profiles](profiles.md) | bind one logical model to several stores |
 | [Modeling class hierarchies](inheritance.md) | model subtypes with `extends` so a supertype query gathers them |
 | [Codelab: one semantic ontology, one data journey](codelab.md) | see the whole lifecycle: author, govern, hydrate, query |
+| [Modeling write operations](actions.md) | declare an action an agent can call, and publish it |
 | [Reference](reference.md) | look up a flag, what push creates, validation, or permissions |
 | [Model specification](model_spec.md) | the normative format: every YAML construct, what's OSI and what's a kcmd extension |
 | [What push and pull preserve](fidelity.md) | understand why something changed or wasn't recovered |
@@ -119,6 +120,14 @@ against the supertype gathers every subtype. See
 [Modeling class hierarchies](inheritance.md) to model one step by step, and
 [Class hierarchies](reference.md#class-hierarchies-extends--labels) for the rules
 push enforces.
+
+A model can also declare **actions**: model-level write operations, the
+write-side counterpart to a metric. An action names a business operation, points
+at the executor that carries it out (an MCP tool, a REST endpoint, or a gRPC
+method), and types each parameter against the ontology, so an entity-typed
+parameter is an object reference rather than a bare string. Actions have no graph
+representation and are governed in Knowledge Catalog. See
+[Modeling write operations](actions.md).
 
 This model names no table and no store, so it is complete enough to govern in
 Knowledge Catalog as-is (step 2). Where each entity reads from — the store and the

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -126,44 +126,50 @@ An action has no graph construct. It is write-side, and a property graph is a
 read surface, so the push emits no node, edge, or measure for it and warns once:
 
 ```
-model 'payments': 1 action(s) published to the model's overview aspect
+model 'payments': 1 action(s) published as semantic-action entries
 (actions have no BigQuery Graph representation).
 ```
 
-Knowledge Catalog is where actions land. They have no `semantic-*` system type
-of their own, so they ride the model anchor's built-in `overview` aspect: a
-Markdown section for a person reading the catalog, followed by a JSON block that
-a pull reads back. For the model above, the aspect holds:
+Knowledge Catalog is where actions land. Each action becomes its own entry,
+parented to the model entry, exactly as a metric does. The entry carries one
+aspect holding the executor and the typed parameters:
 
-````markdown
-## Actions
-
-Write operations defined on this model -- the write-side counterpart to
-metrics. Actions have no BigQuery Graph representation; they are published here
-for discovery and are round-tripped by `kcmd pull`.
-
-### TransferFunds
-
-Move money from one account to another.
-
-- Executor: MCP tool `transfer_funds` on server `//agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/payments`
-- Parameters:
-  - `source`: Account (entity reference)
-  - `target`: Account (entity reference)
-  - `amount`: Float
-
-<!-- kcmd:actions v1 -->
-```json
-[ … the same actions, verbatim, as the canonical copy … ]
+```yaml
+# .../entryGroups/<group>/entries/payments.actions.TransferFunds
+entryType: projects/<project>/locations/global/entryTypes/semantic-action
+parentEntry: .../entryGroups/<group>/entries/payments
+entrySource:
+  displayName: TransferFunds
+  description: Move money from one account to another.
+aspects:
+  <project>.global.semantic-action:
+    executorKind: mcp
+    mcpServer: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/payments
+    mcpTool: transfer_funds
+    parameters:
+      - {name: source, type: Account, isEntityRef: true}
+      - {name: target, type: Account, isEntityRef: true}
+      - {name: amount, type: Float, isEntityRef: false}
+    instructions: Confirm the source account has cleared funds.
 ```
-````
 
-Because that leg is the only destination an action has, a graph-only push has
-nowhere to put one. `kcmd push --no-kc` validates the actions and then warns
-that they will not be deployed.
+The `semantic-action` entry type and aspect type are the one pair `kcmd` creates
+rather than references. Every other element of a model maps to a built-in system
+type under `dataplex-types/global`; there is no built-in type for an action yet,
+so `kcmd init --semantic-model` provisions the pair in your own project at
+`global`, beside the entry group. A later push writes only entries.
 
-Writing the overview needs `dataplex.entryGroups.useOverviewAspect` on the
-destination entry group, in addition to the permissions any push needs — see
+Two consequences follow from the entry shape. A catalog search can list the
+actions in a project by entry type, the way it lists entities or metrics. And
+removing an action from the document deletes its entry on the next push, because
+the model owns the `<model>.actions.` id prefix.
+
+Because Knowledge Catalog is the only destination an action has, a graph-only
+push has nowhere to put one. `kcmd push --no-kc` validates the actions and then
+warns that they will not be deployed.
+
+Publishing an action needs the permission to attach its aspect, in addition to
+the permissions any push needs — see
 [Reference → Permissions](reference.md#permissions).
 
 ## 4. Pull it back
@@ -172,10 +178,11 @@ destination entry group, in addition to the permissions any push needs — see
 kcmd pull
 ```
 
-Pull reads the JSON block after the `<!-- kcmd:actions v1 -->` marker and
-rebuilds each action, so a name, a description, an executor, and typed
-parameters survive the round trip unchanged. The Markdown above the marker is
-for people; the JSON is the canonical copy. What every part of a model does and
+Pull collects the `semantic-action` entries under the model entry and rebuilds
+each action, so a name, a description, an executor, typed parameters, and
+`ai_context.instructions` survive the round trip unchanged. `isEntityRef` is
+re-derived against the entities the pull recovered rather than read back, so it
+stays consistent with the model you get. What every part of a model does and
 does not survive is in
 [What push and pull preserve](fidelity.md).
 

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -18,7 +18,7 @@ data is described. Anything reading the model then knows the operation exists,
 what it takes, and where it lives.
 
 Do not declare an action for a question about the data; that is a
-[metric](README.md#1-author-a-model). Do not expect an action to run: `kcmd`
+[metric](README.md#1-author-the-logical-model). Do not expect an action to run: `kcmd`
 publishes the declaration and never calls the executor. What each caller has to
 supply is covered in [What is not modeled yet](#what-is-not-modeled-yet).
 
@@ -153,7 +153,7 @@ aspects:
       - {name: source, type: Account, isEntityRef: true}
       - {name: target, type: Account, isEntityRef: true}
       - {name: amount, type: Float, isEntityRef: false}
-    instructions: Confirm the source account has cleared funds.
+    instructions: Resolve both accounts before calling. Name the account the money leaves as `source`.
 ```
 
 The `semantic-action` entry type and aspect type are the one pair `kcmd` creates

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -1,0 +1,197 @@
+# Modeling write operations
+
+A semantic model says what the data means, and its metrics say what can be read
+from it. An **action** is the write-side counterpart: a named operation that
+changes state, declared over the same concepts as everything else in the model.
+
+An action does not contain the write. It names the operation, points at the
+**executor** that performs it — an MCP tool, a REST endpoint, a gRPC method —
+and types the operation's inputs against the ontology. Publishing it puts the
+operation in the same place as the data it acts on, so an agent that discovers
+the model discovers what it can do as well as what it can ask.
+
+## When to use it
+
+Declare an action when your organization already has an operation that changes
+the data this model describes, and you want that operation described where the
+data is described. Anything reading the model then knows the operation exists,
+what it takes, and where it lives.
+
+Do not declare an action for a question about the data; that is a
+[metric](README.md#1-author-a-model). Do not expect an action to run: `kcmd`
+publishes the declaration and never calls the executor. What each caller has to
+supply is covered in [What is not modeled yet](#what-is-not-modeled-yet).
+
+## The one thing the model adds
+
+A hand-written tool schema can already say that an input is an integer or a
+string. Only a model that knows the ontology can say what an input *denotes*:
+
+> **A parameter typed by an entity is an object reference.**
+
+`{name: source, type: Account}` says the argument names an account. The loader
+resolves `Account` against the model's entities and marks the parameter as an
+entity reference, so a consumer generating a tool schema knows to accept an
+identifier and resolve it against `Account`'s key rather than pass a number
+through. A parameter typed by a scalar datatype is an ordinary value.
+
+## 1. Declare the action
+
+Actions sit at model level, beside metrics, and each one carries a name, an
+executor, and its parameters:
+
+```yaml
+version: "0.2.0.dev0/google"    # `actions` is a kcmd extension key
+semantic_model:
+  - name: payments
+    entities:
+      - name: Account
+        primary_key: [accountId]
+        source: my-project.bank.account
+        fields:
+          - { name: accountId, datatype: Integer, expression: account_id }
+          - { name: name,      datatype: String,  expression: name }
+          - { name: balance,   datatype: Float,   expression: balance }
+      - name: Transfer
+        primary_key: [transferId]
+        source: my-project.bank.transfer
+        fields:
+          - { name: transferId, datatype: Integer, expression: transfer_id }
+          - { name: amount,     datatype: Float,   expression: amount }
+    actions:
+      - name: TransferFunds
+        description: Move money from one account to another.
+        executor:                             # exactly one kind: mcp / rest / grpc
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/payments
+            tool: transfer_funds
+        parameters:
+          - { name: source, type: Account }   # an entity: an object reference
+          - { name: target, type: Account }
+          - { name: amount, type: Float }     # a scalar: an ordinary value
+        ai_context:
+          instructions: >-
+            Resolve both accounts before calling. Name the account the money
+            leaves as `source`.
+```
+
+The rest of the model — the deployment target, the entity bindings, the
+relationships — is authored as it is for any model; see
+[Deploying a semantic model](README.md).
+
+The executor says where the operation lives. `mcp` (`{server, tool}`) references
+a tool already registered in Agent Registry by the server's resource name plus
+the tool's name within it. `rest` (`{endpoint, method}`) and `grpc`
+(`{service, method}`) are the other kinds, and exactly one kind is required.
+Naming two is a parse error: `executor requires exactly one kind, but 2 given
+(mcp, rest)`.
+
+`description` and `ai_context.instructions` are both carried through to the
+catalog. Write the instructions for the agent that will call the action, as
+above.
+
+## 2. Check it before pushing
+
+```bash
+kcmd push --validate-only
+```
+
+Two things about an action can be statically wrong once the document parses, and
+both are hard errors:
+
+```
+action 'TransferFunds' in model 'payments' (payments.yaml) has parameter
+'target' whose type 'BankAccount' is neither a known entity nor a scalar
+datatype.
+
+action 'TransferFunds' in model 'payments' (payments.yaml) has an mcp executor
+missing its 'tool'.
+```
+
+A parameter type that resolves to neither an entity nor a scalar means the model
+cannot say what that argument denotes, which is the whole contribution an action
+makes. An executor missing a coordinate cannot be dispatched by whatever picks
+the action up. Both checks are static, so they run on every push whatever the
+destination.
+
+## 3. Push it
+
+```bash
+kcmd push
+```
+
+An action has no graph construct. It is write-side, and a property graph is a
+read surface, so the push emits no node, edge, or measure for it and warns once:
+
+```
+model 'payments': 1 action(s) published to the model's overview aspect
+(actions have no BigQuery Graph representation).
+```
+
+Knowledge Catalog is where actions land. They have no `semantic-*` system type
+of their own, so they ride the model anchor's built-in `overview` aspect: a
+Markdown section for a person reading the catalog, followed by a JSON block that
+a pull reads back. For the model above, the aspect holds:
+
+````markdown
+## Actions
+
+Write operations defined on this model -- the write-side counterpart to
+metrics. Actions have no BigQuery Graph representation; they are published here
+for discovery and are round-tripped by `kcmd pull`.
+
+### TransferFunds
+
+Move money from one account to another.
+
+- Executor: MCP tool `transfer_funds` on server `//agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/payments`
+- Parameters:
+  - `source`: Account (entity reference)
+  - `target`: Account (entity reference)
+  - `amount`: Float
+
+<!-- kcmd:actions v1 -->
+```json
+[ … the same actions, verbatim, as the canonical copy … ]
+```
+````
+
+Because that leg is the only destination an action has, a graph-only push has
+nowhere to put one. `kcmd push --no-kc` validates the actions and then warns
+that they will not be deployed.
+
+Writing the overview needs `dataplex.entryGroups.useOverviewAspect` on the
+destination entry group, in addition to the permissions any push needs — see
+[Reference → Permissions](reference.md#permissions).
+
+## 4. Pull it back
+
+```bash
+kcmd pull
+```
+
+Pull reads the JSON block after the `<!-- kcmd:actions v1 -->` marker and
+rebuilds each action, so a name, a description, an executor, and typed
+parameters survive the round trip unchanged. The Markdown above the marker is
+for people; the JSON is the canonical copy. What every part of a model does and
+does not survive is in
+[What push and pull preserve](fidelity.md).
+
+## What is not modeled yet
+
+This is a prototype. Four things a reader reasonably expects are absent, and
+knowing which they are decides how much you can lean on it.
+
+- **An action declares no precondition and no effects.** `precondition` (what
+  has to hold before the call) and `affects` (what the call changes) are out of
+  scope here. A separate change adds model-level **constraints** and a runtime
+  that checks them against a write before it commits.
+- **Nothing checks the write.** Until that change lands, an action is a
+  declaration, and the correctness of what the executor does is the executor's
+  business.
+- **`kcmd` does not call the executor.** Push publishes the action. Dispatching
+  it is the job of whatever reads the model, which is why the executor names
+  coordinates rather than a statement.
+- **Parameter types are the whole type story.** An entity-typed parameter says
+  which entity an argument denotes. Resolving a caller's `"Alice Checking"` to
+  a row is left to the consumer.

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -107,7 +107,7 @@ action 'TransferFunds' in model 'payments' (payments.yaml) has parameter
 datatype.
 
 action 'TransferFunds' in model 'payments' (payments.yaml) has an mcp executor
-missing its 'tool'.
+whose 'tool' is missing or blank.
 ```
 
 A parameter type that resolves to neither an entity nor a scalar means the model
@@ -115,6 +115,9 @@ cannot say what that argument denotes, which is the whole contribution an action
 makes. An executor missing a coordinate cannot be dispatched by whatever picks
 the action up. Both checks are static, so they run on every push whatever the
 destination.
+
+An executor coordinate that is absent altogether is caught earlier, when the
+document is parsed, so the message above is what a blank one produces.
 
 ## 3. Push it
 

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -49,9 +49,11 @@ semantic_model:
         primary_key: [accountId]
         source: my-project.bank.account
         fields:
-          - { name: accountId, datatype: Integer, expression: account_id }
-          - { name: name,      datatype: String,  expression: name }
-          - { name: balance,   datatype: Float,   expression: balance }
+          - { name: accountId,      datatype: Integer, expression: account_id }
+          - { name: name,           datatype: String,  expression: name }
+          - { name: balance,        datatype: Float,   expression: balance }
+          - { name: minimumBalance, datatype: Float,   expression: minimum_balance }
+          - { name: status,         datatype: String,  expression: status }
       - name: Transfer
         primary_key: [transferId]
         source: my-project.bank.transfer

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -35,6 +35,7 @@ agree on every structural row and differ only where a Spanner target has no
 | Relationship (1:1 / 1:N)                                       | `schema-join` link              | ✓ (name normalized⁶)                           | `EDGE TABLE`                                                         | `EDGE TABLE`                                                         |
 | Relationship (M:N / `association`)                             | — not stored                    | —                                              | `EDGE TABLE` (via junction table)                                    | `EDGE TABLE` (via junction table)                                    |
 | Entity `extends`                                               | — not modelled                  | —                                              | `LABEL` clauses + flattened fields                                   | `LABEL` clauses + flattened fields                                   |
+| Action                                                         | `overview` aspect on the model anchor¹² | ✓¹²                                            | — not represented (write-side)                                       | — not represented (write-side)                                       |
 | `description` (entity / metric / field / relationship)         | entry description / aspect      | ✓                                              | `OPTIONS(description)`                                               | — dropped                                                            |
 | `ai_context.synonyms`                                          | — not stored                    | —                                              | `OPTIONS(synonyms=[...])`                                            | — dropped                                                            |
 | `ai_context.instructions`                                      | `guidelines` aspect⁷            | ✓⁷                                             | into `OPTIONS(description)`                                          | — dropped                                                            |
@@ -95,6 +96,13 @@ agree on every structural row and differ only where a Spanner target has no
     Snowflake form a metric was imported from) and uses that verbatim as the
     fallback when no canonical variant exists. See
     [Model spec §2.5](model_spec.md#25-expressions).
+12. **Actions.** Actions are write-side, so neither graph has a construct for
+    them: the push emits nothing for an action and warns once. They are
+    published to Knowledge Catalog on the model anchor's built-in `overview`
+    aspect — Markdown for a reader plus an embedded JSON block — and `pull`
+    recovers them from that JSON. Prototype scope: an action's `precondition`
+    and `affects` are not modelled, so nothing about them is stored either way.
+    See [Modeling write operations](actions.md).
 
 ## To Knowledge Catalog
 
@@ -125,6 +133,13 @@ templates gain the fields. The catalog never stores `ai_context.synonyms` /
 SQL (`importedExpression` — for example the MAQL or Snowflake form a metric was
 imported from). Those stay in your authored document; the vendor SQL and
 expressions are still used when generating graph SQL.
+
+**Actions** are the exception to "one entry per element": they have no
+`semantic-*` type, so they are stored on the model anchor's built-in `overview`
+aspect — Markdown for a reader plus an embedded JSON block. That JSON is the
+canonical copy, so actions round-trip losslessly through `pull` (name,
+description, executor, and typed parameters). Their `precondition` / `affects`
+are out of scope for this prototype and are not stored.
 
 ¹⁰ What you author is the `expression.dialects[]` list; the graph builds from the canonical (BigQuery/ANSI) variant. `importedExpression` / `importedDialect` are not authored keys — the loader *derives* them from a non-canonical dialect entry (e.g. the MAQL or Snowflake form a metric was imported from) and uses that verbatim as the fallback when no canonical variant exists. See [Model spec §2.5](model_spec.md#25-expressions).
 
@@ -174,6 +189,13 @@ design:
 
 Everything else — keys, relationships, the label hierarchy — matches the
 **→ BigQuery** column above.
+
+**Actions** are the exception to "one entry per element": they have no
+`semantic-*` type, so they are stored on the model anchor's built-in `overview`
+aspect — Markdown for humans plus an embedded JSON block. That JSON is the
+canonical copy, so actions round-trip losslessly through `pull` (name,
+description, executor, and typed parameters). Their `precondition`/`affects` are
+out of scope for this prototype and are not stored.
 
 ## What pull recovers
 

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -35,7 +35,7 @@ agree on every structural row and differ only where a Spanner target has no
 | Relationship (1:1 / 1:N)                                       | `schema-join` link              | ✓ (name normalized⁶)                           | `EDGE TABLE`                                                         | `EDGE TABLE`                                                         |
 | Relationship (M:N / `association`)                             | — not stored                    | —                                              | `EDGE TABLE` (via junction table)                                    | `EDGE TABLE` (via junction table)                                    |
 | Entity `extends`                                               | — not modelled                  | —                                              | `LABEL` clauses + flattened fields                                   | `LABEL` clauses + flattened fields                                   |
-| Action                                                         | `overview` aspect on the model anchor¹² | ✓¹²                                            | — not represented (write-side)                                       | — not represented (write-side)                                       |
+| Action                                                         | `semantic-action` entry¹²       | ✓¹²                                            | — not represented (write-side)                                       | — not represented (write-side)                                       |
 | `description` (entity / metric / field / relationship)         | entry description / aspect      | ✓                                              | `OPTIONS(description)`                                               | — dropped                                                            |
 | `ai_context.synonyms`                                          | — not stored                    | —                                              | `OPTIONS(synonyms=[...])`                                            | — dropped                                                            |
 | `ai_context.instructions`                                      | `guidelines` aspect⁷            | ✓⁷                                             | into `OPTIONS(description)`                                          | — dropped                                                            |
@@ -98,17 +98,18 @@ agree on every structural row and differ only where a Spanner target has no
     [Model spec §2.5](model_spec.md#25-expressions).
 12. **Actions.** Actions are write-side, so neither graph has a construct for
     them: the push emits nothing for an action and warns once. They are
-    published to Knowledge Catalog on the model anchor's built-in `overview`
-    aspect — Markdown for a reader plus an embedded JSON block — and `pull`
-    recovers them from that JSON. Prototype scope: an action's `precondition`
-    and `affects` are not modelled, so nothing about them is stored either way.
-    See [Modeling write operations](actions.md).
+    published to Knowledge Catalog as one `semantic-action` entry each, under
+    the model entry, and `pull` reads them back from those entries. Prototype
+    scope: an action's `precondition` and `affects` are not modelled, so nothing
+    about them is stored either way. See
+    [Modeling write operations](actions.md).
 
 ## To Knowledge Catalog
 
 The catalog holds metadata rather than a full copy of your model. Every resource
-type it uses is a built-in system type under `dataplex-types/global` — push
-references them, it never creates them (see
+type it uses is a built-in system type under `dataplex-types/global`, apart from
+the custom `semantic-action` pair that `kcmd init` provisions — push references
+types, it never creates them (see
 [Reference → What gets created in Knowledge Catalog](reference.md#what-gets-created-in-knowledge-catalog)).
 
 What is recorded depends on the push. A catalog-only push (`--no-profile`), or a
@@ -134,12 +135,13 @@ SQL (`importedExpression` — for example the MAQL or Snowflake form a metric wa
 imported from). Those stay in your authored document; the vendor SQL and
 expressions are still used when generating graph SQL.
 
-**Actions** are the exception to "one entry per element": they have no
-`semantic-*` type, so they are stored on the model anchor's built-in `overview`
-aspect — Markdown for a reader plus an embedded JSON block. That JSON is the
-canonical copy, so actions round-trip losslessly through `pull` (name,
-description, executor, and typed parameters). Their `precondition` / `affects`
-are out of scope for this prototype and are not stored.
+**Actions** follow the same one-entry-per-element rule as everything else: each
+becomes a `semantic-action` entry under the model entry, carrying its executor
+and typed parameters in a `semantic-action` aspect. They round-trip losslessly
+through `pull` (name, description, executor, typed parameters, and
+`instructions`). Their `precondition` / `affects` are out of scope for this
+prototype and are not stored. The entry type is custom, so `kcmd init` creates
+it; a model that declares no action never needs it.
 
 ¹⁰ What you author is the `expression.dialects[]` list; the graph builds from the canonical (BigQuery/ANSI) variant. `importedExpression` / `importedDialect` are not authored keys — the loader *derives* them from a non-canonical dialect entry (e.g. the MAQL or Snowflake form a metric was imported from) and uses that verbatim as the fallback when no canonical variant exists. See [Model spec §2.5](model_spec.md#25-expressions).
 
@@ -190,12 +192,9 @@ design:
 Everything else — keys, relationships, the label hierarchy — matches the
 **→ BigQuery** column above.
 
-**Actions** are the exception to "one entry per element": they have no
-`semantic-*` type, so they are stored on the model anchor's built-in `overview`
-aspect — Markdown for humans plus an embedded JSON block. That JSON is the
-canonical copy, so actions round-trip losslessly through `pull` (name,
-description, executor, and typed parameters). Their `precondition`/`affects` are
-out of scope for this prototype and are not stored.
+**Actions** reach neither graph. They are published to Knowledge Catalog as one
+`semantic-action` entry each and round-trip losslessly through `pull` — see
+[To Knowledge Catalog](#to-knowledge-catalog).
 
 ## What pull recovers
 

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -422,8 +422,13 @@ needs more than push does, in the destination project:
   `dataplex.entryTypes.create` — the custom `semantic-action` pair. Init patches
   an aspect type that is already there, so a project set up by an older `kcmd`
   picks up template additions; an entry type that is already there is left
-  alone. Init fails when a call fails, rather than leaving a later push to hit
-  an opaque parsing error.
+  alone.
+
+Only the entry-group permission is required. Actions are one optional
+construct, so init reports a refusal to create their types as a warning and
+carries on; every model that declares no action still pushes and pulls. Any
+other failure to create a type stops init, rather than leaving a later push to
+hit an opaque parsing error.
 
 `kcmd pull` needs read access to the same entry group instead — to list its
 entries and fetch each `semantic-*` entry with its aspects.

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -259,8 +259,10 @@ are **not** probed before deploy — the live pre-flight is BigQuery-only (see
 ## What gets created in Knowledge Catalog
 
 Each element of your model maps to one catalog resource. Every resource type
-below is a built-in system type under `dataplex-types/global` — push references
-them, it never creates them.
+below except `semantic-action` is a built-in system type under
+`dataplex-types/global` — push references them, it never creates them.
+`semantic-action` is custom, and `kcmd init --semantic-model` creates it in your
+own project at `global`; push still writes only entries.
 
 > Set `KC_TYPE_PROJECT` to read these system types from another project, and
 > `DATAPLEX_ENDPOINT` to target a non-prod Dataplex host; both default to
@@ -272,7 +274,7 @@ them, it never creates them.
 | Entity | `semantic-entity` (+ built-in `schema` aspect) | entry | `<model>.entities.<entity>` |
 | Metric | `semantic-metric` | entry | `<model>.metrics.<metric>` |
 | Relationship | `schema-join` | entry link between the two entity entries | derived from the model and relationship names |
-| Actions | built-in `overview` aspect on the model anchor | aspect (not its own entry) | — |
+| Action | `semantic-action` (custom type) | entry | `<model>.actions.<action>` |
 
 An entity entry carries its columns in the `schema` aspect (name, data type,
 description, and any `label` per field), plus the entity's keys and unique keys
@@ -281,12 +283,13 @@ relationship detail — the paired columns and foreign-key direction — in its
 aspect. Any element with `ai_context.instructions` (the model, an entity, or a
 metric) also gets a built-in `guidelines` aspect holding that text.
 
-A model's **actions** have no `semantic-*` system type of their own, so they ride
-the model anchor's built-in `overview` aspect: human-readable Markdown for each
-action (name, description, executor, typed parameters) followed by an embedded
-JSON block that a `pull` recovers them from losslessly. The overview is attached
-only when the model declares actions. (This is the prototype scope — an action's
-`precondition` and `affects` are not modeled yet.)
+An **action** entry carries its executor and its typed parameters in a
+`semantic-action` aspect, along with the action's `ai_context.instructions`.
+That aspect type is provisioned in your project rather than referenced from
+`dataplex-types`, because Dataplex has no built-in action type yet; when one
+ships, the entries move to it and their shape does not change. (This is the
+prototype scope — an action's `precondition` and `affects` are not modeled
+yet.)
 
 Push to Knowledge Catalog is lossy — the catalog holds metadata, not a full copy
 of your model. For exactly what is stored, what is gated behind
@@ -393,14 +396,16 @@ and each aspect type attached, so a push needs, on the destination entry group:
   `schema` aspect (its fields, keys, unique keys, and labels)
 * `dataplex.entryGroups.useGuidelinesAspect` — when the model, an entity, or a
   metric carries `ai_context.instructions`
-* `dataplex.entryGroups.useOverviewAspect` — when the model declares actions
-  (they ride the anchor's built-in `overview` aspect)
 * `dataplex.entryGroups.useSchemaJoinAspect` and
   `dataplex.entryGroups.useSchemaJoinEntryLink` — when the model has relationships
 * the `use<AspectType>Aspect` permission for the `semantic-model`,
   `semantic-entity`, and `semantic-metric` aspect types the push attaches — i.e.
   `dataplex.entryGroups.useSemanticModelAspect`, `useSemanticEntityAspect`, and
   `useSemanticMetricAspect`
+* `dataplex.aspectTypes.use` on the `semantic-action` aspect type, when the
+  model declares actions — that type is custom rather than built-in, so it is
+  authorized on the type resource instead of through an entry-group
+  use-permission
 
 > The `schema` / `guidelines` / `schema-join` use-permissions follow Dataplex's
 > documented `dataplex.entryGroups.use<AspectType>Aspect`
@@ -408,6 +413,17 @@ and each aspect type attached, so a push needs, on the destination entry group:
 > `semantic-*` names follow the same pattern but are not yet in that public
 > reference (the `semantic-*` system aspect types are newer), so confirm them
 > against your project's IAM once granted.
+
+`kcmd init --semantic-model` creates what a later push only references, so it
+needs more than push does, in the destination project:
+
+* `dataplex.entryGroups.create` — the destination entry group
+* `dataplex.aspectTypes.create` / `dataplex.aspectTypes.update` and
+  `dataplex.entryTypes.create` — the custom `semantic-action` pair. Init patches
+  an aspect type that is already there, so a project set up by an older `kcmd`
+  picks up template additions; an entry type that is already there is left
+  alone. Init fails when a call fails, rather than leaving a later push to hit
+  an opaque parsing error.
 
 `kcmd pull` needs read access to the same entry group instead — to list its
 entries and fetch each `semantic-*` entry with its aspects.

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -76,6 +76,7 @@ becomes one part of that graph:
 | Relationship | `EDGE TABLE` | connects the two entities' node tables |
 | Metric | `MEASURE` on a node table | must resolve to a single entity (otherwise the push is rejected — see [Validation](#validation)) and reduce to one supported aggregate over one operand (otherwise that metric is skipped with a warning) |
 | Entity `extends` | extra `LABEL` clauses on the subclass node table | the subclass also matches its supertypes; the supertypes' fields flatten down (see [Class hierarchies](#class-hierarchies-extends--labels)) |
+| Action | *nothing* | actions are write-side and have no graph construct; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
 
 `push` reads the target dataset's location (`bigquery.datasets.get`) so the
 statement runs in the right region; without that permission it falls back to
@@ -271,6 +272,7 @@ them, it never creates them.
 | Entity | `semantic-entity` (+ built-in `schema` aspect) | entry | `<model>.entities.<entity>` |
 | Metric | `semantic-metric` | entry | `<model>.metrics.<metric>` |
 | Relationship | `schema-join` | entry link between the two entity entries | derived from the model and relationship names |
+| Actions | built-in `overview` aspect on the model anchor | aspect (not its own entry) | — |
 
 An entity entry carries its columns in the `schema` aspect (name, data type,
 description, and any `label` per field), plus the entity's keys and unique keys
@@ -278,6 +280,13 @@ description, and any `label` per field), plus the entity's keys and unique keys
 relationship detail — the paired columns and foreign-key direction — in its
 aspect. Any element with `ai_context.instructions` (the model, an entity, or a
 metric) also gets a built-in `guidelines` aspect holding that text.
+
+A model's **actions** have no `semantic-*` system type of their own, so they ride
+the model anchor's built-in `overview` aspect: human-readable Markdown for each
+action (name, description, executor, typed parameters) followed by an embedded
+JSON block that a `pull` recovers them from losslessly. The overview is attached
+only when the model declares actions. (This is the prototype scope — an action's
+`precondition` and `affects` are not modeled yet.)
 
 Push to Knowledge Catalog is lossy — the catalog holds metadata, not a full copy
 of your model. For exactly what is stored, what is gated behind
@@ -324,6 +333,15 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   BigQuery-only: Spanner Graph has no `MEASURE`, so a Spanner target drops its
   metrics by design and imposes no such requirement. Defined in
   [model spec §4.1](model_spec.md#41-narrowings-stricter-than-ossie). *(static)*
+* **Every action is well-formed.** Each action parameter's `type` must resolve to
+  a known entity (an object reference) or a scalar datatype, and each executor
+  must carry its coordinates (an `mcp` server + tool, a `rest` endpoint + method,
+  or a `grpc` service + method) with no blank field. (The "exactly one executor
+  kind" rule is enforced when the model is parsed.) These checks are static, so
+  they run on every push, regardless of destination. Note that actions themselves
+  deploy **only** through the Knowledge Catalog leg — a graph-only `--no-kc` push
+  validates them but has nowhere to put them, and warns that they will not be
+  deployed. *(static)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it
   exactly as the deploy will — a three-part `project.dataset.table`, a four-part
@@ -375,6 +393,8 @@ and each aspect type attached, so a push needs, on the destination entry group:
   `schema` aspect (its fields, keys, unique keys, and labels)
 * `dataplex.entryGroups.useGuidelinesAspect` — when the model, an entity, or a
   metric carries `ai_context.instructions`
+* `dataplex.entryGroups.useOverviewAspect` — when the model declares actions
+  (they ride the anchor's built-in `overview` aspect)
 * `dataplex.entryGroups.useSchemaJoinAspect` and
   `dataplex.entryGroups.useSchemaJoinEntryLink` — when the model has relationships
 * the `use<AspectType>Aspect` permission for the `semantic-model`,

--- a/toolbox/mdcode/package.json
+++ b/toolbox/mdcode/package.json
@@ -17,7 +17,8 @@
     "compile": "npx tsc --noEmit",
     "test:libts": "npx bun test ./tests/libts/scenarios.ts && npx bun test ./tests/libts/layouts/",
     "test:semantic": "npx bun test ./tests/libts/semantic/",
-    "test": "npm run test:libts && npm run test:semantic",
+    "test:tool": "npx bun test ./tests/tool/",
+    "test": "npm run test:libts && npm run test:semantic && npm run test:tool",
     "x:mcp": "npx @modelcontextprotocol/inspector dist/kcmd mcp"
   },
   "keywords": [],

--- a/toolbox/mdcode/src/libts/gcp/dataplex.ts
+++ b/toolbox/mdcode/src/libts/gcp/dataplex.ts
@@ -319,10 +319,11 @@ export class CatalogClient extends api.ApiClient {
       delayMs = Math.min(delayMs * 2, 5000);
 
       const polled = await this.getOperation(op.name);
-      // A permanent failure to read the operation will not resolve itself, so
-      // report it rather than spend the whole timeout rediscovering it. A 5xx
-      // or a throttle is worth another attempt.
-      if (polled.status === 403 || polled.status === 404) {
+      // A client error will not resolve itself, so report it rather than spend
+      // the whole timeout rediscovering it and then blame the timeout. A 5xx or
+      // a throttle is worth another attempt.
+      if (polled.status >= 400 && polled.status < 500 &&
+          polled.status !== 429) {
         return `${what}: reading ${op.name}: ${polled.message || polled.status}`;
       }
       if (polled.status !== 200 || !polled.result) continue;

--- a/toolbox/mdcode/src/libts/gcp/dataplex.ts
+++ b/toolbox/mdcode/src/libts/gcp/dataplex.ts
@@ -242,6 +242,42 @@ export class CatalogClient extends api.ApiClient {
     return res;
   }
 
+  // Creates a custom aspect type. `aspectType` carries the display name,
+  // description and metadataTemplate; the resource name comes from the id.
+  async createAspectType(project: string, location: string, aspectTypeId: string,
+                         aspectType: Omit<AspectType, 'name'>): Promise<api.ApiResult<AspectType>> {
+    const resourceName = `${catalogContainer(project, location)}/aspectTypes`;
+
+    const params: Record<string, any> = { aspectTypeId };
+
+    return await this._post<AspectType>(resourceName, aspectType, params);
+  }
+
+  // Patches an existing aspect type. Dataplex rejects a backwards-incompatible
+  // metadataTemplate change, so an update only ever adds fields.
+  async updateAspectType(project: string, location: string, aspectTypeId: string,
+                         aspectType: Omit<AspectType, 'name'>,
+                         updateMask?: string[]): Promise<api.ApiResult<AspectType>> {
+    const name = `${catalogContainer(project, location)}/aspectTypes/${aspectTypeId}`;
+
+    const params: Record<string, any> = {};
+    if (updateMask && updateMask.length) {
+      params.updateMask = updateMask.join(',');
+    }
+
+    return await this._patch<AspectType>(name, aspectType, params);
+  }
+
+  // Creates a custom entry type.
+  async createEntryType(project: string, location: string, entryTypeId: string,
+                        entryType: Omit<EntryType, 'name'>): Promise<api.ApiResult<EntryType>> {
+    const resourceName = `${catalogContainer(project, location)}/entryTypes`;
+
+    const params: Record<string, any> = { entryTypeId };
+
+    return await this._post<EntryType>(resourceName, entryType, params);
+  }
+
   async createEntryLink(project: string, location: string, entryGroup: string,
                         entryLinkId: string,
                         entryLink: EntryLink): Promise<api.ApiResult<EntryLink>> {

--- a/toolbox/mdcode/src/libts/gcp/dataplex.ts
+++ b/toolbox/mdcode/src/libts/gcp/dataplex.ts
@@ -22,6 +22,22 @@ export interface AspectType {
   [key: string]: any;
 }
 
+// A long-running operation. Creating or updating a type is asynchronous: the
+// call returns one of these immediately, `done` flips to true at completion,
+// and `error` is set when the operation failed.
+export interface Operation {
+  name?: string;
+  done?: boolean;
+  error?: { code?: number; message?: string; };
+}
+
+// Renders a finished operation's failure as a message, or returns undefined
+// when it succeeded.
+function operationFailure(op: Operation, what: string): string|undefined {
+  if (!op.error) return undefined;
+  return `${what}: ${op.error.message || `operation failed (${op.error.code})`}`;
+}
+
 export interface Aspect {
   aspectType?: string;
   data?: Record<string, any>;
@@ -245,19 +261,19 @@ export class CatalogClient extends api.ApiClient {
   // Creates a custom aspect type. `aspectType` carries the display name,
   // description and metadataTemplate; the resource name comes from the id.
   async createAspectType(project: string, location: string, aspectTypeId: string,
-                         aspectType: Omit<AspectType, 'name'>): Promise<api.ApiResult<AspectType>> {
+                         aspectType: Omit<AspectType, 'name'>): Promise<api.ApiResult<Operation>> {
     const resourceName = `${catalogContainer(project, location)}/aspectTypes`;
 
     const params: Record<string, any> = { aspectTypeId };
 
-    return await this._post<AspectType>(resourceName, aspectType, params);
+    return await this._post<Operation>(resourceName, aspectType, params);
   }
 
   // Patches an existing aspect type. Dataplex rejects a backwards-incompatible
   // metadataTemplate change, so an update only ever adds fields.
   async updateAspectType(project: string, location: string, aspectTypeId: string,
                          aspectType: Omit<AspectType, 'name'>,
-                         updateMask?: string[]): Promise<api.ApiResult<AspectType>> {
+                         updateMask?: string[]): Promise<api.ApiResult<Operation>> {
     const name = `${catalogContainer(project, location)}/aspectTypes/${aspectTypeId}`;
 
     const params: Record<string, any> = {};
@@ -265,17 +281,54 @@ export class CatalogClient extends api.ApiClient {
       params.updateMask = updateMask.join(',');
     }
 
-    return await this._patch<AspectType>(name, aspectType, params);
+    return await this._patch<Operation>(name, aspectType, params);
   }
 
   // Creates a custom entry type.
   async createEntryType(project: string, location: string, entryTypeId: string,
-                        entryType: Omit<EntryType, 'name'>): Promise<api.ApiResult<EntryType>> {
+                        entryType: Omit<EntryType, 'name'>): Promise<api.ApiResult<Operation>> {
     const resourceName = `${catalogContainer(project, location)}/entryTypes`;
 
     const params: Record<string, any> = { entryTypeId };
 
-    return await this._post<EntryType>(resourceName, entryType, params);
+    return await this._post<Operation>(resourceName, entryType, params);
+  }
+
+  // Fetches a long-running operation by the resource name the call that started
+  // it returned.
+  async getOperation(operationName: string): Promise<api.ApiResult<Operation>> {
+    return await this._get<Operation>(operationName);
+  }
+
+  // Polls a long-running operation until it finishes, and returns a message
+  // describing the failure when it fails or does not finish in time. Creating a
+  // type is asynchronous, so a caller that skips this races the server: an
+  // entry type that names an aspect type the server cannot see yet is rejected
+  // with `The following aspect types do not exist`.
+  async awaitOperation(op: Operation|undefined, what: string,
+                       timeoutMs = 120000): Promise<string|undefined> {
+    // A response that carries no operation name is already the final resource,
+    // which is what a synchronous implementation of the same call returns.
+    if (!op || !op.name) return undefined;
+    if (op.done) return operationFailure(op, what);
+
+    const deadline = Date.now() + timeoutMs;
+    let delayMs = 500;
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      delayMs = Math.min(delayMs * 2, 5000);
+
+      const polled = await this.getOperation(op.name);
+      // A permanent failure to read the operation will not resolve itself, so
+      // report it rather than spend the whole timeout rediscovering it. A 5xx
+      // or a throttle is worth another attempt.
+      if (polled.status === 403 || polled.status === 404) {
+        return `${what}: reading ${op.name}: ${polled.message || polled.status}`;
+      }
+      if (polled.status !== 200 || !polled.result) continue;
+      if (polled.result.done) return operationFailure(polled.result, what);
+    }
+    return `${what}: timed out after ${timeoutMs}ms waiting for ${op.name}`;
   }
 
   async createEntryLink(project: string, location: string, entryGroup: string,

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -76,6 +76,21 @@ export function generatePropertyGraph(
   const relationships = resolved.model.relationships ?? [];
   const metrics = resolved.model.metrics ?? [];
 
+  // Actions are write-side operations with no read-side graph construct (no
+  // NODE TABLE / EDGE TABLE / MEASURE), so the BigQuery leg emits nothing for
+  // them. Warn once so an author who declared actions is not surprised they are
+  // absent from the graph. Their only destination is Knowledge Catalog (see
+  // knowledge_catalog.actionsOverviewAspectData) -- but that leg runs only when
+  // the KC destination is in the push, so the message stays conditional (a
+  // bq-only push warns separately that actions go nowhere; see commands.ts).
+  const actions = resolved.model.actions ?? [];
+  if (actions.length) {
+    warnings.push(
+        `${actions.length} action(s) are not represented in the BigQuery ` +
+        `property graph (actions are write-side); they are published to ` +
+        `Knowledge Catalog when that destination is included in the push.`);
+  }
+
   // An abstract entity is conceptual: it has no physical table and produces no
   // NODE TABLE, surviving only as a LABEL on its concrete descendants (whose
   // node tables carry its flattened fields). Collect the abstract names so the

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -80,7 +80,7 @@ export function generatePropertyGraph(
   // NODE TABLE / EDGE TABLE / MEASURE), so the BigQuery leg emits nothing for
   // them. Warn once so an author who declared actions is not surprised they are
   // absent from the graph. Their only destination is Knowledge Catalog (see
-  // knowledge_catalog.actionsOverviewAspectData) -- but that leg runs only when
+  // kc_actions.ts) -- but that leg runs only when
   // the KC destination is in the push, so the message stays conditional (a
   // bq-only push warns separately that actions go nowhere; see commands.ts).
   const actions = resolved.model.actions ?? [];

--- a/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
@@ -689,12 +689,45 @@ async function writeEntry(
   if (isExists(res)) {
     // Idempotent re-push: refresh the existing entry's source + aspects.
     const upd = await cat.updateEntry(
-        entry, ['entry_source', 'aspects'], Object.keys(entry.aspects ?? {}));
+        entry, ['entry_source', 'aspects'], reconciledAspectKeys(entry, opts));
     if (!isOk(upd)) return {error: `entry '${entryId}': ${errText(upd)}`};
     return {updated: true};
   }
   if (!isOk(res)) return {error: `entry '${entryId}': ${errText(res)}`};
   return {};
+}
+
+// The built-in aspects the emitter attaches CONDITIONALLY. `guidelines` (only
+// when an object carries ai_context.instructions) can ride any entry, so it is
+// reconciled everywhere. `overview` (only when the model declares actions)
+// rides the model anchor alone, so it is reconciled only there -- naming it on
+// an entity/metric entry would be a harmless no-op, but scoping it keeps the
+// patch honest about where the aspect can live. Every other aspect the emitter
+// writes (semantic-*, schema) is unconditional, so it is always present on a
+// re-push and never needs explicit clearing.
+const OPTIONAL_ASPECT_TYPES = ['guidelines'] as const;
+const ANCHOR_ONLY_ASPECT_TYPES = ['overview'] as const;
+
+// The aspect keys to reconcile when updating an existing entry. A Dataplex
+// entries.patch clears an aspect only when its key is named in `aspectKeys` and
+// absent from the request body; a key that is present is upserted, and one the
+// server does not have is a no-op. Passing only the currently-attached keys
+// therefore leaves a *removed* optional aspect (e.g. the model dropped all its
+// actions, so `overview` is gone) stranded on the server, where a later `pull`
+// would resurrect it. Always naming the optional aspect keys -- present or not
+// -- makes a re-push converge: a still-present one is refreshed, a removed one
+// is deleted, and one that was never there stays absent. The anchor-only keys
+// are reconciled solely on the model anchor, where those aspects can appear.
+function reconciledAspectKeys(entry: Entry, opts: KcDeployOptions): string[] {
+  const proj = opts.systemTypeProject ?? 'dataplex-types';
+  const loc = opts.systemTypeLocation ?? 'global';
+  const keys = new Set(Object.keys(entry.aspects ?? {}));
+  const optional: string[] = [...OPTIONAL_ASPECT_TYPES];
+  if (entry.entryType?.endsWith('/semantic-model')) {
+    optional.push(...ANCHOR_ONLY_ASPECT_TYPES);
+  }
+  for (const type of optional) keys.add(`${proj}.${loc}.${type}`);
+  return [...keys];
 }
 
 // entries.create can briefly 404 on a just-created entry group; retry that

--- a/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
@@ -38,7 +38,6 @@ import {ApiResult} from '../gcp/api';
 import * as context from '../gcp/context';
 import {CatalogClient, Entry, EntryLink} from '../gcp/dataplex';
 
-import {ACTION_ANCHOR_ASPECT_TYPES} from './kc_actions';
 import {generateCatalogResources, KcResources} from './knowledge_catalog';
 import {LoadedModel} from './loader';
 
@@ -698,36 +697,27 @@ async function writeEntry(
   return {};
 }
 
-// The built-in aspects the emitter attaches CONDITIONALLY. `guidelines` (only
-// when an object carries ai_context.instructions) can ride any entry, so it is
-// reconciled everywhere. The aspects carrying the model's actions ride the model
-// anchor alone, so they are reconciled only there -- naming them on an
-// entity/metric entry would be a harmless no-op, but scoping them keeps the
-// patch honest about where the aspect can live. `kc_actions.ts` owns which
-// aspect types those are (ACTION_ANCHOR_ASPECT_TYPES). Every other aspect the
-// emitter writes (semantic-*, schema) is unconditional, so it is always present
-// on a re-push and never needs explicit clearing.
+// The aspects the emitter attaches CONDITIONALLY. `guidelines` (only when an
+// object carries ai_context.instructions) can ride any entry, so it is
+// reconciled everywhere. Every other aspect the emitter writes (semantic-*,
+// schema, semantic-action) is unconditional on the entry that carries it, so it
+// is always present on a re-push and never needs explicit clearing.
 const OPTIONAL_ASPECT_TYPES = ['guidelines'] as const;
 
 // The aspect keys to reconcile when updating an existing entry. A Dataplex
 // entries.patch clears an aspect only when its key is named in `aspectKeys` and
 // absent from the request body; a key that is present is upserted, and one the
 // server does not have is a no-op. Passing only the currently-attached keys
-// therefore leaves a *removed* optional aspect (e.g. the model dropped all its
-// actions, so `overview` is gone) stranded on the server, where a later `pull`
-// would resurrect it. Always naming the optional aspect keys -- present or not
-// -- makes a re-push converge: a still-present one is refreshed, a removed one
-// is deleted, and one that was never there stays absent. The anchor-only keys
-// are reconciled solely on the model anchor, where those aspects can appear.
+// therefore leaves a *removed* optional aspect (e.g. an entity whose
+// ai_context.instructions were deleted) stranded on the server, where a later
+// `pull` would resurrect it. Always naming the optional aspect keys -- present
+// or not -- makes a re-push converge: a still-present one is refreshed, a
+// removed one is deleted, and one that was never there stays absent.
 function reconciledAspectKeys(entry: Entry, opts: KcDeployOptions): string[] {
   const proj = opts.systemTypeProject ?? 'dataplex-types';
   const loc = opts.systemTypeLocation ?? 'global';
   const keys = new Set(Object.keys(entry.aspects ?? {}));
-  const optional: string[] = [...OPTIONAL_ASPECT_TYPES];
-  if (entry.entryType?.endsWith('/semantic-model')) {
-    optional.push(...ACTION_ANCHOR_ASPECT_TYPES);
-  }
-  for (const type of optional) keys.add(`${proj}.${loc}.${type}`);
+  for (const type of OPTIONAL_ASPECT_TYPES) keys.add(`${proj}.${loc}.${type}`);
   return [...keys];
 }
 

--- a/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
@@ -38,6 +38,7 @@ import {ApiResult} from '../gcp/api';
 import * as context from '../gcp/context';
 import {CatalogClient, Entry, EntryLink} from '../gcp/dataplex';
 
+import {ACTION_ANCHOR_ASPECT_TYPES} from './kc_actions';
 import {generateCatalogResources, KcResources} from './knowledge_catalog';
 import {LoadedModel} from './loader';
 
@@ -699,14 +700,14 @@ async function writeEntry(
 
 // The built-in aspects the emitter attaches CONDITIONALLY. `guidelines` (only
 // when an object carries ai_context.instructions) can ride any entry, so it is
-// reconciled everywhere. `overview` (only when the model declares actions)
-// rides the model anchor alone, so it is reconciled only there -- naming it on
-// an entity/metric entry would be a harmless no-op, but scoping it keeps the
-// patch honest about where the aspect can live. Every other aspect the emitter
-// writes (semantic-*, schema) is unconditional, so it is always present on a
-// re-push and never needs explicit clearing.
+// reconciled everywhere. The aspects carrying the model's actions ride the model
+// anchor alone, so they are reconciled only there -- naming them on an
+// entity/metric entry would be a harmless no-op, but scoping them keeps the
+// patch honest about where the aspect can live. `kc_actions.ts` owns which
+// aspect types those are (ACTION_ANCHOR_ASPECT_TYPES). Every other aspect the
+// emitter writes (semantic-*, schema) is unconditional, so it is always present
+// on a re-push and never needs explicit clearing.
 const OPTIONAL_ASPECT_TYPES = ['guidelines'] as const;
-const ANCHOR_ONLY_ASPECT_TYPES = ['overview'] as const;
 
 // The aspect keys to reconcile when updating an existing entry. A Dataplex
 // entries.patch clears an aspect only when its key is named in `aspectKeys` and
@@ -724,7 +725,7 @@ function reconciledAspectKeys(entry: Entry, opts: KcDeployOptions): string[] {
   const keys = new Set(Object.keys(entry.aspects ?? {}));
   const optional: string[] = [...OPTIONAL_ASPECT_TYPES];
   if (entry.entryType?.endsWith('/semantic-model')) {
-    optional.push(...ANCHOR_ONLY_ASPECT_TYPES);
+    optional.push(...ACTION_ANCHOR_ASPECT_TYPES);
   }
   for (const type of optional) keys.add(`${proj}.${loc}.${type}`);
   return [...keys];

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -58,6 +58,12 @@ export interface SemanticModel {
   entities: Entity[];        // the open format's `datasets`
   relationships: Relationship[];
   metrics: Metric[];
+  // Model-level write operations over the ontology -- the write-side counterpart
+  // to metrics (which are the read side). Like metrics they are defined over the
+  // concepts and their relationships, not bound to a single entity. Optional and
+  // absent on models authored before actions existed, so consumers read it as
+  // `actions ?? []`. See Action.
+  actions?: Action[];
   // Vendor extension blocks carried verbatim (round-trip fidelity), including the
   // model-level GOOGLE block. A typed deployment-target view is derived by the
   // consumer that acts on it (e.g. the CLI push), not surfaced on the IR yet.
@@ -284,4 +290,77 @@ export interface Metric {
   type?: DataType;       // logical datatype of the result (the open format's `datatype`)
   aiContext?: AiContext;
   customExtensions?: CustomExtension[];
+}
+
+/**
+ * An action: a model-level, named write operation over the ontology -- the
+ * write-side counterpart to a metric's read. Like a metric it lives on the
+ * model (not a single entity) and may span several entities via its typed
+ * `parameters`.
+ *
+ * The model contributes only what the ontology can say that a plain tool schema
+ * cannot -- typed parameters (an entity-typed one is an object reference). The
+ * mechanics of running it are delegated to an `executor` (e.g. an MCP tool in
+ * Agent Registry); `description` is informational and does not affect runtime.
+ */
+export interface Action {
+  name: string;
+  description?: string;
+  // How the action is executed. Exactly one executor kind (mcp / rest / grpc);
+  // the loader normalizes the open format's single-key executor object to this
+  // discriminated form.
+  executor: Executor;
+  // Inputs, each typed by the ontology: an entity type is an object reference,
+  // a scalar type an ordinary value. See ActionParameter.
+  parameters: ActionParameter[];
+  aiContext?: AiContext;
+  customExtensions?: CustomExtension[];
+}
+
+/**
+ * One input to an action, typed by the ontology.
+ *
+ * `type` is the authored type name, kept verbatim for a lossless round-trip.
+ * `isEntityRef` is DERIVED by the loader: true when `type` resolves to a known
+ * entity (the parameter is an object reference to that entity), false when it
+ * is a scalar `DataType`. A type that resolves to neither leaves `isEntityRef`
+ * undefined and the loader warns.
+ */
+export interface ActionParameter {
+  name: string;
+  type: string;           // entity name (object reference) or a scalar DataType
+  isEntityRef?: boolean;  // derived: true when `type` names a known entity
+}
+
+/**
+ * The mechanics of how an action is executed: exactly one kind, tagged so
+ * consumers can switch on it. The open format expresses it as an object with a
+ * single kind key (`mcp` / `rest` / `grpc`); the loader normalizes that to this
+ * discriminated union. Other kinds (SQL DML, CLI, ...) can be added later.
+ */
+export type Executor =
+  | { kind: 'mcp'; mcp: McpExecutor }
+  | { kind: 'rest'; rest: RestExecutor }
+  | { kind: 'grpc'; grpc: GrpcExecutor };
+
+/**
+ * An MCP executor: references a tool already registered in Agent Registry, by
+ * the MCP server's resource name plus the tool's in-server selector. Agent
+ * Registry is the canonical source consumed at runtime (e.g. by an agent).
+ */
+export interface McpExecutor {
+  server: string;   // e.g. //agentregistry.googleapis.com/.../mcpServers/commerce
+  tool: string;     // the tool's name within that server
+}
+
+/** A REST executor: an HTTP endpoint and method. */
+export interface RestExecutor {
+  endpoint: string;
+  method: string;
+}
+
+/** A gRPC executor: a fully-qualified service and method. */
+export interface GrpcExecutor {
+  service: string;
+  method: string;
 }

--- a/toolbox/mdcode/src/libts/semantic/kc_actions.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_actions.ts
@@ -2,239 +2,455 @@
 //
 // This file holds the whole encoding, and it exists to be replaced.
 //
-// Every other construct in the model maps to a built-in system type under
+// Every other construct in the model maps to a BUILT-IN system type under
 // `projects/dataplex-types/locations/global`. A model, entity, or metric gets
 // its own entry (`semantic-model` / `semantic-entity` / `semantic-metric`); a
 // relationship becomes a `schema-join` entry link; the built-in `schema` and
-// `guidelines` aspects carry the rest. Actions have no such type. Until one
-// exists they ride the model anchor's built-in `overview` aspect, whose
-// `content` is free-form Markdown: a section for a person reading the catalog,
-// then a fenced JSON block after ACTIONS_OVERVIEW_MARKER. The JSON block is the
-// canonical copy and is what a pull parses; the Markdown above it is rendered
-// from the same actions and is never read back.
+// `guidelines` aspects carry the rest. There is no built-in type for an action.
+// Until there is, this file defines a CUSTOM pair, an entry type and an aspect
+// type both named `semantic-action`, provisioned in the destination project at
+// `global` by `kcmd init --semantic-model`. An action is then published exactly
+// the way a metric is: one entry per action, parented to the model anchor,
+// carrying one aspect that holds the executor and the typed parameters.
 //
-// Nothing outside this file knows that encoding. There are four call sites:
-// `knowledge_catalog.ts` asks for the aspects to attach to the anchor,
-// `kc_converter.ts` asks for the actions to recover from it, and
-// `deploy_knowledge_catalog.ts` and `pull_kc.ts` name the aspect types through
-// ACTION_ANCHOR_ASPECT_TYPES rather than the literal 'overview'.
+// The custom pair is what makes an action explicit in the catalog. A search can
+// tell an action apart from anything else by its entry type, and the aspect's
+// fields are typed and queryable rather than prose a reader has to interpret.
 //
-// WHEN A BUILT-IN ACTION TYPE SHIPS. If actions become an aspect on the anchor,
-// point actionAnchorAspects and readActions at it and rename the member of
-// ACTION_ANCHOR_ASPECT_TYPES; the four call sites do not change. If instead
-// each action becomes its own entry, the way a metric is one, this file is
-// deleted: the emitting and reading move beside the metric code in
-// `knowledge_catalog.ts` and `kc_converter.ts`, and generateCatalogResources
-// gains a `<model>.actions.` owned prefix so a removed action is reconciled
-// away like a removed metric.
+// WHEN A BUILT-IN ACTION TYPE SHIPS. Change actionTypeHome to return the
+// system-type home the caller already passes for every other construct, then
+// delete ACTION_ASPECT_TYPE_SPEC, actionEntryTypeSpec, and the
+// provisionActionTypes call in `kcmd init`. Nothing else moves: the entry
+// shape, the entry ids, the owned prefix, the reader, and all four call sites
+// stay as they are.
 //
-// The helpers at the bottom duplicate a few lines from those two modules on
-// purpose. This module imports only the IR and the catalog resource types, so
-// it can be swapped or deleted as a unit.
+// The call sites are `knowledge_catalog.ts` (emit the entries),
+// `kc_converter.ts` (read them back), `pull_kc.ts` (hydrate the aspect), and
+// `src/tool/commands.ts` (provision the two types at init).
+//
+// `instructions` rides the action's own aspect rather than the built-in
+// `guidelines` aspect that an entity or metric uses. A pull derives which
+// aspect types to hydrate from the project the ENTRY type lives in, so an
+// action entry, whose type is custom and therefore in the destination project,
+// would ask for a `guidelines` aspect type that only exists under
+// `dataplex-types`. Keeping the field on the action's own aspect keeps the
+// whole encoding inside the one type this file provisions.
+//
+// The helpers at the bottom duplicate a few lines from the modules above on
+// purpose. This module imports only the IR and the catalog client, so it can be
+// swapped or deleted as a unit.
 
-import type {Aspect, Entry} from '../gcp/dataplex';
+import {AspectType, CatalogClient, Entry, EntryType} from '../gcp/dataplex';
 
-import {Action, ActionParameter, AiContext, CustomExtension, DATA_TYPES, Executor, SemanticModel} from './ir';
+import {Action, ActionParameter, AiContext, DATA_TYPES, Executor, SemanticModel} from './ir';
 
-// Fences the machine-readable action JSON inside the overview Markdown. Write
-// and read locate the block by this marker, so they agree on one delimiter.
-export const ACTIONS_OVERVIEW_MARKER = '<!-- kcmd:actions v1 -->';
+// The bare id shared by the custom entry type and the custom aspect type. They
+// are separate collections, so one name serves both, the way the built-in
+// `semantic-metric` entry type and aspect type share theirs.
+export const ACTION_TYPE_ID = 'semantic-action';
 
-// The bare aspect type ids this encoding attaches to the model anchor, and
-// attaches CONDITIONALLY (a model with no actions carries none of them). The
-// publisher names them when reconciling an updated anchor so a removed action
-// clears the aspect, and a pull requests them so the actions come back.
-export const ACTION_ANCHOR_ASPECT_TYPES = ['overview'] as const;
+// Custom types are provisioned at `global` so an entry group in any region can
+// reference them, matching where the built-in system types live.
+const ACTION_TYPE_LOCATION = 'global';
+
+// Where a destination's action types live. Today that is the destination
+// project itself, because the types are custom and `kcmd init` creates them
+// there. See the file header for what changes when a built-in type ships.
+export function actionTypeHome(dest: {project: string}):
+    {project: string; location: string} {
+  return {project: dest.project, location: ACTION_TYPE_LOCATION};
+}
+
+
+// ---------------------------------------------------------------------------
+// The custom types themselves.
+// ---------------------------------------------------------------------------
+
+// The aspect that carries an action's mechanics.
+//
+// The executor is FLATTENED rather than nested one record per kind: an aspect
+// holds exactly one executor, and a flat record shows the reader which one at a
+// glance instead of three sibling records of which two are empty. `parameters`
+// mirrors ActionParameter, including the derived `isEntityRef` so a consumer
+// that has not loaded the model can still tell an object reference from a
+// scalar.
+//
+// Dataplex rejects a backwards-incompatible template change. A new field must
+// be APPENDED with a fresh index; renumbering an existing one breaks the update
+// for every project that already provisioned this type.
+export const ACTION_ASPECT_TYPE_SPEC: Omit<AspectType, 'name'> = {
+  displayName: 'Semantic Action',
+  description:
+      'A write operation defined on a semantic model: how it is executed, ' +
+      'and the inputs it takes.',
+  metadataTemplate: {
+    name: ACTION_TYPE_ID,
+    type: 'record',
+    recordFields: [
+      {
+        index: 1,
+        name: 'executorKind',
+        type: 'string',
+        constraints: {required: true},
+        annotations: {
+          displayName: 'Executor Kind',
+          description:
+              'How the action is executed: `mcp`, `rest`, or `grpc`. The ' +
+              'fields for that kind, and only those, are set.',
+        },
+      },
+      {
+        index: 2,
+        name: 'mcpServer',
+        type: 'string',
+        annotations: {
+          displayName: 'MCP Server',
+          description: 'Resource name of the MCP server hosting the tool.',
+        },
+      },
+      {
+        index: 3,
+        name: 'mcpTool',
+        type: 'string',
+        annotations: {
+          displayName: 'MCP Tool',
+          description: 'Name of the tool to call on the MCP server.',
+        },
+      },
+      {
+        index: 4,
+        name: 'restEndpoint',
+        type: 'string',
+        annotations: {
+          displayName: 'REST Endpoint',
+          description: 'URL the request is sent to.',
+        },
+      },
+      {
+        index: 5,
+        name: 'restMethod',
+        type: 'string',
+        annotations: {
+          displayName: 'REST Method',
+          description: 'HTTP method, for example POST.',
+        },
+      },
+      {
+        index: 6,
+        name: 'grpcService',
+        type: 'string',
+        annotations: {
+          displayName: 'gRPC Service',
+          description: 'Fully qualified name of the gRPC service.',
+        },
+      },
+      {
+        index: 7,
+        name: 'grpcMethod',
+        type: 'string',
+        annotations: {
+          displayName: 'gRPC Method',
+          description: 'Method on the gRPC service.',
+        },
+      },
+      {
+        index: 8,
+        name: 'parameters',
+        type: 'array',
+        arrayItems: {
+          name: 'parameter',
+          type: 'record',
+          recordFields: [
+            {
+              index: 1,
+              name: 'name',
+              type: 'string',
+              constraints: {required: true},
+              annotations: {displayName: 'Name'},
+            },
+            {
+              index: 2,
+              name: 'type',
+              type: 'string',
+              constraints: {required: true},
+              annotations: {
+                displayName: 'Type',
+                description:
+                    'The authored type: an entity name, or a scalar datatype.',
+              },
+            },
+            {
+              index: 3,
+              name: 'isEntityRef',
+              type: 'bool',
+              annotations: {
+                displayName: 'Is Entity Reference',
+                description:
+                    'True when `type` names an entity, so the parameter ' +
+                    'refers to an object rather than carrying a value.',
+              },
+            },
+          ],
+        },
+        annotations: {
+          displayName: 'Parameters',
+          description:
+              'The inputs the action takes, each typed by the ontology.',
+        },
+      },
+      {
+        index: 9,
+        name: 'instructions',
+        type: 'string',
+        annotations: {
+          displayName: 'Instructions',
+          description:
+              'Guidance for AI consumers (the action\'s ai_context ' +
+              'instructions).',
+        },
+      },
+    ],
+  },
+};
+
+// The entry type an action's entry carries. It requires the aspect above, so an
+// action entry cannot exist without its mechanics.
+export function actionEntryTypeSpec(dest: {project: string}):
+    Omit<EntryType, 'name'> {
+  return {
+    displayName: 'Semantic Action',
+    description: 'A write operation defined on a semantic model.',
+    requiredAspects: [{type: actionAspectTypeName(dest)}],
+  };
+}
+
+// Full resource name of the action entry type for a destination.
+export function actionEntryTypeName(dest: {project: string}): string {
+  const home = actionTypeHome(dest);
+  return `projects/${home.project}/locations/${home.location}/entryTypes/${
+      ACTION_TYPE_ID}`;
+}
+
+// Full resource name of the action aspect type for a destination.
+export function actionAspectTypeName(dest: {project: string}): string {
+  const home = actionTypeHome(dest);
+  return `projects/${home.project}/locations/${home.location}/aspectTypes/${
+      ACTION_TYPE_ID}`;
+}
+
+// Aspect-map key: the `project.location.type` reference form the client keys an
+// entry's aspects by (see dataplex._nameToTypeRef).
+export function actionAspectKey(dest: {project: string}): string {
+  const home = actionTypeHome(dest);
+  return `${home.project}.${home.location}.${ACTION_TYPE_ID}`;
+}
 
 /**
- * The aspects carrying the model's actions, keyed by bare aspect type id, to
- * merge into the model anchor's aspect map.
+ * Creates the two custom action types in a destination, returning an error
+ * message or undefined on success.
  *
- * Empty when the model declares no actions, so an anchor without actions is
+ * Called from `kcmd init --semantic-model`, beside the entry group it already
+ * provisions, so a push still writes nothing but entries. Each type is created
+ * and then, if it is already there, patched: a project provisioned by an
+ * earlier version of kcmd holds an older template, and pushing a field that
+ * template lacks fails with an opaque parsing error. Dataplex rejects a
+ * backwards-incompatible change, so the patch only ever adds appended fields.
+ */
+export async function provisionActionTypes(
+    cat: CatalogClient, dest: {project: string}): Promise<string|undefined> {
+  const home = actionTypeHome(dest);
+
+  const aspect = await cat.createAspectType(
+      home.project, home.location, ACTION_TYPE_ID, ACTION_ASPECT_TYPE_SPEC);
+  if (aspect.status === 409) {
+    const upd = await cat.updateAspectType(
+        home.project, home.location, ACTION_TYPE_ID, ACTION_ASPECT_TYPE_SPEC,
+        ['description', 'display_name', 'metadata_template']);
+    if (upd.status !== 200)
+      return `updating aspect type '${ACTION_TYPE_ID}': ${
+          upd.message || upd.status}`;
+  } else if (aspect.status !== 200) {
+    return `creating aspect type '${ACTION_TYPE_ID}': ${
+        aspect.message || aspect.status}`;
+  }
+
+  // The entry type requires the aspect type above, so it is created second. An
+  // existing one is left alone rather than patched: unlike the aspect type it
+  // carries no template that grows over time, and its required-aspect list is
+  // what an entry already published depends on.
+  const entryType = await cat.createEntryType(
+      home.project, home.location, ACTION_TYPE_ID, actionEntryTypeSpec(dest));
+  if (entryType.status !== 200 && entryType.status !== 409) {
+    return `creating entry type '${ACTION_TYPE_ID}': ${
+        entryType.message || entryType.status}`;
+  }
+
+  return undefined;
+}
+
+
+// ---------------------------------------------------------------------------
+// Write side: the IR -> one entry per action.
+// ---------------------------------------------------------------------------
+
+// What the emitter supplies so this file need not rebuild entry names or repeat
+// the id-collision bookkeeping it already does for entities and metrics.
+export interface ActionEmitContext {
+  // The destination project, which is where the custom types live.
+  project: string;
+  // Full entry resource name for an entry id (Namer.entry).
+  entry(entryId: string): string;
+  // Full entry resource name of the model anchor, the parent of every action.
+  anchor: string;
+  // Reserves an entry id, returning false when it collides with one already
+  // emitted (knowledge_catalog.claim).
+  claim(entryId: string, label: string): boolean;
+}
+
+// The entry id of one action: `<model>.actions.<name>`, alongside
+// `<model>.entities.<name>` and `<model>.metrics.<name>`.
+export function actionEntryId(modelId: string, actionName: string): string {
+  return `${modelId}.actions.${slug(actionName)}`;
+}
+
+// The entry-id prefix a model's actions occupy, so delete reconciliation
+// removes the entry of an action dropped from the model.
+export function actionOwnedPrefix(modelId: string): string {
+  return `${modelId}.actions.`;
+}
+
+/**
+ * One entry per action, to append to the model's entries.
+ *
+ * Empty when the model declares no actions, so a model without actions is
  * unchanged from before actions existed. Warns once when it is non-empty:
  * actions reach Knowledge Catalog and nowhere else, which is worth saying out
  * loud on a push that also deploys a graph.
  */
-export function actionAnchorAspects(
-    model: SemanticModel,
-    warnings: string[]): Record<string, Record<string, any>> {
+export function actionEntries(
+    model: SemanticModel, modelId: string, ctx: ActionEmitContext,
+    warnings: string[]): Entry[] {
   const actions = model.actions ?? [];
-  if (!actions.length) return {};
+  if (!actions.length) return [];
   warnings.push(
-      `model '${model.name}': ${actions.length} action(s) published to the ` +
-      `model's overview aspect (actions have no BigQuery Graph representation).`);
-  return {
-    overview: {
-      content: renderActionsOverview(actions),
-      contentType: 'MARKDOWN',
-    },
-  };
+      `model '${model.name}': ${actions.length} action(s) published as ` +
+      `${ACTION_TYPE_ID} entries (actions have no BigQuery Graph ` +
+      `representation).`);
+
+  const entries: Entry[] = [];
+  for (const action of actions) {
+    const id = actionEntryId(modelId, action.name);
+    if (!ctx.claim(id, `action '${action.name}'`)) continue;
+    entries.push({
+      name: ctx.entry(id),
+      entryType: actionEntryTypeName(ctx),
+      parentEntry: ctx.anchor,
+      entrySource: compact({
+                     displayName: action.name,
+                     description: action.description,
+                   }) as Entry['entrySource'],
+      aspects: {
+        [actionAspectKey(ctx)]: {
+          aspectType: actionAspectTypeName(ctx),
+          data: actionAspectData(action),
+        },
+      },
+    });
+  }
+  return entries;
 }
 
-/**
- * Recovers the model's actions from the anchor, the inverse of
- * actionAnchorAspects.
- *
- * `isEntityRef` is re-derived against `entityNames` (as the loader does)
- * rather than trusted from the stored JSON, so it stays consistent with the
- * model actually pulled. Returns an empty list when the anchor carries no
- * actions, and warns rather than throwing when it carries a malformed block:
- * one bad action degrades itself, not the pull.
- */
-export function readActions(
-    anchor: Entry, entityNames: string[], warnings: string[]): Action[] {
-  const content = overviewContent(anchor);
-  if (content === undefined || !content.includes(ACTIONS_OVERVIEW_MARKER))
-    return [];
-  const json = jsonBlockAfterMarker(content, ACTIONS_OVERVIEW_MARKER);
-  if (json === undefined) {
-    warnings.push(
-        `model actions: overview aspect has the actions marker but no parseable ` +
-        `JSON block; actions are not recovered`);
-    return [];
-  }
-  let parsed: any;
-  try {
-    parsed = JSON.parse(json);
-  } catch (err: any) {
-    warnings.push(`model actions: overview action block is not valid JSON (${
-        err.message || err}); actions are not recovered`);
-    return [];
-  }
-  if (!Array.isArray(parsed)) {
-    warnings.push(
-        `model actions: overview action block is not a JSON array; actions are ` +
-        `not recovered`);
-    return [];
-  }
-  const entitySet = new Set(entityNames);
-  return parsed.map((a: any) => readAction(a, entitySet, warnings))
-      .filter((a): a is Action => a !== undefined);
-}
-
-
-// ---------------------------------------------------------------------------
-// Write side: the IR -> the overview aspect's content.
-// ---------------------------------------------------------------------------
-
-// Renders the actions overview: a Markdown section for humans, then the marker
-// and a fenced JSON array (the canonical IR form) for a lossless pull.
-function renderActionsOverview(actions: Action[]): string {
-  const md: string[] = [
-    '## Actions',
-    '',
-    'Write operations defined on this model -- the write-side counterpart to ' +
-        'metrics. Actions have no BigQuery Graph representation; they are ' +
-        'published here for discovery and are round-tripped by `kcmd pull`.',
-    '',
-  ];
-  for (const a of actions) {
-    md.push(`### ${a.name}`, '');
-    if (a.description) md.push(a.description, '');
-    md.push(`- Executor: ${describeExecutor(a.executor)}`);
-    if (a.parameters.length) {
-      md.push('- Parameters:');
-      for (const p of a.parameters) {
-        const kind = p.isEntityRef ? `${p.type} (entity reference)` : p.type;
-        md.push(`  - \`${p.name}\`: ${kind}`);
-      }
-    }
-    md.push('');
-  }
-  md.push(
-      ACTIONS_OVERVIEW_MARKER, '```json',
-      JSON.stringify(actions.map(actionJson), null, 2), '```', '');
-  return md.join('\n');
-}
-
-// A one-line human description of an executor for the Markdown body.
-function describeExecutor(ex: Executor): string {
-  switch (ex.kind) {
-    case 'mcp':
-      return `MCP tool \`${ex.mcp.tool}\` on server \`${ex.mcp.server}\``;
-    case 'rest':
-      return `REST ${ex.rest.method} \`${ex.rest.endpoint}\``;
-    case 'grpc':
-      return `gRPC \`${ex.grpc.service}/${ex.grpc.method}\``;
-  }
-}
-
-// The canonical JSON form of an action embedded in the overview, mirroring the
-// IR so readAction reconstructs it verbatim. The executor's tagged union is
-// flattened to the open format's single-key object, matching how osi_converter
-// emits it to YAML.
-function actionJson(a: Action): Record<string, any> {
+// The aspect payload for one action: the executor flattened to the fields of
+// its kind, the typed parameters, and any AI instructions.
+function actionAspectData(action: Action): Record<string, any> {
   return compact({
-    name: a.name,
-    description: a.description,
-    executor: executorJson(a.executor),
-    parameters: a.parameters.map(
+    ...executorData(action.executor),
+    parameters: action.parameters.map(
         p => compact({name: p.name, type: p.type, isEntityRef: p.isEntityRef})),
-    aiContext: a.aiContext,
-    customExtensions: a.customExtensions,
+    instructions: action.aiContext?.instructions || undefined,
   });
 }
 
-function executorJson(ex: Executor): Record<string, any> {
+// The executor's kind plus the two coordinates that kind uses. Only the fields
+// of the live kind are set, so the aspect never shows blanks for the others.
+function executorData(ex: Executor): Record<string, any> {
   switch (ex.kind) {
     case 'mcp':
-      return {mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+      return {
+        executorKind: 'mcp',
+        mcpServer: ex.mcp.server,
+        mcpTool: ex.mcp.tool,
+      };
     case 'rest':
-      return {rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}};
+      return {
+        executorKind: 'rest',
+        restEndpoint: ex.rest.endpoint,
+        restMethod: ex.rest.method,
+      };
     case 'grpc':
-      return {grpc: {service: ex.grpc.service, method: ex.grpc.method}};
+      return {
+        executorKind: 'grpc',
+        grpcService: ex.grpc.service,
+        grpcMethod: ex.grpc.method,
+      };
   }
 }
 
 
 // ---------------------------------------------------------------------------
-// Read side: the overview aspect's content -> the IR.
+// Read side: an action entry -> the IR.
 // ---------------------------------------------------------------------------
 
-// Extracts the first ```json ... ``` fenced block that follows `marker` in the
-// content, returning the block's inner text (or undefined when none follows).
-function jsonBlockAfterMarker(content: string, marker: string): string|
-    undefined {
-  const afterMarker =
-      content.slice(content.lastIndexOf(marker) + marker.length);
-  const fence = afterMarker.match(/```json\s*\n([\s\S]*?)\n```/);
-  return fence ? fence[1] : undefined;
+// True when an entry is one of a model's actions, matched by the entry type's
+// id suffix so the project the type lives in need not be known -- which is what
+// lets a pull keep working when the custom type is replaced by a built-in one.
+export function isActionEntry(entry: Entry): boolean {
+  return entry.entryType?.endsWith(`/entryTypes/${ACTION_TYPE_ID}`) ?? false;
 }
 
-// Rebuilds one Action from its embedded JSON (the inverse of actionJson). A
-// record missing a usable name or executor is skipped with a warning, so a
-// malformed block degrades one action rather than the whole pull.
-function readAction(
-    a: any, entityNames: Set<string>, warnings: string[]): Action|undefined {
-  const name = typeof a?.name === 'string' ? a.name : '';
-  if (!name) {
-    warnings.push(
-        'model actions: an action in the overview has no name; skipped');
-    return undefined;
-  }
-  const executor = readExecutor(a?.executor);
+// The aspect type resource names to hydrate for an action entry. Named through
+// the entry type's own project so the pull follows the type wherever it lives.
+export function actionAspectTypes(entryTypeBase: string): string[] {
+  return [`${entryTypeBase}/aspectTypes/${ACTION_TYPE_ID}`];
+}
+
+/**
+ * Recovers one action from its entry, the inverse of actionEntries.
+ *
+ * `isEntityRef` is re-derived against `entityNames` (as the loader does) rather
+ * than trusted from the stored aspect, so it stays consistent with the model
+ * actually pulled. Returns undefined, with a warning, for an entry whose
+ * executor is missing or malformed: one bad entry degrades itself rather than
+ * the pull.
+ */
+export function readAction(
+    entry: Entry, entityNames: string[], warnings: string[]): Action|undefined {
+  const name = entry.entrySource?.displayName || idOf(entry.name);
+  const data = actionAspectDataOf(entry);
+  const executor = readExecutor(data);
   if (!executor) {
     warnings.push(
-        `action '${name}': overview executor is missing or malformed; the ` +
-        `action is skipped`);
+        `action '${name}': the ${ACTION_TYPE_ID} aspect has no usable ` +
+        `executor; the action is skipped`);
     return undefined;
   }
+  const entitySet = new Set(entityNames);
   const parameters =
-      asArray(a?.parameters)
-          .map((p: any) => readParameter(p, entityNames, name, warnings))
+      asArray(data.parameters)
+          .map((p: any) => readParameter(p, entitySet, name, warnings))
           .filter((p): p is ActionParameter => p !== undefined);
+
   const action: Action = {name, executor, parameters};
-  if (typeof a?.description === 'string' && a.description !== '')
-    action.description = a.description;
-  if (a?.aiContext && typeof a.aiContext === 'object')
-    action.aiContext = a.aiContext as AiContext;
-  if (Array.isArray(a?.customExtensions))
-    action.customExtensions = a.customExtensions as CustomExtension[];
+  const description = entry.entrySource?.description;
+  if (description !== undefined && description !== '')
+    action.description = description;
+  if (typeof data.instructions === 'string' && data.instructions !== '')
+    action.aiContext = {instructions: data.instructions} as AiContext;
   return action;
 }
 
-// One action parameter from its JSON, re-deriving isEntityRef against the
-// model's entities (a scalar datatype otherwise). A record missing a name is
+// One action parameter from its aspect record, re-deriving isEntityRef against
+// the model's entities (a scalar datatype otherwise). A record missing a name is
 // dropped.
 function readParameter(
     p: any, entityNames: Set<string>, actionName: string,
@@ -260,28 +476,37 @@ function readParameter(
   return param;
 }
 
-// The IR executor from the embedded single-key JSON object
-// ({mcp}/{rest}/{grpc}, the inverse of executorJson). Returns undefined when no
-// known kind is present or a coordinate is not a string.
-function readExecutor(ex: any): Executor|undefined {
-  // A coordinate must be a present, NON-BLANK string. The overview JSON can
-  // carry an empty string (e.g. a hand-edited block); treat that as malformed
-  // so the reader rejects it exactly as push-side validate would, rather than
-  // recovering an action the next push cannot deploy.
+// The IR executor from the aspect's flat fields, the inverse of executorData.
+// Returns undefined when the kind is unknown or either of its coordinates is
+// missing.
+function readExecutor(data: Record<string, any>): Executor|undefined {
+  // A coordinate must be a present, NON-BLANK string. An aspect edited by hand
+  // can carry an empty one; treat that as malformed so the reader rejects it
+  // exactly as push-side validate would, rather than recovering an action the
+  // next push cannot deploy.
   const str = (v: any): v is string => typeof v === 'string' && v.trim() !== '';
-  if (ex?.mcp && str(ex.mcp.server) && str(ex.mcp.tool))
-    return {kind: 'mcp', mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
-  if (ex?.rest && str(ex.rest.endpoint) && str(ex.rest.method))
-    return {
-      kind: 'rest',
-      rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}
-    };
-  if (ex?.grpc && str(ex.grpc.service) && str(ex.grpc.method))
-    return {
-      kind: 'grpc',
-      grpc: {service: ex.grpc.service, method: ex.grpc.method}
-    };
-  return undefined;
+  switch (data.executorKind) {
+    case 'mcp':
+      if (str(data.mcpServer) && str(data.mcpTool))
+        return {kind: 'mcp', mcp: {server: data.mcpServer, tool: data.mcpTool}};
+      return undefined;
+    case 'rest':
+      if (str(data.restEndpoint) && str(data.restMethod))
+        return {
+          kind: 'rest',
+          rest: {endpoint: data.restEndpoint, method: data.restMethod}
+        };
+      return undefined;
+    case 'grpc':
+      if (str(data.grpcService) && str(data.grpcMethod))
+        return {
+          kind: 'grpc',
+          grpc: {service: data.grpcService, method: data.grpcMethod}
+        };
+      return undefined;
+    default:
+      return undefined;
+  }
 }
 
 
@@ -289,25 +514,30 @@ function readExecutor(ex: any): Executor|undefined {
 // Local helpers (see the file header on why they are not shared).
 // ---------------------------------------------------------------------------
 
-// The overview aspect's `content` string from the anchor's aspect map, matched
-// by the aspect key's `.overview` suffix or the aspectType's
-// `/aspectTypes/overview` suffix, so it is found whichever system-type
-// project/location the emitter used. Undefined when the aspect is absent or
-// carries no string content.
-function overviewContent(anchor: Entry): string|undefined {
-  for (const type of ACTION_ANCHOR_ASPECT_TYPES) {
-    for (const [key, aspect] of Object.entries<Aspect>(anchor.aspects ?? {})) {
-      if (!key.endsWith(`.${type}`) &&
-          !aspect.aspectType?.endsWith(`/aspectTypes/${type}`))
-        continue;
-      const content = aspect.data?.content;
-      if (typeof content === 'string') return content;
+// The action aspect's `data` from an entry, matched by the aspect key's
+// `.semantic-action` suffix or the aspectType's `/aspectTypes/semantic-action`
+// suffix, so it is found whichever project the type was provisioned in.
+function actionAspectDataOf(entry: Entry): Record<string, any> {
+  for (const [key, aspect] of Object.entries(entry.aspects ?? {})) {
+    if (key.endsWith(`.${ACTION_TYPE_ID}`) ||
+        aspect.aspectType?.endsWith(`/aspectTypes/${ACTION_TYPE_ID}`)) {
+      return aspect.data ?? {};
     }
   }
-  return undefined;
+  return {};
 }
 
-// Drops undefined-valued keys so the emitted JSON (and its golden) only shows
+// Entry ids allow letters, numbers, underscores, hyphens, and periods.
+function slug(s: string): string {
+  return s.replace(/[^A-Za-z0-9_.-]/g, '_');
+}
+
+// The id segment of a full entry resource name.
+function idOf(name: string): string {
+  return name.split('/').pop() ?? name;
+}
+
+// Drops undefined-valued keys so the emitted aspect (and its golden) only shows
 // fields the model actually set.
 function compact<T extends Record<string, any>>(obj: T): T {
   const out: Record<string, any> = {};

--- a/toolbox/mdcode/src/libts/semantic/kc_actions.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_actions.ts
@@ -1,32 +1,23 @@
-// How a model's ACTIONS are persisted in Knowledge Catalog.
+// How a model's ACTIONS are encoded in Knowledge Catalog.
 //
-// This file holds the whole encoding, and it exists to be replaced.
-//
-// Every other construct in the model maps to a BUILT-IN system type under
-// `projects/dataplex-types/locations/global`. A model, entity, or metric gets
-// its own entry (`semantic-model` / `semantic-entity` / `semantic-metric`); a
-// relationship becomes a `schema-join` entry link; the built-in `schema` and
-// `guidelines` aspects carry the rest. There is no built-in type for an action.
-// Until there is, this file defines a CUSTOM pair, an entry type and an aspect
-// type both named `semantic-action`, provisioned in the destination project at
-// `global` by `kcmd init --semantic-model`. An action is then published exactly
-// the way a metric is: one entry per action, parented to the model anchor,
-// carrying one aspect that holds the executor and the typed parameters.
+// An action is published exactly the way a metric is: one entry per action,
+// parented to the model anchor, carrying one aspect that holds the executor and
+// the typed parameters. What differs is the type. Every other construct has a
+// built-in system type, and an action does not, so it uses the custom
+// `semantic-action` pair DECLARED IN kc_custom_types.ts and created there by
+// `kcmd init --semantic-model`. That file is the list of what is custom; this
+// one is only the encoding that fills the aspect.
 //
 // The custom pair is what makes an action explicit in the catalog. A search can
 // tell an action apart from anything else by its entry type, and the aspect's
 // fields are typed and queryable rather than prose a reader has to interpret.
 //
-// WHEN A BUILT-IN ACTION TYPE SHIPS. Change actionTypeHome to return the
-// system-type home the caller already passes for every other construct, then
-// delete ACTION_ASPECT_TYPE_SPEC, actionEntryTypeSpec, and the
-// provisionActionTypes call in `kcmd init`. Nothing else moves: the entry
-// shape, the entry ids, the owned prefix, the reader, and all four call sites
-// stay as they are.
+// WHEN A BUILT-IN ACTION TYPE SHIPS, follow the instructions at the top of
+// kc_custom_types.ts. Nothing in this file changes: the readers below match a
+// type by its id suffix, so they do not care which project it lives in.
 //
 // The call sites are `knowledge_catalog.ts` (emit the entries),
-// `kc_converter.ts` (read them back), `pull_kc.ts` (hydrate the aspect), and
-// `src/tool/commands.ts` (provision the two types at init).
+// `kc_converter.ts` (read them back), and `pull_kc.ts` (hydrate the aspect).
 //
 // `instructions` rides the action's own aspect rather than the built-in
 // `guidelines` aspect that an entity or metric uses. A pull derives which
@@ -34,301 +25,31 @@
 // action entry, whose type is custom and therefore in the destination project,
 // would ask for a `guidelines` aspect type that only exists under
 // `dataplex-types`. Keeping the field on the action's own aspect keeps the
-// whole encoding inside the one type this file provisions.
+// whole encoding inside the one type kc_custom_types.ts provisions.
 //
 // The helpers at the bottom duplicate a few lines from the modules above on
-// purpose. This module imports only the IR and the catalog client, so it can be
-// swapped or deleted as a unit.
+// purpose. This module imports only the IR, the entry shape and the type
+// registry, so it can be swapped or deleted as a unit.
 
-import {AspectType, CatalogClient, Entry, EntryType} from '../gcp/dataplex';
+import {Entry} from '../gcp/dataplex';
 
 import {Action, ActionParameter, AiContext, DATA_TYPES, Executor, SemanticModel} from './ir';
-
-// The bare id shared by the custom entry type and the custom aspect type. They
-// are separate collections, so one name serves both, the way the built-in
-// `semantic-metric` entry type and aspect type share theirs.
-export const ACTION_TYPE_ID = 'semantic-action';
-
-// Custom types are provisioned at `global` so an entry group in any region can
-// reference them, matching where the built-in system types live.
-const ACTION_TYPE_LOCATION = 'global';
-
-// Where a destination's action types live. Today that is the destination
-// project itself, because the types are custom and `kcmd init` creates them
-// there. See the file header for what changes when a built-in type ships.
-export function actionTypeHome(dest: {project: string}):
-    {project: string; location: string} {
-  return {project: dest.project, location: ACTION_TYPE_LOCATION};
-}
-
-
-// ---------------------------------------------------------------------------
-// The custom types themselves.
-// ---------------------------------------------------------------------------
-
-// The aspect that carries an action's mechanics.
-//
-// The executor is FLATTENED rather than nested one record per kind: an aspect
-// holds exactly one executor, and a flat record shows the reader which one at a
-// glance instead of three sibling records of which two are empty. `parameters`
-// mirrors ActionParameter, including the derived `isEntityRef` so a consumer
-// that has not loaded the model can still tell an object reference from a
-// scalar.
-//
-// Dataplex rejects a backwards-incompatible template change. A new field must
-// be APPENDED with a fresh index; renumbering an existing one breaks the update
-// for every project that already provisioned this type.
-export const ACTION_ASPECT_TYPE_SPEC: Omit<AspectType, 'name'> = {
-  displayName: 'Semantic Action',
-  description:
-      'A write operation defined on a semantic model: how it is executed, ' +
-      'and the inputs it takes.',
-  metadataTemplate: {
-    name: ACTION_TYPE_ID,
-    type: 'record',
-    recordFields: [
-      {
-        index: 1,
-        name: 'executorKind',
-        type: 'string',
-        constraints: {required: true},
-        annotations: {
-          displayName: 'Executor Kind',
-          description:
-              'How the action is executed: `mcp`, `rest`, or `grpc`. The ' +
-              'fields for that kind, and only those, are set.',
-        },
-      },
-      {
-        index: 2,
-        name: 'mcpServer',
-        type: 'string',
-        annotations: {
-          displayName: 'MCP Server',
-          description: 'Resource name of the MCP server hosting the tool.',
-        },
-      },
-      {
-        index: 3,
-        name: 'mcpTool',
-        type: 'string',
-        annotations: {
-          displayName: 'MCP Tool',
-          description: 'Name of the tool to call on the MCP server.',
-        },
-      },
-      {
-        index: 4,
-        name: 'restEndpoint',
-        type: 'string',
-        annotations: {
-          displayName: 'REST Endpoint',
-          description: 'URL the request is sent to.',
-        },
-      },
-      {
-        index: 5,
-        name: 'restMethod',
-        type: 'string',
-        annotations: {
-          displayName: 'REST Method',
-          description: 'HTTP method, for example POST.',
-        },
-      },
-      {
-        index: 6,
-        name: 'grpcService',
-        type: 'string',
-        annotations: {
-          displayName: 'gRPC Service',
-          description: 'Fully qualified name of the gRPC service.',
-        },
-      },
-      {
-        index: 7,
-        name: 'grpcMethod',
-        type: 'string',
-        annotations: {
-          displayName: 'gRPC Method',
-          description: 'Method on the gRPC service.',
-        },
-      },
-      {
-        index: 8,
-        name: 'parameters',
-        type: 'array',
-        arrayItems: {
-          name: 'parameter',
-          type: 'record',
-          recordFields: [
-            {
-              index: 1,
-              name: 'name',
-              type: 'string',
-              constraints: {required: true},
-              annotations: {displayName: 'Name'},
-            },
-            {
-              index: 2,
-              name: 'type',
-              type: 'string',
-              constraints: {required: true},
-              annotations: {
-                displayName: 'Type',
-                description:
-                    'The authored type: an entity name, or a scalar datatype.',
-              },
-            },
-            {
-              index: 3,
-              name: 'isEntityRef',
-              type: 'bool',
-              annotations: {
-                displayName: 'Is Entity Reference',
-                description:
-                    'True when `type` names an entity, so the parameter ' +
-                    'refers to an object rather than carrying a value.',
-              },
-            },
-          ],
-        },
-        annotations: {
-          displayName: 'Parameters',
-          description:
-              'The inputs the action takes, each typed by the ontology.',
-        },
-      },
-      {
-        index: 9,
-        name: 'instructions',
-        type: 'string',
-        annotations: {
-          displayName: 'Instructions',
-          description:
-              'Guidance for AI consumers (the action\'s ai_context ' +
-              'instructions).',
-        },
-      },
-    ],
-  },
-};
-
-// The entry type an action's entry carries. It requires the aspect above, so an
-// action entry cannot exist without its mechanics.
-export function actionEntryTypeSpec(dest: {project: string}):
-    Omit<EntryType, 'name'> {
-  return {
-    displayName: 'Semantic Action',
-    description: 'A write operation defined on a semantic model.',
-    requiredAspects: [{type: actionAspectTypeName(dest)}],
-  };
-}
+import {ACTION_TYPE_ID, customAspectKey, customAspectTypeName, customEntryTypeName} from './kc_custom_types';
 
 // Full resource name of the action entry type for a destination.
 export function actionEntryTypeName(dest: {project: string}): string {
-  const home = actionTypeHome(dest);
-  return `projects/${home.project}/locations/${home.location}/entryTypes/${
-      ACTION_TYPE_ID}`;
+  return customEntryTypeName(ACTION_TYPE_ID, dest);
 }
 
 // Full resource name of the action aspect type for a destination.
 export function actionAspectTypeName(dest: {project: string}): string {
-  const home = actionTypeHome(dest);
-  return `projects/${home.project}/locations/${home.location}/aspectTypes/${
-      ACTION_TYPE_ID}`;
+  return customAspectTypeName(ACTION_TYPE_ID, dest);
 }
 
 // Aspect-map key: the `project.location.type` reference form the client keys an
-// entry's aspects by (see dataplex._nameToTypeRef).
+// entry's aspects by.
 export function actionAspectKey(dest: {project: string}): string {
-  const home = actionTypeHome(dest);
-  return `${home.project}.${home.location}.${ACTION_TYPE_ID}`;
-}
-
-// What provisioning produced. `error` is a failure the caller must not ignore.
-// `denied` is the narrower case of lacking permission to create a type, which
-// is reported and survived: actions are one optional construct, and a project
-// whose models declare none never needs these types.
-export interface ProvisionResult {
-  error?: string;
-  denied?: string;
-}
-
-/**
- * Creates the two custom action types in a destination.
- *
- * Called from `kcmd init --semantic-model`, beside the entry group it already
- * provisions, so a push still writes nothing but entries. The aspect type is
- * created and then, if it is already there, patched: a project provisioned by
- * an earlier version of kcmd holds an older template, and pushing a field that
- * template lacks fails with an opaque parsing error. Dataplex rejects a
- * backwards-incompatible change, so the patch only ever adds appended fields.
- */
-export async function provisionActionTypes(
-    cat: CatalogClient, dest: {project: string}): Promise<ProvisionResult> {
-  const home = actionTypeHome(dest);
-
-  // Creating a type needs permissions that publishing entries does not. A
-  // caller who lacks them can still init, push and pull every model that
-  // declares no action, so the refusal is reported rather than fatal.
-  const denial = (what: string, status: number, message?: string):
-      ProvisionResult|undefined => status === 403 ?
-      {
-        denied: `no permission to create ${what} in project '${
-            home.project}' (${message || status}); ` +
-            `models that declare actions cannot be pushed until it exists`
-      } :
-      undefined;
-
-  const aspectLabel = `aspect type '${ACTION_TYPE_ID}'`;
-  const aspect = await cat.createAspectType(
-      home.project, home.location, ACTION_TYPE_ID, ACTION_ASPECT_TYPE_SPEC);
-  if (aspect.status === 409) {
-    const upd = await cat.updateAspectType(
-        home.project, home.location, ACTION_TYPE_ID, ACTION_ASPECT_TYPE_SPEC,
-        ['description', 'display_name', 'metadata_template']);
-    const refused = denial(aspectLabel, upd.status, upd.message);
-    if (refused) return refused;
-    if (upd.status !== 200)
-      return {error: `updating ${aspectLabel}: ${upd.message || upd.status}`};
-    const failed =
-        await cat.awaitOperation(upd.result, `updating ${aspectLabel}`);
-    if (failed) return {error: failed};
-  } else if (aspect.status !== 200) {
-    const refused = denial(aspectLabel, aspect.status, aspect.message);
-    if (refused) return refused;
-    return {
-      error: `creating ${aspectLabel}: ${aspect.message || aspect.status}`
-    };
-  } else {
-    // The entry type below names this aspect type in its required aspects, and
-    // the server rejects that while the create is still in flight, so the wait
-    // is load-bearing rather than tidiness.
-    const failed =
-        await cat.awaitOperation(aspect.result, `creating ${aspectLabel}`);
-    if (failed) return {error: failed};
-  }
-
-  // The entry type requires the aspect type above, so it is created second. An
-  // existing one is left alone rather than patched: unlike the aspect type it
-  // carries no template that grows over time, and its required-aspect list is
-  // what an entry already published depends on.
-  const entryLabel = `entry type '${ACTION_TYPE_ID}'`;
-  const entryType = await cat.createEntryType(
-      home.project, home.location, ACTION_TYPE_ID, actionEntryTypeSpec(dest));
-  if (entryType.status === 409) return {};
-  const refused = denial(entryLabel, entryType.status, entryType.message);
-  if (refused) return refused;
-  if (entryType.status !== 200) {
-    return {
-      error: `creating ${entryLabel}: ${entryType.message || entryType.status}`
-    };
-  }
-  // A push may follow immediately, and an entry naming a type that is still
-  // being created is rejected the same way, so wait here too.
-  const failed =
-      await cat.awaitOperation(entryType.result, `creating ${entryLabel}`);
-  return failed ? {error: failed} : {};
+  return customAspectKey(ACTION_TYPE_ID, dest);
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/kc_actions.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_actions.ts
@@ -1,0 +1,322 @@
+// How a model's ACTIONS are persisted in Knowledge Catalog.
+//
+// This file holds the whole encoding, and it exists to be replaced.
+//
+// Every other construct in the model maps to a built-in system type under
+// `projects/dataplex-types/locations/global`. A model, entity, or metric gets
+// its own entry (`semantic-model` / `semantic-entity` / `semantic-metric`); a
+// relationship becomes a `schema-join` entry link; the built-in `schema` and
+// `guidelines` aspects carry the rest. Actions have no such type. Until one
+// exists they ride the model anchor's built-in `overview` aspect, whose
+// `content` is free-form Markdown: a section for a person reading the catalog,
+// then a fenced JSON block after ACTIONS_OVERVIEW_MARKER. The JSON block is the
+// canonical copy and is what a pull parses; the Markdown above it is rendered
+// from the same actions and is never read back.
+//
+// Nothing outside this file knows that encoding. There are four call sites:
+// `knowledge_catalog.ts` asks for the aspects to attach to the anchor,
+// `kc_converter.ts` asks for the actions to recover from it, and
+// `deploy_knowledge_catalog.ts` and `pull_kc.ts` name the aspect types through
+// ACTION_ANCHOR_ASPECT_TYPES rather than the literal 'overview'.
+//
+// WHEN A BUILT-IN ACTION TYPE SHIPS. If actions become an aspect on the anchor,
+// point actionAnchorAspects and readActions at it and rename the member of
+// ACTION_ANCHOR_ASPECT_TYPES; the four call sites do not change. If instead
+// each action becomes its own entry, the way a metric is one, this file is
+// deleted: the emitting and reading move beside the metric code in
+// `knowledge_catalog.ts` and `kc_converter.ts`, and generateCatalogResources
+// gains a `<model>.actions.` owned prefix so a removed action is reconciled
+// away like a removed metric.
+//
+// The helpers at the bottom duplicate a few lines from those two modules on
+// purpose. This module imports only the IR and the catalog resource types, so
+// it can be swapped or deleted as a unit.
+
+import type {Aspect, Entry} from '../gcp/dataplex';
+
+import {Action, ActionParameter, AiContext, CustomExtension, DATA_TYPES, Executor, SemanticModel} from './ir';
+
+// Fences the machine-readable action JSON inside the overview Markdown. Write
+// and read locate the block by this marker, so they agree on one delimiter.
+export const ACTIONS_OVERVIEW_MARKER = '<!-- kcmd:actions v1 -->';
+
+// The bare aspect type ids this encoding attaches to the model anchor, and
+// attaches CONDITIONALLY (a model with no actions carries none of them). The
+// publisher names them when reconciling an updated anchor so a removed action
+// clears the aspect, and a pull requests them so the actions come back.
+export const ACTION_ANCHOR_ASPECT_TYPES = ['overview'] as const;
+
+/**
+ * The aspects carrying the model's actions, keyed by bare aspect type id, to
+ * merge into the model anchor's aspect map.
+ *
+ * Empty when the model declares no actions, so an anchor without actions is
+ * unchanged from before actions existed. Warns once when it is non-empty:
+ * actions reach Knowledge Catalog and nowhere else, which is worth saying out
+ * loud on a push that also deploys a graph.
+ */
+export function actionAnchorAspects(
+    model: SemanticModel,
+    warnings: string[]): Record<string, Record<string, any>> {
+  const actions = model.actions ?? [];
+  if (!actions.length) return {};
+  warnings.push(
+      `model '${model.name}': ${actions.length} action(s) published to the ` +
+      `model's overview aspect (actions have no BigQuery Graph representation).`);
+  return {
+    overview: {
+      content: renderActionsOverview(actions),
+      contentType: 'MARKDOWN',
+    },
+  };
+}
+
+/**
+ * Recovers the model's actions from the anchor, the inverse of
+ * actionAnchorAspects.
+ *
+ * `isEntityRef` is re-derived against `entityNames` (as the loader does)
+ * rather than trusted from the stored JSON, so it stays consistent with the
+ * model actually pulled. Returns an empty list when the anchor carries no
+ * actions, and warns rather than throwing when it carries a malformed block:
+ * one bad action degrades itself, not the pull.
+ */
+export function readActions(
+    anchor: Entry, entityNames: string[], warnings: string[]): Action[] {
+  const content = overviewContent(anchor);
+  if (content === undefined || !content.includes(ACTIONS_OVERVIEW_MARKER))
+    return [];
+  const json = jsonBlockAfterMarker(content, ACTIONS_OVERVIEW_MARKER);
+  if (json === undefined) {
+    warnings.push(
+        `model actions: overview aspect has the actions marker but no parseable ` +
+        `JSON block; actions are not recovered`);
+    return [];
+  }
+  let parsed: any;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err: any) {
+    warnings.push(`model actions: overview action block is not valid JSON (${
+        err.message || err}); actions are not recovered`);
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    warnings.push(
+        `model actions: overview action block is not a JSON array; actions are ` +
+        `not recovered`);
+    return [];
+  }
+  const entitySet = new Set(entityNames);
+  return parsed.map((a: any) => readAction(a, entitySet, warnings))
+      .filter((a): a is Action => a !== undefined);
+}
+
+
+// ---------------------------------------------------------------------------
+// Write side: the IR -> the overview aspect's content.
+// ---------------------------------------------------------------------------
+
+// Renders the actions overview: a Markdown section for humans, then the marker
+// and a fenced JSON array (the canonical IR form) for a lossless pull.
+function renderActionsOverview(actions: Action[]): string {
+  const md: string[] = [
+    '## Actions',
+    '',
+    'Write operations defined on this model -- the write-side counterpart to ' +
+        'metrics. Actions have no BigQuery Graph representation; they are ' +
+        'published here for discovery and are round-tripped by `kcmd pull`.',
+    '',
+  ];
+  for (const a of actions) {
+    md.push(`### ${a.name}`, '');
+    if (a.description) md.push(a.description, '');
+    md.push(`- Executor: ${describeExecutor(a.executor)}`);
+    if (a.parameters.length) {
+      md.push('- Parameters:');
+      for (const p of a.parameters) {
+        const kind = p.isEntityRef ? `${p.type} (entity reference)` : p.type;
+        md.push(`  - \`${p.name}\`: ${kind}`);
+      }
+    }
+    md.push('');
+  }
+  md.push(
+      ACTIONS_OVERVIEW_MARKER, '```json',
+      JSON.stringify(actions.map(actionJson), null, 2), '```', '');
+  return md.join('\n');
+}
+
+// A one-line human description of an executor for the Markdown body.
+function describeExecutor(ex: Executor): string {
+  switch (ex.kind) {
+    case 'mcp':
+      return `MCP tool \`${ex.mcp.tool}\` on server \`${ex.mcp.server}\``;
+    case 'rest':
+      return `REST ${ex.rest.method} \`${ex.rest.endpoint}\``;
+    case 'grpc':
+      return `gRPC \`${ex.grpc.service}/${ex.grpc.method}\``;
+  }
+}
+
+// The canonical JSON form of an action embedded in the overview, mirroring the
+// IR so readAction reconstructs it verbatim. The executor's tagged union is
+// flattened to the open format's single-key object, matching how osi_converter
+// emits it to YAML.
+function actionJson(a: Action): Record<string, any> {
+  return compact({
+    name: a.name,
+    description: a.description,
+    executor: executorJson(a.executor),
+    parameters: a.parameters.map(
+        p => compact({name: p.name, type: p.type, isEntityRef: p.isEntityRef})),
+    aiContext: a.aiContext,
+    customExtensions: a.customExtensions,
+  });
+}
+
+function executorJson(ex: Executor): Record<string, any> {
+  switch (ex.kind) {
+    case 'mcp':
+      return {mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+    case 'rest':
+      return {rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}};
+    case 'grpc':
+      return {grpc: {service: ex.grpc.service, method: ex.grpc.method}};
+  }
+}
+
+
+// ---------------------------------------------------------------------------
+// Read side: the overview aspect's content -> the IR.
+// ---------------------------------------------------------------------------
+
+// Extracts the first ```json ... ``` fenced block that follows `marker` in the
+// content, returning the block's inner text (or undefined when none follows).
+function jsonBlockAfterMarker(content: string, marker: string): string|
+    undefined {
+  const afterMarker =
+      content.slice(content.lastIndexOf(marker) + marker.length);
+  const fence = afterMarker.match(/```json\s*\n([\s\S]*?)\n```/);
+  return fence ? fence[1] : undefined;
+}
+
+// Rebuilds one Action from its embedded JSON (the inverse of actionJson). A
+// record missing a usable name or executor is skipped with a warning, so a
+// malformed block degrades one action rather than the whole pull.
+function readAction(
+    a: any, entityNames: Set<string>, warnings: string[]): Action|undefined {
+  const name = typeof a?.name === 'string' ? a.name : '';
+  if (!name) {
+    warnings.push(
+        'model actions: an action in the overview has no name; skipped');
+    return undefined;
+  }
+  const executor = readExecutor(a?.executor);
+  if (!executor) {
+    warnings.push(
+        `action '${name}': overview executor is missing or malformed; the ` +
+        `action is skipped`);
+    return undefined;
+  }
+  const parameters =
+      asArray(a?.parameters)
+          .map((p: any) => readParameter(p, entityNames, name, warnings))
+          .filter((p): p is ActionParameter => p !== undefined);
+  const action: Action = {name, executor, parameters};
+  if (typeof a?.description === 'string' && a.description !== '')
+    action.description = a.description;
+  if (a?.aiContext && typeof a.aiContext === 'object')
+    action.aiContext = a.aiContext as AiContext;
+  if (Array.isArray(a?.customExtensions))
+    action.customExtensions = a.customExtensions as CustomExtension[];
+  return action;
+}
+
+// One action parameter from its JSON, re-deriving isEntityRef against the
+// model's entities (a scalar datatype otherwise). A record missing a name is
+// dropped.
+function readParameter(
+    p: any, entityNames: Set<string>, actionName: string,
+    warnings: string[]): ActionParameter|undefined {
+  const name = typeof p?.name === 'string' ? p.name : '';
+  const type = typeof p?.type === 'string' ? p.type : '';
+  if (!name) return undefined;
+  const param: ActionParameter = {name, type};
+  if (entityNames.has(type)) {
+    param.isEntityRef = true;
+  } else if ((DATA_TYPES as readonly string[]).includes(type)) {
+    param.isEntityRef = false;
+  } else {
+    // The type resolves to neither an entity in the pulled model nor a scalar
+    // datatype -- e.g. an entity-typed parameter whose entity was not part of
+    // this pull. Leave isEntityRef unset (push-side validate flags it) and warn
+    // so the gap is visible rather than silently dropped.
+    warnings.push(
+        `action '${actionName}': parameter '${name}' type '${type}' is ` +
+        `neither a known entity nor a scalar datatype; pulled without a ` +
+        `resolved type`);
+  }
+  return param;
+}
+
+// The IR executor from the embedded single-key JSON object
+// ({mcp}/{rest}/{grpc}, the inverse of executorJson). Returns undefined when no
+// known kind is present or a coordinate is not a string.
+function readExecutor(ex: any): Executor|undefined {
+  // A coordinate must be a present, NON-BLANK string. The overview JSON can
+  // carry an empty string (e.g. a hand-edited block); treat that as malformed
+  // so the reader rejects it exactly as push-side validate would, rather than
+  // recovering an action the next push cannot deploy.
+  const str = (v: any): v is string => typeof v === 'string' && v.trim() !== '';
+  if (ex?.mcp && str(ex.mcp.server) && str(ex.mcp.tool))
+    return {kind: 'mcp', mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+  if (ex?.rest && str(ex.rest.endpoint) && str(ex.rest.method))
+    return {
+      kind: 'rest',
+      rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}
+    };
+  if (ex?.grpc && str(ex.grpc.service) && str(ex.grpc.method))
+    return {
+      kind: 'grpc',
+      grpc: {service: ex.grpc.service, method: ex.grpc.method}
+    };
+  return undefined;
+}
+
+
+// ---------------------------------------------------------------------------
+// Local helpers (see the file header on why they are not shared).
+// ---------------------------------------------------------------------------
+
+// The overview aspect's `content` string from the anchor's aspect map, matched
+// by the aspect key's `.overview` suffix or the aspectType's
+// `/aspectTypes/overview` suffix, so it is found whichever system-type
+// project/location the emitter used. Undefined when the aspect is absent or
+// carries no string content.
+function overviewContent(anchor: Entry): string|undefined {
+  for (const type of ACTION_ANCHOR_ASPECT_TYPES) {
+    for (const [key, aspect] of Object.entries<Aspect>(anchor.aspects ?? {})) {
+      if (!key.endsWith(`.${type}`) &&
+          !aspect.aspectType?.endsWith(`/aspectTypes/${type}`))
+        continue;
+      const content = aspect.data?.content;
+      if (typeof content === 'string') return content;
+    }
+  }
+  return undefined;
+}
+
+// Drops undefined-valued keys so the emitted JSON (and its golden) only shows
+// fields the model actually set.
+function compact<T extends Record<string, any>>(obj: T): T {
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as T;
+}
+
+function asArray(value: any): any[] {
+  return Array.isArray(value) ? value : [];
+}

--- a/toolbox/mdcode/src/libts/semantic/kc_actions.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_actions.ts
@@ -245,47 +245,90 @@ export function actionAspectKey(dest: {project: string}): string {
   return `${home.project}.${home.location}.${ACTION_TYPE_ID}`;
 }
 
+// What provisioning produced. `error` is a failure the caller must not ignore.
+// `denied` is the narrower case of lacking permission to create a type, which
+// is reported and survived: actions are one optional construct, and a project
+// whose models declare none never needs these types.
+export interface ProvisionResult {
+  error?: string;
+  denied?: string;
+}
+
 /**
- * Creates the two custom action types in a destination, returning an error
- * message or undefined on success.
+ * Creates the two custom action types in a destination.
  *
  * Called from `kcmd init --semantic-model`, beside the entry group it already
- * provisions, so a push still writes nothing but entries. Each type is created
- * and then, if it is already there, patched: a project provisioned by an
- * earlier version of kcmd holds an older template, and pushing a field that
+ * provisions, so a push still writes nothing but entries. The aspect type is
+ * created and then, if it is already there, patched: a project provisioned by
+ * an earlier version of kcmd holds an older template, and pushing a field that
  * template lacks fails with an opaque parsing error. Dataplex rejects a
  * backwards-incompatible change, so the patch only ever adds appended fields.
  */
 export async function provisionActionTypes(
-    cat: CatalogClient, dest: {project: string}): Promise<string|undefined> {
+    cat: CatalogClient, dest: {project: string}): Promise<ProvisionResult> {
   const home = actionTypeHome(dest);
 
+  // Creating a type needs permissions that publishing entries does not. A
+  // caller who lacks them can still init, push and pull every model that
+  // declares no action, so the refusal is reported rather than fatal.
+  const denial = (what: string, status: number, message?: string):
+      ProvisionResult|undefined => status === 403 ?
+      {
+        denied: `no permission to create ${what} in project '${
+            home.project}' (${message || status}); ` +
+            `models that declare actions cannot be pushed until it exists`
+      } :
+      undefined;
+
+  const aspectLabel = `aspect type '${ACTION_TYPE_ID}'`;
   const aspect = await cat.createAspectType(
       home.project, home.location, ACTION_TYPE_ID, ACTION_ASPECT_TYPE_SPEC);
   if (aspect.status === 409) {
     const upd = await cat.updateAspectType(
         home.project, home.location, ACTION_TYPE_ID, ACTION_ASPECT_TYPE_SPEC,
         ['description', 'display_name', 'metadata_template']);
+    const refused = denial(aspectLabel, upd.status, upd.message);
+    if (refused) return refused;
     if (upd.status !== 200)
-      return `updating aspect type '${ACTION_TYPE_ID}': ${
-          upd.message || upd.status}`;
+      return {error: `updating ${aspectLabel}: ${upd.message || upd.status}`};
+    const failed =
+        await cat.awaitOperation(upd.result, `updating ${aspectLabel}`);
+    if (failed) return {error: failed};
   } else if (aspect.status !== 200) {
-    return `creating aspect type '${ACTION_TYPE_ID}': ${
-        aspect.message || aspect.status}`;
+    const refused = denial(aspectLabel, aspect.status, aspect.message);
+    if (refused) return refused;
+    return {
+      error: `creating ${aspectLabel}: ${aspect.message || aspect.status}`
+    };
+  } else {
+    // The entry type below names this aspect type in its required aspects, and
+    // the server rejects that while the create is still in flight, so the wait
+    // is load-bearing rather than tidiness.
+    const failed =
+        await cat.awaitOperation(aspect.result, `creating ${aspectLabel}`);
+    if (failed) return {error: failed};
   }
 
   // The entry type requires the aspect type above, so it is created second. An
   // existing one is left alone rather than patched: unlike the aspect type it
   // carries no template that grows over time, and its required-aspect list is
   // what an entry already published depends on.
+  const entryLabel = `entry type '${ACTION_TYPE_ID}'`;
   const entryType = await cat.createEntryType(
       home.project, home.location, ACTION_TYPE_ID, actionEntryTypeSpec(dest));
-  if (entryType.status !== 200 && entryType.status !== 409) {
-    return `creating entry type '${ACTION_TYPE_ID}': ${
-        entryType.message || entryType.status}`;
+  if (entryType.status === 409) return {};
+  const refused = denial(entryLabel, entryType.status, entryType.message);
+  if (refused) return refused;
+  if (entryType.status !== 200) {
+    return {
+      error: `creating ${entryLabel}: ${entryType.message || entryType.status}`
+    };
   }
-
-  return undefined;
+  // A push may follow immediately, and an entry naming a type that is still
+  // being created is rejected the same way, so wait here too.
+  const failed =
+      await cat.awaitOperation(entryType.result, `creating ${entryLabel}`);
+  return failed ? {error: failed} : {};
 }
 
 
@@ -305,6 +348,10 @@ export interface ActionEmitContext {
   // Reserves an entry id, returning false when it collides with one already
   // emitted (knowledge_catalog.claim).
   claim(entryId: string, label: string): boolean;
+  // Names of the entities this push actually publishes an entry for. An
+  // abstract entity, or one a binding profile pruned, is absent, so a
+  // parameter typed by it would name an entry that does not exist.
+  publishedEntities: Set<string>;
 }
 
 // The entry id of one action: `<model>.actions.<name>`, alongside
@@ -332,15 +379,23 @@ export function actionEntries(
     warnings: string[]): Entry[] {
   const actions = model.actions ?? [];
   if (!actions.length) return [];
-  warnings.push(
-      `model '${model.name}': ${actions.length} action(s) published as ` +
-      `${ACTION_TYPE_ID} entries (actions have no BigQuery Graph ` +
-      `representation).`);
 
   const entries: Entry[] = [];
   for (const action of actions) {
     const id = actionEntryId(modelId, action.name);
     if (!ctx.claim(id, `action '${action.name}'`)) continue;
+    // A parameter typed by an entity this push does not publish leaves the
+    // catalog naming an entity it has no entry for, and a later pull cannot
+    // tell that the type was an entity rather than a misspelled scalar.
+    for (const p of action.parameters ?? []) {
+      if (p.isEntityRef && !ctx.publishedEntities.has(p.type)) {
+        warnings.push(
+            `model '${model.name}': action '${action.name}' parameter ` +
+            `'${p.name}' refers to entity '${p.type}', which this push does ` +
+            `not publish (abstract or unavailable), so a pull will not ` +
+            `recover it as an entity reference.`);
+      }
+    }
     entries.push({
       name: ctx.entry(id),
       entryType: actionEntryTypeName(ctx),
@@ -357,6 +412,12 @@ export function actionEntries(
       },
     });
   }
+  // Counted from what was emitted rather than from the model, so a name
+  // collision that skipped an action does not inflate the number.
+  if (entries.length) warnings.push(
+      `model '${model.name}': ${entries.length} action(s) published as ` +
+      `${ACTION_TYPE_ID} entries (actions have no BigQuery Graph ` +
+      `representation).`);
   return entries;
 }
 

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -54,7 +54,8 @@
 
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
-import {AiContext, CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
+import {Action, ActionParameter, AiContext, CustomExtension, DATA_TYPES, DataType, Entity, Executor, Field, Metric, Relationship, SemanticModel} from './ir';
+import {ACTIONS_OVERVIEW_MARKER} from './knowledge_catalog';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface ReadResult {
@@ -127,6 +128,11 @@ export function modelsFromCatalogResources(
     const model: SemanticModel = {name, entities, relationships, metrics};
     const description = anchor.entrySource?.description;
     if (description !== undefined) model.description = description;
+    // Actions ride the anchor's overview aspect (see
+    // actionsOverviewAspectData); recover them from its embedded JSON block.
+    // Absent overview -> no actions.
+    const actions = readActionsFromOverview(anchor, entityNames, warnings);
+    if (actions.length) model.actions = actions;
     // Deployment targets ride back in the same GOOGLE custom_extensions block
     // the author wrote them in (the inverse of the emitter's modelAspectData).
     const targets = readDeploymentTargets(anchor);
@@ -283,6 +289,143 @@ function readMetric(
   const ai = readAiContext(entry);
   if (ai) metric.aiContext = ai;
   return metric;
+}
+
+
+// Recovers the model's actions from the anchor's `overview` aspect, the inverse
+// of actionsOverviewAspectData. The overview's Markdown is for humans; the
+// machine-readable form is a fenced JSON array after ACTIONS_OVERVIEW_MARKER,
+// so this locates that block, parses it, and rebuilds each Action.
+// `isEntityRef` is re-derived against the reconstructed entities (as the loader
+// does) rather than trusted from the JSON, so it stays consistent with the
+// pulled model. Returns an empty list when there is no overview or no parseable
+// action block.
+function readActionsFromOverview(
+    anchor: Entry, entityNames: string[], warnings: string[]): Action[] {
+  const content = aspectData(anchor, 'overview').content;
+  if (typeof content !== 'string' || !content.includes(ACTIONS_OVERVIEW_MARKER))
+    return [];
+  const json = jsonBlockAfterMarker(content, ACTIONS_OVERVIEW_MARKER);
+  if (json === undefined) {
+    warnings.push(
+        `model actions: overview aspect has the actions marker but no parseable ` +
+        `JSON block; actions are not recovered`);
+    return [];
+  }
+  let parsed: any;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err: any) {
+    warnings.push(`model actions: overview action block is not valid JSON (${
+        err.message || err}); actions are not recovered`);
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    warnings.push(
+        `model actions: overview action block is not a JSON array; actions are ` +
+        `not recovered`);
+    return [];
+  }
+  const entitySet = new Set(entityNames);
+  return parsed.map((a: any) => readAction(a, entitySet, warnings))
+      .filter((a): a is Action => a !== undefined);
+}
+
+
+// Extracts the first ```json ... ``` fenced block that follows `marker` in the
+// content, returning the block's inner text (or undefined when none follows).
+function jsonBlockAfterMarker(content: string, marker: string): string|
+    undefined {
+  const afterMarker =
+      content.slice(content.lastIndexOf(marker) + marker.length);
+  const fence = afterMarker.match(/```json\s*\n([\s\S]*?)\n```/);
+  return fence ? fence[1] : undefined;
+}
+
+
+// Rebuilds one Action from its embedded JSON (the inverse of actionJson). A
+// record missing a usable name or executor is skipped with a warning, so a
+// malformed block degrades one action rather than the whole pull.
+function readAction(
+    a: any, entityNames: Set<string>, warnings: string[]): Action|undefined {
+  const name = typeof a?.name === 'string' ? a.name : '';
+  if (!name) {
+    warnings.push(
+        'model actions: an action in the overview has no name; skipped');
+    return undefined;
+  }
+  const executor = readExecutor(a?.executor);
+  if (!executor) {
+    warnings.push(
+        `action '${name}': overview executor is missing or malformed; the ` +
+        `action is skipped`);
+    return undefined;
+  }
+  const parameters =
+      asArray(a?.parameters)
+          .map((p: any) => readParameter(p, entityNames, name, warnings))
+          .filter((p): p is ActionParameter => p !== undefined);
+  const action: Action = {name, executor, parameters};
+  if (typeof a?.description === 'string' && a.description !== '')
+    action.description = a.description;
+  if (a?.aiContext && typeof a.aiContext === 'object')
+    action.aiContext = a.aiContext as AiContext;
+  if (Array.isArray(a?.customExtensions))
+    action.customExtensions = a.customExtensions as CustomExtension[];
+  return action;
+}
+
+
+// One action parameter from its JSON, re-deriving isEntityRef against the
+// model's entities (a scalar datatype otherwise). A record missing a name is
+// dropped.
+function readParameter(
+    p: any, entityNames: Set<string>, actionName: string,
+    warnings: string[]): ActionParameter|undefined {
+  const name = typeof p?.name === 'string' ? p.name : '';
+  const type = typeof p?.type === 'string' ? p.type : '';
+  if (!name) return undefined;
+  const param: ActionParameter = {name, type};
+  if (entityNames.has(type)) {
+    param.isEntityRef = true;
+  } else if ((DATA_TYPES as readonly string[]).includes(type)) {
+    param.isEntityRef = false;
+  } else {
+    // The type resolves to neither an entity in the pulled model nor a scalar
+    // datatype -- e.g. an entity-typed parameter whose entity was not part of
+    // this pull. Leave isEntityRef unset (push-side validate flags it) and warn
+    // so the gap is visible rather than silently dropped.
+    warnings.push(
+        `action '${actionName}': parameter '${name}' type '${type}' is ` +
+        `neither a known entity nor a scalar datatype; pulled without a ` +
+        `resolved type`);
+  }
+  return param;
+}
+
+
+// The IR executor from the embedded single-key JSON object
+// ({mcp}/{rest}/{grpc}, the inverse of executorJson). Returns undefined when no
+// known kind is present or a coordinate is not a string.
+function readExecutor(ex: any): Executor|undefined {
+  // A coordinate must be a present, NON-BLANK string. The overview JSON can
+  // carry an empty string (e.g. a hand-edited block); treat that as malformed
+  // so the reader rejects it exactly as push-side validate would, rather than
+  // recovering an action the next push cannot deploy.
+  const str = (v: any): v is string => typeof v === 'string' && v.trim() !== '';
+  if (ex?.mcp && str(ex.mcp.server) && str(ex.mcp.tool))
+    return {kind: 'mcp', mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+  if (ex?.rest && str(ex.rest.endpoint) && str(ex.rest.method))
+    return {
+      kind: 'rest',
+      rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}
+    };
+  if (ex?.grpc && str(ex.grpc.service) && str(ex.grpc.method))
+    return {
+      kind: 'grpc',
+      grpc: {service: ex.grpc.service, method: ex.grpc.method}
+    };
+  return undefined;
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -54,8 +54,8 @@
 
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
-import {AiContext, CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
-import {readActions} from './kc_actions';
+import {Action, AiContext, CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
+import {isActionEntry, readAction} from './kc_actions';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface ReadResult {
@@ -85,6 +85,9 @@ export function modelsFromCatalogResources(
       entries.filter(e => semanticType(e) === 'semantic-entity');
   const metricEntries =
       entries.filter(e => semanticType(e) === 'semantic-metric');
+  // Actions have no built-in system type; `kc_actions.ts` owns the custom one
+  // and recognizes an entry carrying it.
+  const actionEntries = entries.filter(isActionEntry);
 
   if (!anchors.length) {
     warnings.push('no semantic-model entry found; nothing to reconstruct');
@@ -128,9 +131,9 @@ export function modelsFromCatalogResources(
     const model: SemanticModel = {name, entities, relationships, metrics};
     const description = anchor.entrySource?.description;
     if (description !== undefined) model.description = description;
-    // Actions have no system type of their own; `kc_actions.ts` owns how they
-    // are persisted on the anchor and how they come back.
-    const actions = readActions(anchor, entityNames, warnings);
+    const actions = childrenOf(anchor.name, actionEntries)
+                        .map(e => readAction(e, entityNames, warnings))
+                        .filter((a): a is Action => a !== undefined);
     if (actions.length) model.actions = actions;
     // Deployment targets ride back in the same GOOGLE custom_extensions block
     // the author wrote them in (the inverse of the emitter's modelAspectData).
@@ -144,7 +147,8 @@ export function modelsFromCatalogResources(
   // Flag children that resolved to no anchor at all (only possible with
   // multiple anchors, where the sole-anchor fallback does not apply).
   if (!soleAnchor) {
-    for (const child of [...entityEntries, ...metricEntries]) {
+    for (const child of [...entityEntries, ...metricEntries,
+                         ...actionEntries]) {
       if (!child.parentEntry || !anchorNames.has(child.parentEntry)) {
         warnings.push(`entry '${
             child.name}' has no resolvable parent semantic-model; omitted`);

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -54,8 +54,8 @@
 
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
-import {Action, ActionParameter, AiContext, CustomExtension, DATA_TYPES, DataType, Entity, Executor, Field, Metric, Relationship, SemanticModel} from './ir';
-import {ACTIONS_OVERVIEW_MARKER} from './knowledge_catalog';
+import {AiContext, CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
+import {readActions} from './kc_actions';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface ReadResult {
@@ -128,10 +128,9 @@ export function modelsFromCatalogResources(
     const model: SemanticModel = {name, entities, relationships, metrics};
     const description = anchor.entrySource?.description;
     if (description !== undefined) model.description = description;
-    // Actions ride the anchor's overview aspect (see
-    // actionsOverviewAspectData); recover them from its embedded JSON block.
-    // Absent overview -> no actions.
-    const actions = readActionsFromOverview(anchor, entityNames, warnings);
+    // Actions have no system type of their own; `kc_actions.ts` owns how they
+    // are persisted on the anchor and how they come back.
+    const actions = readActions(anchor, entityNames, warnings);
     if (actions.length) model.actions = actions;
     // Deployment targets ride back in the same GOOGLE custom_extensions block
     // the author wrote them in (the inverse of the emitter's modelAspectData).
@@ -291,142 +290,6 @@ function readMetric(
   return metric;
 }
 
-
-// Recovers the model's actions from the anchor's `overview` aspect, the inverse
-// of actionsOverviewAspectData. The overview's Markdown is for humans; the
-// machine-readable form is a fenced JSON array after ACTIONS_OVERVIEW_MARKER,
-// so this locates that block, parses it, and rebuilds each Action.
-// `isEntityRef` is re-derived against the reconstructed entities (as the loader
-// does) rather than trusted from the JSON, so it stays consistent with the
-// pulled model. Returns an empty list when there is no overview or no parseable
-// action block.
-function readActionsFromOverview(
-    anchor: Entry, entityNames: string[], warnings: string[]): Action[] {
-  const content = aspectData(anchor, 'overview').content;
-  if (typeof content !== 'string' || !content.includes(ACTIONS_OVERVIEW_MARKER))
-    return [];
-  const json = jsonBlockAfterMarker(content, ACTIONS_OVERVIEW_MARKER);
-  if (json === undefined) {
-    warnings.push(
-        `model actions: overview aspect has the actions marker but no parseable ` +
-        `JSON block; actions are not recovered`);
-    return [];
-  }
-  let parsed: any;
-  try {
-    parsed = JSON.parse(json);
-  } catch (err: any) {
-    warnings.push(`model actions: overview action block is not valid JSON (${
-        err.message || err}); actions are not recovered`);
-    return [];
-  }
-  if (!Array.isArray(parsed)) {
-    warnings.push(
-        `model actions: overview action block is not a JSON array; actions are ` +
-        `not recovered`);
-    return [];
-  }
-  const entitySet = new Set(entityNames);
-  return parsed.map((a: any) => readAction(a, entitySet, warnings))
-      .filter((a): a is Action => a !== undefined);
-}
-
-
-// Extracts the first ```json ... ``` fenced block that follows `marker` in the
-// content, returning the block's inner text (or undefined when none follows).
-function jsonBlockAfterMarker(content: string, marker: string): string|
-    undefined {
-  const afterMarker =
-      content.slice(content.lastIndexOf(marker) + marker.length);
-  const fence = afterMarker.match(/```json\s*\n([\s\S]*?)\n```/);
-  return fence ? fence[1] : undefined;
-}
-
-
-// Rebuilds one Action from its embedded JSON (the inverse of actionJson). A
-// record missing a usable name or executor is skipped with a warning, so a
-// malformed block degrades one action rather than the whole pull.
-function readAction(
-    a: any, entityNames: Set<string>, warnings: string[]): Action|undefined {
-  const name = typeof a?.name === 'string' ? a.name : '';
-  if (!name) {
-    warnings.push(
-        'model actions: an action in the overview has no name; skipped');
-    return undefined;
-  }
-  const executor = readExecutor(a?.executor);
-  if (!executor) {
-    warnings.push(
-        `action '${name}': overview executor is missing or malformed; the ` +
-        `action is skipped`);
-    return undefined;
-  }
-  const parameters =
-      asArray(a?.parameters)
-          .map((p: any) => readParameter(p, entityNames, name, warnings))
-          .filter((p): p is ActionParameter => p !== undefined);
-  const action: Action = {name, executor, parameters};
-  if (typeof a?.description === 'string' && a.description !== '')
-    action.description = a.description;
-  if (a?.aiContext && typeof a.aiContext === 'object')
-    action.aiContext = a.aiContext as AiContext;
-  if (Array.isArray(a?.customExtensions))
-    action.customExtensions = a.customExtensions as CustomExtension[];
-  return action;
-}
-
-
-// One action parameter from its JSON, re-deriving isEntityRef against the
-// model's entities (a scalar datatype otherwise). A record missing a name is
-// dropped.
-function readParameter(
-    p: any, entityNames: Set<string>, actionName: string,
-    warnings: string[]): ActionParameter|undefined {
-  const name = typeof p?.name === 'string' ? p.name : '';
-  const type = typeof p?.type === 'string' ? p.type : '';
-  if (!name) return undefined;
-  const param: ActionParameter = {name, type};
-  if (entityNames.has(type)) {
-    param.isEntityRef = true;
-  } else if ((DATA_TYPES as readonly string[]).includes(type)) {
-    param.isEntityRef = false;
-  } else {
-    // The type resolves to neither an entity in the pulled model nor a scalar
-    // datatype -- e.g. an entity-typed parameter whose entity was not part of
-    // this pull. Leave isEntityRef unset (push-side validate flags it) and warn
-    // so the gap is visible rather than silently dropped.
-    warnings.push(
-        `action '${actionName}': parameter '${name}' type '${type}' is ` +
-        `neither a known entity nor a scalar datatype; pulled without a ` +
-        `resolved type`);
-  }
-  return param;
-}
-
-
-// The IR executor from the embedded single-key JSON object
-// ({mcp}/{rest}/{grpc}, the inverse of executorJson). Returns undefined when no
-// known kind is present or a coordinate is not a string.
-function readExecutor(ex: any): Executor|undefined {
-  // A coordinate must be a present, NON-BLANK string. The overview JSON can
-  // carry an empty string (e.g. a hand-edited block); treat that as malformed
-  // so the reader rejects it exactly as push-side validate would, rather than
-  // recovering an action the next push cannot deploy.
-  const str = (v: any): v is string => typeof v === 'string' && v.trim() !== '';
-  if (ex?.mcp && str(ex.mcp.server) && str(ex.mcp.tool))
-    return {kind: 'mcp', mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
-  if (ex?.rest && str(ex.rest.endpoint) && str(ex.rest.method))
-    return {
-      kind: 'rest',
-      rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}
-    };
-  if (ex?.grpc && str(ex.grpc.service) && str(ex.grpc.method))
-    return {
-      kind: 'grpc',
-      grpc: {service: ex.grpc.service, method: ex.grpc.method}
-    };
-  return undefined;
-}
 
 
 // The inverse of columnDataType/columnMetadataType: maps the schema aspect's

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -255,6 +255,8 @@ export function customAspectKey(id: string, dest: {project: string}): string {
 export interface ProvisionResult {
   error?: string;
   denied?: string;
+  // Problems that left an existing type as it was without stopping init.
+  warnings?: string[];
 }
 
 /**
@@ -272,11 +274,14 @@ export interface ProvisionResult {
  */
 export async function provisionCustomTypes(
     cat: CatalogClient, dest: {project: string}): Promise<ProvisionResult> {
+  const warnings: string[] = [];
   for (const type of CUSTOM_TYPES) {
     const result = await provisionOne(cat, dest, type);
-    if (result.error || result.denied) return result;
+    if (result.warnings) warnings.push(...result.warnings);
+    if (result.error || result.denied)
+      return {...result, warnings: warnings.length ? warnings : undefined};
   }
-  return {};
+  return warnings.length ? {warnings} : {};
 }
 
 // One custom type: its aspect type, then the entry type that requires it.
@@ -297,6 +302,7 @@ async function provisionOne(
       } :
       undefined;
 
+  const warnings: string[] = [];
   const aspectLabel = `aspect type '${type.id}'`;
   const aspect = await cat.createAspectType(
       home.project, home.location, type.id, type.aspectType);
@@ -306,11 +312,21 @@ async function provisionOne(
         ['description', 'display_name', 'metadata_template']);
     const refused = denial(aspectLabel, upd.status, upd.message);
     if (refused) return refused;
-    if (upd.status !== 200)
-      return {error: `updating ${aspectLabel}: ${upd.message || upd.status}`};
-    const failed =
+    // Patching an existing type forward is best effort. An older kcmd run
+    // against a project a newer one provisioned asks Dataplex to remove
+    // template fields, which it rejects, and the type already there is the one
+    // every published entry depends on. Leaving it alone and saying so beats
+    // aborting an init that has already created the entry group, and a push
+    // that needs a field the older template lacks reports that itself.
+    const reason = upd.status !== 200 ?
+        `${upd.message || upd.status}` :
         await cat.awaitOperation(upd.result, `updating ${aspectLabel}`);
-    if (failed) return {error: failed};
+    if (reason) {
+      warnings.push(
+          `left the existing ${aspectLabel} in project '${home.project}' ` +
+          `unchanged (${reason}); a push that needs a field it does not ` +
+          `carry will fail`);
+    }
   } else if (aspect.status !== 200) {
     const refused = denial(aspectLabel, aspect.status, aspect.message);
     if (refused) return refused;
@@ -336,11 +352,13 @@ async function provisionOne(
         ...type.entryType,
         requiredAspects: [{type: customAspectTypeName(type.id, dest)}],
       });
-  if (entryType.status === 409) return {};
+  const collected = warnings.length ? {warnings} : {};
+  if (entryType.status === 409) return collected;
   const refused = denial(entryLabel, entryType.status, entryType.message);
-  if (refused) return refused;
+  if (refused) return {...refused, ...collected};
   if (entryType.status !== 200) {
     return {
+      ...collected,
       error: `creating ${entryLabel}: ${entryType.message || entryType.status}`
     };
   }
@@ -348,5 +366,5 @@ async function provisionOne(
   // being created is rejected the same way, so wait here too.
   const failed =
       await cat.awaitOperation(entryType.result, `creating ${entryLabel}`);
-  return failed ? {error: failed} : {};
+  return failed ? {...collected, error: failed} : collected;
 }

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -1,0 +1,352 @@
+// The entry and aspect types kcmd creates itself.
+//
+// READ THIS FIRST IF YOU OWN DATAPLEX TYPES. Everything a semantic model
+// publishes maps to a BUILT-IN system type under
+// `projects/dataplex-types/locations/global`: a model, an entity and a metric
+// each get an entry (`semantic-model` / `semantic-entity` / `semantic-metric`),
+// a relationship becomes a `schema-join` entry link, and the built-in `schema`
+// and `guidelines` aspects carry the rest. The types listed in CUSTOM_TYPES
+// below are the exceptions. Dataplex has no built-in equivalent for them, so
+// `kcmd init --semantic-model` creates them in the destination project instead.
+// Each record here is a request: please make this one built-in.
+//
+// TO MAKE ONE BUILT-IN. Publish an entry type and an aspect type under
+// `dataplex-types/global` with the same id and the same metadata template as
+// the record below, then delete that record from CUSTOM_TYPES and name the
+// type through `Namer.typeName` in knowledge_catalog.ts, the way every built-in
+// type is already named. Nothing else moves: entry ids, entry shape, the owned
+// prefix for delete reconciliation, and the readers all match a type by its id
+// suffix, so they do not care which project it lives in.
+//
+// TO ADD A NEW CUSTOM TYPE. Append a record. Provisioning, naming and the init
+// wiring are generic over this list, so no other file in this directory needs
+// to change; what does need writing is the encoding that fills the aspect, the
+// way kc_actions.ts does for `semantic-action`.
+//
+// A CUSTOM TYPE IS ONE ENTRY TYPE PLUS ONE ASPECT TYPE that share an id, the
+// way the built-in `semantic-metric` entry type and aspect type share theirs.
+// The entry type requires its own aspect type, so an entry of that type cannot
+// exist without the aspect that gives it meaning. A future type that needs a
+// different arrangement is a reason to generalize this file rather than to add
+// a second mechanism elsewhere.
+//
+// TEMPLATES ARE APPEND-ONLY. Dataplex rejects a backwards-incompatible template
+// change, so a new field must be APPENDED with a fresh index. Renumbering or
+// removing an existing field breaks the update for every project that already
+// provisioned the type.
+
+import {AspectType, CatalogClient, EntryType} from '../gcp/dataplex';
+
+// A type kcmd provisions because no built-in one exists yet.
+export interface CustomType {
+  // Shared by the entry type and the aspect type.
+  id: string;
+  // The entry type, minus the required-aspect list: it always requires exactly
+  // this record's aspect type, which provisionCustomTypes fills in.
+  entryType: Omit<EntryType, 'name'|'requiredAspects'>;
+  // The aspect type, including the metadata template that gives the entry its
+  // typed, queryable fields.
+  aspectType: Omit<AspectType, 'name'>;
+}
+
+// The id of the action type. An action is a write operation defined on a
+// semantic model; kc_actions.ts holds the encoding that fills its aspect.
+export const ACTION_TYPE_ID = 'semantic-action';
+
+// The aspect that carries an action's mechanics.
+//
+// The executor is FLATTENED rather than nested one record per kind: an aspect
+// holds exactly one executor, and a flat record shows the reader which one at a
+// glance instead of three sibling records of which two are empty. `parameters`
+// mirrors the model's own parameter list, including the derived `isEntityRef`
+// so a consumer that has not loaded the model can still tell an object
+// reference from a scalar.
+const ACTION_ASPECT_TYPE: Omit<AspectType, 'name'> = {
+  displayName: 'Semantic Action',
+  description:
+      'A write operation defined on a semantic model: how it is executed, ' +
+      'and the inputs it takes.',
+  metadataTemplate: {
+    name: ACTION_TYPE_ID,
+    type: 'record',
+    recordFields: [
+      {
+        index: 1,
+        name: 'executorKind',
+        type: 'string',
+        constraints: {required: true},
+        annotations: {
+          displayName: 'Executor Kind',
+          description:
+              'How the action is executed: `mcp`, `rest`, or `grpc`. The ' +
+              'fields for that kind, and only those, are set.',
+        },
+      },
+      {
+        index: 2,
+        name: 'mcpServer',
+        type: 'string',
+        annotations: {
+          displayName: 'MCP Server',
+          description: 'Resource name of the MCP server hosting the tool.',
+        },
+      },
+      {
+        index: 3,
+        name: 'mcpTool',
+        type: 'string',
+        annotations: {
+          displayName: 'MCP Tool',
+          description: 'Name of the tool to call on the MCP server.',
+        },
+      },
+      {
+        index: 4,
+        name: 'restEndpoint',
+        type: 'string',
+        annotations: {
+          displayName: 'REST Endpoint',
+          description: 'URL the request is sent to.',
+        },
+      },
+      {
+        index: 5,
+        name: 'restMethod',
+        type: 'string',
+        annotations: {
+          displayName: 'REST Method',
+          description: 'HTTP method, for example POST.',
+        },
+      },
+      {
+        index: 6,
+        name: 'grpcService',
+        type: 'string',
+        annotations: {
+          displayName: 'gRPC Service',
+          description: 'Fully qualified name of the gRPC service.',
+        },
+      },
+      {
+        index: 7,
+        name: 'grpcMethod',
+        type: 'string',
+        annotations: {
+          displayName: 'gRPC Method',
+          description: 'Method on the gRPC service.',
+        },
+      },
+      {
+        index: 8,
+        name: 'parameters',
+        type: 'array',
+        arrayItems: {
+          name: 'parameter',
+          type: 'record',
+          recordFields: [
+            {
+              index: 1,
+              name: 'name',
+              type: 'string',
+              constraints: {required: true},
+              annotations: {displayName: 'Name'},
+            },
+            {
+              index: 2,
+              name: 'type',
+              type: 'string',
+              constraints: {required: true},
+              annotations: {
+                displayName: 'Type',
+                description:
+                    'The authored type: an entity name, or a scalar datatype.',
+              },
+            },
+            {
+              index: 3,
+              name: 'isEntityRef',
+              type: 'bool',
+              annotations: {
+                displayName: 'Is Entity Reference',
+                description:
+                    'True when `type` names an entity, so the parameter ' +
+                    'refers to an object rather than carrying a value.',
+              },
+            },
+          ],
+        },
+        annotations: {
+          displayName: 'Parameters',
+          description:
+              'The inputs the action takes, each typed by the ontology.',
+        },
+      },
+      {
+        index: 9,
+        name: 'instructions',
+        type: 'string',
+        annotations: {
+          displayName: 'Instructions',
+          description:
+              'Guidance for AI consumers (the action\'s ai_context ' +
+              'instructions).',
+        },
+      },
+    ],
+  },
+};
+
+// Every type kcmd provisions. This list is the whole of what is custom.
+export const CUSTOM_TYPES: readonly CustomType[] = [
+  {
+    id: ACTION_TYPE_ID,
+    entryType: {
+      displayName: 'Semantic Action',
+      description: 'A write operation defined on a semantic model.',
+    },
+    aspectType: ACTION_ASPECT_TYPE,
+  },
+];
+
+// Custom types are provisioned at `global` so an entry group in any region can
+// reference them, matching where the built-in system types live.
+const CUSTOM_TYPE_LOCATION = 'global';
+
+// True when kcmd still provisions this id. It turns false the moment the type
+// is deleted from CUSTOM_TYPES, which is how the rest of the code learns that a
+// built-in has taken over.
+export function isCustomType(id: string): boolean {
+  return CUSTOM_TYPES.some(t => t.id === id);
+}
+
+// Where a destination's custom types live: the destination project itself,
+// because `kcmd init` is what creates them there.
+export function customTypeHome(dest: {project: string}):
+    {project: string; location: string} {
+  return {project: dest.project, location: CUSTOM_TYPE_LOCATION};
+}
+
+// Full resource name of a custom entry type in a destination.
+export function customEntryTypeName(
+    id: string, dest: {project: string}): string {
+  const home = customTypeHome(dest);
+  return `projects/${home.project}/locations/${home.location}/entryTypes/${id}`;
+}
+
+// Full resource name of a custom aspect type in a destination.
+export function customAspectTypeName(
+    id: string, dest: {project: string}): string {
+  const home = customTypeHome(dest);
+  return `projects/${home.project}/locations/${home.location}/aspectTypes/${
+      id}`;
+}
+
+// Aspect-map key: the `project.location.type` reference form the client keys an
+// entry's aspects by (see dataplex._nameToTypeRef).
+export function customAspectKey(id: string, dest: {project: string}): string {
+  const home = customTypeHome(dest);
+  return `${home.project}.${home.location}.${id}`;
+}
+
+// What provisioning produced. `error` is a failure the caller must not ignore.
+// `denied` is the narrower case of lacking permission to create a type, which
+// is reported and survived: these types back optional constructs, and a project
+// whose models use none of them never needs them.
+export interface ProvisionResult {
+  error?: string;
+  denied?: string;
+}
+
+/**
+ * Creates every type in CUSTOM_TYPES in a destination.
+ *
+ * Called from `kcmd init --semantic-model`, beside the entry group it already
+ * provisions, so a push still writes nothing but entries. Each aspect type is
+ * created and then, if it is already there, patched: a project provisioned by
+ * an earlier version of kcmd holds an older template, and pushing a field that
+ * template lacks fails with an opaque parsing error. Dataplex rejects a
+ * backwards-incompatible change, so the patch only ever adds appended fields.
+ *
+ * Stops at the first hard failure, and returns as soon as one type is refused
+ * for lack of permission, since the same caller will be refused the next one.
+ */
+export async function provisionCustomTypes(
+    cat: CatalogClient, dest: {project: string}): Promise<ProvisionResult> {
+  for (const type of CUSTOM_TYPES) {
+    const result = await provisionOne(cat, dest, type);
+    if (result.error || result.denied) return result;
+  }
+  return {};
+}
+
+// One custom type: its aspect type, then the entry type that requires it.
+async function provisionOne(
+    cat: CatalogClient, dest: {project: string},
+    type: CustomType): Promise<ProvisionResult> {
+  const home = customTypeHome(dest);
+
+  // Creating a type needs permissions that publishing entries does not. A
+  // caller who lacks them can still init, push and pull every model that uses
+  // none of these types, so the refusal is reported rather than fatal.
+  const denial = (what: string, status: number, message?: string):
+      ProvisionResult|undefined => status === 403 ?
+      {
+        denied: `no permission to create ${what} in project '${
+            home.project}' (${message || status}); ` +
+            `models that need it cannot be pushed until it exists`
+      } :
+      undefined;
+
+  const aspectLabel = `aspect type '${type.id}'`;
+  const aspect = await cat.createAspectType(
+      home.project, home.location, type.id, type.aspectType);
+  if (aspect.status === 409) {
+    const upd = await cat.updateAspectType(
+        home.project, home.location, type.id, type.aspectType,
+        ['description', 'display_name', 'metadata_template']);
+    const refused = denial(aspectLabel, upd.status, upd.message);
+    if (refused) return refused;
+    if (upd.status !== 200)
+      return {error: `updating ${aspectLabel}: ${upd.message || upd.status}`};
+    const failed =
+        await cat.awaitOperation(upd.result, `updating ${aspectLabel}`);
+    if (failed) return {error: failed};
+  } else if (aspect.status !== 200) {
+    const refused = denial(aspectLabel, aspect.status, aspect.message);
+    if (refused) return refused;
+    return {
+      error: `creating ${aspectLabel}: ${aspect.message || aspect.status}`
+    };
+  } else {
+    // The entry type below names this aspect type in its required aspects, and
+    // the server rejects that while the create is still in flight, so the wait
+    // is load-bearing rather than tidiness.
+    const failed =
+        await cat.awaitOperation(aspect.result, `creating ${aspectLabel}`);
+    if (failed) return {error: failed};
+  }
+
+  // The entry type requires the aspect type above, so it is created second. An
+  // existing one is left alone rather than patched: unlike the aspect type it
+  // carries no template that grows over time, and its required-aspect list is
+  // what an entry already published depends on.
+  const entryLabel = `entry type '${type.id}'`;
+  const entryType =
+      await cat.createEntryType(home.project, home.location, type.id, {
+        ...type.entryType,
+        requiredAspects: [{type: customAspectTypeName(type.id, dest)}],
+      });
+  if (entryType.status === 409) return {};
+  const refused = denial(entryLabel, entryType.status, entryType.message);
+  if (refused) return refused;
+  if (entryType.status !== 200) {
+    return {
+      error: `creating ${entryLabel}: ${entryType.message || entryType.status}`
+    };
+  }
+  // A push may follow immediately, and an entry naming a type that is still
+  // being created is rejected the same way, so wait here too.
+  const failed =
+      await cat.awaitOperation(entryType.result, `creating ${entryLabel}`);
+  return failed ? {error: failed} : {};
+}

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -15,9 +15,15 @@
 // `required_aspects`; the emitted aspect set per entry is those plus the
 // optional `guidelines` aspect (attached only when the object carries
 // `ai_context.instructions`):
-//   * semantic-model entry -> { semantic-model, guidelines? }
+//   * semantic-model entry -> { semantic-model, overview?, guidelines? }
 //   * semantic-entity entry -> { semantic-entity, schema, guidelines? }
 //   * semantic-metric entry -> { semantic-metric, guidelines? }
+//
+// Actions (the model's write operations) have no semantic-* system type, so
+// they ride the anchor's built-in `overview` aspect: human-readable Markdown
+// plus an embedded JSON block a pull recovers them from (see
+// actionsOverviewAspectData). The overview is attached only when the model
+// declares actions.
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):
@@ -49,7 +55,7 @@
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
 import {googleDeploymentTargets} from './deployment_target';
-import {AiContext, DataType, Entity, Metric, Relationship, SemanticModel} from './ir';
+import {Action, AiContext, DataType, Entity, Executor, Metric, Relationship, SemanticModel} from './ir';
 
 // Where the `semantic-*` and `schema` system types live: built-in types in
 // project `dataplex-types`, location `global`. Callers may override to reference
@@ -127,12 +133,22 @@ export function generateCatalogResources(
   const modelEntryName = names.entry(modelId);
   claim(seen, modelId, 'entry', `model '${model.name}'`, warnings);
 
+  // The anchor's base aspects: always semantic-model; plus the built-in
+  // `overview` aspect when the model has actions. Actions are write-side and
+  // have no semantic-* system type of their own, so they ride the anchor's
+  // free-form overview (Markdown for humans + an embedded JSON block a pull
+  // recovers them from) rather than getting their own entries.
+  const anchorBase: Record<string, Record<string, any>> = {
+    'semantic-model': modelAspectData(model),
+  };
+  const overview = actionsOverviewAspectData(model, warnings);
+  if (overview) anchorBase['overview'] = overview;
+
   const entries: Entry[] = [{
     name: modelEntryName,
     entryType: names.typeName('entry', 'semantic-model'),
     entrySource: source(model.name, model.description),
-    aspects: aspectsFor(
-        names, {'semantic-model': modelAspectData(model)}, model.aiContext),
+    aspects: aspectsFor(names, anchorBase, model.aiContext),
   }];
 
   // Maps an entity's model name to its published entry name, so a relationship
@@ -347,6 +363,100 @@ function modelAspectData(model: SemanticModel): Record<string, any> {
   return compact({
     deploymentTargets: uris.length ? uris : undefined,
   });
+}
+
+// Fences the machine-readable action JSON inside the overview Markdown. The
+// reader (kc_converter.readActionsFromOverview) locates the block by this
+// marker and parses the fenced JSON, so publish and pull agree on one
+// delimiter.
+export const ACTIONS_OVERVIEW_MARKER = '<!-- kcmd:actions v1 -->';
+
+// The anchor's `overview` aspect carrying the model's actions, or undefined
+// when there are none (so a model without actions carries no overview and the
+// anchor is unchanged from before actions existed). Actions have no BigQuery
+// Graph or semantic-* representation; the overview is their only catalog home.
+// The content is human-readable Markdown followed by a fenced JSON block (after
+// ACTIONS_OVERVIEW_MARKER) that a pull round-trips losslessly.
+function actionsOverviewAspectData(
+    model: SemanticModel, warnings: string[]): Record<string, any>|undefined {
+  const actions = model.actions ?? [];
+  if (!actions.length) return undefined;
+  warnings.push(
+      `model '${model.name}': ${actions.length} action(s) published to the ` +
+      `model's overview aspect (actions have no BigQuery Graph representation).`);
+  return {
+    content: renderActionsOverview(actions),
+    contentType: 'MARKDOWN',
+  };
+}
+
+// Renders the actions overview: a Markdown section for humans, then the marker
+// and a fenced JSON array (the canonical IR form) for a lossless pull.
+function renderActionsOverview(actions: Action[]): string {
+  const md: string[] = [
+    '## Actions',
+    '',
+    'Write operations defined on this model -- the write-side counterpart to ' +
+        'metrics. Actions have no BigQuery Graph representation; they are ' +
+        'published here for discovery and are round-tripped by `kcmd pull`.',
+    '',
+  ];
+  for (const a of actions) {
+    md.push(`### ${a.name}`, '');
+    if (a.description) md.push(a.description, '');
+    md.push(`- Executor: ${describeExecutor(a.executor)}`);
+    if (a.parameters.length) {
+      md.push('- Parameters:');
+      for (const p of a.parameters) {
+        const kind = p.isEntityRef ? `${p.type} (entity reference)` : p.type;
+        md.push(`  - \`${p.name}\`: ${kind}`);
+      }
+    }
+    md.push('');
+  }
+  md.push(
+      ACTIONS_OVERVIEW_MARKER, '```json',
+      JSON.stringify(actions.map(actionJson), null, 2), '```', '');
+  return md.join('\n');
+}
+
+// A one-line human description of an executor for the Markdown body.
+function describeExecutor(ex: Executor): string {
+  switch (ex.kind) {
+    case 'mcp':
+      return `MCP tool \`${ex.mcp.tool}\` on server \`${ex.mcp.server}\``;
+    case 'rest':
+      return `REST ${ex.rest.method} \`${ex.rest.endpoint}\``;
+    case 'grpc':
+      return `gRPC \`${ex.grpc.service}/${ex.grpc.method}\``;
+  }
+}
+
+// The canonical JSON form of an action embedded in the overview, mirroring the
+// IR so kc_converter.readActionsFromOverview reconstructs it verbatim. The
+// executor's tagged union is flattened to the open format's single-key object,
+// matching how osi_converter emits it to YAML.
+function actionJson(a: Action): Record<string, any> {
+  return compact({
+    name: a.name,
+    description: a.description,
+    executor: executorJson(a.executor),
+    parameters: a.parameters.map(
+        p => compact({name: p.name, type: p.type, isEntityRef: p.isEntityRef})),
+    aiContext: a.aiContext,
+    customExtensions: a.customExtensions,
+  });
+}
+
+function executorJson(ex: Executor): Record<string, any> {
+  switch (ex.kind) {
+    case 'mcp':
+      return {mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+    case 'rest':
+      return {rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}};
+    case 'grpc':
+      return {grpc: {service: ex.grpc.service, method: ex.grpc.method}};
+  }
 }
 
 // semantic-entity: the base table(s) backing the entity. importedSystem/

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -22,9 +22,9 @@
 // An action (the model's write operations) is published the same way, one entry
 // per action parented to the anchor, but its entry and aspect types are CUSTOM:
 // there is no built-in type for an action yet, so `kcmd init` provisions the
-// pair in the destination project. Everything about those types, and the aspect
-// the action carries, lives in `kc_actions.ts`; this module only appends the
-// entries that file returns.
+// pair in the destination project. `kc_custom_types.ts` declares those types
+// and `kc_actions.ts` encodes the aspect an action carries; this module only
+// appends the entries the latter returns.
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):
@@ -201,10 +201,10 @@ export function generateCatalogResources(
     });
   }
 
-  // One entry per action, alongside the entities and metrics. Actions are the
-  // only construct with no built-in system type, so `kc_actions.ts` owns both
-  // the types they reference and the aspect they carry; it returns nothing when
-  // the model declares no actions.
+  // One entry per action, alongside the entities and metrics. Actions have no
+  // built-in system type, so they reference the custom pair declared in
+  // `kc_custom_types.ts`, and `kc_actions.ts` fills the aspect; it returns
+  // nothing when the model declares no actions.
   entries.push(...actionEntries(model, modelId, {
     project: opts.project,
     entry: (id: string) => names.entry(id),

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -211,6 +211,9 @@ export function generateCatalogResources(
     anchor: modelEntryName,
     claim: (id: string, label: string) =>
         claim(seen, id, 'entry', label, warnings),
+    // Populated by the entity loop above, so it excludes the abstract and
+    // unavailable entities that loop skipped.
+    publishedEntities: new Set(entityEntryName.keys()),
   }, warnings));
 
   // Relationships map to schema-join entry links between their endpoint entries.

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -15,13 +15,16 @@
 // `required_aspects`; the emitted aspect set per entry is those plus the
 // optional `guidelines` aspect (attached only when the object carries
 // `ai_context.instructions`):
-//   * semantic-model entry -> { semantic-model, overview?, guidelines? }
+//   * semantic-model entry -> { semantic-model, guidelines? }
 //   * semantic-entity entry -> { semantic-entity, schema, guidelines? }
 //   * semantic-metric entry -> { semantic-metric, guidelines? }
 //
-// Actions (the model's write operations) have no system type of their own. How
-// they are persisted instead lives entirely in `kc_actions.ts`; this module only
-// merges whatever aspects that file returns into the anchor.
+// An action (the model's write operations) is published the same way, one entry
+// per action parented to the anchor, but its entry and aspect types are CUSTOM:
+// there is no built-in type for an action yet, so `kcmd init` provisions the
+// pair in the destination project. Everything about those types, and the aspect
+// the action carries, lives in `kc_actions.ts`; this module only appends the
+// entries that file returns.
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):
@@ -54,7 +57,7 @@ import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
 import {googleDeploymentTargets} from './deployment_target';
 import {AiContext, DataType, Entity, Metric, Relationship, SemanticModel} from './ir';
-import {actionAnchorAspects} from './kc_actions';
+import {actionEntries, actionOwnedPrefix} from './kc_actions';
 
 // Where the `semantic-*` and `schema` system types live: built-in types in
 // project `dataplex-types`, location `global`. Callers may override to reference
@@ -132,20 +135,12 @@ export function generateCatalogResources(
   const modelEntryName = names.entry(modelId);
   claim(seen, modelId, 'entry', `model '${model.name}'`, warnings);
 
-  // The anchor's base aspects: always semantic-model, plus whatever aspects
-  // carry the model's actions. Actions have no system type of their own, so
-  // `kc_actions.ts` owns that encoding and returns nothing when the model
-  // declares no actions.
-  const anchorBase: Record<string, Record<string, any>> = {
-    'semantic-model': modelAspectData(model),
-    ...actionAnchorAspects(model, warnings),
-  };
-
   const entries: Entry[] = [{
     name: modelEntryName,
     entryType: names.typeName('entry', 'semantic-model'),
     entrySource: source(model.name, model.description),
-    aspects: aspectsFor(names, anchorBase, model.aiContext),
+    aspects: aspectsFor(
+        names, {'semantic-model': modelAspectData(model)}, model.aiContext),
   }];
 
   // Maps an entity's model name to its published entry name, so a relationship
@@ -206,6 +201,18 @@ export function generateCatalogResources(
     });
   }
 
+  // One entry per action, alongside the entities and metrics. Actions are the
+  // only construct with no built-in system type, so `kc_actions.ts` owns both
+  // the types they reference and the aspect they carry; it returns nothing when
+  // the model declares no actions.
+  entries.push(...actionEntries(model, modelId, {
+    project: opts.project,
+    entry: (id: string) => names.entry(id),
+    anchor: modelEntryName,
+    claim: (id: string, label: string) =>
+        claim(seen, id, 'entry', label, warnings),
+  }, warnings));
+
   // Relationships map to schema-join entry links between their endpoint entries.
   const entryLinks: EntryLink[] = [];
   const seenLinks = new Set<string>();
@@ -219,8 +226,13 @@ export function generateCatalogResources(
     entries,
     entryLinks,
     warnings: [...new Set(warnings)],
-    // Ossie ids are dotted: `<model>.entities.<name>` / `<model>.metrics.<name>`.
-    ownedPrefixes: [`${modelId}.entities.`, `${modelId}.metrics.`],
+    // Ossie ids are dotted: `<model>.entities.<name>` / `<model>.metrics.<name>`
+    // / `<model>.actions.<name>`.
+    ownedPrefixes: [
+      `${modelId}.entities.`,
+      `${modelId}.metrics.`,
+      actionOwnedPrefix(modelId),
+    ],
   };
 }
 

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -19,11 +19,9 @@
 //   * semantic-entity entry -> { semantic-entity, schema, guidelines? }
 //   * semantic-metric entry -> { semantic-metric, guidelines? }
 //
-// Actions (the model's write operations) have no semantic-* system type, so
-// they ride the anchor's built-in `overview` aspect: human-readable Markdown
-// plus an embedded JSON block a pull recovers them from (see
-// actionsOverviewAspectData). The overview is attached only when the model
-// declares actions.
+// Actions (the model's write operations) have no system type of their own. How
+// they are persisted instead lives entirely in `kc_actions.ts`; this module only
+// merges whatever aspects that file returns into the anchor.
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):
@@ -55,7 +53,8 @@
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
 import {googleDeploymentTargets} from './deployment_target';
-import {Action, AiContext, DataType, Entity, Executor, Metric, Relationship, SemanticModel} from './ir';
+import {AiContext, DataType, Entity, Metric, Relationship, SemanticModel} from './ir';
+import {actionAnchorAspects} from './kc_actions';
 
 // Where the `semantic-*` and `schema` system types live: built-in types in
 // project `dataplex-types`, location `global`. Callers may override to reference
@@ -133,16 +132,14 @@ export function generateCatalogResources(
   const modelEntryName = names.entry(modelId);
   claim(seen, modelId, 'entry', `model '${model.name}'`, warnings);
 
-  // The anchor's base aspects: always semantic-model; plus the built-in
-  // `overview` aspect when the model has actions. Actions are write-side and
-  // have no semantic-* system type of their own, so they ride the anchor's
-  // free-form overview (Markdown for humans + an embedded JSON block a pull
-  // recovers them from) rather than getting their own entries.
+  // The anchor's base aspects: always semantic-model, plus whatever aspects
+  // carry the model's actions. Actions have no system type of their own, so
+  // `kc_actions.ts` owns that encoding and returns nothing when the model
+  // declares no actions.
   const anchorBase: Record<string, Record<string, any>> = {
     'semantic-model': modelAspectData(model),
+    ...actionAnchorAspects(model, warnings),
   };
-  const overview = actionsOverviewAspectData(model, warnings);
-  if (overview) anchorBase['overview'] = overview;
 
   const entries: Entry[] = [{
     name: modelEntryName,
@@ -363,100 +360,6 @@ function modelAspectData(model: SemanticModel): Record<string, any> {
   return compact({
     deploymentTargets: uris.length ? uris : undefined,
   });
-}
-
-// Fences the machine-readable action JSON inside the overview Markdown. The
-// reader (kc_converter.readActionsFromOverview) locates the block by this
-// marker and parses the fenced JSON, so publish and pull agree on one
-// delimiter.
-export const ACTIONS_OVERVIEW_MARKER = '<!-- kcmd:actions v1 -->';
-
-// The anchor's `overview` aspect carrying the model's actions, or undefined
-// when there are none (so a model without actions carries no overview and the
-// anchor is unchanged from before actions existed). Actions have no BigQuery
-// Graph or semantic-* representation; the overview is their only catalog home.
-// The content is human-readable Markdown followed by a fenced JSON block (after
-// ACTIONS_OVERVIEW_MARKER) that a pull round-trips losslessly.
-function actionsOverviewAspectData(
-    model: SemanticModel, warnings: string[]): Record<string, any>|undefined {
-  const actions = model.actions ?? [];
-  if (!actions.length) return undefined;
-  warnings.push(
-      `model '${model.name}': ${actions.length} action(s) published to the ` +
-      `model's overview aspect (actions have no BigQuery Graph representation).`);
-  return {
-    content: renderActionsOverview(actions),
-    contentType: 'MARKDOWN',
-  };
-}
-
-// Renders the actions overview: a Markdown section for humans, then the marker
-// and a fenced JSON array (the canonical IR form) for a lossless pull.
-function renderActionsOverview(actions: Action[]): string {
-  const md: string[] = [
-    '## Actions',
-    '',
-    'Write operations defined on this model -- the write-side counterpart to ' +
-        'metrics. Actions have no BigQuery Graph representation; they are ' +
-        'published here for discovery and are round-tripped by `kcmd pull`.',
-    '',
-  ];
-  for (const a of actions) {
-    md.push(`### ${a.name}`, '');
-    if (a.description) md.push(a.description, '');
-    md.push(`- Executor: ${describeExecutor(a.executor)}`);
-    if (a.parameters.length) {
-      md.push('- Parameters:');
-      for (const p of a.parameters) {
-        const kind = p.isEntityRef ? `${p.type} (entity reference)` : p.type;
-        md.push(`  - \`${p.name}\`: ${kind}`);
-      }
-    }
-    md.push('');
-  }
-  md.push(
-      ACTIONS_OVERVIEW_MARKER, '```json',
-      JSON.stringify(actions.map(actionJson), null, 2), '```', '');
-  return md.join('\n');
-}
-
-// A one-line human description of an executor for the Markdown body.
-function describeExecutor(ex: Executor): string {
-  switch (ex.kind) {
-    case 'mcp':
-      return `MCP tool \`${ex.mcp.tool}\` on server \`${ex.mcp.server}\``;
-    case 'rest':
-      return `REST ${ex.rest.method} \`${ex.rest.endpoint}\``;
-    case 'grpc':
-      return `gRPC \`${ex.grpc.service}/${ex.grpc.method}\``;
-  }
-}
-
-// The canonical JSON form of an action embedded in the overview, mirroring the
-// IR so kc_converter.readActionsFromOverview reconstructs it verbatim. The
-// executor's tagged union is flattened to the open format's single-key object,
-// matching how osi_converter emits it to YAML.
-function actionJson(a: Action): Record<string, any> {
-  return compact({
-    name: a.name,
-    description: a.description,
-    executor: executorJson(a.executor),
-    parameters: a.parameters.map(
-        p => compact({name: p.name, type: p.type, isEntityRef: p.isEntityRef})),
-    aiContext: a.aiContext,
-    customExtensions: a.customExtensions,
-  });
-}
-
-function executorJson(ex: Executor): Record<string, any> {
-  switch (ex.kind) {
-    case 'mcp':
-      return {mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
-    case 'rest':
-      return {rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}};
-    case 'grpc':
-      return {grpc: {service: ex.grpc.service, method: ex.grpc.method}};
-  }
 }
 
 // semantic-entity: the base table(s) backing the entity. importedSystem/

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -12,7 +12,7 @@
 import * as yaml from 'yaml';
 import * as z from 'zod';
 
-import {AiContext, CustomExtension, DATA_TYPES, Entity, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, ActionParameter, AiContext, CustomExtension, DATA_TYPES, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface LoadOptions {
@@ -191,6 +191,51 @@ const metricSchema = z.object({
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
 
+// An action executor: exactly one kind. The open format expresses it as an
+// object with a single kind key (mcp/rest/grpc); we accept the union and enforce
+// the "exactly one" rule in a refinement so the message names the violation.
+const executorSchema =
+    z.object({
+       mcp: z.object({server: z.string(), tool: z.string()}).strict().optional(),
+       rest: z.object({endpoint: z.string(), method: z.string()})
+                 .strict()
+                 .optional(),
+       grpc: z.object({service: z.string(), method: z.string()})
+                 .strict()
+                 .optional(),
+     })
+        .strict()
+        .superRefine((ex, ctx) => {
+          const kinds =
+              (['mcp', 'rest', 'grpc'] as const).filter(k => ex[k] !== undefined);
+          if (kinds.length !== 1) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: kinds.length === 0 ?
+                  `executor requires exactly one kind (mcp, rest, or grpc); none given` :
+                  `executor requires exactly one kind, but ${kinds.length} given ` +
+                      `(${kinds.join(', ')})`,
+            });
+          }
+        });
+
+// An action parameter: a name and an ontology type (an entity name for an object
+// reference, or a scalar DataType). The type is validated against the model in
+// convertAction, not here, so the schema stays a plain string.
+const parameterSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+});
+
+const actionSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  executor: executorSchema,
+  parameters: z.array(parameterSchema).optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+});
+
 const modelBase = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -202,6 +247,8 @@ const modelBase = z.object({
   // A native deployment-target key (GOOGLE_VERSION only). Folded into a GOOGLE
   // `custom_extensions` block on the IR after validation (see convertModel).
   deployment_target: z.string().optional(),
+  // Model-level write operations, also GOOGLE_VERSION only (see actionSchema).
+  actions: z.array(actionSchema).optional(),
 });
 
 
@@ -338,6 +385,20 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
          ...ce,
        }).strict();
 
+  const parameter = z.object({
+                       name: z.string(),
+                       type: z.string(),
+                     }).strict();
+
+  const action = z.object({
+                    name: z.string(),
+                    description: z.string().optional(),
+                    executor: executorSchema,
+                    parameters: z.array(parameter).optional(),
+                    ai_context: aiContextSchema.optional(),
+                    ...ce,
+                  }).strict();
+
   const model =
       z.object({
          name: z.string(),
@@ -347,9 +408,15 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
          relationships: z.array(relationship).optional(),
          metrics: z.array(metric).optional(),
          ...ce,
-         // `deployment_target` is a native extension key: extended profile
-         // only.
-         ...(extended ? {deployment_target: z.string().optional()} : {}),
+         // Native extension keys: extended profile only. `actions` is one of
+         // them because vanilla Ossie has no action construct and no
+         // `custom_extensions` encoding for one, so under OSSIE_VERSION an
+         // `actions` key is rejected as unknown rather than silently dropped.
+         ...(extended ? {
+           deployment_target: z.string().optional(),
+           actions: z.array(action).optional(),
+         } :
+                        {}),
        }).strict();
 
   return z
@@ -384,6 +451,9 @@ type FieldDoc = z.infer<typeof fieldBase>;
 type RelationshipDoc = z.infer<typeof relationshipSchema>;
 type MetricDoc = z.infer<typeof metricSchema>;
 type ModelDoc = z.infer<typeof modelBase>;
+type ActionDoc = z.infer<typeof actionSchema>;
+type ParameterDoc = z.infer<typeof parameterSchema>;
+type ExecutorDoc = z.infer<typeof executorSchema>;
 type CustomExtensionDoc = z.infer<typeof customExtensionSchema>;
 // The whole document, as the convert functions see it: `version` plus the
 // superset model shape (every version's keys, each optional -- modelBase is the
@@ -602,9 +672,17 @@ function convertModel(
   rejectDuplicateNames(
       metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`);
 
+  // Actions reference entities as parameter types, so they are converted after
+  // entities are known.
+  const actions =
+      (m.actions ?? []).map(a => convertAction(a, entityNameSet, warnings));
+  rejectDuplicateNames(
+      actions.map(a => a.name), 'action name', `model '${m.name}'`);
+
   const description = composeDescription(m.description);
 
   const model: SemanticModel = {name: m.name, entities, relationships, metrics};
+  if (actions.length) model.actions = actions;
   if (description) model.description = description;
   const ai = aiContextOrUndefined(m.ai_context);
   if (ai) model.aiContext = ai;
@@ -772,6 +850,64 @@ function convertMetric(
   const ce = toCustomExtensions(mt.custom_extensions);
   if (ce) metric.customExtensions = ce;
   return metric;
+}
+
+// Maps an authored action onto the IR. Parameter types are resolved against the
+// model's entities; a type that is neither a known entity nor a scalar datatype
+// is kept verbatim and warned, so the loader stays lenient (a strict `validate`
+// gate can promote these later).
+function convertAction(
+    a: ActionDoc, entityNames: Set<string>, warnings: string[]): Action {
+  const parameters = (a.parameters ?? [])
+                         .map(p => convertParameter(
+                                  p, a.name, entityNames, warnings));
+  // Parameter names address the inputs at dispatch, so a collision is as
+  // ambiguous as a duplicate field or metric name -- reject it the same way.
+  rejectDuplicateNames(
+      parameters.map(p => p.name), 'parameter name', `action '${a.name}'`);
+
+  const action: Action = {
+    name: a.name,
+    executor: convertExecutor(a.executor),
+    parameters,
+  };
+
+  const description = composeDescription(a.description);
+  if (description) action.description = description;
+  const ai = aiContextOrUndefined(a.ai_context);
+  if (ai) action.aiContext = ai;
+  const ce = toCustomExtensions(a.custom_extensions);
+  if (ce) action.customExtensions = ce;
+  return action;
+}
+
+// Resolves a parameter's authored `type` against the ontology: a known entity
+// name makes it an object reference (isEntityRef = true); a scalar DataType makes
+// it a value (isEntityRef = false). A type that is neither is kept verbatim with
+// isEntityRef left unset, and warned.
+function convertParameter(
+    p: ParameterDoc, actionName: string, entityNames: Set<string>,
+    warnings: string[]): ActionParameter {
+  const param: ActionParameter = { name: p.name, type: p.type };
+  if (entityNames.has(p.type)) {
+    param.isEntityRef = true;
+  } else if ((DATA_TYPES as readonly string[]).includes(p.type)) {
+    param.isEntityRef = false;
+  } else {
+    warnings.push(
+      `action '${actionName}': parameter '${p.name}' type '${p.type}' is ` +
+      `neither a known entity nor a scalar datatype (${DATA_TYPES.join('/')})`);
+  }
+  return param;
+}
+
+// Normalizes the open format's single-key executor object to the IR's tagged
+// union. The schema already guaranteed exactly one kind is present.
+function convertExecutor(ex: ExecutorDoc): Executor {
+  if (ex.mcp) return { kind: 'mcp', mcp: { ...ex.mcp } };
+  if (ex.rest) return { kind: 'rest', rest: { ...ex.rest } };
+  // The schema's refinement guarantees one of mcp/rest/grpc is set.
+  return { kind: 'grpc', grpc: { ...ex.grpc! } };
 }
 
 // Collapses an expression's per-dialect variants into at most two forms:

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -42,7 +42,7 @@
 
 import * as yaml from 'yaml';
 
-import {AiContext, CustomExtension, Entity, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, AiContext, CustomExtension, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
 
 // The version stamped on every serialized document. Pull emits kcmd's extended
 // profile: it uses native extension keys (`entities`, `deployment_target`)
@@ -196,6 +196,8 @@ function modelDoc(model: SemanticModel, warnings: string[], logical: boolean):
     relationships: nonEmpty(
         (model.relationships ?? []).map(r => relationshipDoc(r, warnings))),
     metrics: nonEmpty((model.metrics ?? []).map(m => metricDoc(m, warnings))),
+    actions:
+        nonEmpty((model.actions ?? []).map(a => actionDoc(a, warnings))),
   });
 }
 
@@ -275,6 +277,34 @@ function metricDoc(metric: Metric, warnings: string[]): Record<string, any> {
     description: metric.description,
     ai_context: aiContextDoc(metric.aiContext),
   });
+}
+
+// Inverts loader.convertAction. The executor collapses back to the open
+// format's single-key object; parameters emit as {name, type}. `isEntityRef` is
+// derived by the loader on reload, so it is intentionally not emitted.
+function actionDoc(action: Action, warnings: string[]): Record<string, any> {
+  dropExtensions(action.customExtensions, `action '${action.name}'`, warnings);
+  return compact({
+    name: action.name,
+    description: action.description,
+    executor: executorDoc(action.executor),
+    parameters: nonEmpty(
+        (action.parameters ?? []).map(p => ({name: p.name, type: p.type}))),
+    ai_context: aiContextDoc(action.aiContext),
+  });
+}
+
+// Collapses the IR's tagged executor union back to the open format's single-key
+// object ({mcp: {...}} / {rest: {...}} / {grpc: {...}}).
+function executorDoc(ex: Executor): Record<string, any> {
+  switch (ex.kind) {
+    case 'mcp':
+      return {mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+    case 'rest':
+      return {rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}};
+    case 'grpc':
+      return {grpc: {service: ex.grpc.service, method: ex.grpc.method}};
+  }
 }
 
 // Inverts loader.convertRelationship: `from`/`to` are the endpoint entities and

--- a/toolbox/mdcode/src/libts/semantic/pull_kc.ts
+++ b/toolbox/mdcode/src/libts/semantic/pull_kc.ts
@@ -149,7 +149,13 @@ function semanticAspectTypes(entryType: string): string[]|undefined {
   const aspectType = (name: string) => `${typeBase}/aspectTypes/${name}`;
   switch (t) {
     case 'semantic-model':
-      return [aspectType('semantic-model'), aspectType('guidelines')];
+      // The anchor also carries the built-in `overview` aspect when the model
+      // has actions (see actionsOverviewAspectData); fetch it so a pull can
+      // recover them.
+      return [
+        aspectType('semantic-model'), aspectType('overview'),
+        aspectType('guidelines')
+      ];
     case 'semantic-entity':
       return [
         aspectType('semantic-entity'), aspectType('schema'),

--- a/toolbox/mdcode/src/libts/semantic/pull_kc.ts
+++ b/toolbox/mdcode/src/libts/semantic/pull_kc.ts
@@ -19,7 +19,8 @@
 import {CatalogClient, Entry, EntryLink} from '../gcp/dataplex';
 
 import {SemanticModel} from './ir';
-import {ACTION_TYPE_ID, actionAspectTypes} from './kc_actions';
+import {actionAspectTypes} from './kc_actions';
+import {ACTION_TYPE_ID} from './kc_custom_types';
 import {idOf, linkDedupKey, modelsFromCatalogResources} from './kc_converter';
 
 export interface KcPullOptions {
@@ -159,9 +160,10 @@ function semanticAspectTypes(entryType: string): string[]|undefined {
     case 'semantic-metric':
       return [aspectType('semantic-metric'), aspectType('guidelines')];
     case ACTION_TYPE_ID:
-      // An action's entry type is custom, so it lives in the destination
-      // project rather than under `dataplex-types`; `typeBase` already points
-      // there, and kc_actions.ts names the aspects to fetch beneath it.
+      // An action's entry type is custom (see kc_custom_types.ts), so it
+      // lives in the destination project rather than under `dataplex-types`;
+      // `typeBase` already points there, and kc_actions.ts names the aspects
+      // to fetch beneath it.
       return actionAspectTypes(typeBase);
     default:
       return undefined;

--- a/toolbox/mdcode/src/libts/semantic/pull_kc.ts
+++ b/toolbox/mdcode/src/libts/semantic/pull_kc.ts
@@ -19,6 +19,7 @@
 import {CatalogClient, Entry, EntryLink} from '../gcp/dataplex';
 
 import {SemanticModel} from './ir';
+import {ACTION_ANCHOR_ASPECT_TYPES} from './kc_actions';
 import {idOf, linkDedupKey, modelsFromCatalogResources} from './kc_converter';
 
 export interface KcPullOptions {
@@ -149,12 +150,12 @@ function semanticAspectTypes(entryType: string): string[]|undefined {
   const aspectType = (name: string) => `${typeBase}/aspectTypes/${name}`;
   switch (t) {
     case 'semantic-model':
-      // The anchor also carries the built-in `overview` aspect when the model
-      // has actions (see actionsOverviewAspectData); fetch it so a pull can
-      // recover them.
+      // The anchor also carries whatever aspects hold the model's actions (see
+      // kc_actions.ts); fetch them so a pull can recover the actions.
       return [
-        aspectType('semantic-model'), aspectType('overview'),
-        aspectType('guidelines')
+        aspectType('semantic-model'),
+        ...ACTION_ANCHOR_ASPECT_TYPES.map(aspectType),
+        aspectType('guidelines'),
       ];
     case 'semantic-entity':
       return [

--- a/toolbox/mdcode/src/libts/semantic/pull_kc.ts
+++ b/toolbox/mdcode/src/libts/semantic/pull_kc.ts
@@ -19,7 +19,7 @@
 import {CatalogClient, Entry, EntryLink} from '../gcp/dataplex';
 
 import {SemanticModel} from './ir';
-import {ACTION_ANCHOR_ASPECT_TYPES} from './kc_actions';
+import {ACTION_TYPE_ID, actionAspectTypes} from './kc_actions';
 import {idOf, linkDedupKey, modelsFromCatalogResources} from './kc_converter';
 
 export interface KcPullOptions {
@@ -150,13 +150,7 @@ function semanticAspectTypes(entryType: string): string[]|undefined {
   const aspectType = (name: string) => `${typeBase}/aspectTypes/${name}`;
   switch (t) {
     case 'semantic-model':
-      // The anchor also carries whatever aspects hold the model's actions (see
-      // kc_actions.ts); fetch them so a pull can recover the actions.
-      return [
-        aspectType('semantic-model'),
-        ...ACTION_ANCHOR_ASPECT_TYPES.map(aspectType),
-        aspectType('guidelines'),
-      ];
+      return [aspectType('semantic-model'), aspectType('guidelines')];
     case 'semantic-entity':
       return [
         aspectType('semantic-entity'), aspectType('schema'),
@@ -164,6 +158,11 @@ function semanticAspectTypes(entryType: string): string[]|undefined {
       ];
     case 'semantic-metric':
       return [aspectType('semantic-metric'), aspectType('guidelines')];
+    case ACTION_TYPE_ID:
+      // An action's entry type is custom, so it lives in the destination
+      // project rather than under `dataplex-types`; `typeBase` already points
+      // there, and kc_actions.ts names the aspects to fetch beneath it.
+      return actionAspectTypes(typeBase);
     default:
       return undefined;
   }

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -11,7 +11,7 @@
 import {BigQueryClient} from '../gcp/bigquery';
 
 import {googleDeploymentTargets} from './deploy_bigquery';
-import {SemanticModel} from './ir';
+import {Executor, SemanticModel} from './ir';
 import {LoadedModel} from './loader';
 
 // Checks every model against the push requirements and returns the collected
@@ -109,8 +109,63 @@ export function validatePushRequirements(
         }
       }
     }
+
+    // Actions have no BigQuery Graph representation, so their checks are
+    // target-independent: each parameter's type must resolve to something in
+    // the ontology, and the executor must carry the coordinates a runtime needs
+    // to dispatch it. (The "exactly one executor kind" rule is already
+    // guaranteed by the loader schema, so it cannot reach here.)
+    errors.push(...validateActions(model, document));
   }
   return errors;
+}
+
+// Static, target-independent checks for a model's actions. Returns one message
+// per violation. Two things can be statically wrong once the model has parsed:
+//   - a parameter's type resolves to neither a known entity nor a scalar
+//     datatype (the loader left isEntityRef unset and only warned) -- an
+//     unresolvable type is a malformed action, promoted to a hard error here;
+//   - an executor is missing a coordinate a runtime needs to dispatch it (an
+//     empty server/tool, endpoint/method, or service/method) -- the schema
+//     accepts empty strings, so this is caught here rather than at parse.
+function validateActions(model: SemanticModel, document: string): string[] {
+  const errors: string[] = [];
+  for (const action of model.actions ?? []) {
+    const where =
+        `action '${action.name}' in model '${model.name}' (${document})`;
+    for (const param of action.parameters) {
+      if (param.isEntityRef === undefined) {
+        errors.push(`${where} has parameter '${param.name}' whose type '${
+            param.type}' is neither a known entity nor a scalar datatype.`);
+      }
+    }
+    for (const missing of missingExecutorFields(action.executor)) {
+      errors.push(`${where} has an ${
+          action.executor.kind} executor missing its '${missing}'.`);
+    }
+  }
+  return errors;
+}
+
+
+// The executor coordinate fields that are absent or blank. An executor with no
+// gaps yields an empty list.
+function missingExecutorFields(ex: Executor): string[] {
+  const blank = (s: string) => s.trim().length === 0;
+  switch (ex.kind) {
+    case 'mcp':
+      return [['server', ex.mcp.server], ['tool', ex.mcp.tool]]
+          .filter(([, v]) => blank(v))
+          .map(([k]) => k);
+    case 'rest':
+      return [['endpoint', ex.rest.endpoint], ['method', ex.rest.method]]
+          .filter(([, v]) => blank(v))
+          .map(([k]) => k);
+    case 'grpc':
+      return [['service', ex.grpc.service], ['method', ex.grpc.method]]
+          .filter(([, v]) => blank(v))
+          .map(([k]) => k);
+  }
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -141,7 +141,7 @@ function validateActions(model: SemanticModel, document: string): string[] {
     }
     for (const missing of missingExecutorFields(action.executor)) {
       errors.push(`${where} has an ${
-          action.executor.kind} executor missing its '${missing}'.`);
+          action.executor.kind} executor whose '${missing}' is missing or blank.`);
     }
   }
   return errors;

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -601,6 +601,27 @@ export async function push(options: PushOptions): Promise<number> {
           '.');
     }
 
+    // Actions have no BigQuery/Spanner Graph construct -- their only destination
+    // is Knowledge Catalog. A push that omits the KC leg (--no-kc) would
+    // validate a model's actions and then deploy them nowhere, so warn rather
+    // than drop them silently.
+    if (!kcEnabled) {
+      const kcProfileName =
+          namedProfile ?? snapshot.manifest.defaultProfile ?? DEFAULT_PROFILE;
+      const docs = mergeOnce(kcProfileName, false);
+      const prepared =
+          docs ? await prepareOnce(docs, kcProfileName, false) : null;
+      for (const {model} of prepared?.models ?? []) {
+        const n = model.actions?.length ?? 0;
+        if (n) {
+          console.warn(
+              `Warning: model '${model.name}' declares ${n} action(s), which ` +
+              `deploy only to Knowledge Catalog; --no-kc excludes that leg, so ` +
+              `they will not be deployed. Drop --no-kc to deploy them.`);
+        }
+      }
+    }
+
     // Knowledge Catalog records one canonical view of the logical model: the
     // single --profile selection, else the default binding. Alongside a graph
     // deploy the entries reflect that binding (pruned to what it answers); a

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -231,6 +231,7 @@ export async function init(options: InitOptions): Promise<number> {
     // writes references types that already exist under `dataplex-types`.
     // kc_custom_types.ts is the list of what is custom.
     const provisioned = await provisionCustomTypes(catalog, source);
+    for (const w of provisioned.warnings ?? []) console.warn(`Warning: ${w}`);
     if (provisioned.error) {
       console.error(`Error: ${provisioned.error}`);
       return 1;
@@ -634,7 +635,12 @@ export async function push(options: PushOptions): Promise<number> {
           (mergeOnce(kcProfileName, true) ?? []).filter(d => !loadedDocs.has(d.name));
       if (rest.length) {
         const prepared = await prepareOnce(rest, kcProfileName, false);
-        for (const {model} of prepared?.models ?? []) {
+        // prepareModels has already printed why it failed. Ignoring that here
+        // would report a successful push over its own error output, and the
+        // same document fails the default push through the Knowledge Catalog
+        // leg, so --no-kc fails on it too.
+        if (!prepared) return 1;
+        for (const {model} of prepared.models) {
           if (model.actions?.length)
             actionCounts.set(model.name, model.actions.length);
         }

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -14,7 +14,7 @@ import * as deploy from '../libts/semantic/deploy_bigquery';
 import * as kc from '../libts/semantic/deploy_knowledge_catalog';
 import * as deploySpannerLeg from '../libts/semantic/deploy_spanner';
 import {googleDeploymentTargets} from '../libts/semantic/deployment_target';
-import {provisionActionTypes} from '../libts/semantic/kc_actions';
+import {provisionCustomTypes} from '../libts/semantic/kc_custom_types';
 import {LoadedModel, loadSemanticModels} from '../libts/semantic/loader';
 import {serializeModel} from '../libts/semantic/osi_converter';
 import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
@@ -226,11 +226,11 @@ export async function init(options: InitOptions): Promise<number> {
           `${res.message || res.status}`);
       return 1;
     }
-    // Actions are the one construct with no built-in system type, so their
-    // custom entry and aspect types are provisioned here too. Everything else
-    // the push writes references types that already exist under
-    // `dataplex-types`. See kc_actions.ts.
-    const provisioned = await provisionActionTypes(catalog, source);
+    // A few constructs have no built-in system type, so the entry and aspect
+    // types they need are provisioned here too. Everything else the push
+    // writes references types that already exist under `dataplex-types`.
+    // kc_custom_types.ts is the list of what is custom.
+    const provisioned = await provisionCustomTypes(catalog, source);
     if (provisioned.error) {
       console.error(`Error: ${provisioned.error}`);
       return 1;

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -230,11 +230,12 @@ export async function init(options: InitOptions): Promise<number> {
     // custom entry and aspect types are provisioned here too. Everything else
     // the push writes references types that already exist under
     // `dataplex-types`. See kc_actions.ts.
-    const typeErr = await provisionActionTypes(catalog, source);
-    if (typeErr) {
-      console.error(`Error: ${typeErr}`);
+    const provisioned = await provisionActionTypes(catalog, source);
+    if (provisioned.error) {
+      console.error(`Error: ${provisioned.error}`);
       return 1;
     }
+    if (provisioned.denied) console.warn(`Warning: ${provisioned.denied}`);
     fs.mkdirSync(
         path.join('catalog', 'EntryGroups', source.entryGroup),
         {recursive: true});
@@ -549,6 +550,10 @@ export async function push(options: PushOptions): Promise<number> {
     const deployedProfiles: string[] = [];
     const skippedProfiles: string[] = [];
     let deployedGraphs = 0;
+    // Model name -> action count, and the documents already loaded below, so
+    // the --no-kc actions warning can reuse this pass instead of repeating it.
+    const actionCounts = new Map<string, number>();
+    const loadedDocs = new Set<string>();
     for (const profileName of graphProfileNames) {
       // --all-profiles fans out over every model's profiles, so a model that
       // does not define this one is dropped (skipMissing) rather than failing
@@ -562,6 +567,10 @@ export async function push(options: PushOptions): Promise<number> {
       }
       const prepared = await prepareOnce(docs, profileName, true);
       if (!prepared) return 1;
+      for (const d of docs) loadedDocs.add(d.name);
+      for (const {model} of prepared.models) {
+        if (model.actions?.length) actionCounts.set(model.name, model.actions.length);
+      }
       // Fail before any deploy if this profile's targets collide with a graph an
       // earlier profile already claimed this run.
       for (const m of prepared.models) {
@@ -616,19 +625,25 @@ export async function push(options: PushOptions): Promise<number> {
     // validate a model's actions and then deploy them nowhere, so warn rather
     // than drop them silently.
     if (!kcEnabled) {
+      // The loop above already loaded every document that contributes a graph.
+      // Only the rest need loading, which is usually none, and a model that
+      // does not define this profile is skipped rather than failing a warning.
       const kcProfileName =
           namedProfile ?? snapshot.manifest.defaultProfile ?? DEFAULT_PROFILE;
-      const docs = mergeOnce(kcProfileName, false);
-      const prepared =
-          docs ? await prepareOnce(docs, kcProfileName, false) : null;
-      for (const {model} of prepared?.models ?? []) {
-        const n = model.actions?.length ?? 0;
-        if (n) {
-          console.warn(
-              `Warning: model '${model.name}' declares ${n} action(s), which ` +
-              `deploy only to Knowledge Catalog; --no-kc excludes that leg, so ` +
-              `they will not be deployed. Drop --no-kc to deploy them.`);
+      const rest =
+          (mergeOnce(kcProfileName, true) ?? []).filter(d => !loadedDocs.has(d.name));
+      if (rest.length) {
+        const prepared = await prepareOnce(rest, kcProfileName, false);
+        for (const {model} of prepared?.models ?? []) {
+          if (model.actions?.length)
+            actionCounts.set(model.name, model.actions.length);
         }
+      }
+      for (const [name, n] of actionCounts) {
+        console.warn(
+            `Warning: model '${name}' declares ${n} action(s), which ` +
+            `deploy only to Knowledge Catalog; --no-kc excludes that leg, so ` +
+            `they will not be deployed. Drop --no-kc to deploy them.`);
       }
     }
 

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -14,6 +14,7 @@ import * as deploy from '../libts/semantic/deploy_bigquery';
 import * as kc from '../libts/semantic/deploy_knowledge_catalog';
 import * as deploySpannerLeg from '../libts/semantic/deploy_spanner';
 import {googleDeploymentTargets} from '../libts/semantic/deployment_target';
+import {provisionActionTypes} from '../libts/semantic/kc_actions';
 import {LoadedModel, loadSemanticModels} from '../libts/semantic/loader';
 import {serializeModel} from '../libts/semantic/osi_converter';
 import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
@@ -223,6 +224,15 @@ export async function init(options: InitOptions): Promise<number> {
       console.error(
           `Error: failed to create entry group '${source.name}': ` +
           `${res.message || res.status}`);
+      return 1;
+    }
+    // Actions are the one construct with no built-in system type, so their
+    // custom entry and aspect types are provisioned here too. Everything else
+    // the push writes references types that already exist under
+    // `dataplex-types`. See kc_actions.ts.
+    const typeErr = await provisionActionTypes(catalog, source);
+    if (typeErr) {
+      console.error(`Error: ${typeErr}`);
       return 1;
     }
     fs.mkdirSync(

--- a/toolbox/mdcode/tests/libts/semantic/actions.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/actions.test.ts
@@ -2,8 +2,8 @@
 // to metrics -- across the pipeline: loader parsing (executor + typed
 // parameters), the push-time validation gate, and the Knowledge Catalog
 // publish/pull round trip (actions have no BUILT-IN system type; the custom
-// one they use, and everything about how they are persisted, lives in
-// kc_actions.ts). Preconditions and `affects` are intentionally out of scope
+// one they use is declared in kc_custom_types.ts and the encoding that fills
+// it lives in kc_actions.ts). Preconditions and `affects` are out of scope
 // for this prototype.
 
 import {describe, expect, test} from 'bun:test';

--- a/toolbox/mdcode/tests/libts/semantic/actions.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/actions.test.ts
@@ -1,16 +1,16 @@
 // Behavior specification for model-level ACTIONS -- the write-side counterpart
 // to metrics -- across the pipeline: loader parsing (executor + typed
 // parameters), the push-time validation gate, and the Knowledge Catalog
-// publish/pull round trip (actions have no system type of their own; how they
-// are persisted lives in kc_actions.ts). Preconditions and `affects` are
-// intentionally out of scope for this prototype.
+// publish/pull round trip (actions have no BUILT-IN system type; the custom
+// one they use, and everything about how they are persisted, lives in
+// kc_actions.ts). Preconditions and `affects` are intentionally out of scope
+// for this prototype.
 
 import {describe, expect, test} from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import {SemanticModel} from '../../../src/libts/semantic/ir';
-import {ACTIONS_OVERVIEW_MARKER} from '../../../src/libts/semantic/kc_actions';
 import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
 import {generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
 import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
@@ -208,36 +208,61 @@ describe('validatePushRequirements gates actions', () => {
 
 describe('Knowledge Catalog publish/pull round trip', () => {
   const model = loadFixtureModel('actions_place_order.yaml');
+  const ACTION_ENTRY_TYPE = '/entryTypes/semantic-action';
 
-  test('actions are published to the anchor overview aspect', () => {
+  test('each action is published as its own semantic-action entry', () => {
     const {entries, warnings} = generateCatalogResources(model, OPTS);
-    const anchor = entries[0];
-    const overview = anchor.aspects?.['dataplex-types.global.overview'];
-    expect(overview).toBeDefined();
-    const content = overview!.data!.content as string;
-    expect(overview!.data!.contentType).toBe('MARKDOWN');
-    // Human-readable section + the machine-readable marker/JSON block.
-    expect(content).toContain('## Actions');
-    expect(content).toContain('### PlaceOrder');
-    expect(content).toContain(ACTIONS_OVERVIEW_MARKER);
-    expect(content).toContain('"place_order"');
+    const entry = entries.find(e => e.entryType.endsWith(ACTION_ENTRY_TYPE))!;
+    expect(entry).toBeDefined();
+    // The type is custom, so it lives in the DESTINATION project at `global`,
+    // where `kcmd init` provisions it -- not under `dataplex-types` with the
+    // built-in types the other entries reference.
+    expect(entry.entryType)
+        .toBe('projects/dest/locations/global/entryTypes/semantic-action');
+    // Ids sit alongside `<model>.entities.` and `<model>.metrics.`, and the
+    // action hangs off the model anchor the way a metric does.
+    expect(entry.name)
+        .toBe(
+            'projects/dest/locations/us/entryGroups/eg/entries/' +
+            'sales.actions.PlaceOrder');
+    expect(entry.parentEntry).toBe(entries[0].name);
+    expect(entry.entrySource?.displayName).toBe('PlaceOrder');
+    expect(entry.entrySource?.description).toBe('Create an order for a customer');
+
+    const data = entry.aspects!['dest.global.semantic-action'].data!;
+    expect(data.executorKind).toBe('mcp');
+    expect(data.mcpTool).toBe('place_order');
+    // Only the live executor kind's fields are written.
+    expect(data.restEndpoint).toBeUndefined();
+    expect(data.parameters).toEqual([
+      {name: 'customer', type: 'customer', isEntityRef: true},
+      {name: 'quantity', type: 'Integer', isEntityRef: false},
+    ]);
+    expect(data.instructions)
+        .toBe('Resolve the buyer to a customer before calling.');
     // Author is warned actions are catalog-only.
     expect(warnings.some(w => w.includes('action'))).toBe(true);
   });
 
-  test('a pull recovers the actions from the overview', () => {
+  test('the model owns its action entries for delete reconciliation', () => {
+    const {ownedPrefixes} = generateCatalogResources(model, OPTS);
+    expect(ownedPrefixes).toContain('sales.actions.');
+  });
+
+  test('a pull recovers the actions', () => {
     const {entries, entryLinks} = generateCatalogResources(model, OPTS);
     const {models} = modelsFromCatalogResources(entries, entryLinks);
     expect(models[0].actions).toEqual(model.actions);
   });
 
   test('a pull missing the referenced entity drops isEntityRef and warns', () => {
-    // Pull only the anchor: the `customer` entity entry is absent, so the
-    // action's entity-typed `customer` parameter can no longer be resolved.
+    // Pull the anchor and the action, but no entity entries: the `customer`
+    // entity is absent, so the action's entity-typed `customer` parameter can
+    // no longer be resolved.
     const {entries} = generateCatalogResources(model, OPTS);
-    const anchorOnly =
-        entries.filter(e => e.entryType.endsWith('/semantic-model'));
-    const {models, warnings} = modelsFromCatalogResources(anchorOnly);
+    const withoutEntities =
+        entries.filter(e => !e.entryType.endsWith('/semantic-entity'));
+    const {models, warnings} = modelsFromCatalogResources(withoutEntities);
     const params = models[0].actions![0].parameters;
     const customer = params.find(p => p.name === 'customer')!;
     const quantity = params.find(p => p.name === 'quantity')!;
@@ -251,10 +276,10 @@ describe('Knowledge Catalog publish/pull round trip', () => {
         .toBe(true);
   });
 
-  test('a model with no actions carries no overview aspect', () => {
+  test('a model with no actions publishes no action entry', () => {
     const noActions: SemanticModel = {...model, actions: undefined};
     const {entries} = generateCatalogResources(noActions, OPTS);
-    expect(entries[0].aspects?.['dataplex-types.global.overview'])
-        .toBeUndefined();
+    expect(entries.some(e => e.entryType.endsWith(ACTION_ENTRY_TYPE)))
+        .toBe(false);
   });
 });

--- a/toolbox/mdcode/tests/libts/semantic/actions.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/actions.test.ts
@@ -1,8 +1,8 @@
 // Behavior specification for model-level ACTIONS -- the write-side counterpart
 // to metrics -- across the pipeline: loader parsing (executor + typed
 // parameters), the push-time validation gate, and the Knowledge Catalog
-// publish/pull round trip (actions ride the anchor's `overview` aspect, as they
-// have no semantic-* system type of their own). Preconditions and `affects` are
+// publish/pull round trip (actions have no system type of their own; how they
+// are persisted lives in kc_actions.ts). Preconditions and `affects` are
 // intentionally out of scope for this prototype.
 
 import {describe, expect, test} from 'bun:test';
@@ -10,8 +10,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {ACTIONS_OVERVIEW_MARKER} from '../../../src/libts/semantic/kc_actions';
 import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
-import {ACTIONS_OVERVIEW_MARKER, generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
+import {generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
 import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
 import {validatePushRequirements} from '../../../src/libts/semantic/validate';
 

--- a/toolbox/mdcode/tests/libts/semantic/actions.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/actions.test.ts
@@ -1,0 +1,259 @@
+// Behavior specification for model-level ACTIONS -- the write-side counterpart
+// to metrics -- across the pipeline: loader parsing (executor + typed
+// parameters), the push-time validation gate, and the Knowledge Catalog
+// publish/pull round trip (actions ride the anchor's `overview` aspect, as they
+// have no semantic-* system type of their own). Preconditions and `affects` are
+// intentionally out of scope for this prototype.
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
+import {ACTIONS_OVERVIEW_MARKER, generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
+import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
+import {validatePushRequirements} from '../../../src/libts/semantic/validate';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const OPTS = {
+  project: 'dest',
+  location: 'us',
+  entryGroup: 'eg'
+};
+
+function loadFixtureModel(name: string): SemanticModel {
+  const text = fs.readFileSync(path.join(FIXTURES, name), 'utf8');
+  return loadModels(text).models[0];
+}
+
+// A one-entity document with an actions array, for focused loader tests.
+// `actions` is a native extension key, so the document declares the extended
+// profile (see the version gating in loader.ts).
+function withActions(actions: any[], over: any = {}) {
+  return fromDocument({
+    version: '0.2.0.dev0/google',
+    semantic_model: [{
+      name: 'm',
+      datasets: [
+        {name: 'customer', source: 'p.d.c', primary_key: ['id'], fields: []}
+      ],
+      actions,
+      ...over,
+    }],
+  });
+}
+
+const MCP = {
+  mcp: {
+    server: '//agentregistry.googleapis.com/x/mcpServers/commerce',
+    tool: 'place_order'
+  },
+};
+
+
+describe('loader parses actions', () => {
+  test('reads name, description, executor, and typed parameters', () => {
+    const {models, warnings} = withActions([{
+      name: 'PlaceOrder',
+      description: 'Create an order',
+      executor: MCP,
+      parameters: [
+        {name: 'customer', type: 'customer'},
+        {name: 'quantity', type: 'Integer'}
+      ],
+    }]);
+    const [action] = models[0].actions!;
+    expect(action.name).toBe('PlaceOrder');
+    expect(action.description).toBe('Create an order');
+    expect(action.executor).toEqual({kind: 'mcp', mcp: MCP.mcp});
+    expect(action.parameters).toEqual([
+      {name: 'customer', type: 'customer', isEntityRef: true},
+      {name: 'quantity', type: 'Integer', isEntityRef: false},
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  test('a model without actions leaves model.actions unset', () => {
+    const {models} = fromDocument({
+      version: '0.2.0.dev0/google',
+      semantic_model: [{
+        name: 'm',
+        datasets:
+            [{name: 'c', source: 'p.d.c', primary_key: ['id'], fields: []}]
+      }],
+    });
+    expect(models[0].actions).toBeUndefined();
+  });
+
+  test('an unresolvable parameter type is kept verbatim and warned', () => {
+    const {models, warnings} = withActions([{
+      name: 'A',
+      executor: MCP,
+      parameters: [{name: 'x', type: 'Nope'}],
+    }]);
+    const [p] = models[0].actions![0].parameters;
+    expect(p).toEqual({name: 'x', type: 'Nope'});  // isEntityRef unset
+    expect(
+        warnings.some(w => w.includes('parameter \'x\'') && w.includes('Nope')))
+        .toBe(true);
+  });
+
+  test('an executor with two kinds is rejected at parse', () => {
+    expect(() => withActions([{
+             name: 'A',
+             executor: {mcp: MCP.mcp, rest: {endpoint: 'e', method: 'POST'}},
+           }]))
+        .toThrow(/exactly one kind/);
+  });
+
+  test('an executor with no kind is rejected at parse', () => {
+    expect(() => withActions([{name: 'A', executor: {}}]))
+        .toThrow(/exactly one kind/);
+  });
+
+  test('rest and grpc executors normalize to the tagged union', () => {
+    const {models} = withActions([
+      {
+        name: 'R',
+        executor: {rest: {endpoint: 'https://x/orders', method: 'POST'}}
+      },
+      {
+        name: 'G',
+        executor: {grpc: {service: 'commerce.Orders', method: 'Place'}}
+      },
+    ]);
+    expect(models[0].actions![0].executor).toEqual({
+      kind: 'rest',
+      rest: {endpoint: 'https://x/orders', method: 'POST'}
+    });
+    expect(models[0].actions![1].executor).toEqual({
+      kind: 'grpc',
+      grpc: {service: 'commerce.Orders', method: 'Place'}
+    });
+  });
+
+  test('duplicate action names are rejected', () => {
+    expect(() => withActions([
+             {name: 'Dup', executor: MCP},
+             {name: 'Dup', executor: MCP},
+           ])).toThrow(/action name.*Dup/);
+  });
+
+  test('duplicate parameter names within an action are rejected', () => {
+    expect(() => withActions([{
+             name: 'A',
+             executor: MCP,
+             parameters: [
+               {name: 'customer', type: 'customer'},
+               {name: 'customer', type: 'Integer'},
+             ],
+           }])).toThrow(/parameter name.*customer/);
+  });
+});
+
+
+describe('validatePushRequirements gates actions', () => {
+  const target =
+      '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
+  const googleExt = {
+    vendorName: 'GOOGLE',
+    data: JSON.stringify({deploymentTargets: [target]})
+  };
+
+  function loaded(actions: any[]): LoadedModel {
+    const model: SemanticModel = {
+      name: 'm',
+      entities:
+          [{name: 'customer', dataSource: 'p.d.c', keys: ['id'], fields: []}],
+      relationships: [],
+      metrics: [],
+      actions,
+      customExtensions: [googleExt],
+    };
+    return {document: 'doc', model};
+  }
+
+  test('a well-formed action passes', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'PlaceOrder',
+      executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+      parameters: [{name: 'customer', type: 'customer', isEntityRef: true}],
+    }])]);
+    expect(errs).toEqual([]);
+  });
+
+  test('an unresolved parameter type is a hard error', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'A',
+      executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+      parameters: [{name: 'x', type: 'Nope'}],  // isEntityRef unset
+    }])]);
+    expect(errs.some(e => e.includes('parameter \'x\'') && e.includes('Nope')))
+        .toBe(true);
+  });
+
+  test('a blank executor coordinate is a hard error', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'A',
+      executor: {kind: 'mcp', mcp: {server: '', tool: 't'}},
+      parameters: [],
+    }])]);
+    expect(errs.some(e => e.includes('executor') && e.includes('server')))
+        .toBe(true);
+  });
+});
+
+
+describe('Knowledge Catalog publish/pull round trip', () => {
+  const model = loadFixtureModel('actions_place_order.yaml');
+
+  test('actions are published to the anchor overview aspect', () => {
+    const {entries, warnings} = generateCatalogResources(model, OPTS);
+    const anchor = entries[0];
+    const overview = anchor.aspects?.['dataplex-types.global.overview'];
+    expect(overview).toBeDefined();
+    const content = overview!.data!.content as string;
+    expect(overview!.data!.contentType).toBe('MARKDOWN');
+    // Human-readable section + the machine-readable marker/JSON block.
+    expect(content).toContain('## Actions');
+    expect(content).toContain('### PlaceOrder');
+    expect(content).toContain(ACTIONS_OVERVIEW_MARKER);
+    expect(content).toContain('"place_order"');
+    // Author is warned actions are catalog-only.
+    expect(warnings.some(w => w.includes('action'))).toBe(true);
+  });
+
+  test('a pull recovers the actions from the overview', () => {
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    expect(models[0].actions).toEqual(model.actions);
+  });
+
+  test('a pull missing the referenced entity drops isEntityRef and warns', () => {
+    // Pull only the anchor: the `customer` entity entry is absent, so the
+    // action's entity-typed `customer` parameter can no longer be resolved.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const anchorOnly =
+        entries.filter(e => e.entryType.endsWith('/semantic-model'));
+    const {models, warnings} = modelsFromCatalogResources(anchorOnly);
+    const params = models[0].actions![0].parameters;
+    const customer = params.find(p => p.name === 'customer')!;
+    const quantity = params.find(p => p.name === 'quantity')!;
+    // The unresolvable entity type loses isEntityRef and is warned; the scalar
+    // `quantity` still resolves.
+    expect(customer.isEntityRef).toBeUndefined();
+    expect(quantity.isEntityRef).toBe(false);
+    expect(warnings.some(
+               w => w.includes('parameter \'customer\'') &&
+                   w.includes('resolved type')))
+        .toBe(true);
+  });
+
+  test('a model with no actions carries no overview aspect', () => {
+    const noActions: SemanticModel = {...model, actions: undefined};
+    const {entries} = generateCatalogResources(noActions, OPTS);
+    expect(entries[0].aspects?.['dataplex-types.global.overview'])
+        .toBeUndefined();
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/actions.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/actions.test.ts
@@ -283,3 +283,133 @@ describe('Knowledge Catalog publish/pull round trip', () => {
         .toBe(false);
   });
 });
+
+
+// The round trip above covers one MCP action in detail. These cover the shapes
+// that differ: the other two executor kinds, an action with no parameters, and
+// an action with neither a description nor instructions -- the cases where the
+// aspect either takes a different branch or omits fields.
+describe('Knowledge Catalog round trip across executor kinds', () => {
+  const model = loadFixtureModel('actions_executors.yaml');
+  const ACTION_ENTRY_TYPE = '/entryTypes/semantic-action';
+
+  function actionEntriesOf(m: SemanticModel) {
+    return generateCatalogResources(m, OPTS)
+        .entries.filter(e => e.entryType.endsWith(ACTION_ENTRY_TYPE));
+  }
+
+  test('every action becomes one entry, parented to the model anchor', () => {
+    const {entries} = generateCatalogResources(model, OPTS);
+    const actions = entries.filter(e => e.entryType.endsWith(ACTION_ENTRY_TYPE));
+    expect(actions.map(e => e.name.split('/entries/')[1])).toEqual([
+      'commerce.actions.PlaceOrder',
+      'commerce.actions.RefundOrder',
+      'commerce.actions.CloseBooks',
+    ]);
+    for (const e of actions) expect(e.parentEntry).toBe(entries[0].name);
+  });
+
+  test('each executor kind writes only its own coordinates', () => {
+    const byName = new Map(
+        actionEntriesOf(model).map(e => [e.entrySource!.displayName, e]));
+    const dataOf = (name: string) =>
+        byName.get(name)!.aspects!['dest.global.semantic-action'].data!;
+
+    expect(dataOf('PlaceOrder')).toMatchObject({
+      executorKind: 'mcp',
+      mcpServer: '//agentregistry.googleapis.com/x/mcpServers/commerce',
+      mcpTool: 'place_order',
+    });
+    expect(dataOf('RefundOrder')).toMatchObject({
+      executorKind: 'rest',
+      restEndpoint: 'https://commerce.example.com/v1/refunds',
+      restMethod: 'POST',
+    });
+    expect(dataOf('CloseBooks')).toMatchObject({
+      executorKind: 'grpc',
+      grpcService: 'commerce.v1.Ledger',
+      grpcMethod: 'CloseBooks',
+    });
+    // A kind writes nothing belonging to another kind, so the aspect never
+    // carries two executors at once.
+    for (const [kind, foreign] of [
+             ['PlaceOrder', ['restEndpoint', 'restMethod', 'grpcService', 'grpcMethod']],
+             ['RefundOrder', ['mcpServer', 'mcpTool', 'grpcService', 'grpcMethod']],
+             ['CloseBooks', ['mcpServer', 'mcpTool', 'restEndpoint', 'restMethod']],
+    ] as Array<[string, string[]]>) {
+      for (const field of foreign) expect(dataOf(kind)[field]).toBeUndefined();
+    }
+  });
+
+  test('an action with nothing optional omits those fields entirely', () => {
+    const closeBooks = actionEntriesOf(model).find(
+        e => e.entrySource!.displayName === 'CloseBooks')!;
+    // No description, so the entry source carries none, and no instructions.
+    expect(closeBooks.entrySource!.description).toBeUndefined();
+    const data = closeBooks.aspects!['dest.global.semantic-action'].data!;
+    expect(data.instructions).toBeUndefined();
+    expect(data.parameters).toEqual([]);
+  });
+
+  test('a pull recovers every action unchanged', () => {
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    // Entries come back ordered by the catalog rather than by the document, so
+    // compare as a set keyed by name.
+    const byName = (m: SemanticModel) =>
+        Object.fromEntries((m.actions ?? []).map(a => [a.name, a]));
+    expect(byName(models[0])).toEqual(byName(model));
+  });
+
+  test('a second push of the pulled model produces the same entries', () => {
+    // Push -> pull -> push has to be a fixed point: if it were not, a pull
+    // followed by a push would rewrite entries that nobody edited.
+    const first = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(first.entries, first.entryLinks);
+    const second = generateCatalogResources(models[0], OPTS);
+
+    const actionsOf = (entries: typeof first.entries) =>
+        entries.filter(e => e.entryType.endsWith(ACTION_ENTRY_TYPE))
+            .map(e => [e.name, e.aspects!['dest.global.semantic-action'].data])
+            .sort();
+    expect(actionsOf(second.entries)).toEqual(actionsOf(first.entries));
+  });
+});
+
+
+describe('actions referencing entities the push does not publish', () => {
+  test('an abstract entity parameter is published but warned about', () => {
+    // An abstract entity is a table-less supertype, so the Knowledge Catalog
+    // leg skips it. A parameter typed by one therefore names an entity with no
+    // entry, which a later pull cannot tell from a misspelled scalar.
+    const {models} = fromDocument({
+      version: '0.2.0.dev0/google',
+      semantic_model: [{
+        name: 'm',
+        entities: [
+          {name: 'party', abstract: true, fields: []},
+          {
+            name: 'customer',
+            source: 'p.d.c',
+            primary_key: ['id'],
+            fields: [{name: 'id', expression: {dialects: [{dialect: 'ANSI_SQL', expression: 'id'}]}}],
+          },
+        ],
+        actions: [{
+          name: 'Notify',
+          executor: MCP,
+          parameters: [{name: 'who', type: 'party'}],
+        }],
+      }],
+    });
+    // The loader resolved it against the ontology, which includes abstract
+    // entities.
+    expect(models[0].actions![0].parameters[0].isEntityRef).toBe(true);
+
+    const {warnings} = generateCatalogResources(models[0], OPTS);
+    expect(warnings.some(
+               w => w.includes('parameter \'who\'') &&
+                   w.includes('does not publish')))
+        .toBe(true);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
@@ -206,6 +206,25 @@ describe('deployKnowledgeCatalog: re-push upserts', () => {
     expect(create).toHaveBeenCalledTimes(3);
     expect(update).toHaveBeenCalledTimes(3);
   });
+
+  test('re-push names the optional overview key so a removed action aspect is cleared', async () => {
+    const {update} = stubClient({
+      create: () => err(409, 'entry already exists'),
+      update: ok({}),
+    });
+
+    // DOCS declares no actions, so the regenerated anchor carries no overview
+    // aspect. The anchor is written first (anchor-first).
+    await deployKnowledgeCatalog(models(DOCS), CTX, OPTS);
+
+    // Its update must still NAME the overview key in aspectKeys: Dataplex clears
+    // an aspect only when its key is listed and absent from the body. Otherwise
+    // a previously-published overview (an earlier push that HAD actions)
+    // survives on the server and a later pull resurrects the deleted actions.
+    const anchorAspectKeys = update.mock.calls[0][2] ?? [];
+    expect(anchorAspectKeys.some((k: string) => k.endsWith('.overview')))
+        .toBe(true);
+  });
 });
 
 

--- a/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
@@ -178,8 +178,8 @@ describe('deployKnowledgeCatalog: happy path', () => {
     expect(result.created).toBe(3);
     expect(result.updated).toBe(0);
 
-    // Push provisions neither the entry group (created at `init`) nor any type
-    // (the semantic types are built-in): it only writes the three entries.
+    // Push provisions neither the entry group nor any type -- both are created
+    // at `init` -- so it only writes the three entries.
     expect(group).not.toHaveBeenCalled();
     expect(create).toHaveBeenCalledTimes(3);
     expect(update).not.toHaveBeenCalled();
@@ -205,25 +205,6 @@ describe('deployKnowledgeCatalog: re-push upserts', () => {
     expect(result.updated).toBe(3);
     expect(create).toHaveBeenCalledTimes(3);
     expect(update).toHaveBeenCalledTimes(3);
-  });
-
-  test('re-push names the optional overview key so a removed action aspect is cleared', async () => {
-    const {update} = stubClient({
-      create: () => err(409, 'entry already exists'),
-      update: ok({}),
-    });
-
-    // DOCS declares no actions, so the regenerated anchor carries no overview
-    // aspect. The anchor is written first (anchor-first).
-    await deployKnowledgeCatalog(models(DOCS), CTX, OPTS);
-
-    // Its update must still NAME the overview key in aspectKeys: Dataplex clears
-    // an aspect only when its key is listed and absent from the body. Otherwise
-    // a previously-published overview (an earlier push that HAD actions)
-    // survives on the server and a later pull resurrects the deleted actions.
-    const anchorAspectKeys = update.mock.calls[0][2] ?? [];
-    expect(anchorAspectKeys.some((k: string) => k.endsWith('.overview')))
-        .toBe(true);
   });
 });
 
@@ -407,15 +388,18 @@ describe('deployKnowledgeCatalog: delete reconciliation', () => {
   // entity 'sales.entities.orders', and the metric 'sales.metrics.total_revenue'.
   const EMITTED = ['sales', 'sales.entities.orders', 'sales.metrics.total_revenue'];
 
-  test('deletes entities/metrics removed from the model, scoped by owner', async () => {
-    // The group also holds two orphans owned by the 'sales' anchor (an entity
-    // and a metric no longer in the model) plus two entries owned by a
-    // different model. Only the two orphans under 'sales' must be deleted.
+  test('deletes entities/metrics/actions removed from the model, scoped by owner',
+       async () => {
+    // The group also holds three orphans owned by the 'sales' anchor (an
+    // entity, a metric and an action no longer in the model) plus two entries
+    // owned by a different model. Only the three orphans under 'sales' must be
+    // deleted.
     const {del, list} = stubClient({
       existing: [
         ...EMITTED,
         'sales.entities.removed',
         'sales.metrics.removed',
+        'sales.actions.Removed',
         'other',
         'other.entities.x',
       ],
@@ -424,10 +408,14 @@ describe('deployKnowledgeCatalog: delete reconciliation', () => {
     const result = await deployKnowledgeCatalog(models(DOCS), CTX, OPTS);
 
     expect(result.success).toBe(true);
-    expect(result.deleted).toBe(2);
+    expect(result.deleted).toBe(3);
     expect(list).toHaveBeenCalledTimes(1);
     const deletedIds = del.mock.calls.map(c => c[3]).sort();
-    expect(deletedIds).toEqual(['sales.entities.removed', 'sales.metrics.removed']);
+    expect(deletedIds).toEqual([
+      'sales.actions.Removed',
+      'sales.entities.removed',
+      'sales.metrics.removed',
+    ]);
   });
 
   test('recognises owned entries when the server names the project by number',

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_executors.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_executors.yaml
@@ -1,0 +1,63 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0/google).
+#
+# Three actions covering every executor kind, so the Knowledge Catalog round
+# trip is exercised on each branch of the tagged union rather than on `mcp`
+# alone. It also covers the two shapes an action can be missing pieces in: one
+# with no parameters at all, and one with neither a description nor an
+# ai_context. `actions` is a native extension key, so this document declares the
+# extended profile.
+
+version: "0.2.0.dev0/google"
+
+semantic_model:
+  - name: commerce
+    description: Orders and the write operations over them
+    entities:
+      - name: customer
+        source: samples.tpch.customer
+        primary_key: [c_custkey]
+        fields:
+          - name: c_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_custkey
+      - name: orders
+        source: samples.tpch.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+    actions:
+      # MCP executor, an entity-typed parameter, a scalar, and instructions.
+      - name: PlaceOrder
+        description: Create an order for a customer
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/x/mcpServers/commerce
+            tool: place_order
+        parameters:
+          - {name: buyer, type: customer}
+          - {name: quantity, type: Integer}
+        ai_context:
+          instructions: "Resolve the buyer to a customer before calling."
+      # REST executor, no instructions, a Decimal alongside an entity reference.
+      - name: RefundOrder
+        description: Refund a placed order
+        executor:
+          rest:
+            endpoint: https://commerce.example.com/v1/refunds
+            method: POST
+        parameters:
+          - {name: order, type: orders}
+          - {name: amount, type: Decimal}
+      # gRPC executor with no parameters and no description: everything optional
+      # is absent.
+      - name: CloseBooks
+        executor:
+          grpc:
+            service: commerce.v1.Ledger
+            method: CloseBooks

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -1,0 +1,76 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0/google).
+#
+# A minimal star (orders -> customer) plus a model-level ACTION, the write-side
+# counterpart to a metric. PlaceOrder carries an MCP executor (a tool in Agent
+# Registry) and ontology-typed parameters: an entity-typed one (`customer`, an
+# object reference to the customer entity) and scalar ones. Preconditions and
+# affects are intentionally out of scope for this prototype. A BigQuery Graph
+# deployment target keeps the model executable (actions produce no graph
+# element). `actions` is a native extension key, so this document declares the
+# extended profile.
+
+version: "0.2.0.dev0/google"
+
+semantic_model:
+  - name: sales
+    description: Sales orders with customer attributes
+    deployment_target: //bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales
+    entities:
+      - name: orders
+        source: samples.tpch.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+          - name: o_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_custkey
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_totalprice
+      - name: customer
+        source: samples.tpch.customer
+        primary_key: [c_custkey]
+        fields:
+          - name: c_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_custkey
+          - name: c_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_name
+    relationships:
+      - name: orders_to_customer
+        from: orders
+        to: customer
+        from_columns: [o_custkey]
+        to_columns: [c_custkey]
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)
+        description: Total order revenue
+    actions:
+      - name: PlaceOrder
+        description: Create an order for a customer
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/commerce
+            tool: place_order
+        parameters:
+          - {name: customer, type: customer}
+          - {name: quantity, type: Integer}
+        ai_context:
+          instructions: "Resolve the buyer to a customer before calling."

--- a/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
@@ -40,6 +40,7 @@ describe('loader <-> serialize round trip is IR-stable', () => {
     'sales_google_ext.yaml',
     'vendor_dialects.yaml',
     'sales_bq_graph_target.yaml',
+    'actions_place_order.yaml',
   ];
 
   for (const fixture of fixtures) {

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -140,6 +140,25 @@ function toSchemaShape(doc: any): any {
   return d;
 }
 
+// `actions` (model-level write operations, the write-side counterpart to
+// metrics) are a deliberate SUPERSET of released Apache OSI: the Extended-spec
+// proposal adds them, but the vendored osi-schema.json -- pinned to released
+// v0.2.0.dev0 -- does not yet know the keyword, so a model carrying `actions`
+// trips `additionalProperties: false` on the semantic_model item. We tolerate
+// EXACTLY that one extra property (an additionalProperties error naming
+// `actions` on a /semantic_model/<n> path) and nothing else, so an actions
+// fixture validates while every other drift from the spec still fails. When
+// upstream OSI adopts actions, re-vendoring the schema makes this pass with no
+// special-casing and this tolerance can be removed.
+function onlyActionsExtension(errors: typeof validate.errors): boolean {
+  return !!errors && errors.length > 0 &&
+    errors.every(
+      e => e.keyword === 'additionalProperties' &&
+        (e.params as {additionalProperty?: string}).additionalProperty ===
+          'actions' &&
+        /\/semantic_model\/\d+$/.test(e.instancePath));
+}
+
 describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () => {
   test('at least one fixture is discovered', () => {
     expect(fixtures.length).toBeGreaterThan(0);
@@ -171,6 +190,15 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
         if ((rel === 'hierarchy_graph.yaml' ||
              rel === 'reserved_words_inherit.yaml') &&
             onlyExtendsExtension(validate.errors)) {
+          return;
+        }
+        // A model-level `actions` block is a deliberate superset of released
+        // OSI (the Extended-spec proposal); tolerate exactly that extra property
+        // and nothing else, and only on the actions fixtures that legitimately
+        // carry it -- so a stray `actions` slipping into any other fixture still
+        // fails.
+        if (rel.startsWith('actions_') &&
+            onlyActionsExtension(validate.errors)) {
           return;
         }
         const details = (validate.errors ?? [])

--- a/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
+++ b/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
@@ -1,11 +1,12 @@
 // Tests that `kcmd init --semantic-model` provisions the destination entry
-// group and the custom action types (src/tool/commands.ts, init()).
+// group and the custom types (src/tool/commands.ts, init()).
 //
 // Both are created at init -- not on push -- so a semantic-model push writes
 // only entries, matching how the standard layout operates (its push creates
-// entries, never the entry group). The action entry type and aspect type are
-// the one pair kcmd creates rather than references; see kc_actions.ts. These
-// tests spy on the catalog client so no network call is made and run init
+// entries, never the entry group). The types kcmd creates rather than
+// references are declared in kc_custom_types.ts, which today holds the one
+// action pair. These tests spy on the catalog client so no network call is
+// made and run init
 // inside a temp working directory (it writes catalog.yaml + the layout dirs
 // relative to cwd).
 

--- a/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
+++ b/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
@@ -171,6 +171,35 @@ describe('init --semantic-model: entry-group provisioning', () => {
     expect(update.mock.calls[0][4]).toContain('metadata_template');
   });
 
+  test('a rejected template patch leaves the existing type and finishes init',
+       async () => {
+    spyOn(CatalogClient.prototype, 'createEntryGroup')
+        .mockImplementation(async () => ok({name: 'sales-group'}));
+    spyOn(CatalogClient.prototype, 'createAspectType')
+        .mockImplementation(async () => err(409, 'already exists'));
+    // What an OLDER kcmd sees against a project a newer one provisioned: its
+    // template lacks the newer fields, so the patch is a field removal and
+    // Dataplex refuses it.
+    spyOn(CatalogClient.prototype, 'updateAspectType')
+        .mockImplementation(
+            async () => err(400, 'backwards-incompatible template change'));
+    const entryType = spyOn(CatalogClient.prototype, 'createEntryType')
+                          .mockImplementation(async () => err(409, 'exists'));
+    const warned: string[] = [];
+    spyOn(console, 'warn').mockImplementation((...args: any[]) => {
+      warned.push(args.join(' '));
+    });
+
+    // The type already there is the one published entries depend on, so init
+    // reports the refusal and carries on rather than abandoning a workspace
+    // whose entry group it has already created.
+    expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
+    expect(entryType).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(path.join('catalog', 'EntryGroups', 'sales-group')))
+        .toBe(true);
+    expect(warned.some(m => m.includes('unchanged'))).toBe(true);
+  });
+
   test('init survives lacking permission to create the action types',
        async () => {
     spyOn(CatalogClient.prototype, 'createEntryGroup')

--- a/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
+++ b/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
@@ -1,11 +1,13 @@
 // Tests that `kcmd init --semantic-model` provisions the destination entry
-// group (src/tool/commands.ts, init()).
+// group and the custom action types (src/tool/commands.ts, init()).
 //
-// The entry group is created at init -- not on push -- so a semantic-model push
-// writes only entries, matching how the standard layout operates (its push
-// creates entries, never the entry group). These tests spy on the catalog
-// client so no network call is made and run init inside a temp working
-// directory (it writes catalog.yaml + the layout dirs relative to cwd).
+// Both are created at init -- not on push -- so a semantic-model push writes
+// only entries, matching how the standard layout operates (its push creates
+// entries, never the entry group). The action entry type and aspect type are
+// the one pair kcmd creates rather than references; see kc_actions.ts. These
+// tests spy on the catalog client so no network call is made and run init
+// inside a temp working directory (it writes catalog.yaml + the layout dirs
+// relative to cwd).
 
 import {afterEach, beforeEach, describe, expect, mock, spyOn, test} from 'bun:test';
 import * as fs from 'node:fs';
@@ -18,6 +20,9 @@ import {CatalogClient} from '../../src/libts/gcp/dataplex';
 import {init} from '../../src/tool/commands';
 
 const CTX = new ApiContext('test-project', 'us', 'test-token');
+
+// The operation name a type create returns and `getOperation` is polled with.
+const OP = 'projects/proj/locations/global/operations/op-1';
 
 function ok<T>(result?: T): ApiResult<T> {
   return {status: 200, result};
@@ -38,6 +43,16 @@ beforeEach(() => {
   // init() prints the generated catalog.yaml; keep test output quiet.
   spyOn(console, 'log').mockImplementation(() => {});
   spyOn(console, 'error').mockImplementation(() => {});
+  spyOn(console, 'warn').mockImplementation(() => {});
+  // Provisioning the custom action types succeeds by default; the tests that
+  // care about it re-stub these. Each create returns a long-running operation,
+  // so `getOperation` has to answer too.
+  spyOn(CatalogClient.prototype, 'createAspectType')
+      .mockImplementation(async () => ok({name: OP, done: false}));
+  spyOn(CatalogClient.prototype, 'createEntryType')
+      .mockImplementation(async () => ok({name: OP, done: false}));
+  spyOn(CatalogClient.prototype, 'getOperation')
+      .mockImplementation(async () => ok({name: OP, done: true}));
 });
 
 afterEach(() => {
@@ -82,6 +97,100 @@ describe('init --semantic-model: entry-group provisioning', () => {
     expect(group).toHaveBeenCalledTimes(1);
     expect(fs.existsSync(path.join('catalog', 'EntryGroups', 'sales-group')))
         .toBe(true);
+  });
+
+  test('provisions the custom action types in the destination project',
+       async () => {
+    spyOn(CatalogClient.prototype, 'createEntryGroup')
+        .mockImplementation(async () => ok({name: 'sales-group'}));
+    const aspectType = spyOn(CatalogClient.prototype, 'createAspectType')
+                           .mockImplementation(async () => ok({name: OP}));
+    const entryType = spyOn(CatalogClient.prototype, 'createEntryType')
+                          .mockImplementation(async () => ok({name: OP}));
+
+    expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
+
+    // Both types are custom, so they live in the destination project at
+    // `global` -- not beside the built-in types, and not in the entry group's
+    // region.
+    for (const spy of [aspectType, entryType]) {
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [project, location, typeId] = spy.mock.calls[0];
+      expect(project).toBe('proj');
+      expect(location).toBe('global');
+      expect(typeId).toBe('semantic-action');
+    }
+    // The entry type requires the aspect type, so the server rejects it while
+    // the aspect type's create is still running.
+    expect(aspectType.mock.invocationCallOrder[0])
+        .toBeLessThan(entryType.mock.invocationCallOrder[0]);
+  });
+
+  test('waits for each type-creation operation to finish', async () => {
+    spyOn(CatalogClient.prototype, 'createEntryGroup')
+        .mockImplementation(async () => ok({name: 'sales-group'}));
+    // The aspect type is still being created when the call returns.
+    spyOn(CatalogClient.prototype, 'createAspectType')
+        .mockImplementation(async () => ok({name: OP, done: false}));
+    let polls = 0;
+    spyOn(CatalogClient.prototype, 'getOperation')
+        .mockImplementation(async () => ok({name: OP, done: ++polls > 1}));
+    // How many times the operation had been polled when the entry type was
+    // created. The aspect type reports done on the second poll, so anything
+    // less than two means the entry type was created while its required
+    // aspect type was still being created, which the server rejects.
+    let polledBeforeEntryType = -1;
+    spyOn(CatalogClient.prototype, 'createEntryType')
+        .mockImplementation(async () => {
+          polledBeforeEntryType = polls;
+          return ok({name: OP});
+        });
+
+    expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
+    expect(polledBeforeEntryType).toBe(2);
+  });
+
+  test('an already-existing aspect type is patched with the current template',
+       async () => {
+    spyOn(CatalogClient.prototype, 'createEntryGroup')
+        .mockImplementation(async () => ok({name: 'sales-group'}));
+    spyOn(CatalogClient.prototype, 'createAspectType')
+        .mockImplementation(async () => err(409, 'already exists'));
+    const update = spyOn(CatalogClient.prototype, 'updateAspectType')
+                       .mockImplementation(async () => ok({name: OP}));
+    // The entry type is already there too, which is not an error.
+    spyOn(CatalogClient.prototype, 'createEntryType')
+        .mockImplementation(async () => err(409, 'already exists'));
+
+    expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
+
+    // A project provisioned by an earlier kcmd holds an older template, so the
+    // patch names the template field to bring it up to date.
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0][4]).toContain('metadata_template');
+  });
+
+  test('init survives lacking permission to create the action types',
+       async () => {
+    spyOn(CatalogClient.prototype, 'createEntryGroup')
+        .mockImplementation(async () => ok({name: 'sales-group'}));
+    spyOn(CatalogClient.prototype, 'createAspectType')
+        .mockImplementation(async () => err(403, 'permission denied'));
+
+    // Actions are one optional construct: a caller who will never declare one
+    // must still be able to init, push and pull.
+    expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
+    expect(fs.existsSync(path.join('catalog', 'EntryGroups', 'sales-group')))
+        .toBe(true);
+  });
+
+  test('a fatal action-type error fails init', async () => {
+    spyOn(CatalogClient.prototype, 'createEntryGroup')
+        .mockImplementation(async () => ok({name: 'sales-group'}));
+    spyOn(CatalogClient.prototype, 'createAspectType')
+        .mockImplementation(async () => err(400, 'bad metadata template'));
+
+    expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(1);
   });
 
   test('a fatal entry-group error fails init', async () => {


### PR DESCRIPTION
## What

Prototype support for **actions** in the mdcode semantic model — named write operations over the ontology, the write-side counterpart to metrics. Both are model-level and defined over the concepts (not bound to one entity); the difference is direction (a metric reads a value, an action changes state).

An action names a business operation and delegates the mechanics to an **executor**; the model contributes what a plain tool schema can't — **parameters typed by the ontology**, where an entity-typed parameter is an object reference and a scalar type is a value.

## Changes (by pipeline leg)

- **IR** (`ir.ts`): `Action` / `ActionParameter` / `Executor` (tagged union over `mcp` | `rest` | `grpc`).
- **Loader** (`loader.ts`): parse the `actions` block; normalize the open format's single-key executor to the tagged union; resolve each parameter `type` to a known entity (`isEntityRef: true`) or a scalar datatype (`false`), warning on an unresolved type; enforce "exactly one executor kind" at parse.
- **OSI converter** (`osi_converter.ts`): emit actions back to open-format YAML — round-trip stable (covered by the existing loader↔serialize round-trip test via a new fixture).
- **Validate** (`validate.ts`): hard-gate unresolved parameter types and blank executor coordinates; runs for every `--target`, since actions publish to Knowledge Catalog regardless of the BigQuery leg.
- **BigQuery** (`bigquery.ts`): actions are write-side and have no graph construct — warn once, emit nothing.
- **Knowledge Catalog** (`knowledge_catalog.ts` / `kc_converter.ts` / `pull_kc.ts`): actions have no `semantic-*` system type, so they ride the model anchor's built-in **`overview`** aspect (human-readable Markdown + an embedded JSON block); `pull` recovers them losslessly from the JSON.
- **Docs**: authoring section, the BigQuery/KC "what gets created" tables, validation + permissions bullets, and the fidelity matrix.
- **Tests + fixture**: `actions.test.ts` (loader parse, validation, KC publish/pull round trip) and a `PlaceOrder` fixture.

## Scope

This is a prototype. An action's **`precondition`** (gate) and **`affects`** (blast radius) are intentionally **not** modelled yet.

## Testing

- `tsc -p src/libts/tsconfig.json --noEmit` — clean.
- `npm test` — 501 semantic tests pass (incl. the new round-trip and OSI-schema guardrail tolerance for the `actions` superset).