### PR TITLE
docs(semantic-model): link codelab Setup to kcmd build instructions

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -13,8 +13,9 @@ For the deploy mechanics on their own (author, push, update, pull), see the
 
 ## Setup
 
-You need the `gcloud` and `bq` CLIs, and `kcmd` on your `PATH`. `kcmd` uses your
-`gcloud` configuration for credentials, project, and region:
+You need the `gcloud` and `bq` CLIs, and `kcmd` on your `PATH` (build it from
+source: see [Build](../../README.md#build)). `kcmd` uses your `gcloud`
+configuration for credentials, project, and region:
 
 ```bash
 gcloud auth application-default login


### PR DESCRIPTION
The codelab's Setup section said "you need `kcmd` on your `PATH`" but did not say how to get it. A reader without `kcmd` had to hunt for the build steps.

This adds a one-line link from Setup to the mdcode README's [Build](../../README.md#build) section, keeping the build steps in one canonical place rather than duplicating them into the codelab.

One-line doc change; no code.