### PR TITLE
docs(semantic-model): print the console URL with printf, not echo

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -336,7 +336,8 @@ a diagram of node and edge tables — easier to read than the DDL above. Print t
 BigQuery Studio link to the dataset:
 
 ```bash
-echo "https://console.cloud.google.com/bigquery?project=$PROJECT&ws=!1m4!1m3!3m2!1s$PROJECT!2s$DATASET"
+# printf with a single-quoted format string: the `!` are literal, not bash history expansion.
+printf 'https://console.cloud.google.com/bigquery?project=%s&ws=!1m4!1m3!3m2!1s%s!2s%s\n' "$PROJECT" "$PROJECT" "$DATASET"
 ```
 
 Open the link, expand the `$DATASET` dataset in the Explorer, and click the


### PR DESCRIPTION
The BigQuery Studio link in step 4 contains `!` characters. In an interactive bash shell, `echo` triggers **history expansion** on those `!`, replacing them with old commands and producing a corrupted URL.

Switching to `printf` with a single-quoted format string makes the `!` literal, so the command works the same in interactive and non-interactive shells. Output is identical to the intended URL.

One-line doc change; no code.