### PR TITLE
fix(mdcode): tolerate un-addressable existing entry links on kc re-push

### DIFF
--- a/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
@@ -642,11 +642,19 @@ async function createEntryLinks(
   return {linked: links.length};
 }
 
-// Writes one entry link: create, then fall back to an in-place aspect update if
-// it already exists. A link's entry references and type are immutable, so a
-// re-push only refreshes the aspect (the join detail). A relationship whose id
-// changed writes a new link and leaves the old one; reconcileLinks deletes such
-// orphaned links after this model's links are written.
+// Writes one entry link: create, then fall back to a best-effort in-place aspect
+// update if it already exists. A link's entry references and type are immutable,
+// so a re-push only refreshes the aspect (the join detail). A relationship whose
+// id changed writes a new link and leaves the old one; reconcileLinks deletes
+// such orphaned links after this model's links are written.
+//
+// A 409 means the link is already present with its correct (immutable) endpoints
+// and type, so the re-push has succeeded regardless of whether the aspect can be
+// refreshed. Some Dataplex surfaces expose only createEntryLink and
+// :lookupEntryLinks for entry links -- get/update/delete by resource name return
+// NOT_FOUND (404) or a masked PERMISSION_DENIED (403) even for a link that
+// :lookupEntryLinks returns -- so an update failure there must not turn a
+// present, correct link into a push failure.
 async function writeEntryLink(
     cat: CatalogClient, opts: KcDeployOptions,
     link: EntryLink): Promise<{error?: string}> {
@@ -657,7 +665,9 @@ async function writeEntryLink(
     const upd = await cat.updateEntryLink(
         {name: link.name, aspects: link.aspects} as EntryLink,
         Object.keys(link.aspects ?? {}));
-    if (!isOk(upd)) return {error: `entry link '${linkId}': ${errText(upd)}`};
+    if (!isOk(upd) && !isLinkNotAddressable(upd)) {
+      return {error: `entry link '${linkId}': ${errText(upd)}`};
+    }
     return {};
   }
   if (!isOk(res)) return {error: `entry link '${linkId}': ${errText(res)}`};
@@ -770,6 +780,16 @@ function isOk(res: {status: number}): boolean {
 // need to match the error text.
 function isExists(res: {status: number}): boolean {
   return res.status === 409;
+}
+
+// An entry link that create reports already exists (409) but which get/update/
+// delete by resource name cannot address: NOT_FOUND (404) or a masked
+// PERMISSION_DENIED (403). Some Dataplex surfaces expose only createEntryLink
+// and :lookupEntryLinks for entry links, so an in-place aspect update of an
+// existing link fails this way even though the link is present and correct.
+// Treated as a successful (un-refreshable) re-push, not an error.
+function isLinkNotAddressable(res: {status: number}): boolean {
+  return res.status === 404 || res.status === 403;
 }
 
 // A transient "not visible yet" error worth retrying, matching the propagation

--- a/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
@@ -240,6 +240,30 @@ describe('deployKnowledgeCatalog: relationship entry links', () => {
     expect(result.details).toContain('sales-orders-to-customer');
   });
 
+  // Some Dataplex surfaces (e.g. the autopush EAP endpoint) expose only
+  // createEntryLink and :lookupEntryLinks for entry links, so an in-place update
+  // of an already-existing link returns NOT_FOUND (404) -- or a masked
+  // PERMISSION_DENIED (403) -- even though the link is present and correct. The
+  // re-push must still succeed: the link's endpoints and type are immutable, so
+  // only the (un-refreshable) aspect is affected.
+  for (const status of [404, 403]) {
+    test(`an existing link whose aspect update ${status}s is a no-op success`,
+         async () => {
+           const {createLink, updateLink} = stubClient({
+             createLink: () => err(409, 'entry link already exists'),
+             updateLink: err(status, 'Entry Link does not exist'),
+           });
+
+           const result =
+               await deployKnowledgeCatalog(models(STAR_DOCS), CTX, OPTS);
+
+           expect(result.success).toBe(true);
+           expect(result.linked).toBe(1);
+           expect(createLink).toHaveBeenCalledTimes(1);
+           expect(updateLink).toHaveBeenCalledTimes(1);
+         });
+  }
+
   test('a model with no relationships writes no links', async () => {
     const {createLink} = stubClient();
 


### PR DESCRIPTION
## Problem

`kcmd push --target kc` fails on **re-push** (once the schema-join entry
links already exist) with a 403 / `ENTRY_LINK_NOT_FOUND`:

```
entry link 'sales-orders-to-customer': ... Entry Link
'projects/.../entryLinks/sales-orders-to-customer' does not exist.
Error metadata code: ENTRY_LINK_NOT_FOUND
```

A first push succeeds; the second one fails.

## Root cause (verified live against the autopush EAP endpoint)

On a re-push, `createEntryLink` returns **409 ALREADY_EXISTS** (the server
dedups by source/target/link-type). `writeEntryLink` then falls back to
`updateEntryLink` to refresh the schema-join aspect.

But on some Dataplex surfaces — including the autopush EAP endpoint used
for the semantic-model EAP — entry links are reachable **only** via
`createEntryLink` and `:lookupEntryLinks`. The individual **get / update /
delete by resource name** methods return `NOT_FOUND` (404) or a masked
`PERMISSION_DENIED` (403) *even for a link that `:lookupEntryLinks`
returns*. So the in-place aspect update can never succeed there, and the
`!isOk(upd)` branch turned an idempotent re-push into a hard failure.

I confirmed this directly: `:lookupEntryLinks` returns
`sales-orders-to-customer`, while `GET`/`PATCH`/`DELETE` on that exact
resource name all return `ENTRY_LINK_NOT_FOUND`. `ListEntryLinks` is
likewise "not visible to labels: {PUBLIC}".

## Fix

A 409 means the link is already present with its correct, **immutable**
endpoints and link type — the only thing a re-push could change is the
schema-join aspect. So a best-effort aspect update whose failure is the
"link not addressable" class (404 / 403) is treated as a successful no-op
instead of an error. Genuine failures (any other status) still fail the
push. Mirrors how `deleteOwnedLinks` already tolerates a 404 on delete.

## Testing

- New unit tests: an existing link whose aspect update returns 404 (and
  403) is a no-op success (`linked: 1`, push succeeds).
- Full suite: 498 pass.
- Live-validated end to end against the autopush endpoint: the re-push
  that previously failed now reports `linked 2 relationships` and exits 0.