### PR TITLE
mdcode: add the kcmd profiles command and default_profile config

### DIFF
--- a/toolbox/mdcode/src/libts/layouts/semantic-model.ts
+++ b/toolbox/mdcode/src/libts/layouts/semantic-model.ts
@@ -91,6 +91,35 @@ export class SemanticModelLayout implements CatalogLayout {
     return docs;
   }
 
+  // The binding-profile documents beside a model: `<model>.profiles/*.yaml`
+  // under the model's EntryGroup dir. Each is a partial `semantic_model`
+  // document carrying physical bindings that `--profile <name>` merges onto
+  // the logical model; `name` is the file basename (the profile name). The
+  // directory is not globbed for model documents (init's `*.yaml` glob does
+  // not descend), so a profile file is never mistaken for a model.
+  profilePaths(model: string): {name: string; path: string}[] {
+    if (!this._entryGroup) return [];
+    const dir = path.join(
+        this._catalogPath, 'EntryGroups', this._entryGroup,
+        `${model}.profiles`);
+    if (!fs.existsSync(dir)) return [];
+    const out: {name: string; path: string}[] = [];
+    for (const entry of fs.readdirSync(dir)) {
+      if (!entry.endsWith('.yaml')) continue;
+      if (SIDECAR_SUFFIXES.some(s => entry.endsWith(s))) continue;
+      out.push(
+          {name: path.basename(entry, '.yaml'), path: path.join(dir, entry)});
+    }
+    return out.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  // The text of each profile document beside a model, keyed by profile name.
+  // This is the seam the push path merges onto the logical model document.
+  profileDocuments(model: string): {name: string; text: string}[] {
+    return this.profilePaths(model).map(
+        ({name, path: p}) => ({name, text: fs.readFileSync(p, 'utf8')}));
+  }
+
   // True when a model document with this handle already exists on disk. `pull`
   // uses it to report which files it would overwrite vs. create.
   hasModel(name: string): boolean {

--- a/toolbox/mdcode/src/libts/manifest.ts
+++ b/toolbox/mdcode/src/libts/manifest.ts
@@ -10,6 +10,9 @@ import { CatalogSource, createSource, Sources } from './source';
 
 const manifestSchema = z.object({
   scope: z.union([z.string(), z.array(z.string())]),
+  // The binding profile a bare `kcmd push` uses when --profile is omitted
+  // (semantic-model scope). Omitted means the inline 'default' binding.
+  default_profile: z.string().optional(),
   snapshot: z.object({
     entries: z.array(z.string()).optional(),
     aspects: z.array(z.string()).optional()
@@ -40,15 +43,19 @@ export class CatalogManifest {
   readonly source: CatalogSource;
   readonly snapshotConfig?: SnapshotConfig;
   readonly publishingConfig?: PublishingConfig;
+  // The default binding profile for a semantic-model scope (see the schema).
+  readonly defaultProfile?: string;
 
   private constructor(
     source: CatalogSource,
     snapshotConfig?: SnapshotConfig,
-    publishingConfig?: PublishingConfig
+    publishingConfig?: PublishingConfig,
+    defaultProfile?: string
   ) {
     this.source = source;
     this.snapshotConfig = snapshotConfig;
     this.publishingConfig = publishingConfig;
+    this.defaultProfile = defaultProfile;
   }
 
   static async initWithEntryGroup(name: string, ctx: gcp.ApiContext): Promise<CatalogManifest> {
@@ -167,7 +174,8 @@ export class CatalogManifest {
       }
     }
 
-    return new CatalogManifest(source, snapshot, publishing);
+    return new CatalogManifest(
+        source, snapshot, publishing, result.data.default_profile);
   }
 
   save(path: string): void {
@@ -182,6 +190,7 @@ export class CatalogManifest {
 
     const data: any = {
       scope: scope,
+      default_profile: this.defaultProfile ?? undefined,
       snapshot: this.snapshotConfig ?? undefined,
       publishing: this.publishingConfig ?? undefined
     };

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -141,6 +141,16 @@ export interface Field {
   expression?: string;             // target/canonical (GoogleSQL-valid) SQL
   importedExpression?: string;     // original vendor SQL, verbatim
   importedDialect?: string;        // dialect of `importedExpression` (e.g. 'SNOWFLAKE')
+  // Marks a field declared logically but with NO physical column under the
+  // current binding: structurally absent, not null. A metric, relationship, or
+  // action that reads it is unavailable here rather than reading a null (see
+  // the binding-profiles guide). An unbound field carries no `expression`.
+  //
+  // This is the field-level analogue of an entity's `abstract` (a whole class
+  // with no table) and, like the OWL importer's `unbound:` source placeholder,
+  // means "should be bound by some binding, and reading it where it is not is an
+  // error" -- distinct from a bound field whose value merely happens to be null.
+  unbound?: boolean;
   dimension?: Dimension;           // dimension metadata (e.g. temporal role)
   label?: string;                  // human display label (distinct from name/description)
   description?: string;

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -38,12 +38,23 @@ const SUPPORTED_VERSION = '0.2.0.dev0';
 // An expression is supplied as one or more per-dialect variants; we collapse it
 // to at most two forms (target/canonical + imported) by picking dialects.
 // Unknown sibling keys are ignored.
-const expressionSchema = z.object({
+//
+// A one-line string is accepted as shorthand for a single target-dialect
+// variant (`expression: c_name` == `{dialects: [{dialect: BIGQUERY, expression:
+// c_name}]}`) and normalized to the object form here, so the rest of the loader
+// only ever sees the per-dialect object.
+const expressionObjectSchema = z.object({
   dialects: z.array(z.object({
     dialect: z.string(),
     expression: z.string(),
   })).min(1),
 });
+const expressionSchema = z.union([
+  z.string().transform((s): z.infer<typeof expressionObjectSchema> => ({
+    dialects: [{ dialect: DEFAULT_DIALECT, expression: s }],
+  })),
+  expressionObjectSchema,
+]);
 
 // The format's AI-first annotation. It appears at every level (model, dataset,
 // field, relationship, metric) and is either a bare instructions string or a
@@ -75,13 +86,35 @@ const dimensionSchema = z.object({
 
 const fieldSchema = z.object({
   name: z.string(),
-  expression: expressionSchema,
+  // A bound field names its physical column via `expression`; an `unbound`
+  // field has no column under this binding. Exactly one of the two holds
+  // (enforced below), so a field is never both, and a field that is neither -- a
+  // forgotten binding -- is caught here rather than silently dropped.
+  expression: expressionSchema.optional(),
+  unbound: z.boolean().optional(),
   datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
   description: z.string().optional(),
   label: z.string().optional(),
   dimension: dimensionSchema.optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
+}).superRefine((f, ctx) => {
+  if (f.unbound && f.expression !== undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['expression'],
+      message: `field '${f.name}': an unbound field has no column; remove ` +
+          `'expression', or drop 'unbound: true' to bind it to that column`,
+    });
+  }
+  if (!f.unbound && f.expression === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['expression'],
+      message: `field '${f.name}': requires an expression; set 'expression', ` +
+          `or mark it 'unbound: true' if this binding has no column for it`,
+    });
+  }
 });
 
 const datasetSchema = z.object({
@@ -221,6 +254,85 @@ function composeDescription(...parts: (string | undefined)[]): string | undefine
 }
 
 
+// The vendor tag for Google-specific extension blocks (kept in sync with the
+// deploy leg's reader). A model-level `deployment_target:` folds into one.
+const GOOGLE_VENDOR = 'GOOGLE';
+
+// Rewrites the author-friendly sugar forms into the canonical wire shape the
+// schema validates, so the guide's readable syntax and the underlying format
+// are one code path: `entities:` is an alias for `datasets:`, and a model-level
+// `deployment_target:` URI folds into a GOOGLE `custom_extensions` block (the
+// form the deploy leg reads). Conflicts -- both `entities` and `datasets`, or a
+// `deployment_target` that disagrees with an existing GOOGLE block -- are load
+// errors, named here. Operates on the parsed document before schema validation.
+function normalizeDocumentSugars(doc: unknown): unknown {
+  if (!doc || typeof doc !== 'object') return doc;
+  const cloned = structuredClone(doc) as any;
+  const models = cloned.semantic_model;
+  if (!Array.isArray(models)) return cloned;
+  for (const m of models) {
+    if (m && typeof m === 'object') normalizeModelSugars(m);
+  }
+  return cloned;
+}
+
+function normalizeModelSugars(m: any): void {
+  const label = typeof m.name === 'string' ? `model '${m.name}'` : 'model';
+
+  if (m.entities !== undefined) {
+    if (m.datasets !== undefined) {
+      throw new Error(`Semantic model load error: ${label}: set either ` +
+          `'entities' or 'datasets', not both (they are the same key).`);
+    }
+    m.datasets = m.entities;
+    delete m.entities;
+  }
+
+  if (m.deployment_target !== undefined) {
+    const target = m.deployment_target;
+    if (typeof target !== 'string') {
+      throw new Error(`Semantic model load error: ${label}: ` +
+          `'deployment_target' must be a URI string.`);
+    }
+    foldDeploymentTarget(m, target, label);
+    delete m.deployment_target;
+  }
+}
+
+// Merges a `deployment_target` URI into the model's GOOGLE custom_extensions.
+// If a GOOGLE block already declares deploymentTargets, the URI must be among
+// them (the two forms mean the same thing and must agree); otherwise a fresh
+// GOOGLE block is appended.
+function foldDeploymentTarget(m: any, target: string, label: string): void {
+  const exts = Array.isArray(m.custom_extensions) ? m.custom_extensions : [];
+  for (const ext of exts) {
+    if (!ext || ext.vendor_name !== GOOGLE_VENDOR ||
+        typeof ext.data !== 'string') {
+      continue;
+    }
+    let data: any;
+    try {
+      data = JSON.parse(ext.data);
+    } catch {
+      continue;  // a malformed block is the deploy leg's error to report
+    }
+    const list = data?.deploymentTargets;
+    if (Array.isArray(list) && list.length) {
+      if (!list.includes(target)) {
+        throw new Error(`Semantic model load error: ${label}: ` +
+            `'deployment_target' disagrees with the GOOGLE custom_extension ` +
+            `already on this model; set one, or make them match.`);
+      }
+      return;  // agree: nothing to add
+    }
+  }
+  exts.push({
+    vendor_name: GOOGLE_VENDOR,
+    data: JSON.stringify({ deploymentTargets: [target] }),
+  });
+  m.custom_extensions = exts;
+}
+
 /**
  * Loads YAML or JSON text (a document in the AI-first semantics format) into the
  * Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
@@ -241,7 +353,8 @@ export function loadModels(text: string, opts: LoadOptions = {}): LoadResult {
  * `warnings` rather than thrown.
  */
 export function fromDocument(doc: unknown, opts: LoadOptions = {}): LoadResult {
-  const result = documentSchema.safeParse(doc);
+  const normalized = normalizeDocumentSugars(doc);
+  const result = documentSchema.safeParse(normalized);
   if (!result.success) {
     throw new Error(`Semantic model load error: ${result.error.message}`);
   }
@@ -337,18 +450,24 @@ function convertDataset(ds: DatasetDoc, opts: LoadOptions,
 }
 
 function convertField(f: FieldDoc, entityName: string, warnings: string[], dialect: string): Field {
-  const picked = pickDialect(f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
-
   // `label`, `dimension`, and AI-first annotations are carried structurally on
   // the IR (not folded into `description`) so an emitter can route each to its
   // own destination and a 1P round-trip stays lossless.
   const description = composeDescription(f.description);
 
   const field: Field = { name: f.name };
-  if (picked.expression !== undefined) field.expression = picked.expression;
-  if (picked.importedExpression !== undefined) {
-    field.importedExpression = picked.importedExpression;
-    field.importedDialect = picked.importedDialect;
+  if (f.unbound) {
+    // Declared but not bound under this binding: no column, no expression (the
+    // schema guarantees `expression` is absent here). See Field.unbound.
+    field.unbound = true;
+  } else {
+    const picked = pickDialect(
+      f.expression!, dialect, `field '${entityName}.${f.name}'`, warnings);
+    if (picked.expression !== undefined) field.expression = picked.expression;
+    if (picked.importedExpression !== undefined) {
+      field.importedExpression = picked.importedExpression;
+      field.importedDialect = picked.importedDialect;
+    }
   }
   if (f.datatype) field.type = f.datatype;
   if (f.label) field.label = f.label;

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -630,6 +630,21 @@ function parseSource(source: string, opts: LoadOptions,
     return trimmed;
   }
 
+  // A BigQuery resource-name URI (AIP-122) is the readable way to name a
+  // source; rewrite it to the canonical project.dataset.table the generator
+  // emits.
+  const bq = trimmed.match(
+      /^\/\/bigquery\.googleapis\.com\/projects\/([^/]+)\/datasets\/([^/]+)\/tables\/(.+)$/);
+  if (bq) return `${bq[1]}.${bq[2]}.${bq[3]}`;
+
+  // Any other resource URI (Spanner, AlloyDB, an iceberg:// table, ...) is not
+  // a BigQuery table and is not dotted-qualified; keep it verbatim. It rides
+  // through to the consumer that binds it (the BigQuery path does not probe or
+  // emit a non-BigQuery source).
+  if (trimmed.startsWith('//') || /^[a-z][\w+.-]*:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
   const parts = trimmed.split('.').map(unquote);
   if (parts.length === 1 && opts.defaultDataset) parts.unshift(opts.defaultDataset);
   if (parts.length < 3 && opts.defaultProject) parts.unshift(opts.defaultProject);

--- a/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
@@ -1,0 +1,373 @@
+// Merges a logical semantic model with a chosen binding profile, and prunes what
+// the resulting binding cannot answer.
+//
+// A model is authored as ONE logical declaration (entities, fields,
+// relationships, metrics, the grain, and the graph shape) plus zero or more
+// BINDING PROFILES that supply the physical facets it leaves open: each entity's
+// `source`, each field's column (`expression`), and the deployment target.
+// `kcmd push --profile <name>` merges the selected profile onto the logical
+// model BY NAME and deploys the result. See docs/semantic-model/profiles.md.
+//
+// Two passes live here:
+//   - mergeProfile overlays one profile document onto the logical document,
+//     enforcing the binding-only contract: a profile may set physical facets and
+//     may leave a field unbound, but it may not add or remove elements or change
+//     what anything means. It runs on the parsed authoring documents (the
+//     readable, sugared form) before schema validation, so a profile is written
+//     in the same syntax as the model.
+//   - pruneUnavailable runs over the loaded IR and drops each field left unbound
+//     plus everything that depends on it -- a metric whose expression reads it, a
+//     relationship whose join column is unbound, a cross-entity metric over a
+//     dropped relationship -- returning the pruned model and a per-profile
+//     availability report. Availability propagates UP the dependency graph from
+//     the fields a profile binds.
+
+import {Metric, Relationship, SemanticModel} from './ir';
+import {
+  blankStringLiterals,
+  escapeRegExp,
+  referencedEntityNames,
+} from './sql_expr_utils';
+
+// The implicit profile: the inline bindings already in the model document (the
+// combined single-file form). It is never merged -- it IS the document as
+// authored -- so a bare `kcmd push` behaves as it always has.
+export const DEFAULT_PROFILE = 'default';
+
+export interface MergeResult {
+  // The merged authoring document (still in the sugared form), ready to feed
+  // through the normal loader.
+  doc: unknown;
+  warnings: string[];
+  // A binding-only or unknown-name violation, naming the offending path. When
+  // set, `doc` should not be deployed.
+  error?: string;
+}
+
+// Keys a profile may carry at each level. Everything else is a logical
+// declaration the model owns; setting it in a profile is rejected so swapping a
+// profile can move data but never change what the model means.
+const PROFILE_MODEL_KEYS = new Set([
+  'name', 'version', 'deployment_target', 'entities', 'datasets',
+]);
+const PROFILE_ENTITY_KEYS = new Set(['name', 'source', 'fields']);
+const PROFILE_FIELD_KEYS = new Set(['name', 'expression', 'unbound']);
+
+/**
+ * Overlays `profileDoc` onto `logicalDoc`, matching models, entities, fields by
+ * `name`, and returns the merged document. The inputs are never mutated. A
+ * profile supplies physical bindings only; a violation of that contract (setting
+ * a declaration, or naming an element the logical model does not declare) is
+ * returned as `error`, naming the path.
+ */
+export function mergeProfile(
+    logicalDoc: unknown, profileDoc: unknown,
+    profileName: string): MergeResult {
+  const warnings: string[] = [];
+  const merged = structuredClone(logicalDoc) as any;
+  const profile = profileDoc as any;
+
+  if (!merged || typeof merged !== 'object' ||
+      !Array.isArray(merged.semantic_model)) {
+    return {
+      doc: merged, warnings,
+      error: 'the logical model is not a semantic_model document',
+    };
+  }
+  if (!profile || typeof profile !== 'object' ||
+      !Array.isArray(profile.semantic_model)) {
+    return {
+      doc: merged, warnings,
+      error: `profile '${profileName}' is not a semantic_model document`,
+    };
+  }
+
+  const logicalByName = new Map<string, any>();
+  for (const m of merged.semantic_model) {
+    if (m && typeof m === 'object' && typeof m.name === 'string') {
+      logicalByName.set(m.name, m);
+    }
+  }
+
+  for (const pm of profile.semantic_model) {
+    if (!pm || typeof pm !== 'object') continue;
+    const lm = logicalByName.get(pm.name);
+    if (!lm) {
+      return {
+        doc: merged, warnings,
+        error: `profile '${profileName}': model '${
+            pm.name}' is not in the logical model`,
+      };
+    }
+    const err = mergeModel(lm, pm, profileName);
+    if (err) return {doc: merged, warnings, error: err};
+  }
+
+  // A field the profile neither bound nor marked unbound is carried through from
+  // the logical model with no column -- unbound under this profile. Mark it so
+  // the merged document is self-describing and the availability pass sees it.
+  markOmittedFieldsUnbound(merged);
+  return {doc: merged, warnings};
+}
+
+function mergeModel(lm: any, pm: any, profileName: string): string|undefined {
+  for (const k of Object.keys(pm)) {
+    if (!PROFILE_MODEL_KEYS.has(k)) {
+      return declError(profileName, `model '${pm.name}'`, k);
+    }
+  }
+  if (pm.deployment_target !== undefined) {
+    lm.deployment_target = pm.deployment_target;
+  }
+
+  const pEntities = pm.entities ?? pm.datasets;
+  if (pEntities === undefined) return undefined;
+  if (!Array.isArray(pEntities)) {
+    return `profile '${profileName}': 'entities' must be a list`;
+  }
+  const lByName = indexByName(lm.entities ?? lm.datasets);
+  for (const pe of pEntities) {
+    if (!pe || typeof pe !== 'object') continue;
+    const le = lByName.get(pe.name);
+    if (!le) {
+      return `profile '${profileName}': entity '${
+          pe.name}' is not in the logical model`;
+    }
+    const err = mergeEntity(le, pe, profileName);
+    if (err) return err;
+  }
+  return undefined;
+}
+
+function mergeEntity(le: any, pe: any, profileName: string): string|undefined {
+  for (const k of Object.keys(pe)) {
+    if (!PROFILE_ENTITY_KEYS.has(k)) {
+      return declError(profileName, `entity '${pe.name}'`, k);
+    }
+  }
+  if (pe.source !== undefined) le.source = pe.source;
+
+  if (pe.fields === undefined) return undefined;
+  if (!Array.isArray(pe.fields)) {
+    return `profile '${profileName}': entity '${pe.name}' 'fields' must be a list`;
+  }
+  const lByName = indexByName(le.fields ?? []);
+  for (const pf of pe.fields) {
+    if (!pf || typeof pf !== 'object') continue;
+    const lf = lByName.get(pf.name);
+    if (!lf) {
+      return `profile '${profileName}': field '${pe.name}.${
+          pf.name}' is not in the logical model`;
+    }
+    const err = mergeField(lf, pf, pe.name, profileName);
+    if (err) return err;
+  }
+  return undefined;
+}
+
+function mergeField(
+    lf: any, pf: any, entityName: string,
+    profileName: string): string|undefined {
+  for (const k of Object.keys(pf)) {
+    if (!PROFILE_FIELD_KEYS.has(k)) {
+      return declError(profileName, `field '${entityName}.${pf.name}'`, k);
+    }
+  }
+  if (pf.unbound === true) {
+    lf.unbound = true;
+    delete lf.expression;
+    return undefined;
+  }
+  if (pf.expression !== undefined) {
+    if (!isBareColumnRef(pf.expression)) {
+      return `profile '${profileName}': field '${entityName}.${
+          pf.name}' expression must be a bare column reference, not arbitrary ` +
+          `SQL; the computation is the logical model's to define`;
+    }
+    lf.expression = pf.expression;
+    delete lf.unbound;
+  }
+  return undefined;
+}
+
+function declError(profileName: string, where: string, key: string): string {
+  return `profile '${profileName}': ${where} sets '${key}', a logical ` +
+      `declaration the model owns; a profile may set only physical bindings ` +
+      `(source, expression, unbound, deployment_target)`;
+}
+
+// A profile's field expression must be a BARE column reference (e.g. `c_name`),
+// never arbitrary SQL: the computation belongs to the logical model, and only
+// the column it reads may vary per profile. Accepts the bare-string form and the
+// per-dialect object; rejects any variant that contains whitespace or a call.
+function isBareColumnRef(expr: unknown): boolean {
+  const parts: string[] = [];
+  if (typeof expr === 'string') {
+    parts.push(expr);
+  } else if (expr && typeof expr === 'object' &&
+             Array.isArray((expr as any).dialects)) {
+    for (const d of (expr as any).dialects) {
+      if (d && typeof d.expression === 'string') parts.push(d.expression);
+    }
+  } else {
+    return false;
+  }
+  if (!parts.length) return false;
+  return parts.every(s => !/[\s()]/.test(s.trim()));
+}
+
+function indexByName(list: unknown): Map<string, any> {
+  const m = new Map<string, any>();
+  if (Array.isArray(list)) {
+    for (const item of list) {
+      if (item && typeof item === 'object' && typeof item.name === 'string') {
+        m.set(item.name, item);
+      }
+    }
+  }
+  return m;
+}
+
+function markOmittedFieldsUnbound(doc: any): void {
+  for (const m of doc.semantic_model ?? []) {
+    if (!m || typeof m !== 'object') continue;
+    const entities = m.entities ?? m.datasets ?? [];
+    for (const e of entities) {
+      if (!e || typeof e !== 'object' || !Array.isArray(e.fields)) continue;
+      for (const f of e.fields) {
+        if (!f || typeof f !== 'object') continue;
+        if (f.expression === undefined && f.unbound !== true) {
+          f.unbound = true;
+        }
+      }
+    }
+  }
+}
+
+
+// One profile's availability outcome: the fields it leaves unbound, and the
+// building blocks that fall with them.
+export interface AvailabilityReport {
+  profile: string;
+  unboundFields: string[];  // "Entity.field"
+  droppedMetrics: {name: string; reason: string}[];
+  droppedRelationships: {name: string; reason: string}[];
+}
+
+/**
+ * Returns a clone of `model` reduced to what `profileName` can answer: unbound
+ * fields removed from their entities, and every metric or relationship that
+ * depends on an unbound field dropped. The input is never mutated. The report
+ * names each dropped block and the unbound field that stops it, so a caller can
+ * state the withheld coverage. A model with nothing unbound resolves unchanged.
+ */
+export function pruneUnavailable(model: SemanticModel, profileName: string):
+    {model: SemanticModel; report: AvailabilityReport} {
+  const clone: SemanticModel = structuredClone(model);
+  const report: AvailabilityReport = {
+    profile: profileName,
+    unboundFields: [],
+    droppedMetrics: [],
+    droppedRelationships: [],
+  };
+
+  // A field is bound when it has a column (expression) and is not marked
+  // unbound; otherwise it is unbound (structurally absent under this profile).
+  const unbound = new Set<string>();
+  for (const e of clone.entities ?? []) {
+    for (const f of e.fields ?? []) {
+      if (f.unbound || f.expression === undefined) {
+        unbound.add(`${e.name}.${f.name}`);
+      }
+    }
+  }
+  report.unboundFields = [...unbound];
+
+  // Drop unbound fields: they have no column, so the graph emits none. (A bound
+  // field whose value is null still emits a column -- unbound is not null.)
+  for (const e of clone.entities ?? []) {
+    e.fields = (e.fields ?? []).filter(
+        f => !(f.unbound || f.expression === undefined));
+  }
+
+  // A relationship is available only when the join columns on BOTH ends are
+  // bound (its endpoints' `columns` name fields on those entities).
+  const keptRels: Relationship[] = [];
+  for (const r of clone.relationships ?? []) {
+    const missing = unboundJoinField(r, unbound);
+    if (missing) {
+      report.droppedRelationships.push(
+          {name: r.name, reason: `join column ${missing} is unbound`});
+    } else {
+      keptRels.push(r);
+    }
+  }
+  clone.relationships = keptRels;
+
+  // A metric is available only when every field it references is bound and --
+  // when it spans entities -- a relationship connecting them survives.
+  const entityNames = (clone.entities ?? []).map(e => e.name);
+  const keptMetrics: Metric[] = [];
+  for (const mt of clone.metrics ?? []) {
+    const expr = mt.expression ?? '';
+    const hit = firstUnboundReferenced(expr, unbound);
+    if (hit) {
+      report.droppedMetrics.push(
+          {name: mt.name, reason: `field ${hit} is unbound`});
+      continue;
+    }
+    const refs = referencedEntityNames(expr, entityNames);
+    if (refs.length > 1 && !connectingRelationshipKept(refs, keptRels)) {
+      report.droppedMetrics.push({
+        name: mt.name,
+        reason: `no available relationship connects ${refs.join(', ')}`,
+      });
+      continue;
+    }
+    keptMetrics.push(mt);
+  }
+  clone.metrics = keptMetrics;
+
+  return {model: clone, report};
+}
+
+// The first unbound "Entity.field" a metric expression references (qualified),
+// or null. Text inside string literals is ignored.
+function firstUnboundReferenced(
+    expr: string, unbound: Set<string>): string|null {
+  const scannable = blankStringLiterals(expr);
+  for (const key of unbound) {
+    const dot = key.indexOf('.');
+    const entity = key.slice(0, dot);
+    const field = key.slice(dot + 1);
+    const re = new RegExp(
+        `(?<![\\w\`])\`?${escapeRegExp(entity)}\`?\\.\`?${
+            escapeRegExp(field)}\`?(?![\\w])`);
+    if (re.test(scannable)) return key;
+  }
+  return null;
+}
+
+// The first join field of a relationship that is unbound on its own end, or
+// null when both ends' join columns are bound.
+function unboundJoinField(r: Relationship, unbound: Set<string>): string|null {
+  for (const c of r.source?.columns ?? []) {
+    const key = `${r.source.entity}.${c}`;
+    if (unbound.has(key)) return key;
+  }
+  for (const c of r.destination?.columns ?? []) {
+    const key = `${r.destination.entity}.${c}`;
+    if (unbound.has(key)) return key;
+  }
+  return null;
+}
+
+// Whether any surviving relationship directly connects two of the referenced
+// entities -- the minimal check that a cross-entity metric still has a join path
+// after unavailable relationships were dropped.
+function connectingRelationshipKept(
+    refEntities: string[], kept: Relationship[]): boolean {
+  const set = new Set(refEntities);
+  return kept.some(
+      r => set.has(r.source.entity) && set.has(r.destination.entity));
+}

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -157,5 +157,12 @@ function billingProject(model: SemanticModel, defaultProject: string): string {
 function probeableRef(dataSource: string|undefined): string|null {
   const trimmed = (dataSource ?? '').trim();
   if (!trimmed || /\s/.test(trimmed)) return null;
+  // A non-BigQuery resource URI (Spanner/AlloyDB/iceberg/...) is not a
+  // BigQuery table, so the BigQuery pre-flight does not probe it. (BigQuery
+  // source URIs are normalized to project.dataset.table by the loader, so a
+  // URI reaching here is non-BigQuery.)
+  if (trimmed.startsWith('//') || /^[a-z][\w+.-]*:\/\//i.test(trimmed)) {
+    return null;
+  }
   return trimmed;
 }

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -251,7 +251,8 @@ export async function push(options: PushOptions): Promise<number> {
     // `<model>.profiles/<name>.yaml`; the implicit 'default' means the inline
     // bindings already in the model document, so it is never merged (a bare
     // push behaves as it always has). Orthogonal to --target.
-    const profileName = options.profile ?? DEFAULT_PROFILE;
+    const profileName =
+        options.profile ?? snapshot.manifest.defaultProfile ?? DEFAULT_PROFILE;
     let docs = layout.modelDocuments();
     if (profileName !== DEFAULT_PROFILE) {
       const merged: {name: string; text: string}[] = [];
@@ -420,6 +421,98 @@ export async function push(options: PushOptions): Promise<number> {
     console.error('Error pushing catalog entries:', result.details);
     return 1;
   }
+}
+
+
+// Lists a semantic model's binding profiles and, per profile, its resolved
+// deployment target and sources plus what it cannot answer (the availability
+// report). Read-only: it merges and prunes each profile the way push does, but
+// deploys nothing and runs no live probe, so a user can see coverage before
+// choosing a profile. Returns a process exit code (0 on success).
+export async function profiles(): Promise<number> {
+  const ctx = context.ApiContext.default();
+  const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
+  if (snapshot.manifest.source.type !== Sources.SEMANTIC_MODEL) {
+    console.error(
+        'Error: `kcmd profiles` applies only to a semantic-model scope.');
+    return 1;
+  }
+  const layout = snapshot.layout as SemanticModelLayout;
+  const source = snapshot.manifest.source as SemanticModelSource;
+  const defaultProfile = snapshot.manifest.defaultProfile;
+
+  const docs = layout.modelDocuments();
+  if (!docs.length) {
+    console.log('No semantic model documents found.');
+    return 0;
+  }
+
+  for (const doc of docs) {
+    console.log(`Model '${doc.name}' (${source.entryGroup}):`);
+    const available = layout.profileDocuments(doc.name);
+    if (!available.length) {
+      console.log(
+          `  no binding profiles; the model document is its own inline ` +
+          `'default' binding.`);
+      continue;
+    }
+    for (const {name, text} of available) {
+      let logicalDoc: unknown;
+      let profileDoc: unknown;
+      try {
+        logicalDoc = yaml.parse(doc.text);
+        profileDoc = yaml.parse(text);
+      } catch (err: any) {
+        console.error(`  profile '${name}': parse error: ${err?.message ?? err}`);
+        continue;
+      }
+      const merged = mergeProfile(logicalDoc, profileDoc, name);
+      if (merged.error) {
+        console.error(`  profile '${name}': ${merged.error}`);
+        continue;
+      }
+      const loaded = loadSemanticModels(
+          [{name: doc.name, text: yaml.stringify(merged.doc)}],
+          {defaultProject: source.project ?? ctx.project});
+      if (loaded.error) {
+        console.error(`  profile '${name}': ${loaded.error}`);
+        continue;
+      }
+      const model = loaded.models[0].model;
+      const {report} = pruneUnavailable(model, name);
+      const marker = name === defaultProfile ? ' (default)' : '';
+      console.log(`  profile '${name}'${marker}`);
+
+      let targets: string[] = [];
+      try {
+        targets = deploy.deploymentTargetUris(model);
+      } catch {
+        // A malformed deployment target is a push-time error; here just show
+        // none rather than abort the listing.
+      }
+      console.log(`    target: ${targets.length ? targets.join(', ') : '(none)'}`);
+      console.log('    sources:');
+      for (const e of model.entities ?? []) {
+        console.log(`      ${e.name} -> ${e.dataSource || '(unbound)'}`);
+      }
+
+      const withheld: string[] = [];
+      for (const f of report.unboundFields) withheld.push(`field ${f} (unbound)`);
+      for (const d of report.droppedRelationships) {
+        withheld.push(`relationship ${d.name} (${d.reason})`);
+      }
+      for (const d of report.droppedMetrics) {
+        withheld.push(`metric ${d.name} (${d.reason})`);
+      }
+      if (withheld.length) {
+        console.log('    cannot answer:');
+        for (const w of withheld) console.log(`      ${w}`);
+      } else {
+        console.log('    cannot answer: nothing withheld.');
+      }
+    }
+  }
+  return 0;
 }
 
 

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -19,6 +19,13 @@ import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
 import {serializeModel} from '../libts/semantic/osi_converter';
 import {convertOwlToOsi} from '../libts/semantic/converters/owl/convert';
 import {validateBigQueryDataSources, validatePushRequirements} from '../libts/semantic/validate';
+import {
+  AvailabilityReport,
+  DEFAULT_PROFILE,
+  mergeProfile,
+  pruneUnavailable,
+} from '../libts/semantic/resolve_profiles';
+import * as yaml from 'yaml';
 
 
 export interface InitOptions {
@@ -66,6 +73,12 @@ export interface PushOptions {
   // so both the BigQuery and Knowledge Catalog legs see the filled expressions.
   // Semantic-model push only. See ../libts/semantic/transpile.
   transpile?: boolean;
+  // Binding profile to merge onto the logical model before deploying: reads
+  // `<model>.profiles/<name>.yaml` and overlays its physical bindings by name.
+  // Orthogonal to `target` (which destination) -- this chooses which physical
+  // binding. Omitted means the inline bindings in the model document (the
+  // implicit 'default' profile). Semantic-model push only.
+  profile?: string;
 }
 
 
@@ -233,7 +246,51 @@ export async function push(options: PushOptions): Promise<number> {
     // fails the whole push before any destination runs. defaultProject is the
     // scope's declared project (deterministic) rather than the ambient gcloud
     // project, which can drift from where the model's tables live.
-    const docs = layout.modelDocuments();
+    // Resolve the binding profile -- which physical binding to merge onto the
+    // logical model. A named profile is merged from its
+    // `<model>.profiles/<name>.yaml`; the implicit 'default' means the inline
+    // bindings already in the model document, so it is never merged (a bare
+    // push behaves as it always has). Orthogonal to --target.
+    const profileName = options.profile ?? DEFAULT_PROFILE;
+    let docs = layout.modelDocuments();
+    if (profileName !== DEFAULT_PROFILE) {
+      const merged: {name: string; text: string}[] = [];
+      for (const doc of docs) {
+        const available = layout.profileDocuments(doc.name);
+        const chosen = available.find(p => p.name === profileName);
+        if (!chosen) {
+          const names = available.map(p => p.name);
+          console.error(
+              `Error: unknown profile '${profileName}' for model '${
+                  doc.name}'; ` +
+              (names.length ?
+                   `defined profiles: ${names.join(', ')}.` :
+                   `no profiles are defined for this model.`));
+          return 1;
+        }
+        let logicalDoc: unknown;
+        let profileDoc: unknown;
+        try {
+          logicalDoc = yaml.parse(doc.text);
+          profileDoc = yaml.parse(chosen.text);
+        } catch (err: any) {
+          console.error(
+              `Error: could not parse model '${doc.name}' or profile '${
+                  profileName}': ${err?.message ?? err}`);
+          return 1;
+        }
+        const res = mergeProfile(logicalDoc, profileDoc, profileName);
+        if (res.error) {
+          console.error(`Error: ${res.error}`);
+          return 1;
+        }
+        for (const w of res.warnings) {
+          console.warn(`Warning: [${doc.name}] ${w}`);
+        }
+        merged.push({name: doc.name, text: yaml.stringify(res.doc)});
+      }
+      docs = merged;
+    }
     const loaded = loadSemanticModels(
         docs, {defaultProject: source.project ?? ctx.project});
     if (loaded.error) {
@@ -260,6 +317,32 @@ export async function push(options: PushOptions): Promise<number> {
       models = transpiled.models;
       for (const w of transpiled.warnings) {
         console.warn(`Warning: ${w}`);
+      }
+    }
+
+    // Prune what the chosen binding cannot answer: drop each unbound field and
+    // everything that depends on it (a metric that reads it, a relationship
+    // whose join column is unbound), so the deployed graph presents only what
+    // the profile binds. Availability propagates up the dependency graph. Runs
+    // for every profile, including 'default' (a no-op when nothing is unbound).
+    const availability: AvailabilityReport[] = [];
+    models = models.map(({document, model}) => {
+      const {model: pruned, report} = pruneUnavailable(model, profileName);
+      availability.push(report);
+      return {document, model: pruned};
+    });
+    for (const r of availability) {
+      const dropped = r.droppedMetrics.length + r.droppedRelationships.length;
+      if (r.unboundFields.length || dropped) {
+        console.warn(
+            `Note: profile '${r.profile}' leaves ${
+                r.unboundFields.length} field(s) unbound` +
+            (dropped ?
+                 `; ${r.droppedMetrics.length} metric(s) and ${
+                     r.droppedRelationships.length} relationship(s) ` +
+                     `unavailable` :
+                 '') +
+            '.');
       }
     }
 
@@ -305,6 +388,7 @@ export async function push(options: PushOptions): Promise<number> {
   // catalog snapshot they are inert. Warn rather than silently ignore them, so
   // a user who expected (say) --transpile to run isn't misled by a clean exit.
   const semanticOnlyFlags: Array<[boolean, string]> = [
+    [options.profile !== undefined, '--profile'],
     [!!options.transpile, '--transpile'],
     [options.target !== undefined, '--target'],
     [!!options.print, '--print'],

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -66,6 +66,21 @@ cli.command('push', 'Push catalog entries')
    });
 
 
+cli.command('profiles', 'List a semantic model\'s binding profiles and what each can answer')
+   .action(async () => {
+      let exitCode = 1;
+      try {
+        exitCode = await commands.profiles();
+      }
+      catch (err: any) {
+        console.error('Error:', err.message || err);
+        exitCode = 1;
+      }
+
+      process.exit(exitCode);
+   });
+
+
 cli.command('owl <action> <file>', 'OWL ontology tools (action: import a .ttl ontology into an OSI model)')
    .option('--out <path>', 'Write the generated OSI document to this path instead of the semantic-model layout dir')
    .action(async (action, file, options) => {

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -51,6 +51,7 @@ cli.command('push', 'Push catalog entries')
    .option('--target <targets>', 'Semantic-model push destination(s): bq, kc, all (default), or a comma-separated list (e.g. bq,kc)')
    .option('--print', 'Print each pushed destination\'s generated artifact in its native format (BigQuery Graph SQL DDL, Knowledge Catalog entry plan); scope with --target (semantic-model push only)')
    .option('--transpile', 'Rewrite vendor-dialect (e.g. Snowflake/Databricks) expressions to GoogleSQL before deploying, filling target expressions the loader left unset; semantic-model push only')
+   .option('--profile <name>', 'Binding profile to merge onto the logical model before deploying (reads <model>.profiles/<name>.yaml); orthogonal to --target; defaults to the inline bindings; semantic-model push only')
    .action(async (options) => {
       let exitCode = 1;
       try {

--- a/toolbox/mdcode/tests/libts/semantic/loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/loader.test.ts
@@ -977,3 +977,139 @@ describe('field label and time-dimension role align with the format models', () 
     expect(isTimeDimension(f)).toBe(false);
   });
 });
+
+
+describe('authoring sugars: entities alias, bare-string expression, deployment_target', () => {
+  const URI =
+    '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
+
+  test("'entities:' is an alias for 'datasets:'", () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        entities: [
+          { name: 'a', source: 'proj.ds.tbl', primary_key: ['id'],
+            fields: [{ name: 'id', expression: expr('id') }] },
+        ],
+      }],
+    });
+    expect(models[0].entities.map(e => e.name)).toEqual(['a']);
+    expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
+  });
+
+  test("declaring both 'entities' and 'datasets' is an error", () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        entities: [{ name: 'a', source: 's', fields: [] }],
+        datasets: [{ name: 'b', source: 's', fields: [] }],
+      }],
+    })).toThrow(/set either 'entities' or 'datasets', not both/);
+  });
+
+  test('a bare-string expression expands to the target-dialect object', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'a', source: 'proj.ds.tbl', primary_key: ['id'],
+          fields: [{ name: 'id', expression: 'id_col' }],
+        }],
+      }],
+    });
+    expect(models[0].entities[0].fields[0].expression).toBe('id_col');
+  });
+
+  test("a top-level 'deployment_target' folds into the GOOGLE block form", () => {
+    const sugar = fromDocument({
+      semantic_model: [{
+        name: 'm', deployment_target: URI,
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'id', expression: 'id' }] }],
+      }],
+    });
+    const explicit = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        custom_extensions: [{ vendor_name: 'GOOGLE',
+          data: JSON.stringify({ deploymentTargets: [URI] }) }],
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'id', expression: 'id' }] }],
+      }],
+    });
+    expect(sugar.models[0].customExtensions)
+      .toEqual(explicit.models[0].customExtensions);
+    expect(sugar.models[0].customExtensions).toEqual([
+      { vendorName: 'GOOGLE',
+        data: JSON.stringify({ deploymentTargets: [URI] }) },
+    ]);
+  });
+
+  test("'deployment_target' agreeing with a GOOGLE block adds no duplicate", () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm', deployment_target: URI,
+        custom_extensions: [{ vendor_name: 'GOOGLE',
+          data: JSON.stringify({ deploymentTargets: [URI] }) }],
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'id', expression: 'id' }] }],
+      }],
+    });
+    expect(models[0].customExtensions).toEqual([
+      { vendorName: 'GOOGLE',
+        data: JSON.stringify({ deploymentTargets: [URI] }) },
+    ]);
+  });
+
+  test("'deployment_target' disagreeing with a GOOGLE block is an error", () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm', deployment_target: URI,
+        custom_extensions: [{ vendor_name: 'GOOGLE',
+          data: JSON.stringify({ deploymentTargets: ['//other/target'] }) }],
+        datasets: [{ name: 'a', source: 's', fields: [] }],
+      }],
+    })).toThrow(/disagrees with the GOOGLE custom_extension/);
+  });
+});
+
+describe('fields may be declared unbound (no physical column)', () => {
+  test('an unbound field loads with no expression', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'a', source: 's', primary_key: ['id'],
+          fields: [
+            { name: 'id', expression: 'id' },
+            { name: 'credit', unbound: true },
+          ],
+        }],
+      }],
+    });
+    const [id, credit] = models[0].entities[0].fields;
+    expect(id.unbound).toBeUndefined();
+    expect(credit.unbound).toBe(true);
+    expect(credit.expression).toBeUndefined();
+  });
+
+  test('a field that is both bound and unbound is an error', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'credit', unbound: true, expression: 'c' }] }],
+      }],
+    })).toThrow(/an unbound field has no column/);
+  });
+
+  test('a field that is neither bound nor unbound is an error naming the field', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'credit' }] }],
+      }],
+    })).toThrow(/field 'credit': requires an expression/);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/resolve_profiles.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/resolve_profiles.test.ts
@@ -1,0 +1,255 @@
+// Behavior specification for the binding-profile passes
+// (src/libts/semantic/resolve_profiles.ts): mergeProfile overlays a profile's
+// physical bindings onto a logical model by name and enforces the binding-only
+// contract; pruneUnavailable drops what a binding cannot answer and reports it.
+// Builders are minimal literals in the readable authoring form (mergeProfile) or
+// the IR (pruneUnavailable), mirroring resolve_inheritance.test.ts.
+
+import {describe, expect, test} from 'bun:test';
+
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {mergeProfile, pruneUnavailable} from '../../../src/libts/semantic/resolve_profiles';
+
+const GRAPH =
+    '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/commerce';
+const TBL = (t: string) =>
+    `//bigquery.googleapis.com/projects/p/datasets/d/tables/${t}`;
+
+function logicalDoc(): any {
+  return {
+    semantic_model: [{
+      name: 'commerce',
+      entities: [
+        {
+          name: 'Customer',
+          primary_key: ['key'],
+          fields: [
+            {name: 'key', label: 'Customer ID'},
+            {name: 'name'},
+            {name: 'lifetimeValue'},
+            {name: 'availableCredit'},
+          ],
+        },
+        {
+          name: 'Order',
+          primary_key: ['key'],
+          fields: [
+            {name: 'key'},
+            {name: 'customerKey'},
+            {name: 'orderDate', dimension: {is_time: true}},
+          ],
+        },
+      ],
+      relationships: [{
+        name: 'PlacedBy', from: 'Order', to: 'Customer',
+        from_columns: ['customerKey'], to_columns: ['key'],
+      }],
+      metrics: [
+        {name: 'order_count', expression: 'COUNT(Order.key)'},
+        {name: 'avg_lifetime_value', expression: 'AVG(Customer.lifetimeValue)'},
+      ],
+    }],
+  };
+}
+
+// The analytical binding: BigQuery sources, lifetimeValue bound, availableCredit
+// explicitly unbound.
+function analyticalDoc(): any {
+  return {
+    semantic_model: [{
+      name: 'commerce',
+      deployment_target: GRAPH,
+      entities: [
+        {
+          name: 'Customer',
+          source: TBL('customer'),
+          fields: [
+            {name: 'key', expression: 'c_custkey'},
+            {name: 'name', expression: 'c_name'},
+            {name: 'lifetimeValue', expression: 'c_ltv'},
+            {name: 'availableCredit', unbound: true},
+          ],
+        },
+        {
+          name: 'Order',
+          source: TBL('orders'),
+          fields: [
+            {name: 'key', expression: 'o_orderkey'},
+            {name: 'customerKey', expression: 'o_custkey'},
+            {name: 'orderDate', expression: 'o_orderdate'},
+          ],
+        },
+      ],
+    }],
+  };
+}
+
+const modelOf = (doc: any) => doc.semantic_model[0];
+const entityOf = (doc: any, name: string) =>
+    (modelOf(doc).entities ?? modelOf(doc).datasets).find(
+        (e: any) => e.name === name);
+const fieldOf = (doc: any, entity: string, field: string) =>
+    entityOf(doc, entity).fields.find((f: any) => f.name === field);
+
+
+describe('mergeProfile overlays physical bindings by name', () => {
+  test('applies source and expression, preserving logical facets', () => {
+    const {doc, error} = mergeProfile(logicalDoc(), analyticalDoc(), 'analytical');
+    expect(error).toBeUndefined();
+    expect(entityOf(doc, 'Customer').source).toBe(TBL('customer'));
+    const key = fieldOf(doc, 'Customer', 'key');
+    expect(key.expression).toBe('c_custkey');
+    expect(key.label).toBe('Customer ID');  // logical facet preserved
+    expect(modelOf(doc).deployment_target).toBe(GRAPH);
+  });
+
+  test('an explicit unbound field drops its column', () => {
+    const {doc} = mergeProfile(logicalDoc(), analyticalDoc(), 'analytical');
+    const credit = fieldOf(doc, 'Customer', 'availableCredit');
+    expect(credit.unbound).toBe(true);
+    expect(credit.expression).toBeUndefined();
+  });
+
+  test('a field the profile omits is carried through as unbound', () => {
+    const profile = analyticalDoc();
+    // Drop availableCredit entirely from the profile (silent omission).
+    entityOf(profile, 'Customer').fields =
+        entityOf(profile, 'Customer').fields.filter(
+            (f: any) => f.name !== 'availableCredit');
+    const {doc, error} = mergeProfile(logicalDoc(), profile, 'analytical');
+    expect(error).toBeUndefined();
+    expect(fieldOf(doc, 'Customer', 'availableCredit').unbound).toBe(true);
+  });
+
+  test('the inputs are never mutated', () => {
+    const logical = logicalDoc();
+    const profile = analyticalDoc();
+    const before = JSON.stringify(logical);
+    mergeProfile(logical, profile, 'analytical');
+    expect(JSON.stringify(logical)).toBe(before);
+  });
+
+  test('a profile that sets a declaration facet is rejected', () => {
+    const profile = analyticalDoc();
+    fieldOf(profile, 'Customer', 'name').label = 'Renamed';  // logical facet
+    const {error} = mergeProfile(logicalDoc(), profile, 'analytical');
+    expect(error).toMatch(/sets 'label'/);
+  });
+
+  test('a profile that defines a metric is rejected', () => {
+    const profile = analyticalDoc();
+    modelOf(profile).metrics = [{name: 'x', expression: 'COUNT(Order.key)'}];
+    const {error} = mergeProfile(logicalDoc(), profile, 'analytical');
+    expect(error).toMatch(/sets 'metrics'/);
+  });
+
+  test('a profile naming an unknown entity is rejected', () => {
+    const profile = analyticalDoc();
+    entityOf(profile, 'Order').name = 'Nope';
+    const {error} = mergeProfile(logicalDoc(), profile, 'analytical');
+    expect(error).toMatch(/entity 'Nope' is not in the logical model/);
+  });
+
+  test('a profile naming an unknown field is rejected', () => {
+    const profile = analyticalDoc();
+    entityOf(profile, 'Customer').fields.push({name: 'ghost', expression: 'g'});
+    const {error} = mergeProfile(logicalDoc(), profile, 'analytical');
+    expect(error).toMatch(/field 'Customer.ghost' is not in the logical model/);
+  });
+
+  test('a profile expression that is arbitrary SQL is rejected', () => {
+    const profile = analyticalDoc();
+    fieldOf(profile, 'Customer', 'lifetimeValue').expression = 'c_a + c_b';
+    const {error} = mergeProfile(logicalDoc(), profile, 'analytical');
+    expect(error).toMatch(/bare column reference/);
+  });
+});
+
+
+// A loaded IR model with one field left unbound, for the pruning pass.
+function irModel(): SemanticModel {
+  return {
+    name: 'commerce',
+    entities: [
+      {
+        name: 'Customer', dataSource: 'p.d.customer', keys: ['key'],
+        fields: [
+          {name: 'key', expression: 'c_custkey'},
+          {name: 'name', expression: 'c_name'},
+          {name: 'lifetimeValue', unbound: true},
+        ],
+      },
+      {
+        name: 'Order', dataSource: 'p.d.orders', keys: ['key'],
+        fields: [
+          {name: 'key', expression: 'o_orderkey'},
+          {name: 'customerKey', expression: 'o_custkey'},
+        ],
+      },
+    ],
+    relationships: [{
+      name: 'PlacedBy',
+      source: {entity: 'Order', columns: ['customerKey']},
+      destination: {entity: 'Customer', columns: ['key']},
+    }],
+    metrics: [
+      {name: 'order_count', expression: 'COUNT(Order.key)', entity: 'Order'},
+      {
+        name: 'avg_lifetime_value',
+        expression: 'AVG(Customer.lifetimeValue)', entity: 'Customer',
+      },
+    ],
+  };
+}
+
+const fieldNames = (m: SemanticModel, entity: string) =>
+    m.entities.find(e => e.name === entity)!.fields.map(f => f.name);
+const metricNames = (m: SemanticModel) => (m.metrics ?? []).map(mt => mt.name);
+const relNames = (m: SemanticModel) => (m.relationships ?? []).map(r => r.name);
+
+
+describe('pruneUnavailable drops what a binding cannot answer', () => {
+  test('an unbound field is removed from its entity', () => {
+    const {model, report} = pruneUnavailable(irModel(), 'operational');
+    expect(fieldNames(model, 'Customer')).toEqual(['key', 'name']);
+    expect(report.unboundFields).toContain('Customer.lifetimeValue');
+  });
+
+  test('a metric that reads an unbound field is dropped and reported', () => {
+    const {model, report} = pruneUnavailable(irModel(), 'operational');
+    expect(metricNames(model)).toEqual(['order_count']);
+    const dropped = report.droppedMetrics.find(
+        d => d.name === 'avg_lifetime_value');
+    expect(dropped?.reason).toMatch(/Customer\.lifetimeValue/);
+  });
+
+  test('a metric whose fields are all bound survives', () => {
+    const {model} = pruneUnavailable(irModel(), 'operational');
+    expect(metricNames(model)).toContain('order_count');
+  });
+
+  test('a relationship keeps when its join fields are bound', () => {
+    const {model} = pruneUnavailable(irModel(), 'operational');
+    expect(relNames(model)).toEqual(['PlacedBy']);
+  });
+
+  test('a relationship drops when a join field is unbound', () => {
+    const m = irModel();
+    // Unbind the FK field the relationship joins on.
+    const customerKey =
+        m.entities.find(e => e.name === 'Order')!.fields.find(
+            f => f.name === 'customerKey')!;
+    customerKey.unbound = true;
+    delete customerKey.expression;
+    const {model, report} = pruneUnavailable(m, 'operational');
+    expect(relNames(model)).toEqual([]);
+    expect(report.droppedRelationships[0].name).toBe('PlacedBy');
+  });
+
+  test('the input is never mutated', () => {
+    const m = irModel();
+    const before = JSON.stringify(m);
+    pruneUnavailable(m, 'operational');
+    expect(JSON.stringify(m)).toBe(before);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/semantic_model_layout.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/semantic_model_layout.test.ts
@@ -94,3 +94,41 @@ describe('SemanticModelLayout write path', () => {
     expect(() => l.removeModelDocument('ghost')).not.toThrow();
   });
 });
+
+
+describe('SemanticModelLayout profile discovery', () => {
+  function writeModel(eg: string, name: string, text: string): void {
+    const dir = path.join(catalogPath, 'EntryGroups', eg);
+    fs.mkdirSync(dir, {recursive: true});
+    fs.writeFileSync(path.join(dir, `${name}.yaml`), text);
+  }
+  function writeProfile(eg: string, model: string, name: string): void {
+    const dir = path.join(catalogPath, 'EntryGroups', eg, `${model}.profiles`);
+    fs.mkdirSync(dir, {recursive: true});
+    fs.writeFileSync(path.join(dir, `${name}.yaml`), `# ${name}\n`);
+  }
+
+  test('profileDocuments reads <model>.profiles/*.yaml by name', async () => {
+    writeModel('eg', 'commerce', 'version: x\n');
+    writeProfile('eg', 'commerce', 'analytical');
+    writeProfile('eg', 'commerce', 'operational');
+    const l = await layout('eg');
+    expect(l.profileDocuments('commerce').map(p => p.name)).toEqual(
+        ['analytical', 'operational']);
+    expect(l.profileDocuments('commerce')[0].text).toBe('# analytical\n');
+  });
+
+  test('a model with no profiles directory yields none', async () => {
+    writeModel('eg', 'commerce', 'version: x\n');
+    const l = await layout('eg');
+    expect(l.profileDocuments('commerce')).toEqual([]);
+  });
+
+  test('a .profiles directory is not discovered as a model document', async () => {
+    writeModel('eg', 'commerce', 'version: x\n');
+    writeProfile('eg', 'commerce', 'analytical');
+    const l = await layout('eg');
+    // Only the logical model, never the profile files, surfaces as a model.
+    expect(l.modelDocuments().map(d => d.name)).toEqual(['commerce']);
+  });
+});

--- a/toolbox/mdcode/tests/tool/profiles.test.ts
+++ b/toolbox/mdcode/tests/tool/profiles.test.ts
@@ -1,0 +1,168 @@
+// Tests for `kcmd profiles` (src/tool/commands.ts, profiles()) and the
+// catalog.yaml `default_profile` it reads (src/libts/manifest.ts). The command
+// is read-only -- it merges and prunes each profile the way push does but
+// deploys nothing and makes no network call -- so it runs in a temp working
+// directory with a pinned context, mirroring init_semantic_model.test.ts.
+
+import {afterEach, beforeEach, describe, expect, mock, spyOn, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {ApiContext} from '../../src/libts/gcp/context';
+import {CatalogManifest} from '../../src/libts/manifest';
+import {profiles} from '../../src/tool/commands';
+
+const CTX = new ApiContext('test-project', 'us', 'test-token');
+
+const LOGICAL = `version: "0.2.0.dev0"
+semantic_model:
+  - name: commerce
+    entities:
+      - name: Customer
+        primary_key: [key]
+        fields:
+          - { name: key, label: Customer ID }
+          - { name: lifetimeValue }
+          - { name: availableCredit }
+      - name: Order
+        primary_key: [key]
+        fields:
+          - { name: key }
+    metrics:
+      - name: order_count
+        expression: COUNT(Order.key)
+      - name: avg_lifetime_value
+        expression: AVG(Customer.lifetimeValue)
+`;
+
+const ANALYTICAL = `version: "0.2.0.dev0"
+semantic_model:
+  - name: commerce
+    deployment_target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce
+    entities:
+      - name: Customer
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/customer
+        fields:
+          - { name: key, expression: c_custkey }
+          - { name: lifetimeValue, expression: c_ltv }
+          - { name: availableCredit, unbound: true }
+      - name: Order
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
+        fields:
+          - { name: key, expression: o_orderkey }
+`;
+
+const OPERATIONAL = `version: "0.2.0.dev0"
+semantic_model:
+  - name: commerce
+    deployment_target: //spanner.googleapis.com/projects/acme-ops/instances/prod/databases/commerce/propertyGraphs/commerce
+    entities:
+      - name: Customer
+        source: //spanner.googleapis.com/projects/acme-ops/instances/prod/databases/commerce/tables/Customer
+        fields:
+          - { name: key, expression: CustomerId }
+          - { name: availableCredit, expression: AvailableCredit }
+          - { name: lifetimeValue, unbound: true }
+      - name: Order
+        source: //spanner.googleapis.com/projects/acme-ops/instances/prod/databases/commerce/tables/Orders
+        fields:
+          - { name: key, expression: OrderId }
+`;
+
+let dir = '';
+let cwd = '';
+let logs: string[] = [];
+
+function catalogYaml(defaultProfile?: string): string {
+  return `scope: semantic-model.test-project.us.commerce_eg\n` +
+      (defaultProfile ? `default_profile: ${defaultProfile}\n` : '');
+}
+
+function writeWorkspace(defaultProfile?: string): void {
+  fs.writeFileSync(path.join(dir, 'catalog.yaml'), catalogYaml(defaultProfile));
+  const eg = path.join(dir, 'catalog', 'EntryGroups', 'commerce_eg');
+  fs.mkdirSync(path.join(eg, 'commerce.profiles'), {recursive: true});
+  fs.writeFileSync(path.join(eg, 'commerce.yaml'), LOGICAL);
+  fs.writeFileSync(path.join(eg, 'commerce.profiles', 'analytical.yaml'), ANALYTICAL);
+  fs.writeFileSync(path.join(eg, 'commerce.profiles', 'operational.yaml'), OPERATIONAL);
+}
+
+beforeEach(() => {
+  cwd = process.cwd();
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kcmd-profiles-'));
+  process.chdir(dir);
+  logs = [];
+  spyOn(ApiContext, 'default').mockReturnValue(CTX);
+  spyOn(console, 'log').mockImplementation((...a: any[]) => {
+    logs.push(a.join(' '));
+  });
+  spyOn(console, 'error').mockImplementation((...a: any[]) => {
+    logs.push(a.join(' '));
+  });
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  if (dir) fs.rmSync(dir, {recursive: true, force: true});
+  dir = '';
+  mock.restore();
+});
+
+
+describe('kcmd profiles', () => {
+  test('lists each profile with its target, sources, and withheld coverage',
+       async () => {
+         writeWorkspace('analytical');
+         const code = await profiles();
+         expect(code).toBe(0);
+         const out = logs.join('\n');
+
+         // Both profiles listed; the default one is marked.
+         expect(out).toContain("profile 'analytical' (default)");
+         expect(out).toContain("profile 'operational'");
+         expect(out).not.toContain("profile 'operational' (default)");
+
+         // Resolved targets and normalized sources.
+         expect(out).toContain(
+             'target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce');
+         expect(out).toContain('Customer -> acme-analytics.sales.customer');
+         expect(out).toContain(
+             'Customer -> //spanner.googleapis.com/projects/acme-ops/instances/prod/databases/commerce/tables/Customer');
+
+         // Withheld coverage: availableCredit only under analytical,
+         // lifetimeValue (and the metric on it) only under operational.
+         expect(out).toContain('field Customer.availableCredit (unbound)');
+         expect(out).toContain('field Customer.lifetimeValue (unbound)');
+         expect(out).toContain('metric avg_lifetime_value');
+       });
+
+  test('marks no profile default when none is configured', async () => {
+    writeWorkspace(undefined);
+    const code = await profiles();
+    expect(code).toBe(0);
+    expect(logs.join('\n')).not.toContain('(default)');
+  });
+});
+
+
+describe('catalog.yaml default_profile round-trips', () => {
+  test('load reads default_profile and save writes it back', async () => {
+    const p = path.join(dir, 'catalog.yaml');
+    fs.writeFileSync(p, catalogYaml('analytical'));
+    const loaded = await CatalogManifest.load(p, CTX);
+    expect(loaded.defaultProfile).toBe('analytical');
+
+    const p2 = path.join(dir, 'catalog2.yaml');
+    loaded.save(p2);
+    const reloaded = await CatalogManifest.load(p2, CTX);
+    expect(reloaded.defaultProfile).toBe('analytical');
+  });
+
+  test('a manifest without default_profile has none', async () => {
+    const p = path.join(dir, 'catalog.yaml');
+    fs.writeFileSync(p, catalogYaml(undefined));
+    const loaded = await CatalogManifest.load(p, CTX);
+    expect(loaded.defaultProfile).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Third and final PR implementing **binding profiles** (design: \`docs/semantic-model/profiles.md\`).

> **Stacked on #359 (which stacks on #358).** Until those merge, this PR's diff also shows their commits. Review #358 → #359 → this.

Completes the feature with the reporting surface and the CI default.

## What changes

- **\`kcmd profiles\`** — lists each of a model's binding profiles and, per profile, its resolved deployment target and sources plus what it cannot answer (the unbound fields and the metrics/relationships that fall with them). Read-only: it merges and prunes each profile the way \`push\` does but deploys nothing and makes no network call, so coverage can be inspected before choosing a profile.
- **\`default_profile\` in \`catalog.yaml\`** — the profile a bare \`kcmd push\` uses when \`--profile\` is omitted. Precedence: \`--profile\`, then \`default_profile\`, then the inline \`default\` binding. Round-trips through manifest load/save.

Sample output on the guide's example:

\`\`\`
Model 'commerce' (commerce_eg):
  profile 'analytical' (default)
    target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce
    sources:
      Customer -> acme-analytics.sales.customer
      Order -> acme-analytics.sales.orders
    cannot answer:
      field Customer.availableCredit (unbound)
  profile 'operational'
    target: //spanner.googleapis.com/.../propertyGraphs/commerce
    sources:
      Customer -> //spanner.googleapis.com/.../tables/Customer
      Order -> //spanner.googleapis.com/.../tables/Orders
    cannot answer:
      field Customer.lifetimeValue (unbound)
      metric avg_lifetime_value (field Customer.lifetimeValue is unbound)
\`\`\`

## Test

- \`tests/tool/profiles.test.ts\` — the command's listing, default marking, resolved/normalized sources, withheld coverage; and \`default_profile\` load/save round-trip.
- \`npx tsc --noEmit\` clean; semantic + tool suites green (520 pass).