### PR TITLE
docs(semantic-model): remove the local workspace in codelab cleanup

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -429,3 +429,9 @@ for E in sales sales.entities.orders sales.entities.customer sales.entities.line
 done
 curl -s -X DELETE -H "Authorization: Bearer $TOKEN" "${DATAPLEX_ENDPOINT:-https://dataplex.googleapis.com}/v1/$EG"
 ```
+
+Remove the local workspace that step 1 created:
+
+```bash
+rm -rf ~/datacloud-codelab
+```


### PR DESCRIPTION
Step 1 of the codelab creates `~/datacloud-codelab`, but the Clean up section only removed the BigQuery dataset and the Knowledge Catalog entries, leaving the local workspace directory behind. This adds `rm -rf ~/datacloud-codelab` so cleanup fully undoes what the codelab created.

One-line doc change; no code.