### PR TITLE
fix(viewer): exclude log.md from concept nodes

### DIFF
--- a/okf/src/reference_agent/viewer/generator.py
+++ b/okf/src/reference_agent/viewer/generator.py
@@ -15,6 +15,7 @@ from reference_agent.bundle.document import (
 )
 
 _INDEX_NAME = "index.md"
+_LOG_NAME = "log.md"
 _LINK_RE = re.compile(r"\]\(([^)\s]+\.md)(?:#[A-Za-z0-9_\-]*)?\)")
 _TYPE_PALETTE = {
     "BigQuery Dataset": "#8b5cf6",
@@ -89,7 +90,7 @@ def _extract_links(body: str, doc_dir: Path, bundle_root: Path) -> list[str]:
 def _walk_concepts(bundle_root: Path) -> list[Concept]:
     concepts: list[Concept] = []
     for md_path in sorted(bundle_root.rglob("*.md")):
-        if md_path.name == _INDEX_NAME:
+        if md_path.name in {_INDEX_NAME, _LOG_NAME}:
             continue
         rel = md_path.relative_to(bundle_root).with_suffix("")
         concept_id = "/".join(rel.parts)

--- a/okf/tests/test_viewer.py
+++ b/okf/tests/test_viewer.py
@@ -79,8 +79,9 @@ def _make_bundle(root: Path) -> None:
         COUNT(DISTINCT user_id) per day.
         """,
     )
-    # An auto-generated index that should NOT appear as a concept node.
+    # Reserved files that should NOT appear as concept nodes.
     _write(root / "index.md", "# My Bundle\n- tables/users\n- tables/events\n")
+    _write(root / "log.md", "# Update history\n")
 
 
 def _extract_bundle_data(html: str) -> dict:
@@ -113,6 +114,7 @@ def test_index_md_is_not_a_concept(tmp_path: Path):
     data = _extract_bundle_data(out.read_text(encoding="utf-8"))
     ids = {n["data"]["id"] for n in data["nodes"]}
     assert "index" not in ids
+    assert "log" not in ids
     assert ids == {
         "datasets/my_dataset",
         "tables/users",


### PR DESCRIPTION
#202 Issue

## Summary

- Exclude reserved `log.md` files from viewer concept nodes.
- Add a regression test ensuring both `index.md` and `log.md` are excluded.

## Motivation

The OKF specification defines both `index.md` and `log.md` as reserved filenames, but the viewer only excluded `index.md` when walking Markdown files.

This change brings the viewer behavior in line with the specification.

## Testing

- `pytest tests/test_viewer.py`
- 7 tests passed
- `git diff --check`