### PR TITLE
mdcode: override Dataplex endpoint and KC type project via env vars

### DIFF
--- a/toolbox/mdcode/README.md
+++ b/toolbox/mdcode/README.md
@@ -194,6 +194,16 @@ models.
 
 NOTE: The CLI uses `gcloud` to obtain authentication tokens, so ensure you are authenticated via `gcloud auth application-default login`.
 
+#### Environment variables
+
+Two optional variables override where `kcmd` talks to the catalog. Both default
+to production, so you normally leave them unset.
+
+| Variable | Effect |
+|----------|--------|
+| `DATAPLEX_ENDPOINT` | Base URL for the Knowledge Catalog (Dataplex) API. Defaults to `https://dataplex.googleapis.com`. Set it to reach a non-prod host. |
+| `KC_TYPE_PROJECT` | Project the built-in `semantic-*` system types are read from on a semantic-model push. Defaults to `dataplex-types`. |
+
 ### MCP Server
 
 To use the Metadata as Code tools as MCP tools in an agentic system such as the Gemini CLI, add the following to your MCP settings file:

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -169,6 +169,10 @@ Each element of your model maps to one catalog resource. Every resource type
 below is a built-in system type under `dataplex-types/global` — push references
 them, it never creates them.
 
+> Set `KC_TYPE_PROJECT` to read these system types from another project, and
+> `DATAPLEX_ENDPOINT` to target a non-prod Dataplex host; both default to
+> production (`dataplex-types` / `https://dataplex.googleapis.com`).
+
 | Model element | Catalog resource | Kind | Id |
 |---|---|---|---|
 | Model | `semantic-model` | entry — anchor / parent of the rest | `<model>` |

--- a/toolbox/mdcode/src/libts/gcp/dataplex.ts
+++ b/toolbox/mdcode/src/libts/gcp/dataplex.ts
@@ -85,7 +85,11 @@ interface EntryLinkList {
 export class CatalogClient extends api.ApiClient {
 
   constructor(ctx: context.ApiContext) {
-    super('https://dataplex.googleapis.com', 'v1', ctx);
+    // Defaults to the production Dataplex endpoint. Override via DATAPLEX_ENDPOINT
+    // to target a non-prod host (e.g. an autopush/sandbox EAP), same env-var
+    // knob style as GCP_LOG.
+    super(process.env.DATAPLEX_ENDPOINT || 'https://dataplex.googleapis.com',
+          'v1', ctx);
   }
 
   async getEntryGroup(project: string, location: string,

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -387,6 +387,10 @@ async function pushKnowledgeCatalog(
     validateOnly: options.validateOnly,
     forceRemove: options.forceRemove,
     emitExpressions: options.emitExpressions,
+    // The semantic-* system types live in `dataplex-types/global` on prod.
+    // Override via KC_TYPE_PROJECT to reference them from another project
+    // (e.g. `dataplex-autopush-types` on the autopush/sandbox EAP).
+    systemTypeProject: process.env.KC_TYPE_PROJECT,
   });
 
   for (const w of result.warnings) {


### PR DESCRIPTION
## What

Two tiny, opt-in env-var knobs so `kcmd` can target a non-prod Dataplex host without patching + rebuilding the source:

- **`DATAPLEX_ENDPOINT`** — overrides the `CatalogClient` API endpoint. Falls back to `https://dataplex.googleapis.com`. Same env-var style as the existing `GCP_LOG` knob.
- **`KC_TYPE_PROJECT`** — feeds the already-plumbed `systemTypeProject` option on the KC push (which project the `semantic-*` system types are read from). Falls back to `dataplex-types`.

## Why

The `semantic-model` / `semantic-entity` / `semantic-metric` entry types are currently enabled only on the Dataplex autopush/sandbox EAP (types live in `dataplex-autopush-types`, host is `autopush-dataplex.sandbox.googleapis.com`). To exercise KC push/pull against that EAP today you have to edit two source lines and rebuild:

```
sed -i "s#https://dataplex.googleapis.com#$DATAPLEX_ENDPOINT#" src/libts/gcp/dataplex.ts
# + thread systemTypeProject into the deploy call
```

That's a hack a codelab/demo shouldn't require. `deployKnowledgeCatalog` already accepts `systemTypeProject`; the push command just never populated it, and the endpoint had no override at all.

## Behavior change

None for existing users. Both knobs default to the current prod values (`|| 'https://dataplex.googleapis.com'`, `?? 'dataplex-types'`). When the entry types reach GA, leave the env vars unset and everything targets prod exactly as before.

## Verification

Built and ran end-to-end against the autopush EAP with **only** these two env vars set (no source patching): `push --target kc` wrote 4 entries + linked the relationship, `pull` round-tripped the model. All existing tests pass (509, 0 fail).
