### PR TITLE
mdcode: binding profiles design doc (proposed)

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -1,4 +1,4 @@
-# Binding a model to different sources with profiles
+# One logical model, many physical bindings
 
 > **Status: proposed.** This page is the design for an upcoming feature, written
 > as the user guide first so we can iterate on how it reads. Nothing here is
@@ -33,22 +33,27 @@ You author the model once and choose the profile when you deploy or query. The
 same mechanism also covers a narrower case: a dev, staging, and prod copy of one
 store are three profiles that differ only in the project they point at.
 
-## How it works: a base and its overrides
+## How it works: a logical model and its bindings
 
 A model and its profiles form a class hierarchy, the same way an entity
 `extends` a supertype:
 
-- The **model file** (`<model>.yaml`) is the **base** — the complete
-  declaration, whose inline bindings are the profile named `default`.
-- A **profile** is a **subclass**: a document in the *identical schema* as the
-  model, carrying only the bindings it changes.
-- `kcmd push --profile <name>` **merges** the profile onto the base — matching
-  entities, fields, relationships, and metrics **by name** — and deploys the
-  result. A profile is never deployed alone: the base supplies every
-  declaration, and the profile supplies the bindings its store provides.
+- The **logical model** (`<model>.yaml`) is the **base**: the complete
+  declaration — entities, fields, relationships, metrics, the grain, and the
+  graph shape — with no physical binding.
+- A **binding profile** is a **subclass**: a document in the *identical schema*
+  that supplies the physical facets the logical model leaves open — each entity's
+  `source`, each field's column, and the deployment target.
+- `kcmd push --profile <name>` **merges** the profile onto the logical model —
+  matching entities, fields, relationships, and metrics **by name** — and
+  deploys the result. A profile is never deployed alone: the logical model
+  supplies every declaration, and the profile supplies the bindings its store
+  provides.
 
-A profile is a model document with holes, so there is one schema to learn.
-Authoring a profile is "copy the model file, keep only the bindings that change."
+Because the two share one schema, a binding may also sit inline in the logical
+model as a profile named `default`. The layout on this page keeps the logical
+model standalone and each binding in its own file, so the split between logical
+and physical is visible on disk.
 
 ## Sources are URIs
 
@@ -64,23 +69,23 @@ field reads.
 ## What a profile may change — the contract
 
 A model separates two things. **Declaration** is logical: which entities,
-fields, relationships, and metrics exist, what each means, and how each metric
-computes. The base owns all of it. **Binding** is physical: which store each
-entity reads from, and which column each field reads. A profile sets binding and
-leaves declaration alone.
+fields, relationships, and metrics exist, what each means, how each metric
+computes, the grain, and the graph shape. The logical model owns all of it.
+**Binding** is physical: which store each entity reads from, and which column
+each field reads. A profile sets binding and leaves declaration alone.
 
-| A profile **may** set (binding) | A profile **may not** touch (declaration, base-only) |
+| A profile **may** set (physical binding) | A profile **may not** touch (logical, in the model) |
 |---|---|
-| an entity's `source` (its store URI) | adding or removing entities, fields, or metrics |
-| a field's column (its `expression`, **as a bare column reference**) | a field's `label`, `description`, `dimension`, `datatype` |
-| whether a field is bound at all under this profile | any `ai_context` / synonyms |
-| an entity's `primary_key` / `unique_keys` | a field `expression` that is arbitrary SQL, which changes the computation rather than the binding |
-| a relationship's `from_columns` / `to_columns` | a relationship's `from` / `to` (the shape of the graph) |
-| a table-backed relationship's `source` / `keys` | any `metric` definition |
-| the deployment target | |
+| an entity's `source` (its store URI) | which entities, fields, relationships, or metrics exist, and what each means |
+| a field's column (its `expression`, a bare column reference) | a field's `label`, `description`, `dimension`, `datatype` |
+| whether a field is bound at all under this profile | the grain (`primary_key` / `unique_keys`) and graph shape (`from`/`to`, `from_columns`/`to_columns`) |
+| the deployment target | a field `expression` that is arbitrary SQL, which changes the computation |
+| a many-to-many relationship's junction `source` | any `metric` definition; any `ai_context` / synonyms |
 
 An element's `name` is not overridden — it is the key that pairs a profile
-element with the base element it refines.
+element with the model element it binds. The grain and the join columns name
+*fields* rather than physical columns, so they belong to the logical model; each
+field's column is resolved per profile from its `expression`.
 
 **Why metrics never appear in a profile.** A metric like
 `SUM(OrderedAs.extendedPrice * (1 - OrderedAs.discount))` references field
@@ -113,8 +118,8 @@ fields a profile binds. The chain runs as far as the model does:
 So an operational-only field such as live credit carries its operational-only
 metrics and actions with it, and a warehouse-only field such as lifetime value
 carries its reports; each is present where its inputs are, and unavailable
-everywhere else. The base still declares each thing once; a profile
-answers the part of the model its store can back.
+everywhere else. The logical model still declares each thing once; a profile
+answers the part of it that its store can back.
 
 **Unbound is not null.** A bound field whose data happens to be empty — a
 customer with no phone on file — is null: the field exists and the value is
@@ -124,59 +129,58 @@ apart is what lets a query fail against a store that cannot answer it instead of
 returning a blank that reads like real data.
 
 **Leaving a field unbound is explicit.** A profile leaves a field unbound in one
-of two ways. The base declares the field but gives it no column, so no profile
-has it until one binds it. Alternatively, a profile that would otherwise inherit
-the base's column sets `unbound: true` on the field to drop it. Silently omitting
-a field does neither — an omitted field inherits the base's column, and if that
-column is absent from the profile's store, validation fails and names it. So a
-forgotten binding is caught, and an intentional non-binding is written down.
+of two ways. The logical model declares the field, and no profile that omits a
+column for it has it until one binds it. Alternatively, a profile that would
+otherwise inherit a column sets `unbound: true` on the field to drop it. Silently
+omitting a field that another profile binds does neither — the field stays
+declared and simply has no column under the omitting profile, which is caught if
+a metric needs it. When a bound column is absent from the profile's store,
+validation fails and names it. So a forgotten binding is caught, and an
+intentional non-binding is written down.
 
 ## File layout
 
-Profiles live in a directory next to the model, one file per profile. Each file
-is a `semantic_model` document carrying only that profile's bindings:
+The logical model is one file. Its bindings live beside it, one file per
+profile:
 
 ```
 catalog/EntryGroups/commerce_eg/
-  commerce.yaml                  # base declaration + inline `default` binding
+  commerce.yaml                  # the logical model — declarations only, no bindings
   commerce.profiles/
-    operational.yaml             # a semantic_model subclass — same schema as commerce.yaml
-    analytics.yaml
+    analytical.yaml              # BigQuery bindings
+    operational.yaml             # Spanner bindings
 ```
 
-One file per profile keeps them isolated: `--profile operational` reads only
-`operational.yaml`, so an edit to one profile cannot break another, and each
-profile can be reviewed and owned on its own. The `default` binding stays inline
-in `commerce.yaml`, so a model with a single binding needs no directory.
+Each binding file is a `semantic_model` document in the same schema as the
+logical model, carrying only physical facets. `--profile analytical` reads
+`commerce.yaml` plus `analytical.yaml`, so nothing in one binding can affect
+another, and each binding can be reviewed and owned on its own.
 
-## Example — an operational and an analytical binding
+## Example — one model, an analytical and an operational binding
 
-The base holds the declaration and its analytics binding in BigQuery.
-`lifetimeValue` is a warehouse-only field, bound here; `availableCredit` is a
-live operational-only field, declared but left unbound (no column):
+The logical model declares the business and nothing physical: no sources, no
+columns, no deployment target. `lifetimeValue` and `availableCredit` are both
+declared here, though no single store carries both:
 
 ```yaml
-# commerce.yaml
+# commerce.yaml — logical model
 version: "0.2.0.dev0"
 semantic_model:
   - name: commerce
-    deployment_target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce
     entities:
       - name: Customer
-        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/customer
         primary_key: [key]
         fields:
-          - { name: key,             expression: c_custkey }
-          - { name: name,            expression: c_name, label: Customer Name }
-          - { name: lifetimeValue,   expression: c_ltv, label: Lifetime Value }
+          - { name: key,             label: Customer ID }
+          - { name: name,            label: Customer Name }
+          - { name: lifetimeValue,   label: Lifetime Value }
           - { name: availableCredit, label: Available Credit }
       - name: Order
-        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
         primary_key: [key]
         fields:
-          - { name: key,         expression: o_orderkey }
-          - { name: customerKey, expression: o_custkey }
-          - { name: orderDate,   expression: o_orderdate, dimension: {is_time: true} }
+          - { name: key }
+          - { name: customerKey }
+          - { name: orderDate, dimension: {is_time: true} }
     relationships:
       - name: PlacedBy
         from: Order
@@ -190,13 +194,38 @@ semantic_model:
         expression: AVG(Customer.lifetimeValue)
 ```
 
-The operational profile points the same model at the live Spanner store. Spanner
-holds the same customers under different table and column names, binds the live
-`availableCredit`, and does not carry the modeled `lifetimeValue`, so the profile
-marks it `unbound`:
+The analytical binding points the model at the BigQuery warehouse. The warehouse
+carries the modeled `lifetimeValue` and does not hold live credit, so
+`availableCredit` is `unbound`:
 
 ```yaml
-# commerce.profiles/operational.yaml
+# commerce.profiles/analytical.yaml — BigQuery bindings
+version: "0.2.0.dev0"
+semantic_model:
+  - name: commerce
+    deployment_target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce
+    entities:
+      - name: Customer
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/customer
+        fields:
+          - { name: key,             expression: c_custkey }
+          - { name: name,            expression: c_name }
+          - { name: lifetimeValue,   expression: c_ltv }
+          - { name: availableCredit, unbound: true }
+      - name: Order
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
+        fields:
+          - { name: key,         expression: o_orderkey }
+          - { name: customerKey, expression: o_custkey }
+          - { name: orderDate,   expression: o_orderdate }
+```
+
+The operational binding points the same model at the live Spanner store. Spanner
+holds the same customers under different table and column names, binds the live
+`availableCredit`, and does not carry the modeled `lifetimeValue`:
+
+```yaml
+# commerce.profiles/operational.yaml — Spanner bindings
 version: "0.2.0.dev0"
 semantic_model:
   - name: commerce
@@ -204,7 +233,6 @@ semantic_model:
     entities:
       - name: Customer
         source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Customer
-        primary_key: [CustomerId]
         fields:
           - { name: key,             expression: CustomerId }
           - { name: name,            expression: FullName }
@@ -212,53 +240,44 @@ semantic_model:
           - { name: lifetimeValue,   unbound: true }
       - name: Order
         source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Orders
-        primary_key: [OrderId]
         fields:
           - { name: key,         expression: OrderId }
           - { name: customerKey, expression: CustomerId }
           - { name: orderDate,   expression: OrderDate }
-    relationships:
-      - name: PlacedBy
-        from_columns: [CustomerId]
-        to_columns: [CustomerId]
 ```
 
-`kcmd push --profile operational` deploys the merged model against Spanner. The
-two stores hold different facts, so the profiles answer different parts of the
-same model:
+Neither binding restates the grain, the `PlacedBy` relationship, the labels, or
+the metric definitions; those live once in the logical model. `kcmd push
+--profile operational` deploys the merged model against Spanner, and the two
+bindings answer different parts of the same model:
 
-- `order_count` depends only on `Order.key`, bound under both profiles, so it is
+- `order_count` depends only on `Order.key`, bound under both bindings, so it is
   available under either.
 - `avg_lifetime_value` depends on `Customer.lifetimeValue`. The warehouse binds
   it, so the metric is available analytically; the operational store marks it
   unbound, so the metric is unavailable there.
-- `availableCredit` is unbound in the base and bound only operationally, so it —
-  and a live credit-limit action written on top of it — is available under the
-  operational profile and absent under the analytical one.
-
-`orderDate` flips only its column and keeps its time-dimension role from the
-base. `Customer Name` and every metric definition are never restated.
+- `availableCredit` is bound only operationally, so it — and a live credit-limit
+  action written on top of it — is available under the operational binding and
+  absent under the analytical one.
 
 ## Merge rules
 
 - `entities`, `fields`, `relationships`, and `metrics` merge **by `name`**. A
-  name present only in the base is inherited unchanged.
+  name present only in the logical model is carried through unchanged.
 - Scalars — `source`, `expression`, `deployment_target` — **replace**.
-- Key tuples — `primary_key`, `from_columns`, `to_columns` — **replace as a
-  whole**; they are atomic rather than merged element by element.
-- A field with `unbound: true` in a profile **drops** the base's binding for
-  that field under that profile.
+- A field with `unbound: true` in a profile **drops** any column for that field
+  under that profile.
 - Profiles are **binding-only**: a profile sets physical facets and may leave a
-  field unbound. It cannot add or remove entities, fields, or metrics, and
-  cannot change what any of them mean.
+  field unbound. It cannot add or remove entities, fields, or metrics, change
+  the grain or graph shape, or change what anything means.
 
 ## Command line
 
 ```bash
-kcmd push                                 # the default profile (base as-is)
-kcmd push --profile operational           # merge operational onto base, deploy the result
-kcmd push --profile analytics             # deploy against the analytics warehouse
-kcmd push --profile analytics --target kc # profile and destination-type are independent
+kcmd push --profile analytical            # merge analytical bindings onto the model, deploy
+kcmd push --profile operational           # deploy against the operational store
+kcmd push --profile analytical --target kc # profile and destination-type are independent
+kcmd push                                 # uses default_profile from catalog.yaml
 kcmd profiles                             # list profiles, their resolved sources, and what each cannot answer
 ```
 
@@ -272,7 +291,7 @@ Set the default so a bare `kcmd push` in CI does the right thing, in
 
 ```yaml
 scope: semantic-model.acme.us.commerce_eg
-default_profile: analytics
+default_profile: analytical
 ```
 
 ## Validation
@@ -283,15 +302,16 @@ writes nothing.
 - **Unknown profile** — `--profile stg` when `stg` is not defined fails and lists
   the profiles that are.
 - **Missing or ambiguous target** — a profile that deploys a graph must resolve
-  to one `deployment_target` (from the base or the profile).
+  to one `deployment_target`.
 - **Declaration override** — a profile that sets a `label`, `dimension`,
-  `ai_context`, a `metric`, a relationship `from`/`to`, or a field `expression`
-  that is not a bare column reference is rejected, naming the offending path.
-- **Unknown name** — a profile element whose `name` is not in the base is
-  rejected. Profiles refine declarations; they do not add them.
-- **Unresolvable column** — a column a profile binds, or inherits from the base,
-  that the profile's store does not have fails and names it. This is what turns a
-  forgotten binding into a loud error rather than an accidental unbinding.
+  `ai_context`, a `metric`, the grain, a relationship's `from`/`to`, or a field
+  `expression` that is not a bare column reference is rejected, naming the
+  offending path.
+- **Unknown name** — a profile element whose `name` is not in the logical model
+  is rejected. Profiles bind declarations; they do not add them.
+- **Unresolvable column** — a column a profile binds that the profile's store
+  does not have fails and names it. This is what turns a mistyped binding into a
+  loud error.
 - **Availability report** — push resolves the dependency graph and reports, per
   profile, each metric, action, and traversal it cannot answer, together with
   the unbound field that stops it. Withheld coverage is stated rather than
@@ -299,23 +319,16 @@ writes nothing.
 
 ## Notes
 
-**The deployment target is a first-class key.** So a profile can override it
-readably, `deployment_target:` is a model key rather than a JSON string inside a
-`GOOGLE custom_extensions` block. The custom-extension form is still accepted and
-means the same thing.
+**The deployment target is a first-class key.** So a profile can set it readably,
+`deployment_target:` is a model key rather than a JSON string inside a `GOOGLE
+custom_extensions` block. The custom-extension form is still accepted and means
+the same thing.
 
 **Bare-string expressions.** A field's `expression` may be written as a one-line
 string (`expression: c_name`) instead of the full per-dialect object. The two
 forms mean the same thing and expand to the same wire representation.
 
-**An abstract base.** Validation runs on base + profile, so the base need not
-carry sources. A base that omits every `source` and `deployment_target` is
-abstract: it declares the model, deploys on its own for nothing, and each profile
-supplies the physical bindings. Leaving a single field unbound in the base is the
-same idea at field granularity, and both match the `abstract` marker an entity
-can already carry.
-
-**Dialect comes from the store.** A profile carries no SQL dialect. The
-dialect follows from the store a profile binds to; the engine lowers each
-`expression` to that store's query language when it runs. A profile chooses the
-data, and the execution engine chooses the dialect.
+**Dialect comes from the store.** A profile carries no SQL dialect. The dialect
+follows from the store a profile binds to; the engine lowers each `expression` to
+that store's query language when it runs. A profile chooses the data, and the
+execution engine chooses the dialect.

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -13,25 +13,26 @@ from, never what the model means. Because every profile shares one model,
 `Customer`, `revenue`, and each relationship mean the same thing whichever
 profile serves them.
 
-## One model, many stores
+## Why a model gets more than one binding
 
-The same concept usually lives in more than one system. A `Customer` sits in a
-live operational database and in a day-stale analytics warehouse; an `Order` is
-written transactionally in one store and reported on in another. A profile lets
-one model serve both kinds of consumer from a single definition:
+The same concept usually lives in more than one system, and a profile binds the
+model to one of them. The systems differ along whatever axis matters to you:
 
-- **An operational profile** reads from the live operational stores, such as
-  AlloyDB or Spanner. An operational agent uses it to check current state before
-  it acts — a customer's balance, a part's availability — and write actions run
-  against it.
-- **An analytical profile** reads from the analytics warehouse, such as
-  BigQuery: a copy scaled and shaped for reporting. Dashboards, BI tools, and
-  conversational analytics agents read through it, and each inherits the same
-  metric definitions, so `revenue` is computed the same way across all of them.
+- **Different backends for different consumers.** A live operational store —
+  AlloyDB, Spanner, a SaaS API — holds the `Customer` an agent reads to check
+  current state before it acts, and writes back to. An analytics warehouse such
+  as BigQuery holds a copy of that same `Customer`, scaled for reporting, that
+  dashboards and conversational-analytics agents read. One profile binds each,
+  and every consumer inherits the same metric definitions, so `revenue` is
+  computed the same way wherever it is asked.
+- **Different environments of one backend.** A dev, staging, and prod copy of one
+  store are three profiles that differ only in the project they point at.
+- **Different physical layouts.** The same model can bind a table exported to
+  files in a lake, an Iceberg copy, or a partner's differently-named schema.
 
-You author the model once and choose the profile when you deploy or query. The
-same mechanism also covers a narrower case: a dev, staging, and prod copy of one
-store are three profiles that differ only in the project they point at.
+A profile is a named binding, and its meaning is yours to decide; the cases above
+only illustrate the range. You author the model once and choose the profile when
+you deploy or query.
 
 ## How it works: a logical model and its bindings
 

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -1,0 +1,268 @@
+# Binding a model to different sources with profiles
+
+> **Status: proposed.** This page is the design for an upcoming feature, written
+> as the user guide first so we can iterate on how it *reads* before building it.
+> Nothing here is implemented yet.
+
+One semantic model often has to deploy against more than one physical home: a
+dev copy and a prod copy, or two differently-shaped copies of the same data
+(for example, one imported from another warehouse). Today a model binds to
+exactly one set of tables — each entity's `source`, each field's column, and the
+deployment target are all fixed in the model document. A **binding profile** lets
+you keep one logical model and swap the physical binding at push time.
+
+A profile is a named, complete physical realization of a model: where each
+entity's data lives, which column each field reads, and which graph the model
+deploys to. You select one per push with `--profile`; the model's *meaning* —
+its entities, fields, metrics, and relationships — is identical no matter which
+profile you pick.
+
+## When you need one
+
+| You have… | Use a profile to… |
+|---|---|
+| A dev, staging, and prod copy with the **same layout** | repoint the sources and deployment target per environment — a few lines each |
+| A **differently-shaped copy** (different table and column names) | remap sources *and* columns *and* join keys, while the metrics and labels stay put |
+
+Profiles do **not** change how the model is computed or what it means. They
+relocate data; they don't redefine it. Pointing a model at a genuinely
+different execution engine (say Spanner instead of BigQuery), where the SQL
+dialect and deploy mechanism differ, is out of scope for profiles — that's a
+separate, larger capability.
+
+## How it works: a base and its overrides
+
+Think of it as a class hierarchy, the same way an entity `extends` a supertype:
+
+- Your **model file** (`<model>.yaml`) is the **base** — a complete model whose
+  inline bindings are the profile named `default`. With no profile selected, this
+  is exactly what deploys.
+- A **profile** is a **subclass**: a document in the *identical schema* as the
+  model, with only the parts it changes filled in.
+- `kcmd push --profile <name>` **merges** the profile onto the base — matching
+  entities, fields, relationships, and metrics **by name** — and deploys the
+  merged result. A profile is never deployed alone; base + profile must together
+  form a complete, valid model.
+
+Because a profile is just a model document with holes, there's one schema to
+learn. Authoring a profile is "copy the model file, delete everything that
+doesn't change."
+
+## What a profile may change — the contract
+
+A profile may set only the **physical** facets of a model. Everything else is
+owned by the base and is rejected if a profile tries to set it. This is the
+guarantee: switching profiles can move the data, but it can never change what the
+model means, so `dev` and `prod` always compute the same answer.
+
+| A profile **may** override (physical) | A profile **may not** touch (logical, base-only) |
+|---|---|
+| the model's `deployment_target` | adding or removing entities, fields, or metrics |
+| an entity's `source` | a field's `label`, `description`, `dimension`, `datatype` |
+| an entity's `primary_key` / `unique_keys` | any `ai_context` / synonyms |
+| a field's column (its `expression`, **as a bare column reference**) | a field `expression` that is arbitrary SQL (that's computation, not binding) |
+| a relationship's `from_columns` / `to_columns` | a relationship's `from` / `to` (the shape of the graph) |
+| a junction table's `source` / keys / columns | any `metric` definition |
+
+An element's `name` is not "overridden" — it's the key that pairs a profile
+element with the base element it refines.
+
+**Why metrics never appear in a profile.** A metric like
+`SUM(orders.o_totalprice)` references the field *name* `o_totalprice`, not a
+column. Field names are stable across profiles — only their column bindings
+change — so the metric is correct under every profile without being restated.
+The contract and the arithmetic line up for free.
+
+## File layout
+
+Profiles live in a directory next to the model, one file per profile. Each file
+is a `semantic_model` document carrying only that profile's deltas:
+
+```
+catalog/EntryGroups/sales_eg/
+  sales.yaml                    # base model + inline `default` binding
+  sales.profiles/
+    prod.yaml                   # a semantic_model subclass — same schema as sales.yaml
+    snowflake_export.yaml
+```
+
+One file per profile keeps them isolated: `--profile prod` reads only
+`prod.yaml`, so an edit or a typo in `dev.yaml` can never break a prod deploy,
+and each profile can be reviewed and owned on its own. The `default` binding
+stays inline in `sales.yaml`, so a simple model needs no `sales.profiles/`
+directory at all.
+
+## Example 1 — environments (same layout)
+
+The base holds the model and the dev binding:
+
+```yaml
+# sales.yaml
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    deployment_target: //bigquery.googleapis.com/projects/acme-dev/datasets/sales/propertyGraphs/sales
+    datasets:
+      - name: orders
+        source: acme-dev.sales.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression: {dialects: [{dialect: BIGQUERY, expression: o_orderkey}]}
+          - name: o_orderdate
+            expression: {dialects: [{dialect: BIGQUERY, expression: o_orderdate}]}
+            label: Order Date
+            dimension: {is_time: true}
+          - name: o_totalprice
+            expression: {dialects: [{dialect: BIGQUERY, expression: o_totalprice}]}
+      - name: customer
+        source: acme-dev.sales.customer
+        primary_key: [c_custkey]
+        fields:
+          - name: c_custkey
+            expression: {dialects: [{dialect: BIGQUERY, expression: c_custkey}]}
+          - name: c_name
+            expression: {dialects: [{dialect: BIGQUERY, expression: c_name}]}
+    relationships:
+      - name: orders_to_customer
+        from: orders
+        to: customer
+        from_columns: [o_custkey]
+        to_columns: [c_custkey]
+    metrics:
+      - name: total_revenue
+        expression: {dialects: [{dialect: BIGQUERY, expression: SUM(orders.o_totalprice)}]}
+```
+
+The prod profile changes only the project and the target — everything else is
+inherited:
+
+```yaml
+# sales.profiles/prod.yaml
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    deployment_target: //bigquery.googleapis.com/projects/acme-prod/datasets/sales/propertyGraphs/sales
+    datasets:
+      - name: orders
+        source: acme-prod.sales.orders
+      - name: customer
+        source: acme-prod.sales.customer
+```
+
+`kcmd push --profile prod` deploys the whole model against `acme-prod`. Columns,
+keys, the relationship, and the metric all come from the base.
+
+## Example 2 — a different physical layout
+
+A copy imported from Snowflake: different table names, different column names,
+different key columns. The profile overrides down to the column and the join
+keys — and the base model above is untouched, so `total_revenue` and the
+`Order Date` label still mean exactly what they did.
+
+```yaml
+# sales.profiles/snowflake_export.yaml
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    deployment_target: //bigquery.googleapis.com/projects/acme/datasets/sf/propertyGraphs/sales
+    datasets:
+      - name: orders
+        source: sf_import.PUBLIC.ORDERS
+        primary_key: [ORDER_KEY]
+        fields:
+          - name: o_orderkey
+            expression: {dialects: [{dialect: BIGQUERY, expression: ORDER_KEY}]}
+          - name: o_orderdate
+            expression: {dialects: [{dialect: BIGQUERY, expression: ORDER_DATE}]}   # inherits label + dimension
+          - name: o_totalprice
+            expression: {dialects: [{dialect: BIGQUERY, expression: TOTAL_PRICE}]}
+      - name: customer
+        source: sf_import.PUBLIC.CUSTOMER
+        primary_key: [CUST_KEY]
+        fields:
+          - name: c_custkey
+            expression: {dialects: [{dialect: BIGQUERY, expression: CUST_KEY}]}
+          - name: c_name
+            expression: {dialects: [{dialect: BIGQUERY, expression: CUST_NAME}]}
+    relationships:
+      - name: orders_to_customer
+        from_columns: [CUST_KEY_FK]
+        to_columns: [CUST_KEY]
+```
+
+`o_orderdate` flips only its column; it keeps `label: Order Date` and its
+time-dimension role from the base. The imported tables live in BigQuery (via
+BigLake / a federated catalog) — the model still executes as a BigQuery Graph,
+so the SQL dialect is unchanged.
+
+## Merge rules
+
+- `datasets`, `fields`, `relationships`, and `metrics` merge **by `name`**. A
+  name present only in the base is inherited unchanged.
+- Scalars — `source`, `expression`, `deployment_target` — **replace**.
+- Key tuples — `primary_key`, `from_columns`, `to_columns` — **replace as a
+  whole**; they are atomic, not merged element by element.
+- Profiles are **override-only**: a profile can refine physical facets of things
+  that exist in the base. It cannot add new entities/fields/metrics or delete
+  them.
+
+## Command line
+
+```bash
+kcmd push                                # the default profile (base as-is)
+kcmd push --profile prod                 # merge prod onto base, deploy the result
+kcmd push --profile snowflake_export     # deploy over the Snowflake-shaped copy
+kcmd push --profile prod --target kc     # profile and destination-type are independent
+kcmd profiles                            # list profiles and their resolved deployment target
+```
+
+`--profile` chooses **which physical binding**. The existing `--target
+bq|kc|all` chooses **which destination type** (BigQuery Graph, Knowledge
+Catalog, or both). They are orthogonal — any profile can go to either
+destination.
+
+Set the default so a bare `kcmd push` in CI does the right thing, in
+`catalog.yaml`:
+
+```yaml
+scope: semantic-model.acme.us.sales_eg
+default_profile: prod
+```
+
+## Validation
+
+Profiles are checked as part of push; `--validate-only` runs the checks and
+writes nothing.
+
+- **Unknown profile** — `--profile stg` when `stg` isn't defined fails and lists
+  the profiles that are.
+- **Missing or ambiguous target** — the merged model must resolve to exactly one
+  `deployment_target` (from the base or the profile); zero or more than one is
+  rejected.
+- **Logical override** — a profile that sets a `label`, `dimension`,
+  `ai_context`, a `metric`, a relationship `from`/`to`, or a field `expression`
+  that isn't a bare column reference is rejected, naming the offending path.
+  Profiles are physical-only.
+- **Unknown name** — a profile element whose `name` isn't in the base is
+  rejected. Profiles override; they don't add.
+
+## Notes
+
+**The deployment target is now a first-class key.** So a profile can override it
+readably, `deployment_target:` moves out of the `GOOGLE custom_extensions` block
+and onto the model. The old custom-extension form is still accepted and means
+the same thing, so existing models keep working.
+
+**An abstract base.** Validation runs on base + profile, so the base doesn't have
+to carry sources at all. A base that omits `source` and `deployment_target` is
+effectively abstract: it won't deploy on its own, and *every* profile must supply
+the physical bindings. This is the same mechanism as the inline `default`, just
+with the base left empty — the same way an entity can be `abstract`.
+
+**Dialect is deferred on purpose.** A profile carries no SQL dialect. The dialect
+is a property of the execution backend, which the deployment target implies —
+every profile today targets a BigQuery Graph, so there is one dialect and nothing
+to choose. When a non-BigQuery execution backend is supported, the dialect will
+be derived from that backend (and transpiled), not authored per profile, so the
+profile schema won't change.

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -38,17 +38,17 @@ store are three profiles that differ only in the project they point at.
 A model and its profiles form a class hierarchy, the same way an entity
 `extends` a supertype:
 
-- The **model file** (`<model>.yaml`) is the **base** — a complete model whose
-  inline sources are the profile named `default`.
+- The **model file** (`<model>.yaml`) is the **base** — the complete
+  declaration, whose inline bindings are the profile named `default`.
 - A **profile** is a **subclass**: a document in the *identical schema* as the
-  model, carrying only the parts it changes.
+  model, carrying only the bindings it changes.
 - `kcmd push --profile <name>` **merges** the profile onto the base — matching
   entities, fields, relationships, and metrics **by name** — and deploys the
-  result. A profile is never deployed alone; base + profile must together form a
-  complete, valid model.
+  result. A profile is never deployed alone: the base supplies every
+  declaration, and the profile supplies the bindings its store provides.
 
 A profile is a model document with holes, so there is one schema to learn.
-Authoring a profile is "copy the model file, keep only what changes."
+Authoring a profile is "copy the model file, keep only the bindings that change."
 
 ## Sources are URIs
 
@@ -63,38 +63,82 @@ field reads.
 
 ## What a profile may change — the contract
 
-A profile may set only the **physical** facets of a model. Everything else is
-owned by the base and is rejected if a profile sets it. This is the guarantee:
-switching profiles moves where the data is read, and can never change what the
-model means, so an operational agent and an analytics dashboard compute the same
-`revenue`.
+A model separates two things. **Declaration** is logical: which entities,
+fields, relationships, and metrics exist, what each means, and how each metric
+computes. The base owns all of it. **Binding** is physical: which store each
+entity reads from, and which column each field reads. A profile sets binding and
+leaves declaration alone.
 
-| A profile **may** override (physical) | A profile **may not** touch (logical, base-only) |
+| A profile **may** set (binding) | A profile **may not** touch (declaration, base-only) |
 |---|---|
 | an entity's `source` (its store URI) | adding or removing entities, fields, or metrics |
 | a field's column (its `expression`, **as a bare column reference**) | a field's `label`, `description`, `dimension`, `datatype` |
-| an entity's `primary_key` / `unique_keys` | any `ai_context` / synonyms |
-| a relationship's `from_columns` / `to_columns` | a field `expression` that is arbitrary SQL, which changes the computation rather than the binding |
-| a table-backed relationship's `source` / `keys` | a relationship's `from` / `to` (the shape of the graph) |
-| the deployment target (for a profile that deploys a graph) | any `metric` definition |
+| whether a field is bound at all under this profile | any `ai_context` / synonyms |
+| an entity's `primary_key` / `unique_keys` | a field `expression` that is arbitrary SQL, which changes the computation rather than the binding |
+| a relationship's `from_columns` / `to_columns` | a relationship's `from` / `to` (the shape of the graph) |
+| a table-backed relationship's `source` / `keys` | any `metric` definition |
+| the deployment target | |
 
 An element's `name` is not overridden — it is the key that pairs a profile
 element with the base element it refines.
 
 **Why metrics never appear in a profile.** A metric like
 `SUM(OrderedAs.extendedPrice * (1 - OrderedAs.discount))` references field
-*names* rather than columns. Field names are stable across profiles — only their column
-bindings change — so the metric is correct under every profile without being
-restated.
+*names* rather than columns. Field names are stable across profiles — only their
+column bindings change — so the metric is correct under every profile where its
+fields are bound, without being restated. Where a field it references is not
+bound, the metric is unavailable under that profile; the next section explains
+why.
+
+## Availability follows the bindings
+
+A store holds what it holds. An operational database keeps a customer's live
+credit; a warehouse keeps a modeled lifetime value; neither carries the other's
+column. A profile binds whatever subset its store serves, and leaves the rest
+unbound.
+
+What a profile can answer is therefore derived from what it binds, by one rule.
+**A building block is available under a profile when every field it depends on is
+bound there. When any input is unbound, the block is unbound too, and so is
+anything built on it.** Availability propagates up the dependency graph from the
+fields a profile binds. The chain runs as far as the model does:
+
+- a field is bound when the profile gives its column;
+- a metric is available when every field its expression references is bound;
+- an action is available when every field it reads or writes is bound;
+- a relationship is available when the join columns on both ends are bound, and
+  a traversal or cross-entity metric over it is available only when the
+  relationship is.
+
+So an operational-only field such as live credit carries its operational-only
+metrics and actions with it, and a warehouse-only field such as lifetime value
+carries its reports; each is present where its inputs are, and unavailable
+everywhere else. The base still declares each thing once; a profile
+answers the part of the model its store can back.
+
+**Unbound is not null.** A bound field whose data happens to be empty — a
+customer with no phone on file — is null: the field exists and the value is
+missing. An unbound field does not exist under that profile at all, and anything
+that reads it is unavailable there rather than reading a null. Keeping the two
+apart is what lets a query fail against a store that cannot answer it instead of
+returning a blank that reads like real data.
+
+**Leaving a field unbound is explicit.** A profile leaves a field unbound in one
+of two ways. The base declares the field but gives it no column, so no profile
+has it until one binds it. Alternatively, a profile that would otherwise inherit
+the base's column sets `unbound: true` on the field to drop it. Silently omitting
+a field does neither — an omitted field inherits the base's column, and if that
+column is absent from the profile's store, validation fails and names it. So a
+forgotten binding is caught, and an intentional non-binding is written down.
 
 ## File layout
 
 Profiles live in a directory next to the model, one file per profile. Each file
-is a `semantic_model` document carrying only that profile's deltas:
+is a `semantic_model` document carrying only that profile's bindings:
 
 ```
 catalog/EntryGroups/commerce_eg/
-  commerce.yaml                  # base model + inline `default` binding
+  commerce.yaml                  # base declaration + inline `default` binding
   commerce.profiles/
     operational.yaml             # a semantic_model subclass — same schema as commerce.yaml
     analytics.yaml
@@ -107,7 +151,9 @@ in `commerce.yaml`, so a model with a single binding needs no directory.
 
 ## Example — an operational and an analytical binding
 
-The base holds the model and its analytics binding in BigQuery:
+The base holds the declaration and its analytics binding in BigQuery.
+`lifetimeValue` is a warehouse-only field, bound here; `availableCredit` is a
+live operational-only field, declared but left unbound (no column):
 
 ```yaml
 # commerce.yaml
@@ -120,8 +166,10 @@ semantic_model:
         source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/customer
         primary_key: [key]
         fields:
-          - { name: key,  expression: c_custkey }
-          - { name: name, expression: c_name, label: Customer Name }
+          - { name: key,             expression: c_custkey }
+          - { name: name,            expression: c_name, label: Customer Name }
+          - { name: lifetimeValue,   expression: c_ltv, label: Lifetime Value }
+          - { name: availableCredit, label: Available Credit }
       - name: Order
         source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
         primary_key: [key]
@@ -138,28 +186,32 @@ semantic_model:
     metrics:
       - name: order_count
         expression: COUNT(Order.key)
+      - name: avg_lifetime_value
+        expression: AVG(Customer.lifetimeValue)
 ```
 
 The operational profile points the same model at the live Spanner store. Spanner
-holds the same data under different table and column names, so the profile
-overrides the sources *and* the columns. The `label: Customer Name`, the time
-dimension on `orderDate`, the `PlacedBy` relationship, and the `order_count`
-metric all stay in the base:
+holds the same customers under different table and column names, binds the live
+`availableCredit`, and does not carry the modeled `lifetimeValue`, so the profile
+marks it `unbound`:
 
 ```yaml
 # commerce.profiles/operational.yaml
 version: "0.2.0.dev0"
 semantic_model:
   - name: commerce
+    deployment_target: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/propertyGraphs/commerce
     entities:
       - name: Customer
-        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/customers/tables/Customer
+        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Customer
         primary_key: [CustomerId]
         fields:
-          - { name: key,  expression: CustomerId }
-          - { name: name, expression: FullName }
+          - { name: key,             expression: CustomerId }
+          - { name: name,            expression: FullName }
+          - { name: availableCredit, expression: AvailableCredit }
+          - { name: lifetimeValue,   unbound: true }
       - name: Order
-        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/orders/tables/Orders
+        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Orders
         primary_key: [OrderId]
         fields:
           - { name: key,         expression: OrderId }
@@ -171,9 +223,21 @@ semantic_model:
         to_columns: [CustomerId]
 ```
 
-`kcmd push --profile operational` deploys the merged model against Spanner.
-`orderDate` flips only its column; it keeps its time-dimension role from the
-base. `order_count` and `Customer Name` are never restated.
+`kcmd push --profile operational` deploys the merged model against Spanner. The
+two stores hold different facts, so the profiles answer different parts of the
+same model:
+
+- `order_count` depends only on `Order.key`, bound under both profiles, so it is
+  available under either.
+- `avg_lifetime_value` depends on `Customer.lifetimeValue`. The warehouse binds
+  it, so the metric is available analytically; the operational store marks it
+  unbound, so the metric is unavailable there.
+- `availableCredit` is unbound in the base and bound only operationally, so it —
+  and a live credit-limit action written on top of it — is available under the
+  operational profile and absent under the analytical one.
+
+`orderDate` flips only its column and keeps its time-dimension role from the
+base. `Customer Name` and every metric definition are never restated.
 
 ## Merge rules
 
@@ -182,8 +246,11 @@ base. `order_count` and `Customer Name` are never restated.
 - Scalars — `source`, `expression`, `deployment_target` — **replace**.
 - Key tuples — `primary_key`, `from_columns`, `to_columns` — **replace as a
   whole**; they are atomic rather than merged element by element.
-- Profiles are **override-only**: a profile refines physical facets of things
-  that exist in the base. It cannot add new entities, fields, or metrics.
+- A field with `unbound: true` in a profile **drops** the base's binding for
+  that field under that profile.
+- Profiles are **binding-only**: a profile sets physical facets and may leave a
+  field unbound. It cannot add or remove entities, fields, or metrics, and
+  cannot change what any of them mean.
 
 ## Command line
 
@@ -192,7 +259,7 @@ kcmd push                                 # the default profile (base as-is)
 kcmd push --profile operational           # merge operational onto base, deploy the result
 kcmd push --profile analytics             # deploy against the analytics warehouse
 kcmd push --profile analytics --target kc # profile and destination-type are independent
-kcmd profiles                             # list profiles and their resolved sources
+kcmd profiles                             # list profiles, their resolved sources, and what each cannot answer
 ```
 
 `--profile` chooses **which physical binding**. The existing `--target
@@ -217,21 +284,18 @@ writes nothing.
   the profiles that are.
 - **Missing or ambiguous target** — a profile that deploys a graph must resolve
   to one `deployment_target` (from the base or the profile).
-- **Logical override** — a profile that sets a `label`, `dimension`,
+- **Declaration override** — a profile that sets a `label`, `dimension`,
   `ai_context`, a `metric`, a relationship `from`/`to`, or a field `expression`
   that is not a bare column reference is rejected, naming the offending path.
 - **Unknown name** — a profile element whose `name` is not in the base is
-  rejected. Profiles override; they do not add.
-
-## Partial binding (under consideration)
-
-A store need not serve every attribute of an entity. Under partial binding, a
-profile maps whatever subset a source can provide, and attributes it does not
-bind resolve to null in that profile. An entity then does not have to bind fully
-under every profile — an operational store can expose live balances that the
-warehouse lacks, and a warehouse can expose derived attributes the operational
-store never stores. This relaxes the rule that base + profile must bind every
-field, and is gated on real usage before it ships.
+  rejected. Profiles refine declarations; they do not add them.
+- **Unresolvable column** — a column a profile binds, or inherits from the base,
+  that the profile's store does not have fails and names it. This is what turns a
+  forgotten binding into a loud error rather than an accidental unbinding.
+- **Availability report** — push resolves the dependency graph and reports, per
+  profile, each metric, action, and traversal it cannot answer, together with
+  the unbound field that stops it. Withheld coverage is stated rather than
+  discovered later.
 
 ## Notes
 
@@ -245,10 +309,11 @@ string (`expression: c_name`) instead of the full per-dialect object. The two
 forms mean the same thing and expand to the same wire representation.
 
 **An abstract base.** Validation runs on base + profile, so the base need not
-carry sources. A base that omits `source` and `deployment_target` is abstract: it
-does not deploy on its own, and every profile supplies the physical bindings.
-This is the same mechanism as the inline `default`, with the base left empty, and
-matches the `abstract` marker an entity can already carry.
+carry sources. A base that omits every `source` and `deployment_target` is
+abstract: it declares the model, deploys on its own for nothing, and each profile
+supplies the physical bindings. Leaving a single field unbound in the base is the
+same idea at field granularity, and both match the `abstract` marker an entity
+can already carry.
 
 **Dialect comes from the store.** A profile carries no SQL dialect. The
 dialect follows from the store a profile binds to; the engine lowers each

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -1,77 +1,91 @@
 # Binding a model to different sources with profiles
 
 > **Status: proposed.** This page is the design for an upcoming feature, written
-> as the user guide first so we can iterate on how it *reads* before building it.
-> Nothing here is implemented yet.
+> as the user guide first so we can iterate on how it reads. Nothing here is
+> implemented yet.
 
-One semantic model often has to deploy against more than one physical home: a
-dev copy and a prod copy, or two differently-shaped copies of the same data
-(for example, one imported from another warehouse). Today a model binds to
-exactly one set of tables — each entity's `source`, each field's column, and the
-deployment target are all fixed in the model document. A **binding profile** lets
-you keep one logical model and swap the physical binding at push time.
+A semantic model describes a business logically — its entities, the
+relationships between them, and the metrics over them — independent of where the
+data physically lives. A **binding profile** maps that one logical model onto a
+concrete set of sources. You keep the model as a single canonical definition and
+select a profile per scenario; a profile changes only where each entity reads
+from, never what the model means. Because every profile shares one model,
+`Customer`, `revenue`, and each relationship mean the same thing whichever
+profile serves them.
 
-A profile is a named, complete physical realization of a model: where each
-entity's data lives, which column each field reads, and which graph the model
-deploys to. You select one per push with `--profile`; the model's *meaning* —
-its entities, fields, metrics, and relationships — is identical no matter which
-profile you pick.
+## One model, many stores
 
-## When you need one
+The same concept usually lives in more than one system. A `Customer` sits in a
+live operational database and in a day-stale analytics warehouse; an `Order` is
+written transactionally and reported on in BigQuery. A profile lets one model
+serve both kinds of consumer from a single definition:
 
-| You have… | Use a profile to… |
-|---|---|
-| A dev, staging, and prod copy with the **same layout** | repoint the sources and deployment target per environment — a few lines each |
-| A **differently-shaped copy** (different table and column names) | remap sources *and* columns *and* join keys, while the metrics and labels stay put |
+- **An operational profile** reads from the live operational stores, such as
+  AlloyDB or Spanner. An operational agent uses it to check current state before
+  it acts — a customer's balance, a part's availability — and write actions run
+  against it.
+- **An analytical profile** reads from the analytics warehouse, such as
+  BigQuery: a copy scaled and shaped for reporting. Dashboards, BI tools, and
+  conversational analytics agents read through it, and each inherits the same
+  metric definitions, so `revenue` is computed the same way across all of them.
 
-Profiles do **not** change how the model is computed or what it means. They
-relocate data; they don't redefine it. Pointing a model at a different
-execution engine (say Spanner instead of BigQuery), where the SQL
-dialect and deploy mechanism differ, is out of scope for profiles — that's a
-separate, larger capability.
+You author the model once and choose the profile when you deploy or query. The
+same mechanism also covers a narrower case: a dev, staging, and prod copy of one
+store are three profiles that differ only in the project they point at.
 
 ## How it works: a base and its overrides
 
-Think of it as a class hierarchy, the same way an entity `extends` a supertype:
+A model and its profiles form a class hierarchy, the same way an entity
+`extends` a supertype:
 
-- Your **model file** (`<model>.yaml`) is the **base** — a complete model whose
-  inline bindings are the profile named `default`. With no profile selected, this
-  is what deploys.
+- The **model file** (`<model>.yaml`) is the **base** — a complete model whose
+  inline sources are the profile named `default`.
 - A **profile** is a **subclass**: a document in the *identical schema* as the
-  model, with only the parts it changes filled in.
+  model, carrying only the parts it changes.
 - `kcmd push --profile <name>` **merges** the profile onto the base — matching
   entities, fields, relationships, and metrics **by name** — and deploys the
-  merged result. A profile is never deployed alone; base + profile must together
-  form a complete, valid model.
+  result. A profile is never deployed alone; base + profile must together form a
+  complete, valid model.
 
-Because a profile is just a model document with holes, there's one schema to
-learn. Authoring a profile is "copy the model file, delete everything that
-doesn't change."
+A profile is a model document with holes, so there is one schema to learn.
+Authoring a profile is "copy the model file, keep only what changes."
+
+## Sources are URIs
+
+Each entity names where its data lives with `source`, a URI. A Google Cloud
+source is an [AIP-122](https://google.aip.dev/122) resource name —
+`//bigquery.googleapis.com/…`, `//spanner.googleapis.com/…`,
+`//alloydb.googleapis.com/…` — read with ambient IAM. Anything else is a
+`scheme://…` URI, such as an `iceberg://…` table that the deployment manifest
+resolves to an endpoint. A profile moves an entity between stores by swapping
+this URI, and — when the two stores shape the data differently — the column each
+field reads.
 
 ## What a profile may change — the contract
 
 A profile may set only the **physical** facets of a model. Everything else is
-owned by the base and is rejected if a profile tries to set it. This is the
-guarantee: switching profiles can move the data, but it can never change what the
-model means, so `dev` and `prod` always compute the same answer.
+owned by the base and is rejected if a profile sets it. This is the guarantee:
+switching profiles moves where the data is read, and can never change what the
+model means, so an operational agent and an analytics dashboard compute the same
+`revenue`.
 
 | A profile **may** override (physical) | A profile **may not** touch (logical, base-only) |
 |---|---|
-| the model's `deployment_target` | adding or removing entities, fields, or metrics |
-| an entity's `source` | a field's `label`, `description`, `dimension`, `datatype` |
+| an entity's `source` (its store URI) | adding or removing entities, fields, or metrics |
+| a field's column (its `expression`, **as a bare column reference**) | a field's `label`, `description`, `dimension`, `datatype` |
 | an entity's `primary_key` / `unique_keys` | any `ai_context` / synonyms |
-| a field's column (its `expression`, **as a bare column reference**) | a field `expression` that is arbitrary SQL, which changes the computation rather than the binding |
-| a relationship's `from_columns` / `to_columns` | a relationship's `from` / `to` (the shape of the graph) |
-| a junction table's `source` / keys / columns | any `metric` definition |
+| a relationship's `from_columns` / `to_columns` | a field `expression` that is arbitrary SQL, which changes the computation rather than the binding |
+| a table-backed relationship's `source` / `keys` | a relationship's `from` / `to` (the shape of the graph) |
+| the deployment target (for a profile that deploys a graph) | any `metric` definition |
 
-An element's `name` is not "overridden" — it's the key that pairs a profile
+An element's `name` is not overridden — it is the key that pairs a profile
 element with the base element it refines.
 
 **Why metrics never appear in a profile.** A metric like
-`SUM(orders.o_totalprice)` references the field *name* `o_totalprice` rather
-than a column. Field names are stable across profiles — only their column bindings
-change — so the metric is correct under every profile without being restated.
-The contract and the arithmetic line up for free.
+`SUM(OrderedAs.extendedPrice * (1 - OrderedAs.discount))` references field
+*names* rather than columns. Field names are stable across profiles — only their column
+bindings change — so the metric is correct under every profile without being
+restated.
 
 ## File layout
 
@@ -79,142 +93,106 @@ Profiles live in a directory next to the model, one file per profile. Each file
 is a `semantic_model` document carrying only that profile's deltas:
 
 ```
-catalog/EntryGroups/sales_eg/
-  sales.yaml                    # base model + inline `default` binding
-  sales.profiles/
-    prod.yaml                   # a semantic_model subclass — same schema as sales.yaml
-    snowflake_export.yaml
+catalog/EntryGroups/commerce_eg/
+  commerce.yaml                  # base model + inline `default` binding
+  commerce.profiles/
+    operational.yaml             # a semantic_model subclass — same schema as commerce.yaml
+    analytics.yaml
 ```
 
-One file per profile keeps them isolated: `--profile prod` reads only
-`prod.yaml`, so an edit or a typo in `dev.yaml` can never break a prod deploy,
-and each profile can be reviewed and owned on its own. The `default` binding
-stays inline in `sales.yaml`, so a simple model needs no `sales.profiles/`
-directory at all.
+One file per profile keeps them isolated: `--profile operational` reads only
+`operational.yaml`, so an edit to one profile cannot break another, and each
+profile can be reviewed and owned on its own. The `default` binding stays inline
+in `commerce.yaml`, so a model with a single binding needs no directory.
 
-## Example 1 — environments (same layout)
+## Example — an operational and an analytical binding
 
-The base holds the model and the dev binding:
+The base holds the model and its analytics binding in BigQuery:
 
 ```yaml
-# sales.yaml
+# commerce.yaml
 version: "0.2.0.dev0"
 semantic_model:
-  - name: sales
-    deployment_target: //bigquery.googleapis.com/projects/acme-dev/datasets/sales/propertyGraphs/sales
-    datasets:
-      - name: orders
-        source: acme-dev.sales.orders
-        primary_key: [o_orderkey]
+  - name: commerce
+    deployment_target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce
+    entities:
+      - name: Customer
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/customer
+        primary_key: [key]
         fields:
-          - name: o_orderkey
-            expression: {dialects: [{dialect: BIGQUERY, expression: o_orderkey}]}
-          - name: o_orderdate
-            expression: {dialects: [{dialect: BIGQUERY, expression: o_orderdate}]}
-            label: Order Date
-            dimension: {is_time: true}
-          - name: o_totalprice
-            expression: {dialects: [{dialect: BIGQUERY, expression: o_totalprice}]}
-      - name: customer
-        source: acme-dev.sales.customer
-        primary_key: [c_custkey]
+          - { name: key,  expression: c_custkey }
+          - { name: name, expression: c_name, label: Customer Name }
+      - name: Order
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
+        primary_key: [key]
         fields:
-          - name: c_custkey
-            expression: {dialects: [{dialect: BIGQUERY, expression: c_custkey}]}
-          - name: c_name
-            expression: {dialects: [{dialect: BIGQUERY, expression: c_name}]}
+          - { name: key,         expression: o_orderkey }
+          - { name: customerKey, expression: o_custkey }
+          - { name: orderDate,   expression: o_orderdate, dimension: {is_time: true} }
     relationships:
-      - name: orders_to_customer
-        from: orders
-        to: customer
-        from_columns: [o_custkey]
-        to_columns: [c_custkey]
+      - name: PlacedBy
+        from: Order
+        to: Customer
+        from_columns: [customerKey]
+        to_columns: [key]
     metrics:
-      - name: total_revenue
-        expression: {dialects: [{dialect: BIGQUERY, expression: SUM(orders.o_totalprice)}]}
+      - name: order_count
+        expression: COUNT(Order.key)
 ```
 
-The prod profile changes only the project and the target — everything else is
-inherited:
+The operational profile points the same model at the live Spanner store. Spanner
+holds the same data under different table and column names, so the profile
+overrides the sources *and* the columns. The `label: Customer Name`, the time
+dimension on `orderDate`, the `PlacedBy` relationship, and the `order_count`
+metric all stay in the base:
 
 ```yaml
-# sales.profiles/prod.yaml
+# commerce.profiles/operational.yaml
 version: "0.2.0.dev0"
 semantic_model:
-  - name: sales
-    deployment_target: //bigquery.googleapis.com/projects/acme-prod/datasets/sales/propertyGraphs/sales
-    datasets:
-      - name: orders
-        source: acme-prod.sales.orders
-      - name: customer
-        source: acme-prod.sales.customer
-```
-
-`kcmd push --profile prod` deploys the whole model against `acme-prod`. Columns,
-keys, the relationship, and the metric all come from the base.
-
-## Example 2 — a different physical layout
-
-A copy imported from Snowflake: different table names, different column names,
-different key columns. The profile overrides down to the column and the join
-keys — and the base model above is untouched, so `total_revenue` and the
-`Order Date` label still mean what they did.
-
-```yaml
-# sales.profiles/snowflake_export.yaml
-version: "0.2.0.dev0"
-semantic_model:
-  - name: sales
-    deployment_target: //bigquery.googleapis.com/projects/acme/datasets/sf/propertyGraphs/sales
-    datasets:
-      - name: orders
-        source: sf_import.PUBLIC.ORDERS
-        primary_key: [ORDER_KEY]
+  - name: commerce
+    entities:
+      - name: Customer
+        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/customers/tables/Customer
+        primary_key: [CustomerId]
         fields:
-          - name: o_orderkey
-            expression: {dialects: [{dialect: BIGQUERY, expression: ORDER_KEY}]}
-          - name: o_orderdate
-            expression: {dialects: [{dialect: BIGQUERY, expression: ORDER_DATE}]}   # inherits label + dimension
-          - name: o_totalprice
-            expression: {dialects: [{dialect: BIGQUERY, expression: TOTAL_PRICE}]}
-      - name: customer
-        source: sf_import.PUBLIC.CUSTOMER
-        primary_key: [CUST_KEY]
+          - { name: key,  expression: CustomerId }
+          - { name: name, expression: FullName }
+      - name: Order
+        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/orders/tables/Orders
+        primary_key: [OrderId]
         fields:
-          - name: c_custkey
-            expression: {dialects: [{dialect: BIGQUERY, expression: CUST_KEY}]}
-          - name: c_name
-            expression: {dialects: [{dialect: BIGQUERY, expression: CUST_NAME}]}
+          - { name: key,         expression: OrderId }
+          - { name: customerKey, expression: CustomerId }
+          - { name: orderDate,   expression: OrderDate }
     relationships:
-      - name: orders_to_customer
-        from_columns: [CUST_KEY_FK]
-        to_columns: [CUST_KEY]
+      - name: PlacedBy
+        from_columns: [CustomerId]
+        to_columns: [CustomerId]
 ```
 
-`o_orderdate` flips only its column; it keeps `label: Order Date` and its
-time-dimension role from the base. The imported tables live in BigQuery (via
-BigLake / a federated catalog) — the model still executes as a BigQuery Graph,
-so the SQL dialect is unchanged.
+`kcmd push --profile operational` deploys the merged model against Spanner.
+`orderDate` flips only its column; it keeps its time-dimension role from the
+base. `order_count` and `Customer Name` are never restated.
 
 ## Merge rules
 
-- `datasets`, `fields`, `relationships`, and `metrics` merge **by `name`**. A
+- `entities`, `fields`, `relationships`, and `metrics` merge **by `name`**. A
   name present only in the base is inherited unchanged.
 - Scalars — `source`, `expression`, `deployment_target` — **replace**.
 - Key tuples — `primary_key`, `from_columns`, `to_columns` — **replace as a
   whole**; they are atomic rather than merged element by element.
-- Profiles are **override-only**: a profile can refine physical facets of things
-  that exist in the base. It cannot add new entities/fields/metrics or delete
-  them.
+- Profiles are **override-only**: a profile refines physical facets of things
+  that exist in the base. It cannot add new entities, fields, or metrics.
 
 ## Command line
 
 ```bash
-kcmd push                                # the default profile (base as-is)
-kcmd push --profile prod                 # merge prod onto base, deploy the result
-kcmd push --profile snowflake_export     # deploy over the Snowflake-shaped copy
-kcmd push --profile prod --target kc     # profile and destination-type are independent
-kcmd profiles                            # list profiles and their resolved deployment target
+kcmd push                                 # the default profile (base as-is)
+kcmd push --profile operational           # merge operational onto base, deploy the result
+kcmd push --profile analytics             # deploy against the analytics warehouse
+kcmd push --profile analytics --target kc # profile and destination-type are independent
+kcmd profiles                             # list profiles and their resolved sources
 ```
 
 `--profile` chooses **which physical binding**. The existing `--target
@@ -226,8 +204,8 @@ Set the default so a bare `kcmd push` in CI does the right thing, in
 `catalog.yaml`:
 
 ```yaml
-scope: semantic-model.acme.us.sales_eg
-default_profile: prod
+scope: semantic-model.acme.us.commerce_eg
+default_profile: analytics
 ```
 
 ## Validation
@@ -235,34 +213,44 @@ default_profile: prod
 Profiles are checked as part of push; `--validate-only` runs the checks and
 writes nothing.
 
-- **Unknown profile** — `--profile stg` when `stg` isn't defined fails and lists
+- **Unknown profile** — `--profile stg` when `stg` is not defined fails and lists
   the profiles that are.
-- **Missing or ambiguous target** — the merged model must resolve to exactly one
-  `deployment_target` (from the base or the profile); zero or more than one is
-  rejected.
+- **Missing or ambiguous target** — a profile that deploys a graph must resolve
+  to one `deployment_target` (from the base or the profile).
 - **Logical override** — a profile that sets a `label`, `dimension`,
   `ai_context`, a `metric`, a relationship `from`/`to`, or a field `expression`
-  that isn't a bare column reference is rejected, naming the offending path.
-  Profiles are physical-only.
-- **Unknown name** — a profile element whose `name` isn't in the base is
-  rejected. Profiles override; they don't add.
+  that is not a bare column reference is rejected, naming the offending path.
+- **Unknown name** — a profile element whose `name` is not in the base is
+  rejected. Profiles override; they do not add.
+
+## Partial binding (under consideration)
+
+A store need not serve every attribute of an entity. Under partial binding, a
+profile maps whatever subset a source can provide, and attributes it does not
+bind resolve to null in that profile. An entity then does not have to bind fully
+under every profile — an operational store can expose live balances that the
+warehouse lacks, and a warehouse can expose derived attributes the operational
+store never stores. This relaxes the rule that base + profile must bind every
+field, and is gated on real usage before it ships.
 
 ## Notes
 
-**The deployment target is now a first-class key.** So a profile can override it
-readably, `deployment_target:` moves out of the `GOOGLE custom_extensions` block
-and onto the model. The old custom-extension form is still accepted and means
-the same thing, so existing models keep working.
+**The deployment target is a first-class key.** So a profile can override it
+readably, `deployment_target:` is a model key rather than a JSON string inside a
+`GOOGLE custom_extensions` block. The custom-extension form is still accepted and
+means the same thing.
 
-**An abstract base.** Validation runs on base + profile, so the base doesn't have
-to carry sources at all. A base that omits `source` and `deployment_target` is
-effectively abstract: it won't deploy on its own, and *every* profile must supply
-the physical bindings. This is the same mechanism as the inline `default`, just
-with the base left empty — the same way an entity can be `abstract`.
+**Bare-string expressions.** A field's `expression` may be written as a one-line
+string (`expression: c_name`) instead of the full per-dialect object. The two
+forms mean the same thing and expand to the same wire representation.
 
-**Dialect is deferred on purpose.** A profile carries no SQL dialect. The dialect
-is a property of the execution backend, which the deployment target implies —
-every profile today targets a BigQuery Graph, so there is one dialect and nothing
-to choose. When a non-BigQuery execution backend is supported, the dialect will
-be derived from that backend (and transpiled) rather than authored per profile, so the
-profile schema won't change.
+**An abstract base.** Validation runs on base + profile, so the base need not
+carry sources. A base that omits `source` and `deployment_target` is abstract: it
+does not deploy on its own, and every profile supplies the physical bindings.
+This is the same mechanism as the inline `default`, with the base left empty, and
+matches the `abstract` marker an entity can already carry.
+
+**Dialect comes from the store.** A profile carries no SQL dialect. The
+dialect follows from the store a profile binds to; the engine lowers each
+`expression` to that store's query language when it runs. A profile chooses the
+data, and the execution engine chooses the dialect.

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -25,8 +25,8 @@ profile you pick.
 | A **differently-shaped copy** (different table and column names) | remap sources *and* columns *and* join keys, while the metrics and labels stay put |
 
 Profiles do **not** change how the model is computed or what it means. They
-relocate data; they don't redefine it. Pointing a model at a genuinely
-different execution engine (say Spanner instead of BigQuery), where the SQL
+relocate data; they don't redefine it. Pointing a model at a different
+execution engine (say Spanner instead of BigQuery), where the SQL
 dialect and deploy mechanism differ, is out of scope for profiles — that's a
 separate, larger capability.
 
@@ -36,7 +36,7 @@ Think of it as a class hierarchy, the same way an entity `extends` a supertype:
 
 - Your **model file** (`<model>.yaml`) is the **base** — a complete model whose
   inline bindings are the profile named `default`. With no profile selected, this
-  is exactly what deploys.
+  is what deploys.
 - A **profile** is a **subclass**: a document in the *identical schema* as the
   model, with only the parts it changes filled in.
 - `kcmd push --profile <name>` **merges** the profile onto the base — matching
@@ -60,7 +60,7 @@ model means, so `dev` and `prod` always compute the same answer.
 | the model's `deployment_target` | adding or removing entities, fields, or metrics |
 | an entity's `source` | a field's `label`, `description`, `dimension`, `datatype` |
 | an entity's `primary_key` / `unique_keys` | any `ai_context` / synonyms |
-| a field's column (its `expression`, **as a bare column reference**) | a field `expression` that is arbitrary SQL (that's computation, not binding) |
+| a field's column (its `expression`, **as a bare column reference**) | a field `expression` that is arbitrary SQL, which changes the computation rather than the binding |
 | a relationship's `from_columns` / `to_columns` | a relationship's `from` / `to` (the shape of the graph) |
 | a junction table's `source` / keys / columns | any `metric` definition |
 
@@ -68,8 +68,8 @@ An element's `name` is not "overridden" — it's the key that pairs a profile
 element with the base element it refines.
 
 **Why metrics never appear in a profile.** A metric like
-`SUM(orders.o_totalprice)` references the field *name* `o_totalprice`, not a
-column. Field names are stable across profiles — only their column bindings
+`SUM(orders.o_totalprice)` references the field *name* `o_totalprice` rather
+than a column. Field names are stable across profiles — only their column bindings
 change — so the metric is correct under every profile without being restated.
 The contract and the arithmetic line up for free.
 
@@ -158,7 +158,7 @@ keys, the relationship, and the metric all come from the base.
 A copy imported from Snowflake: different table names, different column names,
 different key columns. The profile overrides down to the column and the join
 keys — and the base model above is untouched, so `total_revenue` and the
-`Order Date` label still mean exactly what they did.
+`Order Date` label still mean what they did.
 
 ```yaml
 # sales.profiles/snowflake_export.yaml
@@ -202,7 +202,7 @@ so the SQL dialect is unchanged.
   name present only in the base is inherited unchanged.
 - Scalars — `source`, `expression`, `deployment_target` — **replace**.
 - Key tuples — `primary_key`, `from_columns`, `to_columns` — **replace as a
-  whole**; they are atomic, not merged element by element.
+  whole**; they are atomic rather than merged element by element.
 - Profiles are **override-only**: a profile can refine physical facets of things
   that exist in the base. It cannot add new entities/fields/metrics or delete
   them.
@@ -264,5 +264,5 @@ with the base left empty — the same way an entity can be `abstract`.
 is a property of the execution backend, which the deployment target implies —
 every profile today targets a BigQuery Graph, so there is one dialect and nothing
 to choose. When a non-BigQuery execution backend is supported, the dialect will
-be derived from that backend (and transpiled), not authored per profile, so the
+be derived from that backend (and transpiled) rather than authored per profile, so the
 profile schema won't change.

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -17,8 +17,8 @@ profile serves them.
 
 The same concept usually lives in more than one system. A `Customer` sits in a
 live operational database and in a day-stale analytics warehouse; an `Order` is
-written transactionally and reported on in BigQuery. A profile lets one model
-serve both kinds of consumer from a single definition:
+written transactionally in one store and reported on in another. A profile lets
+one model serve both kinds of consumer from a single definition:
 
 - **An operational profile** reads from the live operational stores, such as
   AlloyDB or Spanner. An operational agent uses it to check current state before
@@ -140,21 +140,27 @@ intentional non-binding is written down.
 
 ## File layout
 
-The logical model is one file. Its bindings live beside it, one file per
+A binding may also sit inline in the logical model — logical and physical in a
+single file — which is how the `default` profile works, and a model with one
+binding needs nothing more. Keeping them in separate files, as below, is one
+layout among several: it keeps the logical model reusable across bindings and
+lets each binding be reviewed and owned on its own.
+
+The logical model is one file, and its bindings live beside it, one file per
 profile:
 
 ```
 catalog/EntryGroups/commerce_eg/
   commerce.yaml                  # the logical model — declarations only, no bindings
   commerce.profiles/
-    analytical.yaml              # BigQuery bindings
-    operational.yaml             # Spanner bindings
+    analytical.yaml              # bindings for the analytics warehouse
+    operational.yaml             # bindings for the operational store
 ```
 
 Each binding file is a `semantic_model` document in the same schema as the
 logical model, carrying only physical facets. `--profile analytical` reads
 `commerce.yaml` plus `analytical.yaml`, so nothing in one binding can affect
-another, and each binding can be reviewed and owned on its own.
+another.
 
 ## Example — one model, an analytical and an operational binding
 


### PR DESCRIPTION
## What

Adds `toolbox/mdcode/docs/semantic-model/profiles.md` — a **proposed** design for *binding profiles* on semantic models, written as the user guide first so we can iterate on how it reads before building.

Marked **Status: proposed**; nothing is implemented and the README nav is untouched.

## The idea

Keep one logical model; swap its physical binding at push time via named profiles.

- **Base + overrides.** The model file is the base (its inline bindings are the `default` profile). A profile is a subclass in the *identical schema* carrying only its deltas; `kcmd push --profile <name>` deep-merges it onto the base (matched by `name`) and deploys the union.
- **Physical-only contract.** A profile may override `source`, field columns, keys, and the deployment target — never labels, dimensions, `ai_context`, or metrics. Guarantee: switching profiles moves the data but never changes what the model means.
- **File layout.** One file per profile under `<model>.profiles/`, so a profile can be edited, reviewed, and owned in isolation.
- **CLI.** `--profile` (which binding) is orthogonal to the existing `--target bq|kc` (which destination); `default_profile:` in `catalog.yaml`; new `kcmd profiles` to list.

## Scope notes

- Covers same-layout environment swaps (dev/staging/prod) and differently-shaped copies (different table/column/key names).
- Different execution backends and per-profile SQL dialect are explicitly deferred.
- Requires one format change: promoting the deployment target to a first-class `deployment_target:` key (old `GOOGLE` custom-extension form still accepted).

Draft for review of the design/wording; implementation to follow.