### PR TITLE
feat(mdcode): add Spanner Graph as a kcmd push target

### DIFF
--- a/toolbox/mdcode/README.md
+++ b/toolbox/mdcode/README.md
@@ -171,22 +171,26 @@ kcmd status
 kcmd push
 ```
 
-For the semantic-model scope, `kcmd push` deploys the model's BigQuery Graph
-(`CREATE OR REPLACE PROPERTY GRAPH`) to the project and dataset named by the
-model's GOOGLE deployment target; pass `--validate-only` to print the generated
-DDL without executing it. This path additionally reads the target dataset's
-metadata (`bigquery.datasets.get`) to pin the query job's processing location.
-The call degrades gracefully when the permission is absent, so a narrower
-service account still works but falls back to BigQuery's own location inference.
-A dataset `source` that omits its project is qualified with the scope's
-declared project (the `<projectId>` in the init scope), not the ambient
-`gcloud` project; write a fully-qualified `project.dataset.table` source when
-the tables live elsewhere.
+For the semantic-model scope, `kcmd push` deploys the model as a property graph
+(`CREATE OR REPLACE PROPERTY GRAPH`) to the backend named by the model's GOOGLE
+deployment target — **BigQuery Graph** or **Spanner Graph**; the same authored
+model deploys to either, and swapping the target URI switches backends. Pass
+`--validate-only` to print the generated DDL without executing it. For a BigQuery
+target this path additionally reads the target dataset's metadata
+(`bigquery.datasets.get`) to pin the query job's processing location; the call
+degrades gracefully when the permission is absent, so a narrower service account
+still works but falls back to BigQuery's own location inference. A dataset
+`source` that omits its project is qualified with the scope's declared project
+(the `<projectId>` in the init scope), not the ambient `gcloud` project; write a
+fully-qualified `project.dataset.table` source when the tables live elsewhere.
+(A Spanner target names its tables inside one database, so a `source` is reduced
+to its final segment, and Spanner Graph has no `MEASURE`, so metrics are dropped
+with a warning.)
 
 `kcmd push` also deploys the model to Knowledge Catalog (entries for the model,
 its entities and metrics, and `schema-join` links for its relationships). Use
-`--target bq|kc|all` (default `all`) to choose destinations, `--print` to dump
-each destination's generated artifact, and `--force-remove` to delete models
+`--target bq|spanner|kc|all` (default `all`) to choose destinations, `--print` to
+dump each destination's generated artifact, and `--force-remove` to delete models
 left in the entry group that the push no longer includes. See
 [docs/semantic-model/](docs/semantic-model/README.md) for the full guide,
 including how re-push reconciles removed entities, metrics, relationships, and

--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -8,8 +8,8 @@ now split by what you came to do:
 - **[End-to-end codelab](semantic-model/codelab.md)** — author, govern, hydrate,
   and query one model, start to finish.
 - **[Reference](semantic-model/reference.md)** — every flag, what push creates in
-  BigQuery and Knowledge Catalog (including class hierarchies), validation, and
-  permissions.
+  BigQuery Graph, Spanner Graph, and Knowledge Catalog (including class
+  hierarchies), validation, and permissions.
 - **[What push and pull preserve](semantic-model/fidelity.md)** — the
   round-trip fidelity matrix: what survives a deploy, what a pull recovers, and
   what neither keeps.

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -5,8 +5,11 @@ them, and the relationships between them, authored as a single
 [Apache Ossie](https://ossie.apache.org/) document. `kcmd push` deploys one
 model to two destinations at once:
 
-* **BigQuery** — a queryable `CREATE OR REPLACE PROPERTY GRAPH` over the model's
-  tables, so the model can be traversed and its metrics computed in SQL.
+* **A property graph** — a queryable `CREATE OR REPLACE PROPERTY GRAPH` over the
+  model's tables, so the model can be traversed (and, on BigQuery, its metrics
+  computed) in SQL. The graph backend is **BigQuery Graph** or **Spanner
+  Graph**, chosen by the deployment target you declare — the same authored model
+  deploys to either (see [Deployment targets](#deployment-targets-required)).
 * **Knowledge Catalog** — catalog entries and links that make the
   model discoverable as metadata.
 
@@ -87,32 +90,44 @@ rules.
 
 ### Deployment targets (required)
 
-Every model must declare exactly one **deployment target** — the BigQuery
-property graph it deploys to — in a `GOOGLE` custom extension, as shown above. A
-target is a URI of the form:
+Every model must declare exactly one **deployment target** — the property graph
+it deploys to — in a `GOOGLE` custom extension, as shown above. The target's
+**host selects the graph backend**:
 
 ```
+# BigQuery Graph
 //bigquery.googleapis.com/projects/<project>/datasets/<dataset>/propertyGraphs/<graphName>
+
+# Spanner Graph
+//spanner.googleapis.com/projects/<project>/instances/<instance>/databases/<database>/propertyGraphs/<graphName>
 ```
 
-The target's project and dataset are where the property graph is created; the
-same URIs are also recorded on the model's Knowledge Catalog entry. A model with
-no deployment target — or with more than one — is rejected at push time (see
+A BigQuery target's project and dataset are where the property graph is created;
+a Spanner target's instance and database are. Swapping one target URI for the
+other is all it takes to deploy the same model to the other backend. The target
+is also recorded on the model's Knowledge Catalog entry. A model with no
+deployment target — or with more than one — is rejected at push time (see
 [Validation](reference.md#validation)).
 
 ### Table sources
 
-Each entity's `source` is its backing BigQuery table. A `source` written as
+Each entity's `source` is its backing table.
+
+For a **BigQuery** target, `source` is the BigQuery table. A `source` written as
 `dataset.table` (two parts) is qualified with the scope's project — the
 `<projectId>` from `init`. Write the full `project.dataset.table` when a table
-lives in another project.
+lives in another project. Sources are not limited to native BigQuery tables: a
+name with more than three parts — for example a four-part
+`catalog.database.schema.table` reference — points at a table in a **federated
+REST catalog**, such as an Apache Iceberg table exposed through BigLake. Write it
+exactly as BigQuery resolves the name, and validation resolves it the same way
+the deploy does (see [Validation](reference.md#validation)).
 
-Sources are not limited to native BigQuery tables. A name with more than
-three parts — for example a four-part `catalog.database.schema.table`
-reference — points at a table in a **federated REST catalog**, such as an
-Apache Iceberg table exposed through BigLake. Write it exactly as BigQuery
-resolves the name, and validation resolves it the same way the deploy does (see
-[Validation](reference.md#validation)).
+For a **Spanner** target, the graph and its tables live inside the one Spanner
+database the target names, so a `source` is reduced to its **final segment** —
+the table name in that database (`demo.sales.Orders` → `Orders`). That lets one
+authored `source` serve both backends; a Spanner-native `source` form is a
+planned [profiles](profiles.md) feature.
 
 ## 2. Push
 
@@ -120,27 +135,34 @@ resolves the name, and validation resolves it the same way the deploy does (see
 kcmd push
 ```
 
-With no flags this deploys to **every** destination, BigQuery first. The most
-common flags:
+With no flags this deploys to **every** destination — the model's graph backend
+(BigQuery Graph or Spanner Graph, whichever its target names) and Knowledge
+Catalog — the graph first. The most common flags:
 
 ```bash
-kcmd push --target bq          # BigQuery only
+kcmd push --target bq          # BigQuery Graph only
+kcmd push --target spanner     # Spanner Graph only
+kcmd push --target kc          # Knowledge Catalog only
 kcmd push --validate-only      # run all checks, write nothing
 kcmd push --print              # also print the generated DDL / entry plan
 ```
 
-See [Reference → push flags](reference.md#push) for the full list. Destinations
-always deploy BigQuery-first and fail fast, so a rejected model never
-half-deploys — the checks that gate it are in
-[Validation](reference.md#validation).
+See [Reference → push flags](reference.md#push) for the full list. The graph leg
+deploys first and fails fast, so a rejected model never half-deploys — the checks
+that gate it are in [Validation](reference.md#validation).
 
-**What push creates.** In BigQuery, a single `CREATE OR REPLACE PROPERTY GRAPH`
-per deployment target: each entity becomes a node table, each relationship an
-edge table, each metric a measure. In Knowledge Catalog, one entry per model,
-entity, and metric, plus `schema-join` links for relationships. The exact
-mapping — and the class-hierarchy handling — is in
-[Reference → What gets created](reference.md#what-gets-created-in-bigquery); what
-of your metadata survives the trip (and what doesn't) is in
+**What push creates.** In **BigQuery**, a single `CREATE OR REPLACE PROPERTY
+GRAPH` per deployment target: each entity becomes a node table, each relationship
+an edge table, each metric a measure. In **Spanner**, the same
+`CREATE OR REPLACE PROPERTY GRAPH` with bare table names and no measures —
+Spanner Graph has no `MEASURE`, so metrics are dropped with a warning while the
+graph structure (nodes, edges, labels, inheritance) still deploys. In
+**Knowledge Catalog**, one entry per model, entity, and metric, plus
+`schema-join` links for relationships. The exact mapping — and the
+class-hierarchy handling — is in
+[Reference → What gets created](reference.md#what-gets-created-in-bigquery) (and
+[in Spanner](reference.md#what-gets-created-in-spanner)); what of your metadata
+survives the trip (and what doesn't) is in
 [What push and pull preserve](fidelity.md).
 
 ## Updating and removing models
@@ -180,6 +202,9 @@ Every push prints one line per destination summarizing what it did. For a
 Deployed 1 BigQuery Graph(s).
 Wrote 5 new and 2 updated Knowledge Catalog entries; removed 1 orphaned entry; linked 2 relationships; unlinked 1 orphaned link.
 ```
+
+A Spanner-targeting model prints `Deployed 1 Spanner Graph(s).` in place of the
+BigQuery line.
 
 ## Pull
 

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -443,7 +443,104 @@ query, so the correct answer is the default one.
 
 ---
 
-## 5. Clean up
+## 5. Deploy the same model to Spanner Graph
+
+The model you authored is backend-agnostic — the one BigQuery-specific choice in
+it is the deployment target. Swap that target for a Spanner Graph URI and the
+**same document** deploys to Spanner Graph. You can inspect the generated DDL
+without a Spanner database, because the generator runs under `--validate-only`:
+
+```bash
+# Point $GRAPH at a Spanner Graph target instead of the BigQuery one from step 1.
+export SPANNER_INSTANCE=<your-spanner-instance>
+export SPANNER_DB=<your-googlesql-database>
+SPANNER_TARGET=//spanner.googleapis.com/projects/$PROJECT/instances/$SPANNER_INSTANCE/databases/$SPANNER_DB/propertyGraphs/$GRAPH
+
+# Rewrite the deployment target in place (cleanup in step 6 removes the workspace).
+sed -i "s#//bigquery.googleapis.com/[^\"]*#$SPANNER_TARGET#" catalog/EntryGroups/$DATASET/sales.yaml
+
+kcmd push --target spanner --validate-only --print
+```
+
+```
+Validating semantic model for Spanner Graph...
+Warning: metric 'revenue' is not emitted: Spanner Graph has no MEASURE, so model-level metrics have no home in it
+-- Spanner Graph --
+CREATE OR REPLACE PROPERTY GRAPH sales
+NODE TABLES (
+  orders AS orders
+    KEY(o_orderkey)
+    PROPERTIES(
+      o_orderkey,
+      o_custkey,
+      net_amount
+    ),
+  customer AS customer
+    KEY(c_custkey)
+    PROPERTIES(
+      c_custkey,
+      c_name
+    ),
+  lineitem AS lineitem
+    KEY(l_linekey)
+    PROPERTIES(
+      l_linekey,
+      l_orderkey
+    )
+)
+EDGE TABLES (
+  orders AS orders_to_customer
+    KEY(o_orderkey)
+    SOURCE KEY(o_orderkey) REFERENCES orders(o_orderkey)
+    DESTINATION KEY(o_custkey) REFERENCES customer(c_custkey),
+  lineitem AS lineitem_to_orders
+    KEY(l_linekey)
+    SOURCE KEY(l_linekey) REFERENCES lineitem(l_linekey)
+    DESTINATION KEY(l_orderkey) REFERENCES orders(o_orderkey)
+);
+
+Validation complete; no changes applied.
+```
+
+Three things differ from the BigQuery DDL in step 4, and nothing else:
+
+- **Bare table and graph names.** A Spanner property graph names tables inside
+  one database, so there is no backticked `project.dataset.` qualifier — each
+  `source`'s final segment (`$PROJECT.$DATASET.orders` → `orders`) is the table.
+- **No `MEASURE`.** Spanner Graph has no measures, so `revenue` is dropped with
+  the warning above rather than emitted onto the `orders` node. Author metrics as
+  usual — a BigQuery target still emits them, and step 3's Knowledge Catalog
+  entries still record `revenue`.
+- **No `OPTIONS`.** Descriptions and synonyms are not written into the Spanner
+  DDL; they live in Knowledge Catalog instead.
+
+The nodes, edges, and keys are identical to the BigQuery graph.
+
+To actually apply it, drop `--validate-only` and point the target at a Spanner
+database that already holds `orders`, `customer`, and `lineitem` — the Spanner
+leg applies the DDL through the `updateDatabaseDdl` long-running operation and
+does not create or pre-check those tables:
+
+```bash
+kcmd push --target spanner
+# -> Deployed 1 Spanner Graph(s).
+```
+
+Then query it with Spanner's Graph Query Language, for example
+`GRAPH sales MATCH (o:orders)-[:orders_to_customer]->(c:customer) RETURN c.c_name, o.net_amount`.
+Aggregates like `revenue` are computed in your application or in SQL, not by the
+graph, since Spanner Graph has no measure.
+
+Restore the BigQuery target before the rest of the codelab, if you kept the
+workspace:
+
+```bash
+sed -i "s#//spanner.googleapis.com/[^\"]*#//bigquery.googleapis.com/$BQ_DS/propertyGraphs/$GRAPH#" catalog/EntryGroups/$DATASET/sales.yaml
+```
+
+---
+
+## 6. Clean up
 
 Drop the BigQuery dataset (tables + property graph):
 

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -1,7 +1,7 @@
 # What push and pull preserve
 
-Your model document is the source of truth. Pushing it (to BigQuery and to
-Knowledge Catalog) and pulling it back are each **lossy in specific ways**: the
+Your model document is the source of truth. Pushing it (to a property graph and
+to Knowledge Catalog) and pulling it back are each **lossy in specific ways**: the
 graph keeps what it can query, the catalog keeps metadata, and `pull` can only
 return what the catalog was given. This page is the one authoritative map of what
 survives each direction. Keep your authored document.
@@ -10,7 +10,9 @@ survives each direction. Keep your authored document.
 
 Rows are what you authored; columns are its fate in each direction. `✓` = comes
 back as authored; `—` = not present in that destination. Footnotes carry the
-nuances that don't fit a cell.
+nuances that don't fit a cell. The **→ BigQuery graph** column describes a
+BigQuery target; a Spanner target keeps the same graph *structure* but no
+measures and no `OPTIONS` metadata — see [To Spanner Graph](#to-spanner-graph).
 
 | Authored element | → BigQuery graph | → Knowledge Catalog | Recovered by `pull` |
 |---|---|---|---|
@@ -67,6 +69,30 @@ dropped (only the primary key is emitted). The imported vendor SQL is not carrie
 as a separate form: the graph builds from the canonical `expression` when
 present, and falls back to the imported vendor SQL verbatim only when the model
 was never transpiled to a canonical form.
+
+## To Spanner Graph
+
+A Spanner target keeps the queryable **structure** and drops the descriptive
+metadata. The node tables, edge tables, and labels (including the `extends`
+hierarchy, with fields flattened down) deploy exactly as they do for BigQuery,
+but with bare table and graph names. Two things do not make the trip, both by
+design:
+
+- **Metrics.** Spanner Graph has no `MEASURE`, so every model-level metric is
+  dropped with a warning. The BigQuery-only rule that a metric resolve to one
+  entity does not apply. Author your metrics as usual — a BigQuery target still
+  emits them, and Knowledge Catalog still records each `semantic-metric` entry —
+  they simply have no home in the Spanner graph.
+- **`OPTIONS` metadata.** Spanner Graph carries no per-element `OPTIONS`, so
+  `description`, `synonyms`, `instructions`, `examples`, and field `label` are not
+  written into the Spanner DDL. They still reach Knowledge Catalog on the same
+  push (the model's / entities' / metrics' descriptions and `instructions` land
+  on their entries and the `guidelines` aspect), so the descriptive layer lives in
+  the catalog rather than in the Spanner graph. This mirrors how BigQuery drops
+  its graph-*statement* `OPTIONS` while keeping per-element ones.
+
+Everything else — keys, relationships, the label hierarchy — matches the
+**→ BigQuery graph** column above.
 
 ## To Knowledge Catalog
 

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -23,18 +23,19 @@ existing group is fine) and creates its local directory,
 kcmd push
 ```
 
-With no flags, deploys to every destination, BigQuery first.
+With no flags, deploys to every destination — the model's graph backend and
+Knowledge Catalog — the graph first.
 
 | Flag | Effect |
 |------|--------|
-| `--target <bq\|kc\|all>` | Which destination(s) to deploy to; accepts a comma-separated list (`bq,kc`). Default `all`. |
+| `--target <bq\|spanner\|kc\|all>` | Which destination(s) to deploy to; accepts a comma-separated list (`bq,kc`). Default `all`. `bq` and `spanner` are the two graph backends; each model routes to whichever its deployment target names, so `--target spanner` on a BigQuery-targeting model reports it has nothing to do. |
 | `--validate-only` | Run every validation check and report pass/fail, but write nothing. |
-| `--print` | Print each destination's generated artifact (BigQuery DDL, Knowledge Catalog entry plan). Combine with `--validate-only` to preview without deploying. |
+| `--print` | Print each destination's generated artifact (BigQuery or Spanner Graph SQL DDL, Knowledge Catalog entry plan). Combine with `--validate-only` to preview without deploying. |
 | `--force-remove` | Delete models in the entry group that this push no longer includes (see [Updating and removing models](README.md#updating-and-removing-models)). |
 | `--emit-expressions` | Also write the SQL-expression fields (per-field `schema.semantics` and `semantic-metric.expression`) to Knowledge Catalog. Off by default: the published system-type templates do not carry them yet. Knowledge Catalog push only. |
 
-Destinations always deploy BigQuery-first and fail fast, so a rejected model
-never half-deploys.
+The graph leg deploys first and fails fast, so a rejected model never
+half-deploys.
 
 ### pull
 
@@ -163,6 +164,40 @@ model inheritance today, so an abstract entity has no physical resource to
 catalog and is skipped there (with a warning); its concrete subtypes are
 published normally.
 
+## What gets created in Spanner
+
+When the deployment target is a Spanner Graph URI, `push` executes the same
+`CREATE OR REPLACE PROPERTY GRAPH` — but generated for Spanner Graph, which
+differs from BigQuery Graph in four ways:
+
+| Model element | Spanner construct | Notes |
+|---|---|---|
+| Model | `PROPERTY GRAPH` | named by the URI's `propertyGraphs/<g>` segment, **bare** (no backticked `project.dataset.` prefix) |
+| Entity | `NODE TABLE` | backed by the entity's `source` reduced to its final segment (`proj.ds.Orders` → `Orders`), a table in the target database |
+| Relationship | `EDGE TABLE` | connects the two entities' node tables |
+| Metric | — dropped | Spanner Graph has no `MEASURE`, so every model-level metric is skipped with a warning; the graph structure still deploys |
+| Entity `extends` | extra `LABEL` clauses on the subclass node table | same label-and-flatten handling as BigQuery (see [Class hierarchies](#class-hierarchies-extends--labels)) |
+
+- **Bare table and graph names.** A Spanner property graph lives inside one
+  database and names tables in that same database, so the generator emits bare
+  names — no `project.dataset.` qualifier on either the tables or the graph.
+- **No `MEASURE`.** Metrics are dropped (warned per metric), never errored. The
+  BigQuery-only rule that a metric must resolve to a single entity therefore does
+  not apply to a Spanner target (see [Validation](#validation)).
+- **No per-element `OPTIONS`.** `description` / `synonyms` are not emitted into
+  the Spanner DDL; they ride into Knowledge Catalog instead — mirroring how
+  BigQuery's graph-level `OPTIONS` is dropped. See
+  [What push and pull preserve](fidelity.md#to-spanner-graph).
+- **Async DDL.** The statement is applied through the Spanner Admin
+  `updateDatabaseDdl` long-running operation, polled to completion (BigQuery runs
+  its DDL through `jobs.query`). No region detection is needed — the DDL runs in
+  the database the target names.
+
+Under `--validate-only` nothing is applied; add `--print` to see the generated
+Spanner DDL. Unlike the BigQuery leg, a Spanner-targeting model's source tables
+are **not** probed before deploy — the live pre-flight is BigQuery-only (see
+[Validation](#validation)).
+
 ## What gets created in Knowledge Catalog
 
 Each element of your model maps to one catalog resource. Every resource type
@@ -198,41 +233,56 @@ of your model. For exactly what is stored, what is gated behind
 touched**, so a model that cannot deploy fails fast instead of half-deploying:
 
 * **Exactly one deployment target per model, and it must be a valid BigQuery
-  Graph URI.** A model with no target — or with more than one — is rejected, and
-  so is a single target whose URI does not match
-  `//bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>` (for
-  example a `propertyGraph`/`propertyGraphs` typo, or a
+  Graph or Spanner Graph URI.** A model with no target — or with more than one —
+  is rejected, and so is a single target whose URI matches neither
+  `//bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>` nor
+  `//spanner.googleapis.com/projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>`
+  (for example a `propertyGraph`/`propertyGraphs` typo, or a
   `…/entryGroups/@bigquery/entries/…` entry form). The error names the offending
-  URI and the expected form. This gate runs before any destination leg and for
-  every `--target`, so a malformed target writes **nothing** — not to BigQuery
+  URI and the expected forms. This gate runs before any destination leg and for
+  every `--target`, so a malformed target writes **nothing** — not to the graph
   and **not to Knowledge Catalog**; the push aborts with a non-zero exit and no
   entries are created. *(static)*
 * **Every metric on a BigQuery Graph model resolves to exactly one entity** —
   otherwise it would be dropped from the BigQuery Graph. Set the metric's attach
-  entity, or scope its expression to a single entity. *(static)*
-* **Every entity's source table is reachable.** Each `source` is probed with a
-  dry-run query, so BigQuery resolves it exactly as the deploy will — a
-  three-part `project.dataset.table`, a four-part federated REST-catalog name
-  (e.g. an Iceberg table via BigLake), or a quoted identifier all work. A table
-  that does not exist or that you cannot access fails the push, naming the table
-  and the entity; a `source` that is a query (not a table) is skipped. *(live —
-  needs BigQuery access)*
+  entity, or scope its expression to a single entity. This rule is
+  BigQuery-only: Spanner Graph has no `MEASURE`, so a Spanner target drops its
+  metrics by design and imposes no such requirement. *(static)*
+* **Every entity's source table is reachable.** For a **BigQuery-targeting**
+  model, each `source` is probed with a dry-run query, so BigQuery resolves it
+  exactly as the deploy will — a three-part `project.dataset.table`, a four-part
+  federated REST-catalog name (e.g. an Iceberg table via BigLake), or a quoted
+  identifier all work. A table that does not exist or that you cannot access fails
+  the push, naming the table and the entity; a `source` that is a query (not a
+  table) is skipped. A **Spanner-targeting** model's sources live in Spanner
+  (a different system) and are **not** probed here. *(live — needs BigQuery
+  access)*
 
-The live table check runs for **every** `--target`, because the same tables back
-both destinations — so even a Knowledge-Catalog-only push confirms the model
-could deploy to BigQuery.
+The live table check runs for **every** `--target` over the BigQuery-targeting
+models, because the same tables back both a BigQuery graph and its Knowledge
+Catalog entries — so even a Knowledge-Catalog-only push of a BigQuery-targeting
+model confirms it could deploy to BigQuery.
 
 ## Permissions
 
 `push` needs access to whichever destinations you deploy to.
 
-**BigQuery** — for `--target bq` or `all`, and for the validation pre-flight:
+**BigQuery** — for `--target bq` (or `all`) on a BigQuery-targeting model, and
+for the validation pre-flight:
 
 * `bigquery.jobs.create` in the deployment-target project — to run the deploy's
   `CREATE OR REPLACE PROPERTY GRAPH` and the validation dry-run query
 * read access on each entity's source table, so the dry-run can resolve it
 * `bigquery.datasets.get` on the target dataset (region detection; optional —
   push degrades gracefully without it)
+
+**Spanner** — for `--target spanner` (or `all`) on a Spanner-targeting model, on
+the database the target names:
+
+* `spanner.databases.updateDdl` — to apply the `CREATE OR REPLACE PROPERTY GRAPH`
+  through `updateDatabaseDdl`
+* `spanner.databaseOperations.get` — to poll the long-running operation to
+  completion
 
 **Knowledge Catalog / Dataplex** — for `--target kc` or `all`:
 

--- a/toolbox/mdcode/src/libts/gcp/spanner.ts
+++ b/toolbox/mdcode/src/libts/gcp/spanner.ts
@@ -30,13 +30,15 @@ export class SpannerClient extends api.ApiClient {
 
   // Applies DDL statements to a database. This is asynchronous: the response is
   // a long-running Operation whose `name` the caller polls with getOperation
-  // until `done`. Statements are applied in order.
+  // until `done`. Statements are applied in order. The REST binding for
+  // updateDatabaseDdl is PATCH on the `.../ddl` collection (a POST 404s --
+  // verified live), so this uses PATCH, not the more common POST-to-create.
   async updateDatabaseDdl(
       project: string, instance: string, database: string,
       statements: string[]): Promise<api.ApiResult<Operation>> {
     const name =
         `projects/${project}/instances/${instance}/databases/${database}/ddl`;
-    return await this._post<Operation>(name, {statements});
+    return await this._patch<Operation>(name, {statements});
   }
 
   // Fetches a long-running operation by its resource name (as returned in

--- a/toolbox/mdcode/src/libts/gcp/spanner.ts
+++ b/toolbox/mdcode/src/libts/gcp/spanner.ts
@@ -1,0 +1,48 @@
+// API client for Cloud Spanner (Database Admin surface).
+//
+// The semantic-model Spanner leg only needs to run DDL and a table existence
+// probe, so this exposes just those: updateDatabaseDdl (which returns a
+// long-running operation), getOperation (to poll it), and getTable (a cheap
+// pre-flight over information schema is out of scope here; see the deploy leg).
+//
+
+import * as api from './api';
+import * as context from './context';
+
+
+// A long-running operation, as returned by updateDatabaseDdl and fetched by
+// getOperation. `done` flips to true at completion; `error` is set on failure
+// (a google.rpc.Status).
+export interface Operation {
+  name?: string;
+  done?: boolean;
+  error?: {code?: number; message?: string; [key: string]: any};
+  response?: {[key: string]: any};
+  metadata?: {[key: string]: any};
+  [key: string]: any;
+}
+
+
+export class SpannerClient extends api.ApiClient {
+  constructor(ctx: context.ApiContext) {
+    super('https://spanner.googleapis.com', 'v1', ctx);
+  }
+
+  // Applies DDL statements to a database. This is asynchronous: the response is
+  // a long-running Operation whose `name` the caller polls with getOperation
+  // until `done`. Statements are applied in order.
+  async updateDatabaseDdl(
+      project: string, instance: string, database: string,
+      statements: string[]): Promise<api.ApiResult<Operation>> {
+    const name =
+        `projects/${project}/instances/${instance}/databases/${database}/ddl`;
+    return await this._post<Operation>(name, {statements});
+  }
+
+  // Fetches a long-running operation by its resource name (as returned in
+  // Operation.name, e.g.
+  // `projects/.../instances/.../databases/.../operations/...`).
+  async getOperation(operationName: string): Promise<api.ApiResult<Operation>> {
+    return await this._get<Operation>(operationName);
+  }
+}

--- a/toolbox/mdcode/src/libts/semantic/deploy_bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_bigquery.ts
@@ -17,31 +17,17 @@ import {BigQueryClient, QueryResponse} from '../gcp/bigquery';
 import * as context from '../gcp/context';
 
 import {generatePropertyGraph} from './bigquery';
-import {SemanticModel} from './ir';
+// The GOOGLE deployment-target reader lives in its own module so both deploy
+// legs (BigQuery, Spanner) and the push-time validator share one parse. The
+// BigQuery-facing views are re-exported here so existing importers
+// (validate.ts, knowledge_catalog.ts, and the deploy tests) keep their
+// historical import path.
+import {BigQueryGraphTarget, bigQueryGraphTargets, deploymentTargetUris, googleDeploymentTargets} from './deployment_target';
 import {LoadedModel} from './loader';
 
+export {bigQueryGraphTargets, deploymentTargetUris, googleDeploymentTargets};
+export type {BigQueryGraphTarget};
 
-// Our own vendor tag in the Ossie `custom_extensions` list.
-const GOOGLE_VENDOR = 'GOOGLE';
-
-// A BigQuery Graph deployment target, e.g.
-// //bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>
-// The capture groups are restricted to valid BigQuery identifier characters:
-// the components are interpolated into DDL unescaped (see qualifyGraph), so a
-// permissive `[^/]+` would let backticks or semicolons through. A URI that
-// fails this full match is collected as `malformed` (see
-// googleDeploymentTargets) and named in the deploy/validation error, rather than
-// being silently skipped and later misreported as "no target declared".
-const BQ_GRAPH_TARGET =
-    /^\/\/bigquery\.googleapis\.com\/projects\/([A-Za-z0-9_-]+)\/datasets\/([A-Za-z0-9_-]+)\/propertyGraphs\/([A-Za-z0-9_-]+)$/;
-
-
-export interface BigQueryGraphTarget {
-  project: string;
-  dataset: string;
-  graphName: string;
-  uri: string;
-}
 
 export interface DeployOptions {
   validateOnly?: boolean;
@@ -63,81 +49,6 @@ export interface DeployResult {
   warnings: string[];
   // Number of graphs actually executed against BigQuery (0 for validateOnly).
   deployed: number;
-}
-
-
-// Reads a model's GOOGLE custom_extension(s) in a single pass and returns the
-// deployment-target facts every caller derives from them: every declared
-// deploymentTarget URI (`uris`), the subset that parse as BigQuery Graph targets
-// (`targets`), and the URIs that did not parse as a BigQuery Graph target
-// (`malformed`, kept so a caller can name a typo instead of silently skipping).
-// The extension `data` is an opaque, vendor-serialized JSON string (the loader
-// keeps it verbatim); we own its `deploymentTargets` shape. Throws on malformed
-// extension JSON. bigQueryGraphTargets and deploymentTargetUris are thin views
-// over this, and validation calls it directly so a push parses each extension
-// once rather than once per reader.
-export function googleDeploymentTargets(model: SemanticModel):
-    {uris: string[]; targets: BigQueryGraphTarget[]; malformed: string[]} {
-  const uris: string[] = [];
-  const targets: BigQueryGraphTarget[] = [];
-  const malformed: string[] = [];
-
-  for (const ext of model.customExtensions ?? []) {
-    if (ext.vendorName !== GOOGLE_VENDOR) {
-      continue;
-    }
-
-    let data: any;
-    try {
-      data = JSON.parse(ext.data);
-    } catch {
-      throw new Error(`Model '${
-          model.name}': GOOGLE custom_extension 'data' is not valid JSON.`);
-    }
-
-    const list = data?.deploymentTargets;
-    if (!Array.isArray(list)) {
-      continue;
-    }
-
-    for (const uri of list) {
-      if (typeof uri !== 'string') {
-        continue;
-      }
-      uris.push(uri);
-      const m = uri.match(BQ_GRAPH_TARGET);
-      if (m) {
-        targets.push({project: m[1], dataset: m[2], graphName: m[3], uri});
-      } else {
-        // We only support BigQuery Graph deployment targets, so any URI that
-        // does not parse as one -- a host/scheme/segment/identifier typo, or an
-        // unrelated destination -- is collected as malformed and rejected
-        // (validate.ts, and the deploy leg) rather than silently ignored.
-        malformed.push(uri);
-      }
-    }
-  }
-
-  return {uris, targets, malformed};
-}
-
-
-// The BigQuery Graph deployment targets a model declares in its GOOGLE custom
-// extension, plus any BigQuery-prefixed URIs that failed to parse. A view over
-// googleDeploymentTargets.
-export function bigQueryGraphTargets(model: SemanticModel):
-    {targets: BigQueryGraphTarget[]; malformed: string[]} {
-  const {targets, malformed} = googleDeploymentTargets(model);
-  return {targets, malformed};
-}
-
-
-// Every deploymentTarget URI a model declares, regardless of whether each parses
-// as a BigQuery Graph target. Validation uses this to require that a model
-// declares at least one deployment target; bigQueryGraphTargets narrows to the
-// BigQuery graphs. Throws on malformed extension JSON.
-export function deploymentTargetUris(model: SemanticModel): string[] {
-  return googleDeploymentTargets(model).uris;
 }
 
 
@@ -258,11 +169,11 @@ async function datasetLocation(
 }
 
 
-// Deploys the BigQuery Graph for each pre-loaded model. Emits no console output;
-// the generated DDL and any warnings are returned for the caller to print. The
-// models are parsed once by the caller (loadSemanticModels) and shared with the
-// Knowledge Catalog leg; each carries its originating document name for
-// diagnostics.
+// Deploys the BigQuery Graph for each pre-loaded model. Emits no console
+// output; the generated DDL and any warnings are returned for the caller to
+// print. The models are parsed once by the caller (loadSemanticModels) and
+// shared with the Knowledge Catalog leg; each carries its originating document
+// name for diagnostics.
 export async function deployBigQuery(
     models: LoadedModel[], ctx: context.ApiContext,
     options: DeployOptions = {}): Promise<DeployResult> {
@@ -299,8 +210,7 @@ export async function deployBigQuery(
     try {
       ({targets, malformed} = bigQueryGraphTargets(model));
     } catch (err: any) {
-      return fail(
-          `Model '${model.name}' (${document}): ${err.message || err}`);
+      return fail(`Model '${model.name}' (${document}): ${err.message || err}`);
     }
     if (!targets.length) {
       // A malformed-but-present target must not be reported as "none
@@ -320,8 +230,8 @@ export async function deployBigQuery(
     // Malformed targets alongside valid ones: surface them so a typo'd URI is
     // not silently dropped when the deploy otherwise succeeds.
     for (const bad of malformed) {
-      warnings.push(`[${
-          model.name}] ignoring unparseable BigQuery Graph target: ${bad}`);
+      warnings.push(
+          `[${model.name}] ignoring unparseable BigQuery Graph target: ${bad}`);
     }
 
     for (const target of targets) {
@@ -357,8 +267,8 @@ export async function deployBigQuery(
             ` (${deployed} graph(s) already deployed in this run; ` +
                 `CREATE OR REPLACE changes are not rolled back)` :
             '';
-        return fail(`Failed to deploy '${target.graphName}': ${
-            outcome.error}${partial}`);
+        return fail(`Failed to deploy '${target.graphName}': ${outcome.error}${
+            partial}`);
       }
 
       deployed++;

--- a/toolbox/mdcode/src/libts/semantic/deploy_spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_spanner.ts
@@ -1,0 +1,200 @@
+// Deploys a semantic model's Spanner Graph.
+//
+// This is the Spanner leg of `kcmd push` for the semantic-model scope, a
+// sibling to deploy_bigquery: it consumes models already parsed into the
+// semantic IR (see loadSemanticModels, shared across legs so a `--target all`
+// push parses each document once), lowers each to `CREATE OR REPLACE PROPERTY
+// GRAPH` DDL (generator: ./spanner), and applies that DDL to the Spanner
+// database named by the model's GOOGLE deployment target.
+//
+// Spanner DDL is asynchronous: updateDatabaseDdl returns a long-running
+// operation which this leg polls to completion, unlike the BigQuery leg's
+// jobs.query.
+//
+// This is a library module: it emits no console output. The generated DDL and
+// any loader/generator warnings are returned in `DeployResult` for the CLI
+// (src/tool/commands.ts) to print.
+//
+
+import * as context from '../gcp/context';
+import {Operation, SpannerClient} from '../gcp/spanner';
+
+import {SpannerGraphTarget, spannerGraphTargets} from './deployment_target';
+import {LoadedModel} from './loader';
+import {generateSpannerPropertyGraph} from './spanner';
+
+
+export interface DeployOptions {
+  validateOnly?: boolean;
+  // Poll bounds for a slow DDL operation, overridable so tests can exercise the
+  // exhaustion path without burning wall-clock. Default to the module
+  // constants.
+  maxOperationPolls?: number;
+  pollBackoffMs?: number;
+}
+
+export interface DeployResult {
+  success: boolean;
+  details?: string;
+  // Generated DDL, one entry per target (each prefixed with a `-- <uri>`
+  // comment), in deploy order. Populated even for validateOnly, where nothing
+  // is executed, so the caller can print or inspect it.
+  ddl: string[];
+  // Loader and generator warnings collected across all documents.
+  warnings: string[];
+  // Number of graphs actually applied to Spanner (0 for validateOnly).
+  deployed: number;
+}
+
+
+// Upper bound on getOperation polls before we give up on an operation that
+// never reports completion.
+const MAX_OPERATION_POLLS = 60;
+
+// Pause between polls of a running operation.
+const POLL_BACKOFF_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+
+// Waits for an updateDatabaseDdl long-running operation to complete and reports
+// any terminal error. The initial POST returns an Operation (usually not yet
+// `done`); we poll getOperation on its `name` until it is, then judge success
+// by its `error` field.
+async function awaitOperationDone(
+    spanner: SpannerClient,
+    started: {status: number; message?: string; result?: Operation},
+    maxPolls: number,
+    backoffMs: number): Promise<{ok: boolean; error?: string}> {
+  if (started.status !== 200) {
+    return {ok: false, error: started.message || String(started.status)};
+  }
+  let op = started.result;
+  if (!op) {
+    return {
+      ok: false,
+      error: started.message ||
+          'updateDatabaseDdl returned status 200 with no operation body',
+    };
+  }
+  const opName = op.name;
+
+  let polls = 0;
+  while (!op?.done && opName && polls < maxPolls) {
+    if (polls > 0) {
+      await sleep(backoffMs);
+    }
+    polls++;
+    const res = await spanner.getOperation(opName);
+    if (res.status !== 200) {
+      return {ok: false, error: res.message || String(res.status)};
+    }
+    op = res.result;
+  }
+
+  if (!op?.done) {
+    return {
+      ok: false,
+      error: opName ?
+          `operation ${opName} did not complete after ${maxPolls} polls` :
+          'updateDatabaseDdl returned no operation name to poll',
+    };
+  }
+  if (op.error) {
+    return {ok: false, error: op.error.message || `code ${op.error.code}`};
+  }
+  return {ok: true};
+}
+
+
+// Deploys the Spanner Graph for each pre-loaded model. Emits no console output;
+// the generated DDL and any warnings are returned for the caller to print. The
+// models are parsed once by the caller (loadSemanticModels) and shared with the
+// other legs; each carries its originating document name for diagnostics.
+export async function deploySpanner(
+    models: LoadedModel[], ctx: context.ApiContext,
+    options: DeployOptions = {}): Promise<DeployResult> {
+  const spanner = new SpannerClient(ctx);
+  const ddl: string[] = [];
+  const warnings: string[] = [];
+  let deployed = 0;
+  let modelsSeen = 0;
+
+  const fail = (details: string): DeployResult =>
+      ({success: false, details, ddl, warnings, deployed});
+
+  const maxPolls = options.maxOperationPolls ?? MAX_OPERATION_POLLS;
+  const backoffMs = options.pollBackoffMs ?? POLL_BACKOFF_MS;
+
+  for (const {document, model} of models) {
+    modelsSeen++;
+    let targets: SpannerGraphTarget[];
+    let malformed: string[];
+    try {
+      ({targets, malformed} = spannerGraphTargets(model));
+    } catch (err: any) {
+      return fail(`Model '${model.name}' (${document}): ${err.message || err}`);
+    }
+    if (!targets.length) {
+      // A malformed-but-present target must not be reported as "none declared".
+      if (malformed.length) {
+        return fail(
+            `Model '${model.name}' (${document}) declares Spanner Graph ` +
+            `deploymentTarget(s) that could not be parsed: ` +
+            `${malformed.join(', ')}. Expected //spanner.googleapis.com/` +
+            `projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>.`);
+      }
+      return fail(
+          `Model '${model.name}' (${document}) declares no Spanner Graph ` +
+          `deploymentTarget in a GOOGLE custom_extension; nothing to deploy.`);
+    }
+    for (const bad of malformed) {
+      warnings.push(
+          `[${model.name}] ignoring unparseable Spanner Graph target: ${bad}`);
+    }
+
+    for (const target of targets) {
+      const gen = generateSpannerPropertyGraph(model, {
+        graphName: target.graphName,
+      });
+      for (const w of gen.warnings) {
+        warnings.push(`[${model.name} -> ${target.graphName}] ${w}`);
+      }
+      ddl.push(`-- ${target.uri}\n${gen.ddl}`);
+
+      if (options.validateOnly) {
+        continue;
+      }
+
+      const started = await spanner.updateDatabaseDdl(
+          target.project, target.instance, target.database, [gen.ddl]);
+      const outcome =
+          await awaitOperationDone(spanner, started, maxPolls, backoffMs);
+      if (!outcome.ok) {
+        // CREATE OR REPLACE statements are applied one graph at a time, so any
+        // graphs already deployed in this run have mutated the database and are
+        // not rolled back. Surface that alongside the failing target.
+        const partial = deployed ?
+            ` (${deployed} graph(s) already deployed in this run; ` +
+                `CREATE OR REPLACE changes are not rolled back)` :
+            '';
+        return fail(`Failed to deploy '${target.graphName}': ${outcome.error}${
+            partial}`);
+      }
+
+      deployed++;
+    }
+  }
+
+  if (!modelsSeen) {
+    if (options.validateOnly) {
+      warnings.push('No semantic model documents found; nothing to validate.');
+      return {success: true, ddl, warnings, deployed};
+    }
+    return fail('No semantic model documents found; nothing to deploy.');
+  }
+
+  return {success: true, ddl, warnings, deployed};
+}

--- a/toolbox/mdcode/src/libts/semantic/deploy_spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_spanner.ts
@@ -168,8 +168,14 @@ export async function deploySpanner(
         continue;
       }
 
+      // updateDatabaseDdl takes each statement WITHOUT a trailing semicolon:
+      // Spanner's DDL parser rejects one ("Expecting 'EOF' but found ';'" --
+      // verified live), unlike BigQuery's jobs.query, which accepts it. The
+      // generator terminates its DDL with `;` for the printed/golden artifact,
+      // so strip it here for the wire statement only.
+      const statement = gen.ddl.replace(/;\s*$/, '');
       const started = await spanner.updateDatabaseDdl(
-          target.project, target.instance, target.database, [gen.ddl]);
+          target.project, target.instance, target.database, [statement]);
       const outcome =
           await awaitOperationDone(spanner, started, maxPolls, backoffMs);
       if (!outcome.ok) {

--- a/toolbox/mdcode/src/libts/semantic/deployment_target.ts
+++ b/toolbox/mdcode/src/libts/semantic/deployment_target.ts
@@ -1,0 +1,159 @@
+// Reads a model's GOOGLE deployment-target extension and classifies each
+// declared target URI.
+//
+// A semantic model names where its graph deploys with `deploymentTargets` in a
+// GOOGLE `custom_extensions` block (the loader folds a model-level
+// `deployment_target:` key into the same block). Two destination types are
+// recognized here, each an AIP-122 resource name:
+//
+//   BigQuery Graph:
+//     //bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>
+//   Spanner Graph:
+//     //spanner.googleapis.com/projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>
+//
+// The deploy legs (deploy_bigquery, deploy_spanner) and the push-time validator
+// all derive their targets from this one reader, so a `--target all` push
+// parses each model's extension once rather than once per reader.
+//
+// The capture groups are restricted to valid identifier characters: the
+// components are interpolated into DDL unescaped (see the generators), so a
+// permissive `[^/]+` would let backticks or semicolons through. A URI that
+// matches neither destination type is collected as `malformed` (rejected by the
+// validator and named in errors) rather than silently skipped.
+
+import {SemanticModel} from './ir';
+
+
+// Our own vendor tag in the Ossie `custom_extensions` list.
+const GOOGLE_VENDOR = 'GOOGLE';
+
+// A BigQuery Graph deployment target.
+const BQ_GRAPH_TARGET =
+    /^\/\/bigquery\.googleapis\.com\/projects\/([A-Za-z0-9_-]+)\/datasets\/([A-Za-z0-9_-]+)\/propertyGraphs\/([A-Za-z0-9_-]+)$/;
+
+// A Spanner Graph deployment target. Instance and database ids follow Spanner's
+// resource-id grammar (lowercase letters, digits, hyphens); the graph name is a
+// GoogleSQL identifier. As with BigQuery, the segments are interpolated into
+// DDL (the graph name) and into the Spanner Admin API path (project/instance/
+// database), so the character classes stay strict.
+const SPANNER_GRAPH_TARGET =
+    /^\/\/spanner\.googleapis\.com\/projects\/([A-Za-z0-9_-]+)\/instances\/([A-Za-z0-9_-]+)\/databases\/([A-Za-z0-9_-]+)\/propertyGraphs\/([A-Za-z0-9_-]+)$/;
+
+
+export interface BigQueryGraphTarget {
+  project: string;
+  dataset: string;
+  graphName: string;
+  uri: string;
+}
+
+export interface SpannerGraphTarget {
+  project: string;
+  instance: string;
+  database: string;
+  graphName: string;
+  uri: string;
+}
+
+export interface GoogleDeploymentTargets {
+  // Every declared deploymentTarget URI, in declaration order.
+  uris: string[];
+  // The subset that parse as BigQuery Graph targets.
+  bigQuery: BigQueryGraphTarget[];
+  // The subset that parse as Spanner Graph targets.
+  spanner: SpannerGraphTarget[];
+  // URIs that parse as NEITHER a BigQuery nor a Spanner Graph target (a
+  // host/scheme/segment/identifier typo, or an unsupported destination). Kept
+  // so a caller can name the typo instead of silently dropping it.
+  malformed: string[];
+}
+
+
+// Reads a model's GOOGLE custom_extension(s) in a single pass and returns the
+// deployment-target facts every caller derives from them. The extension `data`
+// is an opaque, vendor-serialized JSON string (the loader keeps it verbatim);
+// we own its `deploymentTargets` shape. Throws on malformed extension JSON.
+export function googleDeploymentTargets(model: SemanticModel):
+    GoogleDeploymentTargets {
+  const uris: string[] = [];
+  const bigQuery: BigQueryGraphTarget[] = [];
+  const spanner: SpannerGraphTarget[] = [];
+  const malformed: string[] = [];
+
+  for (const ext of model.customExtensions ?? []) {
+    if (ext.vendorName !== GOOGLE_VENDOR) {
+      continue;
+    }
+
+    let data: any;
+    try {
+      data = JSON.parse(ext.data);
+    } catch {
+      throw new Error(`Model '${
+          model.name}': GOOGLE custom_extension 'data' is not valid JSON.`);
+    }
+
+    const list = data?.deploymentTargets;
+    if (!Array.isArray(list)) {
+      continue;
+    }
+
+    for (const uri of list) {
+      if (typeof uri !== 'string') {
+        continue;
+      }
+      uris.push(uri);
+      const bq = uri.match(BQ_GRAPH_TARGET);
+      if (bq) {
+        bigQuery.push({project: bq[1], dataset: bq[2], graphName: bq[3], uri});
+        continue;
+      }
+      const sp = uri.match(SPANNER_GRAPH_TARGET);
+      if (sp) {
+        spanner.push({
+          project: sp[1],
+          instance: sp[2],
+          database: sp[3],
+          graphName: sp[4],
+          uri,
+        });
+        continue;
+      }
+      // Matches no supported destination type: collect it as malformed
+      // (rejected by the validator) rather than silently ignoring it.
+      malformed.push(uri);
+    }
+  }
+
+  return {uris, bigQuery, spanner, malformed};
+}
+
+
+// The BigQuery Graph deployment targets a model declares, plus any URIs that
+// parse as no supported destination type. A view over googleDeploymentTargets,
+// preserving the historical shape the BigQuery leg and Knowledge Catalog leg
+// consume. Note `malformed` excludes a valid Spanner Graph target: a Spanner
+// URI is a recognized destination, just not a BigQuery one, so it is not
+// reported as a BigQuery typo.
+export function bigQueryGraphTargets(model: SemanticModel):
+    {targets: BigQueryGraphTarget[]; malformed: string[]} {
+  const {bigQuery, malformed} = googleDeploymentTargets(model);
+  return {targets: bigQuery, malformed};
+}
+
+
+// The Spanner Graph deployment targets a model declares, plus any URIs that
+// parse as no supported destination type. Symmetric to bigQueryGraphTargets.
+export function spannerGraphTargets(model: SemanticModel):
+    {targets: SpannerGraphTarget[]; malformed: string[]} {
+  const {spanner, malformed} = googleDeploymentTargets(model);
+  return {targets: spanner, malformed};
+}
+
+
+// Every deploymentTarget URI a model declares, regardless of whether each
+// parses as a supported target. Validation uses this to require that a model
+// declares exactly one deployment target. Throws on malformed extension JSON.
+export function deploymentTargetUris(model: SemanticModel): string[] {
+  return googleDeploymentTargets(model).uris;
+}

--- a/toolbox/mdcode/src/libts/semantic/deployment_target.ts
+++ b/toolbox/mdcode/src/libts/semantic/deployment_target.ts
@@ -69,12 +69,24 @@ export interface GoogleDeploymentTargets {
 }
 
 
+// Memoizes the parse per model object so the several callers within one push
+// (validation, source-project lookup, per-leg routing, each deploy leg) share a
+// single parse rather than re-running JSON.parse + the regexes once per reader.
+// Keyed by model identity: the IR object is stable through a push (the loader,
+// transpile, and inheritance passes each hand on a fixed set of objects) and
+// its customExtensions are not mutated after loading. The returned value is
+// read-only by convention -- no caller mutates its arrays.
+const targetsCache = new WeakMap<SemanticModel, GoogleDeploymentTargets>();
+
 // Reads a model's GOOGLE custom_extension(s) in a single pass and returns the
 // deployment-target facts every caller derives from them. The extension `data`
 // is an opaque, vendor-serialized JSON string (the loader keeps it verbatim);
 // we own its `deploymentTargets` shape. Throws on malformed extension JSON.
 export function googleDeploymentTargets(model: SemanticModel):
     GoogleDeploymentTargets {
+  const cached = targetsCache.get(model);
+  if (cached) return cached;
+
   const uris: string[] = [];
   const bigQuery: BigQueryGraphTarget[] = [];
   const spanner: SpannerGraphTarget[] = [];
@@ -125,7 +137,9 @@ export function googleDeploymentTargets(model: SemanticModel):
     }
   }
 
-  return {uris, bigQuery, spanner, malformed};
+  const result: GoogleDeploymentTargets = {uris, bigQuery, spanner, malformed};
+  targetsCache.set(model, result);
+  return result;
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -48,7 +48,7 @@
 
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
-import {bigQueryGraphTargets} from './deploy_bigquery';
+import {googleDeploymentTargets} from './deployment_target';
 import {AiContext, DataType, Entity, Metric, Relationship, SemanticModel} from './ir';
 
 // Where the `semantic-*` and `schema` system types live: built-in types in
@@ -312,13 +312,16 @@ function entityByName(model: SemanticModel, name: string): Entity|undefined {
 // these shapes so any schema-driven change is a visible, reviewable diff.
 // ---------------------------------------------------------------------------
 
-// semantic-model: the BigQuery Graph deployment target URIs this model deploys
-// to (the same targets the BigQuery leg executes against). Empty data is valid;
-// the aspect is still attached to satisfy the entry type's required_aspects.
+// semantic-model: every recognized graph deployment target URI this model
+// deploys to -- BigQuery Graph and/or Spanner Graph, the same targets the graph
+// legs execute against. Recording both backends keeps the entry faithful for a
+// Spanner-targeted model (so a later `kcmd pull` reconstructs a bound model).
+// Empty data is valid; the aspect is still attached to satisfy required_aspects.
 function modelAspectData(model: SemanticModel): Record<string, any> {
-  const {targets} = bigQueryGraphTargets(model);
+  const {bigQuery, spanner} = googleDeploymentTargets(model);
+  const uris = [...bigQuery, ...spanner].map(t => t.uri);
   return compact({
-    deploymentTargets: targets.length ? targets.map(t => t.uri) : undefined,
+    deploymentTargets: uris.length ? uris : undefined,
   });
 }
 

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -1,0 +1,382 @@
+// Generates Spanner Graph DDL from the Semantic Model IR.
+//
+// The IR (./ir) is pure semantics. This module is one of its consumers, a
+// sibling to ./bigquery: it emits a single `CREATE OR REPLACE PROPERTY GRAPH`
+// statement over the entities' existing Spanner input tables. It shares the IR,
+// the inheritance-resolution pass, and the edge/association shapes with the
+// BigQuery generator, but differs from it in three ways that follow from
+// Spanner Graph's DDL:
+//
+//   1. Input tables are referenced by BARE name -- a property graph lives
+//   inside
+//      one Spanner database and names tables in that same database, so there is
+//      no `project.dataset` qualifier. The graph name is likewise bare.
+//   2. There are NO measures. Spanner Graph has no `MEASURE(...)`; model-level
+//      metrics have no home in it, so each is skipped with a warning (the graph
+//      structure -- nodes, edges, labels, properties -- still deploys).
+//   3. There is NO per-element `OPTIONS` clause. Spanner Graph carries no
+//      description/synonyms on labels or properties, so element metadata is not
+//      emitted here (it rides into Knowledge Catalog instead, as with
+//      BigQuery's graph-level options).
+//
+// See:
+// https://docs.cloud.google.com/spanner/docs/reference/standard-sql/graph-schema-statements
+//
+
+import {Association, Entity, Field, Relationship, SemanticModel} from './ir';
+import {resolveInheritance} from './resolve_inheritance';
+import {stripQualifier} from './sql_expr_utils';
+
+export interface GenerateOptions {
+  graphName?: string;  // default: model.name
+}
+
+export interface GenerateResult {
+  ddl: string;         // CREATE OR REPLACE PROPERTY GRAPH ...
+  warnings: string[];  // skipped metrics, unresolved table refs, etc.
+}
+
+/**
+ * Generates the Spanner Graph DDL for a semantic model.
+ *
+ * The generated statement references the entities' existing Spanner tables; it
+ * does not create them. Returns the DDL plus any warnings collected while
+ * mapping the IR (e.g. metrics dropped because Spanner Graph has no measure).
+ *
+ * Throws when the model yields no valid node table -- it declares no entities,
+ * or every entity lacks a KEY -- since a property graph with an empty NODE
+ * TABLES block is invalid DDL that Spanner would reject.
+ */
+export function generateSpannerPropertyGraph(
+    model: SemanticModel, opts: GenerateOptions = {}): GenerateResult {
+  const warnings: string[] = [];
+
+  // Resolve entity-level inheritance (`extends`) before generating, exactly as
+  // the BigQuery leg does: this flattens each subclass's inherited fields down
+  // and expands `extends` to the full transitive ancestor set, so labels and
+  // property signatures can be read straight off the resolved model.
+  const resolved = resolveInheritance(model);
+  warnings.push(...resolved.warnings);
+
+  const entities = resolved.model.entities ?? [];
+  const relationships = resolved.model.relationships ?? [];
+  const metrics = resolved.model.metrics ?? [];
+
+  // Spanner Graph has no MEASURE, so a model-level metric cannot be expressed
+  // in the graph. Drop each with a warning rather than silently omit it, so an
+  // author who expects a metric in the graph learns it lives elsewhere (a
+  // BigQuery graph, or Knowledge Catalog).
+  for (const metric of metrics) {
+    warnings.push(
+        `metric '${metric.name}' is not emitted: Spanner Graph has no ` +
+        `MEASURE, so model-level metrics have no home in it`);
+  }
+
+  // An abstract entity is conceptual: it has no physical table and produces no
+  // NODE TABLE, surviving only as a LABEL on its concrete descendants.
+  const abstractNames =
+      new Set(entities.filter(e => e.abstract).map(e => e.name));
+
+  // A graph node table requires a non-empty KEY. Skip an entity whose primary
+  // key is empty (and, below, any edge that references it) rather than emit
+  // `KEY()` -- invalid DDL.
+  const skipped = new Set<string>();
+  const validEntities = entities.filter(entity => {
+    if (abstractNames.has(entity.name)) {
+      skipped.add(entity.name);
+      return false;
+    }
+    if (entity.keys && entity.keys.length) return true;
+    warnings.push(
+        `entity '${
+            entity.name}': empty KEY (no primary key); node table skipped, ` +
+        `as a graph node requires a KEY`);
+    skipped.add(entity.name);
+    return false;
+  });
+
+  // An abstract class that is no concrete entity's ancestor produces no graph
+  // element at all; warn and drop it rather than let it vanish silently.
+  const ancestorsUsed = new Set<string>();
+  for (const entity of validEntities) {
+    for (const a of entity.extends ?? []) ancestorsUsed.add(a);
+  }
+  for (const name of abstractNames) {
+    if (!ancestorsUsed.has(name)) {
+      warnings.push(
+          `abstract entity '${name}' is not a supertype of any concrete ` +
+          `entity; it has no table and no descendant to label, so it produces ` +
+          `no graph element`);
+    }
+  }
+
+  // A property graph must have at least one NODE TABLE; an empty `NODE TABLES
+  // ()` block is invalid DDL. Fail loudly (matching the BigQuery leg) rather
+  // than emit a graph Spanner would reject.
+  if (!validEntities.length) {
+    let reason: string;
+    if (!entities.length) {
+      reason = 'the model declares no entities';
+    } else if (entities.every(e => e.abstract)) {
+      reason =
+          'every entity is abstract (a table-less supertype forms no node table)';
+    } else {
+      reason =
+          'every entity was skipped because it has no primary key (a graph node requires a KEY)';
+    }
+    throw new Error(
+        `cannot generate a property graph: ${reason}; a graph requires at ` +
+        `least one NODE TABLE` +
+        (warnings.length ? `\n${warnings.join('\n')}` : ''));
+  }
+
+  // A subclass's `LABEL <ancestor>` block re-lists that ancestor's (flattened)
+  // signature, so the label renderer must reach every label carrier by name:
+  // node-forming entities plus abstract (table-less) supertypes. A concrete
+  // entity dropped for an empty KEY is deliberately excluded.
+  const labelByName =
+      new Map(entities.filter(e => e.abstract || !skipped.has(e.name))
+                  .map(e => [e.name, e]));
+
+  const nodeTables = validEntities.map(
+      entity => renderNodeTable(
+          entity, labelByName, ancestorsUsed.has(entity.name), warnings));
+
+  const entitiesByName = new Map(validEntities.map(e => [e.name, e]));
+  const edgeTables =
+      relationships
+          .filter(rel => {
+            const dangling = [rel.source.entity, rel.destination.entity].filter(
+                n => skipped.has(n));
+            if (!dangling.length) return true;
+            warnings.push(
+                `relationship '${rel.name}': references skipped entity ` +
+                `${dangling.map(n => `'${n}'`).join(', ')}; edge omitted`);
+            return false;
+          })
+          .map(rel => renderEdgeTable(rel, entitiesByName, warnings));
+
+  const graphName = qualifyGraph(resolved.model, opts);
+
+  const blocks: string[] = [
+    `CREATE OR REPLACE PROPERTY GRAPH ${graphName}`,
+    `NODE TABLES (\n${nodeTables.join(',\n')}\n)`,
+  ];
+  if (edgeTables.length) {
+    blocks.push(`EDGE TABLES (\n${edgeTables.join(',\n')}\n)`);
+  }
+
+  return {ddl: blocks.join('\n') + ';\n', warnings: dedupe(warnings)};
+}
+
+
+function renderNodeTable(
+    entity: Entity, labelByName: Map<string, Entity>, isSupertype: boolean,
+    warnings: string[]): string {
+  const table =
+      spannerTable(entity.dataSource, warnings, `entity '${entity.name}'`);
+
+  const properties =
+      entity.fields.map(f => renderFieldProperty(f, entity.name));
+
+  const lines = [
+    line(1, `${table} AS ${entity.name}`),
+    line(2, `KEY(${entity.keys.join(', ')})`),
+  ];
+
+  // A node participating in the hierarchy -- as a subclass (it declares
+  // ancestor LABELs) or as a shared supertype (a subclass binds its label) --
+  // uses an EXPLICIT `DEFAULT LABEL`, mirroring the BigQuery leg's validated
+  // shape; a node outside any hierarchy keeps the implicit form.
+  const hasAncestors = !!(entity.extends && entity.extends.length);
+  if (hasAncestors || isSupertype) lines.push(line(2, 'DEFAULT LABEL'));
+  if (properties.length) lines.push(propertiesBlock(properties));
+
+  // Inheritance: declare one LABEL per transitive ancestor (resolveInheritance
+  // expanded `extends` to the full ancestor set), each re-listing that
+  // ancestor's own properties so `MATCH (:Ancestor)` also matches this
+  // subclass.
+  for (const ancestorName of entity.extends ?? []) {
+    const ancestor = labelByName.get(ancestorName);
+    if (!ancestor) {
+      warnings.push(
+          `entity '${entity.name}' extends '${ancestorName}', which has no ` +
+          `node table and is not abstract (it was dropped, e.g. for an empty ` +
+          `KEY); the '${ancestorName}' label is omitted from '${entity.name}'`);
+      continue;
+    }
+    lines.push(line(2, `LABEL ${ancestorName}`));
+    const signature =
+        ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
+    if (signature.length) lines.push(propertiesBlock(signature));
+  }
+  return lines.join('\n');
+}
+
+
+function renderEdgeTable(
+    rel: Relationship, entitiesByName: Map<string, Entity>,
+    warnings: string[]): string {
+  if (rel.association) {
+    return renderAssociationEdge(
+        rel, rel.association, entitiesByName, warnings);
+  }
+  // A direct foreign key: the SOURCE entity's own table backs the edge (one
+  // edge row per source row). Its FK columns reference the destination's key
+  // columns; the edge is keyed by, and references its source node through, the
+  // source entity's own key.
+  const sourceEntity = entitiesByName.get(rel.source.entity);
+  let backing: string;
+  let sourceKey: string[];
+  if (!sourceEntity) {
+    warnings.push(`relationship '${rel.name}': unknown source entity '${
+        rel.source.entity}'`);
+    backing = quoteIdent(rel.source.entity);
+    sourceKey = rel.source.columns;
+  } else {
+    backing = spannerTable(
+        sourceEntity.dataSource, warnings, `relationship '${rel.name}'`);
+    sourceKey = sourceEntity.keys;
+  }
+
+  const key = sourceKey.join(', ');
+  const lines = [
+    line(1, `${backing} AS ${rel.name}`),
+    line(2, `KEY(${key})`),
+    line(2, `SOURCE KEY(${key}) REFERENCES ${rel.source.entity}(${key})`),
+    line(
+        2,
+        `DESTINATION KEY(${rel.source.columns.join(', ')}) REFERENCES ${
+            rel.destination.entity}(${rel.destination.columns.join(', ')})`),
+  ];
+  return lines.join('\n');
+}
+
+
+// Renders a many-to-many edge backed by an association (junction) table. The
+// edge has its OWN backing table and KEY, each endpoint's SOURCE/DESTINATION
+// KEY names the junction columns referencing that entity's declared key, and
+// the junction's own `fields` become edge PROPERTIES.
+function renderAssociationEdge(
+    rel: Relationship, assoc: Association, entitiesByName: Map<string, Entity>,
+    warnings: string[]): string {
+  const backing =
+      spannerTable(assoc.dataSource, warnings, `relationship '${rel.name}'`);
+  if (!assoc.keys?.length) {
+    warnings.push(
+        `relationship '${rel.name}': association table has no KEY; the edge ` +
+        `table will be invalid (an edge requires a KEY)`);
+  }
+
+  const refColumns = (end: {entity: string; columns: string[]}): string => {
+    const entity = entitiesByName.get(end.entity);
+    if (!entity) {
+      warnings.push(
+          `relationship '${rel.name}': unknown entity '${end.entity}'`);
+      return end.columns.join(', ');
+    }
+    return entity.keys.join(', ');
+  };
+
+  const lines = [
+    line(1, `${backing} AS ${rel.name}`),
+    line(2, `KEY(${assoc.keys.join(', ')})`),
+    line(
+        2,
+        `SOURCE KEY(${assoc.sourceColumns.join(', ')}) REFERENCES ${
+            rel.source.entity}(${refColumns(rel.source)})`),
+    line(
+        2,
+        `DESTINATION KEY(${assoc.destinationColumns.join(', ')}) REFERENCES ${
+            rel.destination.entity}(${refColumns(rel.destination)})`),
+  ];
+
+  const properties =
+      (assoc.fields ?? []).map(f => renderFieldProperty(f, rel.name));
+  if (properties.length) lines.push(propertiesBlock(properties));
+
+  return lines.join('\n');
+}
+
+
+// Renders a field as a graph property: a bare column when the expression is
+// just the column, else `<expr> AS <name>`. Spanner Graph carries no
+// per-property OPTIONS, so no metadata is attached (unlike the BigQuery leg).
+function renderFieldProperty(field: Field, entity: string): string {
+  const expr = fieldExpression(field);
+  const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
+  return local === field.name ? field.name : `${local} AS ${field.name}`;
+}
+
+
+// The target/canonical expression, falling back to the imported vendor SQL when
+// that is all the IR carries (see the Field expression-fidelity contract).
+function fieldExpression(f: Field): string|undefined {
+  return f.expression ?? f.importedExpression;
+}
+
+
+// Maps the IR's `dataSource` to the BARE Spanner table name the graph
+// references. A property graph names input tables within its own database, so
+// only the final segment of a qualified `project.dataset.table` (or any dotted
+// source) is meaningful; the leading qualifiers name where a BigQuery copy
+// lives and have no bearing on the Spanner table. A verbatim query (contains
+// whitespace) cannot back a graph element table, so it is passed through
+// parenthesized with a warning.
+function spannerTable(
+    dataSource: string, warnings: string[], context: string): string {
+  const trimmed = (dataSource ?? '').trim();
+  if (!trimmed) {
+    warnings.push(
+        `${context}: empty data source; the table reference will be invalid`);
+    return quoteIdent('');
+  }
+  if (/\s/.test(trimmed)) {
+    warnings.push(
+        `${context}: data source '${
+            trimmed}' looks like a query, not a table reference; ` +
+        `emitting it verbatim (a graph element table requires a table)`);
+    return `(${trimmed})`;
+  }
+  const last = trimmed.split('.').map(unquote).pop() ?? trimmed;
+  return quoteIdent(last);
+}
+
+
+// Builds the bare graph name from opts/model. Unlike BigQuery -- where the
+// graph name is `project.dataset.name` -- a Spanner graph lives in one database
+// and is named by a single identifier.
+function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
+  return quoteIdent(opts.graphName ?? model.name);
+}
+
+
+// Renders a Spanner GoogleSQL identifier: bare when it is a simple identifier,
+// else backtick-quoted (with any backtick escaped). Graph names, table names,
+// and the like flow through here so a hyphenated or otherwise non-simple name
+// does not produce invalid DDL.
+function quoteIdent(name: string): string {
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) return name;
+  return `\`${name.replace(/`/g, '\\`')}\``;
+}
+
+function unquote(part: string): string {
+  return part.replace(/^[`"]/, '').replace(/[`"]$/, '');
+}
+
+
+// Indentation: one nesting level == one INDENT, matching the BigQuery leg so
+// the two generators' output reads consistently.
+const INDENT = '  ';
+const pad = (depth: number): string => INDENT.repeat(depth);
+const line = (depth: number, text: string): string => `${pad(depth)}${text}`;
+const list = (depth: number, lines: string[]): string =>
+    lines.map(l => line(depth, l)).join(',\n');
+
+function propertiesBlock(properties: string[]): string {
+  return `${line(2, 'PROPERTIES(')}\n${list(3, properties)}\n${line(2, ')')}`;
+}
+
+function dedupe(items: string[]): string[] {
+  return [...new Set(items)];
+}

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -338,8 +338,35 @@ function spannerTable(
         `emitting it verbatim (a graph element table requires a table)`);
     return `(${trimmed})`;
   }
-  const last = trimmed.split('.').map(unquote).pop() ?? trimmed;
+  const last = splitDotted(trimmed).map(unquote).pop() ?? trimmed;
   return quoteIdent(last);
+}
+
+
+// Splits a dotted source into its segments, treating a backtick- or
+// double-quote-delimited segment as opaque so a dot INSIDE quotes does not
+// split an identifier: `proj.ds.`weird.name`` yields ['proj', 'ds',
+// '`weird.name`'], not a spurious break inside the quoted table name.
+function splitDotted(source: string): string[] {
+  const parts: string[] = [];
+  let cur = '';
+  let quote: string|null = null;
+  for (const ch of source) {
+    if (quote) {
+      cur += ch;
+      if (ch === quote) quote = null;
+    } else if (ch === '`' || ch === '"') {
+      quote = ch;
+      cur += ch;
+    } else if (ch === '.') {
+      parts.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  parts.push(cur);
+  return parts;
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -9,6 +9,7 @@
 // they read the GOOGLE deployment-target extension the BigQuery leg owns.
 
 import {BigQueryClient} from '../gcp/bigquery';
+
 import {googleDeploymentTargets} from './deploy_bigquery';
 import {SemanticModel} from './ir';
 import {LoadedModel} from './loader';
@@ -32,27 +33,33 @@ export function validatePushRequirements(models: LoadedModel[]): string[] {
     }
 
     // Every model must declare exactly one deployment target -- a single
-    // BigQuery Graph URI (we do not support zero or several graphs per model).
+    // BigQuery Graph OR Spanner Graph URI (we do not support zero or several
+    // graphs per model). The target's host selects which deploy leg runs.
     if (deployInfo.uris.length !== 1) {
       errors.push(
           `model '${model.name}' (${document}) declares ${
-              deployInfo.uris.length} deploymentTargets; exactly one BigQuery ` +
-          `Graph target is required under its GOOGLE custom_extension.`);
-    } else if (deployInfo.malformed.length) {
-      // The single target is present but is not a valid BigQuery Graph URI.
+              deployInfo.uris
+                  .length} deploymentTargets; exactly one BigQuery ` +
+          `Graph or Spanner Graph target is required under its GOOGLE ` +
+          `custom_extension.`);
+    } else if (deployInfo.bigQuery.length + deployInfo.spanner.length === 0) {
+      // The single target is present but is not a supported graph URI.
       errors.push(
           `model '${model.name}' (${document}) deploymentTarget '${
-              deployInfo.malformed[0]}' is not a valid BigQuery Graph URI; ` +
-          `expected //bigquery.googleapis.com/projects/<p>/datasets/<d>/` +
-          `propertyGraphs/<g>.`);
+              deployInfo.malformed[0]}' is not a valid BigQuery Graph or ` +
+          `Spanner Graph URI; expected //bigquery.googleapis.com/projects/<p>/` +
+          `datasets/<d>/propertyGraphs/<g> or //spanner.googleapis.com/` +
+          `projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>.`);
     }
 
     // A model that targets a BigQuery graph must have every metric resolve to a
     // single entity, or the metric cannot lower to a MEASURE and would be
     // silently dropped from the graph. The loader sets metric.entity only when
     // the expression resolves to exactly one entity, so an unset entity is the
-    // "references zero or multiple entities" case.
-    if (deployInfo.targets.length > 0) {
+    // "references zero or multiple entities" case. Spanner Graph has no
+    // MEASURE, so it imposes no such requirement (its metrics are dropped by
+    // design).
+    if (deployInfo.bigQuery.length > 0) {
       for (const metric of model.metrics ?? []) {
         if (!metric.entity) {
           errors.push(
@@ -68,12 +75,13 @@ export function validatePushRequirements(models: LoadedModel[]): string[] {
 }
 
 
-// Live pre-flight over the same models: confirms every entity's BigQuery source
-// table is reachable BEFORE any destination leg runs, so a push -- to BigQuery
-// or to Knowledge Catalog -- fails fast when the model could not deploy, rather
-// than surfacing a missing table only once the BigQuery leg executes its DDL.
-// The entity sources are BigQuery tables regardless of --target, so this runs
-// for every destination and for --validate-only.
+// Live pre-flight over the BigQuery-targeting models: confirms every entity's
+// BigQuery source table is reachable BEFORE any destination leg runs, so a push
+// fails fast when the model could not deploy, rather than surfacing a missing
+// table only once the BigQuery leg executes its DDL. The caller passes only the
+// models whose deployment target is a BigQuery Graph; a Spanner-targeting
+// model's sources are Spanner tables (probed against a different system) and
+// are not checked here.
 //
 // Each distinct source is probed with a dry-run query (`SELECT 1 FROM <ref>`,
 // suffixed `WHERE FALSE` so it scans no data),
@@ -81,22 +89,26 @@ export function validatePushRequirements(models: LoadedModel[]): string[] {
 // covers every reference form the generator emits -- a three-part
 // `project.dataset.table`, a four-part federated REST-catalog / Lakehouse name
 // (e.g. an Apache Iceberg table via BigLake), and quoted identifiers -- rather
-// than only a three-part name. A source the loader kept verbatim because it is a
-// query (contains whitespace) is not a table and is skipped. The dry-run is
-// billed to the model's BigQuery deployment-target project (the same project the
-// deploy runs against), falling back to `defaultProject`. Each distinct (billing
-// project, reference) pair is probed once. Returns one message per unreachable
-// table (empty when all pass).
+// than only a three-part name. A source the loader kept verbatim because it is
+// a query (contains whitespace) is not a table and is skipped. The dry-run is
+// billed to the model's BigQuery deployment-target project (the same project
+// the deploy runs against), falling back to `defaultProject`. Each distinct
+// (billing project, reference) pair is probed once. Returns one message per
+// unreachable table (empty when all pass).
 export async function validateBigQueryDataSources(
     models: LoadedModel[], bq: BigQueryClient,
     defaultProject: string): Promise<string[]> {
   // Dedup by billing project + reference so a table shared across
   // entities/models is probed once; keep the first reference for a locatable
   // error message.
-  const refs = new Map<string, {
-    project: string; ref: string; document: string; model: string;
+  const refs = new Map < string, {
+    project: string;
+    ref: string;
+    document: string;
+    model: string;
     entity: string;
-  }>();
+  }
+  >();
   for (const {document, model} of models) {
     const project = billingProject(model, defaultProject);
     for (const entity of model.entities ?? []) {
@@ -105,7 +117,11 @@ export async function validateBigQueryDataSources(
       const key = `${project}\u0000${ref}`;
       if (!refs.has(key)) {
         refs.set(key, {
-          project, ref, document, model: model.name, entity: entity.name,
+          project,
+          ref,
+          document,
+          model: model.name,
+          entity: entity.name,
         });
       }
     }
@@ -113,20 +129,20 @@ export async function validateBigQueryDataSources(
 
   const errors: string[] = [];
   for (const {project, ref, document, model, entity} of refs.values()) {
-    const res =
-        await bq.query(
+    const res = await bq.query(
         project, `SELECT 1 FROM \`${ref}\` WHERE FALSE`, undefined, true);
     if (res.status === 200) continue;
     const msg = res.message?.trim() || `HTTP ${res.status}`;
     const why = /not found/i.test(msg) ?
         'does not exist' :
         /access denied|permission denied|not authorized|does not have permission/i
-                .test(msg) ?
+            .test(msg) ?
         'is not accessible (permission denied)' :
         `could not be verified (${msg})`;
     errors.push(
         `entity '${entity}' in model '${model}' (${document}) references ` +
-        `BigQuery table '${ref}', which ${why}; the model cannot be deployed. ` +
+        `BigQuery table '${ref}', which ${
+            why}; the model cannot be deployed. ` +
         `Create the table or grant access to it, or fix the entity's source.`);
   }
   return errors;
@@ -141,7 +157,8 @@ export async function validateBigQueryDataSources(
 // already rejected a malformed GOOGLE extension.
 function billingProject(model: SemanticModel, defaultProject: string): string {
   try {
-    return googleDeploymentTargets(model).targets[0]?.project ?? defaultProject;
+    return googleDeploymentTargets(model).bigQuery[0]?.project ??
+        defaultProject;
   } catch {
     return defaultProject;
   }

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -122,6 +122,19 @@ export function resolveTargets(target?: string|boolean): PushTarget[]|
 }
 
 
+// Whether the user explicitly named destinations (a comma-separated list), as
+// opposed to the omitted default or the `all` keyword. A graph leg the user
+// named directly but that no model targets is a misconfiguration (hard error);
+// the same leg pulled in only by `all`/default is a clean skip, because the
+// model is simply bound to a different backend.
+export function isExplicitSelection(target?: string|boolean): boolean {
+  if (typeof target !== 'string') return false;
+  const tokens =
+      target.toLowerCase().split(',').map(t => t.trim()).filter(t => t.length);
+  return tokens.length > 0 && !tokens.includes('all');
+}
+
+
 // True when a loaded model declares a deployment target of the given graph type
 // ('bigquery' or 'spanner'). Used to route each model to the leg that can
 // deploy it. Safe by the time it runs: validatePushRequirements has already
@@ -308,33 +321,53 @@ export async function push(options: PushOptions): Promise<number> {
 
     // Live pre-flight, before any destination runs: every BigQuery-targeting
     // model's source table must be reachable, so a push fails fast when the
-    // model could not deploy. Only the BigQuery-targeting models are probed
-    // (their sources are BigQuery tables); a Spanner model's sources live in
-    // Spanner. Runs for every --target and for --validate-only.
-    const accessErrors = await validateBigQueryDataSources(
-        bqModels, new BigQueryClient(ctx), source.project ?? ctx.project);
-    if (accessErrors.length) {
-      for (const e of accessErrors) {
-        console.error(`Error: ${e}`);
+    // model could not deploy. Scoped to a run that actually touches BigQuery:
+    // only when the BigQuery leg is requested (default `all` includes it) and a
+    // model targets it -- a Spanner-only or kc-only push does not query
+    // BigQuery tables, so probing them would fail a run on a target the user
+    // did not request. A Spanner model's sources live in Spanner and are not
+    // checked here. Runs for --validate-only too.
+    if (targets.includes('bigquery') && bqModels.length) {
+      const accessErrors = await validateBigQueryDataSources(
+          bqModels, new BigQueryClient(ctx), source.project ?? ctx.project);
+      if (accessErrors.length) {
+        for (const e of accessErrors) {
+          console.error(`Error: ${e}`);
+        }
+        return 1;
       }
-      return 1;
     }
+
+    // A graph leg the user named explicitly (not via `all`/default) but that no
+    // model targets is a misconfiguration, not a no-op: fail rather than report
+    // success having deployed nothing. A leg pulled in only by `all`/default is
+    // skipped quietly, since the model is simply bound to another backend.
+    const explicit = isExplicitSelection(options.target);
 
     // Run the resolved destinations in canonical order (BigQuery first); the
     // early return below fails fast, skipping later legs when an earlier one
-    // fails. A graph leg with no model targeting it is a clean no-op: the
-    // models are targeted at another backend, not misconfigured.
+    // fails.
     for (const target of targets) {
       let code = 0;
       if (target === 'bigquery') {
         if (bqModels.length) {
           code = await pushBigQuery(bqModels, ctx, options);
+        } else if (explicit) {
+          console.error(
+              'Error: --target requested BigQuery Graph, but no model declares ' +
+              'a BigQuery Graph deployment target.');
+          return 1;
         } else {
           console.log('No model targets BigQuery Graph; skipping.');
         }
       } else if (target === 'spanner') {
         if (spannerModels.length) {
           code = await pushSpanner(spannerModels, ctx, options);
+        } else if (explicit) {
+          console.error(
+              'Error: --target requested Spanner Graph, but no model declares ' +
+              'a Spanner Graph deployment target.');
+          return 1;
         } else {
           console.log('No model targets Spanner Graph; skipping.');
         }

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -5,25 +5,27 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import * as kcmd from '../libts';
-import * as dataplex from '../libts/gcp/dataplex';
+import {BigQueryClient} from '../libts/gcp/bigquery';
 import * as context from '../libts/gcp/context';
-import { Sources } from '../libts/source';
-import { SemanticModelLayout } from '../libts/layouts/semantic-model';
-import { SemanticModelSource } from '../libts/sources/semantic-model';
+import * as dataplex from '../libts/gcp/dataplex';
+import {SemanticModelLayout} from '../libts/layouts/semantic-model';
+import {convertOwlToOsi} from '../libts/semantic/converters/owl/convert';
 import * as deploy from '../libts/semantic/deploy_bigquery';
 import * as kc from '../libts/semantic/deploy_knowledge_catalog';
-import {BigQueryClient} from '../libts/gcp/bigquery';
+import * as deploySpannerLeg from '../libts/semantic/deploy_spanner';
+import {googleDeploymentTargets} from '../libts/semantic/deployment_target';
 import {LoadedModel, loadSemanticModels} from '../libts/semantic/loader';
-import {transpileModels} from '../libts/semantic/transpile';
-import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
 import {serializeModel} from '../libts/semantic/osi_converter';
-import {convertOwlToOsi} from '../libts/semantic/converters/owl/convert';
+import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
+import {transpileModels} from '../libts/semantic/transpile';
 import {validateBigQueryDataSources, validatePushRequirements} from '../libts/semantic/validate';
+import {Sources} from '../libts/source';
+import {SemanticModelSource} from '../libts/sources/semantic-model';
 
 
 export interface InitOptions {
   entryGroup?: string;
-  bigqueryDataset?: string | string[];
+  bigqueryDataset?: string|string[];
   kb?: string;
   semanticModel?: string;
   pull?: boolean;
@@ -62,20 +64,20 @@ export interface PushOptions {
   // Rewrite vendor-dialect expressions (e.g. Snowflake/Databricks) to GoogleSQL
   // before deploying, filling any target `expression` the loader left unset
   // because only an `importedExpression` was supplied. Off by default (a model
-  // authored in GoogleSQL/ANSI needs nothing). Runs once over the shared models,
-  // so both the BigQuery and Knowledge Catalog legs see the filled expressions.
-  // Semantic-model push only. See ../libts/semantic/transpile.
+  // authored in GoogleSQL/ANSI needs nothing). Runs once over the shared
+  // models, so both the BigQuery and Knowledge Catalog legs see the filled
+  // expressions. Semantic-model push only. See ../libts/semantic/transpile.
   transpile?: boolean;
 }
 
 
-export type PushTarget = 'bigquery' | 'kc';
+export type PushTarget = 'bigquery'|'spanner'|'kc';
 
 // All known semantic-model push destinations, in canonical run order. `all`
 // expands to this list, and resolveTargets always emits in this order so the
 // run is deterministic and BigQuery-first fail-fast holds regardless of how the
 // user ordered the flag. Append new destinations here as they land.
-const DESTINATIONS: PushTarget[] = ['bigquery', 'kc'];
+const DESTINATIONS: PushTarget[] = ['bigquery', 'spanner', 'kc'];
 
 // The default when --target is omitted: push to every destination.
 const DEFAULT_TARGET = 'all';
@@ -84,6 +86,8 @@ const DEFAULT_TARGET = 'all';
 const TARGET_ALIASES: Record<string, PushTarget> = {
   bq: 'bigquery',
   bigquery: 'bigquery',
+  spanner: 'spanner',
+  sp: 'spanner',
   kc: 'kc',
 };
 
@@ -92,16 +96,17 @@ const TARGET_ALIASES: Record<string, PushTarget> = {
 // Accepts a comma-separated list ('bq,kc'), the keyword 'all' (every
 // destination), and defaults to 'all'. The result is always in canonical
 // DESTINATIONS order.
-export function resolveTargets(target?: string | boolean): PushTarget[] | undefined {
+export function resolveTargets(target?: string|boolean): PushTarget[]|
+    undefined {
   // cac yields boolean `true` for a bare `--target` (no value); treat any
   // non-string as an invalid selection so the caller reports it rather than
   // throwing on `.toLowerCase()`.
   if (target !== undefined && typeof target !== 'string') return undefined;
   const tokens = (target ?? DEFAULT_TARGET)
-    .toLowerCase()
-    .split(',')
-    .map(t => t.trim())
-    .filter(t => t.length);
+                     .toLowerCase()
+                     .split(',')
+                     .map(t => t.trim())
+                     .filter(t => t.length);
   if (!tokens.length) return undefined;
   const selected = new Set<PushTarget>();
   for (const tok of tokens) {
@@ -117,28 +122,44 @@ export function resolveTargets(target?: string | boolean): PushTarget[] | undefi
 }
 
 
+// True when a loaded model declares a deployment target of the given graph type
+// ('bigquery' or 'spanner'). Used to route each model to the leg that can
+// deploy it. Safe by the time it runs: validatePushRequirements has already
+// rejected a malformed GOOGLE extension, so googleDeploymentTargets does not
+// throw; the try/catch is a defensive fallback that routes an unparseable model
+// nowhere.
+function hasTargetType(
+    loaded: LoadedModel, type: 'bigquery'|'spanner'): boolean {
+  try {
+    const t = googleDeploymentTargets(loaded.model);
+    return type === 'bigquery' ? t.bigQuery.length > 0 : t.spanner.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+
 export async function init(options: InitOptions): Promise<number> {
   const ctx = context.ApiContext.default();
 
   let manifest: kcmd.CatalogManifest;
   if (options.entryGroup) {
-    manifest = await kcmd.CatalogManifest.initWithEntryGroup(options.entryGroup, ctx);
-  }
-  else if (options.kb) {
-    manifest = await kcmd.CatalogManifest.initWithKnowledgeBase(options.kb, ctx);
-  }
-  else if (options.bigqueryDataset) {
+    manifest =
+        await kcmd.CatalogManifest.initWithEntryGroup(options.entryGroup, ctx);
+  } else if (options.kb) {
+    manifest =
+        await kcmd.CatalogManifest.initWithKnowledgeBase(options.kb, ctx);
+  } else if (options.bigqueryDataset) {
     let datasets = '';
     if (Array.isArray(options.bigqueryDataset)) {
       datasets = options.bigqueryDataset.join(',');
-    }
-    else {
+    } else {
       datasets = options.bigqueryDataset!;
     }
     manifest = await kcmd.CatalogManifest.initWithBigQuery(datasets, ctx);
-  }
-  else if (options.semanticModel) {
-    manifest = await kcmd.CatalogManifest.initWithSemanticModel(options.semanticModel, ctx);
+  } else if (options.semanticModel) {
+    manifest = await kcmd.CatalogManifest.initWithSemanticModel(
+        options.semanticModel, ctx);
     const source = manifest.source as SemanticModelSource;
     // Provision the destination entry group now, at init, so push writes only
     // entries -- matching how the standard layout operates (its push creates
@@ -146,19 +167,19 @@ export async function init(options: InitOptions): Promise<number> {
     // (409) is success.
     const catalog = new dataplex.CatalogClient(ctx);
     const res = await catalog.createEntryGroup(
-      source.project, source.location, source.entryGroup);
+        source.project, source.location, source.entryGroup);
     if (res.status !== 200 && res.status !== 409) {
       console.error(
-        `Error: failed to create entry group '${source.name}': ` +
-        `${res.message || res.status}`);
+          `Error: failed to create entry group '${source.name}': ` +
+          `${res.message || res.status}`);
       return 1;
     }
     fs.mkdirSync(
-      path.join('catalog', 'EntryGroups', source.entryGroup),
-      { recursive: true });
-  }
-  else {
-    console.error('Error: Must provide --entry-group, --bigquery-dataset, --kb, or --semantic-model');
+        path.join('catalog', 'EntryGroups', source.entryGroup),
+        {recursive: true});
+  } else {
+    console.error(
+        'Error: Must provide --entry-group, --bigquery-dataset, --kb, or --semantic-model');
     return 1;
   }
 
@@ -174,7 +195,8 @@ export async function init(options: InitOptions): Promise<number> {
 
 
 export interface PullOptions {
-  // Reconstruct + report only; never writes a file. Mirrors push --validate-only.
+  // Reconstruct + report only; never writes a file. Mirrors push
+  // --validate-only.
   dryRun?: boolean;
   // Authorize replacing a differently-named local model with the catalog's.
   // Without it, a pull whose catalog model id differs from the local model on
@@ -201,8 +223,7 @@ export async function pull(options: PullOptions = {}): Promise<number> {
   if (result.success) {
     console.log('Successfully updated local snapshot.');
     return 0;
-  }
-  else {
+  } else {
     console.error('Error pulling catalog entries:', result.details);
     return 1;
   }
@@ -222,8 +243,9 @@ export async function push(options: PushOptions): Promise<number> {
     const targets = resolveTargets(options.target);
     if (!targets) {
       console.error(
-        `Error: invalid --target '${options.target}'; expected bq, kc, all, ` +
-        `or a comma-separated list (e.g. bq,kc).`);
+          `Error: invalid --target '${
+              options.target}'; expected bq, spanner, kc, all, ` +
+          `or a comma-separated list (e.g. bq,kc).`);
       return 1;
     }
 
@@ -276,12 +298,21 @@ export async function push(options: PushOptions): Promise<number> {
       return 1;
     }
 
-    // Live pre-flight over the same models, before any destination runs: every
-    // entity's BigQuery source table must be reachable, so a push to either
-    // BigQuery or Knowledge Catalog fails fast when the model could not deploy.
-    // Runs for every --target and for --validate-only.
+    // A model declares exactly one deployment target (enforced above); its host
+    // selects which graph leg deploys it. Partition the shared models by target
+    // type so each leg only sees the models it can deploy, and Knowledge
+    // Catalog (which records every model regardless of graph backend) sees them
+    // all.
+    const bqModels = models.filter(m => hasTargetType(m, 'bigquery'));
+    const spannerModels = models.filter(m => hasTargetType(m, 'spanner'));
+
+    // Live pre-flight, before any destination runs: every BigQuery-targeting
+    // model's source table must be reachable, so a push fails fast when the
+    // model could not deploy. Only the BigQuery-targeting models are probed
+    // (their sources are BigQuery tables); a Spanner model's sources live in
+    // Spanner. Runs for every --target and for --validate-only.
     const accessErrors = await validateBigQueryDataSources(
-        models, new BigQueryClient(ctx), source.project ?? ctx.project);
+        bqModels, new BigQueryClient(ctx), source.project ?? ctx.project);
     if (accessErrors.length) {
       for (const e of accessErrors) {
         console.error(`Error: ${e}`);
@@ -291,11 +322,25 @@ export async function push(options: PushOptions): Promise<number> {
 
     // Run the resolved destinations in canonical order (BigQuery first); the
     // early return below fails fast, skipping later legs when an earlier one
-    // fails.
+    // fails. A graph leg with no model targeting it is a clean no-op: the
+    // models are targeted at another backend, not misconfigured.
     for (const target of targets) {
-      const code = target === 'bigquery'
-        ? await pushBigQuery(models, ctx, options)
-        : await pushKnowledgeCatalog(models, ctx, options, source);
+      let code = 0;
+      if (target === 'bigquery') {
+        if (bqModels.length) {
+          code = await pushBigQuery(bqModels, ctx, options);
+        } else {
+          console.log('No model targets BigQuery Graph; skipping.');
+        }
+      } else if (target === 'spanner') {
+        if (spannerModels.length) {
+          code = await pushSpanner(spannerModels, ctx, options);
+        } else {
+          console.log('No model targets Spanner Graph; skipping.');
+        }
+      } else {
+        code = await pushKnowledgeCatalog(models, ctx, options, source);
+      }
       if (code !== 0) return code;
     }
     return 0;
@@ -313,26 +358,25 @@ export async function push(options: PushOptions): Promise<number> {
   ];
   for (const [set, flag] of semanticOnlyFlags) {
     if (set) {
-      console.warn(
-          `Warning: ${flag} only applies to a semantic-model push; ignoring it.`);
+      console.warn(`Warning: ${
+          flag} only applies to a semantic-model push; ignoring it.`);
     }
   }
 
   const catalog = new dataplex.CatalogClient(ctx);
   const sync = new kcmd.CatalogSync(catalog, snapshot);
 
-  console.log(options.validateOnly
-    ? 'Validating catalog entries...'
-    : 'Pushing catalog entries...');
+  console.log(
+      options.validateOnly ? 'Validating catalog entries...' :
+                             'Pushing catalog entries...');
   const result = await sync.push(options);
 
   if (result.success) {
-    console.log(options.validateOnly
-      ? 'Validation complete; no changes applied.'
-      : 'Successfully pushed catalog entries.');
+    console.log(
+        options.validateOnly ? 'Validation complete; no changes applied.' :
+                               'Successfully pushed catalog entries.');
     return 0;
-  }
-  else {
+  } else {
     console.error('Error pushing catalog entries:', result.details);
     return 1;
   }
@@ -342,11 +386,11 @@ export async function push(options: PushOptions): Promise<number> {
 // Deploys the semantic model's BigQuery Graph leg (over the pre-loaded models)
 // and prints the result. Returns a process exit code (0 on success).
 async function pushBigQuery(
-  models: LoadedModel[], ctx: context.ApiContext,
-  options: PushOptions): Promise<number> {
-  console.log(options.validateOnly
-    ? 'Validating semantic model for BigQuery Graph...'
-    : 'Pushing semantic model (BigQuery Graph)...');
+    models: LoadedModel[], ctx: context.ApiContext,
+    options: PushOptions): Promise<number> {
+  console.log(
+      options.validateOnly ? 'Validating semantic model for BigQuery Graph...' :
+                             'Pushing semantic model (BigQuery Graph)...');
   const result = await deploy.deployBigQuery(models, ctx, options);
 
   for (const w of result.warnings) {
@@ -363,9 +407,41 @@ async function pushBigQuery(
     console.error('Error pushing semantic model to BigQuery:', result.details);
     return 1;
   }
-  console.log(options.validateOnly
-    ? 'Validation complete; no changes applied.'
-    : `Deployed ${result.deployed} BigQuery Graph(s).`);
+  console.log(
+      options.validateOnly ? 'Validation complete; no changes applied.' :
+                             `Deployed ${result.deployed} BigQuery Graph(s).`);
+  return 0;
+}
+
+
+// Deploys the semantic model's Spanner Graph leg (over the pre-loaded models)
+// and prints the result. Sibling to pushBigQuery. Returns a process exit code
+// (0 on success).
+async function pushSpanner(
+    models: LoadedModel[], ctx: context.ApiContext,
+    options: PushOptions): Promise<number> {
+  console.log(
+      options.validateOnly ? 'Validating semantic model for Spanner Graph...' :
+                             'Pushing semantic model (Spanner Graph)...');
+  const result = await deploySpannerLeg.deploySpanner(models, ctx, options);
+
+  for (const w of result.warnings) {
+    console.warn(`Warning: ${w}`);
+  }
+  if (options.print) {
+    console.log('-- Spanner Graph --');
+    for (const block of result.ddl) {
+      console.log(`${block}\n`);
+    }
+  }
+
+  if (!result.success) {
+    console.error('Error pushing semantic model to Spanner:', result.details);
+    return 1;
+  }
+  console.log(
+      options.validateOnly ? 'Validation complete; no changes applied.' :
+                             `Deployed ${result.deployed} Spanner Graph(s).`);
   return 0;
 }
 
@@ -375,11 +451,12 @@ async function pushBigQuery(
 // scope (project.location.entryGroup). Returns a process exit code (0 on
 // success).
 async function pushKnowledgeCatalog(
-  models: LoadedModel[], ctx: context.ApiContext,
-  options: PushOptions, source: SemanticModelSource): Promise<number> {
-  console.log(options.validateOnly
-    ? 'Validating semantic model for Knowledge Catalog...'
-    : 'Pushing semantic model (Knowledge Catalog)...');
+    models: LoadedModel[], ctx: context.ApiContext, options: PushOptions,
+    source: SemanticModelSource): Promise<number> {
+  console.log(
+      options.validateOnly ?
+          'Validating semantic model for Knowledge Catalog...' :
+          'Pushing semantic model (Knowledge Catalog)...');
   const result = await kc.deployKnowledgeCatalog(models, ctx, {
     project: source.project,
     location: source.location,
@@ -405,26 +482,26 @@ async function pushKnowledgeCatalog(
 
   if (!result.success) {
     console.error(
-      'Error pushing semantic model to Knowledge Catalog:', result.details);
+        'Error pushing semantic model to Knowledge Catalog:', result.details);
     return 1;
   }
   const n = result.created + result.updated;
-  const removed = result.deleted
-    ? `; removed ${result.deleted} orphaned entr${
-        result.deleted === 1 ? 'y' : 'ies'}`
-    : '';
-  const linked = result.linked
-    ? `; linked ${result.linked} relationship${result.linked === 1 ? '' : 's'}`
-    : '';
-  const unlinked = result.unlinked
-    ? `; unlinked ${result.unlinked} orphaned link${
-        result.unlinked === 1 ? '' : 's'}`
-    : '';
-  console.log(options.validateOnly
-    ? 'Validation complete; no changes applied.'
-    : `Wrote ${result.created} new and ${result.updated} updated ` +
-        `Knowledge Catalog entr${n === 1 ? 'y' : 'ies'}${removed}${linked}${
-            unlinked}.`);
+  const removed = result.deleted ? `; removed ${result.deleted} orphaned entr${
+                                       result.deleted === 1 ? 'y' : 'ies'}` :
+                                   '';
+  const linked = result.linked ? `; linked ${result.linked} relationship${
+                                     result.linked === 1 ? '' : 's'}` :
+                                 '';
+  const unlinked = result.unlinked ?
+      `; unlinked ${result.unlinked} orphaned link${
+          result.unlinked === 1 ? '' : 's'}` :
+      '';
+  console.log(
+      options.validateOnly ?
+          'Validation complete; no changes applied.' :
+          `Wrote ${result.created} new and ${result.updated} updated ` +
+              `Knowledge Catalog entr${n === 1 ? 'y' : 'ies'}${removed}${
+                  linked}${unlinked}.`);
   return 0;
 }
 
@@ -438,16 +515,17 @@ async function pushKnowledgeCatalog(
 // unless --force-remove authorizes deleting the stale local model first.
 // Returns a process exit code (0 on success).
 async function pullSemanticModel(
-  ctx: context.ApiContext, snapshot: kcmd.CatalogSnapshot,
-  options: PullOptions): Promise<number> {
+    ctx: context.ApiContext, snapshot: kcmd.CatalogSnapshot,
+    options: PullOptions): Promise<number> {
   // The semantic-model source always resolves to the SemanticModel layout
   // (see createLayout), so these casts are safe.
   const layout = snapshot.layout as SemanticModelLayout;
   const source = snapshot.manifest.source as SemanticModelSource;
 
-  console.log(options.dryRun
-    ? 'Reconstructing semantic model from Knowledge Catalog (dry run)...'
-    : 'Pulling semantic model from Knowledge Catalog...');
+  console.log(
+      options.dryRun ?
+          'Reconstructing semantic model from Knowledge Catalog (dry run)...' :
+          'Pulling semantic model from Knowledge Catalog...');
 
   const catalog = new dataplex.CatalogClient(ctx);
   const result = await pullKnowledgeCatalog(catalog, {
@@ -473,28 +551,28 @@ async function pullSemanticModel(
   // Compare by the on-disk path each name maps to, not the raw name: a catalog
   // model name and a local document whose names sanitize to the same file (e.g.
   // 'a/b' -> 'a_b.yaml') are the same model, not a stale conflict.
-  const catalogPaths = new Set(result.models.map(m => layout.modelPath(m.name)));
+  const catalogPaths =
+      new Set(result.models.map(m => layout.modelPath(m.name)));
   const staleLocal = layout.modelDocuments()
-    .map(d => d.name)
-    .filter(n => !catalogPaths.has(layout.modelPath(n)));
+                         .map(d => d.name)
+                         .filter(n => !catalogPaths.has(layout.modelPath(n)));
   if (staleLocal.length) {
     if (!options.forceRemove) {
       const localList = staleLocal.map(n => `'${n}'`).join(', ');
       const catalogList = [...catalogNames].map(n => `'${n}'`).join(', ');
       console.error(
-        `Error: local model(s) ${localList} do not match the catalog ` +
-        `model ${catalogList} in this entry group. An entry group holds ` +
-        `one model, so pull will not leave two behind. Re-run with ` +
-        `--force-remove to delete the local model(s) and pull the ` +
-        `catalog's.`);
+          `Error: local model(s) ${localList} do not match the catalog ` +
+          `model ${catalogList} in this entry group. An entry group holds ` +
+          `one model, so pull will not leave two behind. Re-run with ` +
+          `--force-remove to delete the local model(s) and pull the ` +
+          `catalog's.`);
       return 1;
     }
     for (const name of staleLocal) {
       const p = layout.modelPath(name);
       if (options.dryRun) {
         console.log(`  would remove ${p}`);
-      }
-      else {
+      } else {
         layout.removeModelDocument(name);
         console.log(`  removed ${p}`);
       }
@@ -524,26 +602,29 @@ async function pullSemanticModel(
     writtenBy.set(target, model.name);
     if (options.dryRun) {
       console.log(`  would ${existed ? 'update' : 'create'} ${target}`);
-    }
-    else {
+    } else {
       layout.writeModelDocument(model.name, serialized.yaml);
       console.log(`  ${existed ? 'updated' : 'created'} ${target}`);
     }
-    if (existed) updated++;
-    else created++;
+    if (existed)
+      updated++;
+    else
+      created++;
   }
 
-  console.log(options.dryRun
-    ? `Dry run: would write ${created} new and ${updated} updated model document(s).`
-    : `Wrote ${created} new and ${updated} updated model document(s).`);
+  console.log(
+      options.dryRun ?
+          `Dry run: would write ${created} new and ${
+              updated} updated model document(s).` :
+          `Wrote ${created} new and ${updated} updated model document(s).`);
   return 0;
 }
 
 
 export interface OwlImportOptions {
   // Write the generated OSI document to this path instead of the semantic-model
-  // layout dir. When omitted, the model lands in the scope's model layout so the
-  // next `kcmd push` picks it up.
+  // layout dir. When omitted, the model lands in the scope's model layout so
+  // the next `kcmd push` picks it up.
   out?: string;
 }
 
@@ -558,11 +639,11 @@ const OWL_EXTENSIONS = /\.owl\.ttl$|\.ttl$|\.owl$/i;
 // deployment target added before `kcmd push` will deploy it (to either
 // destination). Returns a process exit code.
 export async function owl(
-  action: string, file: string, options: OwlImportOptions): Promise<number> {
+    action: string, file: string, options: OwlImportOptions): Promise<number> {
   if (action !== 'import') {
     console.error(
-      `Error: unknown owl action '${action}'; the only action is 'import' `
-      + `(usage: kcmd owl import <file.ttl>).`);
+        `Error: unknown owl action '${action}'; the only action is 'import' ` +
+        `(usage: kcmd owl import <file.ttl>).`);
     return 1;
   }
 
@@ -585,42 +666,45 @@ export async function owl(
     console.warn(`Warning: ${w}`);
   }
 
-  const { classes, datatypeProperties, objectProperties } = result.stats;
+  const {classes, datatypeProperties, objectProperties} = result.stats;
 
   // Guard: an ontology with no owl:Class yields a model with no datasets, which
   // is not a loadable OSI model. Fail clearly -- before the summary, so we do
-  // not print a "converted 0 classes" line for a model we are about to reject --
-  // rather than writing an empty artifact that only errors on a later push/pull.
+  // not print a "converted 0 classes" line for a model we are about to reject
+  // -- rather than writing an empty artifact that only errors on a later
+  // push/pull.
   if (classes === 0) {
-    console.error(
-      `Error: no owl:Class declarations found in '${file}'; nothing to import.`);
+    console.error(`Error: no owl:Class declarations found in '${
+        file}'; nothing to import.`);
     return 1;
   }
 
   console.log(
-    `converted ${classes} ${plural(classes, 'class', 'classes')}, `
-    + `${objectProperties} `
-    + `${plural(objectProperties, 'object property', 'object properties')}, `
-    + `${datatypeProperties} `
-    + `${plural(datatypeProperties, 'datatype property', 'datatype properties')}`);
+      `converted ${classes} ${plural(classes, 'class', 'classes')}, ` +
+      `${objectProperties} ` +
+      `${plural(objectProperties, 'object property', 'object properties')}, ` +
+      `${datatypeProperties} ` +
+      `${
+          plural(
+              datatypeProperties, 'datatype property',
+              'datatype properties')}`);
 
   // Sink: an explicit --out path writes directly; otherwise the semantic-model
   // layout places the document under the scope's entry group so `kcmd push`
   // finds it.
   let writtenPath: string;
   if (options.out) {
-    fs.mkdirSync(path.dirname(path.resolve(options.out)), { recursive: true });
+    fs.mkdirSync(path.dirname(path.resolve(options.out)), {recursive: true});
     fs.writeFileSync(options.out, result.yaml);
     writtenPath = options.out;
-  }
-  else {
+  } else {
     const ctx = context.ApiContext.default();
     const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
     if (snapshot.manifest.source.type !== Sources.SEMANTIC_MODEL) {
       console.error(
-        `Error: this catalog is not a semantic-model scope, so there is no `
-        + `model layout to write into. Run \`kcmd init --semantic-model ...\` `
-        + `first, or pass --out <path> to write the OSI document directly.`);
+          `Error: this catalog is not a semantic-model scope, so there is no ` +
+          `model layout to write into. Run \`kcmd init --semantic-model ...\` ` +
+          `first, or pass --out <path> to write the OSI document directly.`);
       return 1;
     }
     const layout = snapshot.layout as SemanticModelLayout;
@@ -630,9 +714,9 @@ export async function owl(
 
   console.log(`wrote ${writtenPath}`);
   console.log(
-    `note: this model is UNBOUND (placeholder \`unbound:\` sources, no deployment target).\n`
-    + `      \`kcmd push\` is rejected until you bind each entity's source table and add\n`
-    + `      a BigQuery deployment target -- validation needs both, for every --target.`);
+      `note: this model is UNBOUND (placeholder \`unbound:\` sources, no deployment target).\n` +
+      `      \`kcmd push\` is rejected until you bind each entity's source table and add\n` +
+      `      a BigQuery deployment target -- validation needs both, for every --target.`);
   return 0;
 }
 

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -2,102 +2,123 @@
 //
 
 import * as cac from 'cac';
+
 import * as commands from './commands';
 import * as mcp from './mcp';
 
 
 const cli = cac.cac('kcmd').version('1.0.0').help();
 cli.command('init', 'Initialize a new catalog snapshot')
-   .option('--entry-group <id>', 'Identifier of the EntryGroup (project.location.id)')
-   .option('--bigquery-dataset <id...>', 'Identifier of the BigQuery dataset(s) (project.datasetId)')
-   .option('--kb <id>', 'Identifier of the Knowledge Base EntryGroup (project.location.id)')
-   .option('--semantic-model <id>', 'Semantic model scope as <projectId>.<locationId>.<entryGroupId>')
-   .option('--pull', 'Optionally pull catalog entries during initialization')
-   .action(async (options) => {
+    .option(
+        '--entry-group <id>',
+        'Identifier of the EntryGroup (project.location.id)')
+    .option(
+        '--bigquery-dataset <id...>',
+        'Identifier of the BigQuery dataset(s) (project.datasetId)')
+    .option(
+        '--kb <id>',
+        'Identifier of the Knowledge Base EntryGroup (project.location.id)')
+    .option(
+        '--semantic-model <id>',
+        'Semantic model scope as <projectId>.<locationId>.<entryGroupId>')
+    .option('--pull', 'Optionally pull catalog entries during initialization')
+    .action(async (options) => {
       let exitCode = 1;
       try {
         exitCode = await commands.init(options);
-      }
-      catch (err: any) {
+      } catch (err: any) {
         console.error('Error:', err.message || err);
         exitCode = 1;
       }
 
       process.exit(exitCode);
-   });
+    });
 
 
 cli.command('pull', 'Pull catalog entries')
-   .option('--dry-run', 'Reconstruct and report only; do not write files (semantic-model scope)')
-   .option('--force-remove', 'Delete a differently-named local model and replace it with the catalog\'s; without it, a pull that would leave two models in the entry group fails (semantic-model scope)')
-   .action(async (options) => {
+    .option(
+        '--dry-run',
+        'Reconstruct and report only; do not write files (semantic-model scope)')
+    .option(
+        '--force-remove',
+        'Delete a differently-named local model and replace it with the catalog\'s; without it, a pull that would leave two models in the entry group fails (semantic-model scope)')
+    .action(async (options) => {
       let exitCode = 1;
       try {
         exitCode = await commands.pull(options);
-      }
-      catch (err: any) {
+      } catch (err: any) {
         console.error('Error:', err.message || err);
         exitCode = 1;
       }
-      
+
       process.exit(exitCode);
-   });
+    });
 
 cli.command('push', 'Push catalog entries')
-   .option('--force', 'Force push changes')
-   .option('--force-remove', 'Delete Knowledge Catalog models in the entry group that this push does not include (removed/renamed models); semantic-model push only')
-   .option('--emit-expressions', 'Emit SQL-expression fields not yet in the published Knowledge Catalog system-type templates (per-field schema semantics, metric expression); off by default, enable once the templates support them; semantic-model push only')
-   .option('--validate-only', 'Only validate changes without applying')
-   .option('--target <targets>', 'Semantic-model push destination(s): bq, kc, all (default), or a comma-separated list (e.g. bq,kc)')
-   .option('--print', 'Print each pushed destination\'s generated artifact in its native format (BigQuery Graph SQL DDL, Knowledge Catalog entry plan); scope with --target (semantic-model push only)')
-   .option('--transpile', 'Rewrite vendor-dialect (e.g. Snowflake/Databricks) expressions to GoogleSQL before deploying, filling target expressions the loader left unset; semantic-model push only')
-   .action(async (options) => {
+    .option('--force', 'Force push changes')
+    .option(
+        '--force-remove',
+        'Delete Knowledge Catalog models in the entry group that this push does not include (removed/renamed models); semantic-model push only')
+    .option(
+        '--emit-expressions',
+        'Emit SQL-expression fields not yet in the published Knowledge Catalog system-type templates (per-field schema semantics, metric expression); off by default, enable once the templates support them; semantic-model push only')
+    .option('--validate-only', 'Only validate changes without applying')
+    .option(
+        '--target <targets>',
+        'Semantic-model push destination(s): bq, spanner, kc, all (default), or a comma-separated list (e.g. bq,kc)')
+    .option(
+        '--print',
+        'Print each pushed destination\'s generated artifact in its native format (BigQuery/Spanner Graph SQL DDL, Knowledge Catalog entry plan); scope with --target (semantic-model push only)')
+    .option(
+        '--transpile',
+        'Rewrite vendor-dialect (e.g. Snowflake/Databricks) expressions to GoogleSQL before deploying, filling target expressions the loader left unset; semantic-model push only')
+    .action(async (options) => {
       let exitCode = 1;
       try {
         exitCode = await commands.push(options);
-      }
-      catch (err: any) {
+      } catch (err: any) {
         console.error('Error:', err.message || err);
         exitCode = 1;
       }
-      
+
       process.exit(exitCode);
-   });
+    });
 
 
-cli.command('owl <action> <file>', 'OWL ontology tools (action: import a .ttl ontology into an OSI model)')
-   .option('--out <path>', 'Write the generated OSI document to this path instead of the semantic-model layout dir')
-   .action(async (action, file, options) => {
+cli.command(
+       'owl <action> <file>',
+       'OWL ontology tools (action: import a .ttl ontology into an OSI model)')
+    .option(
+        '--out <path>',
+        'Write the generated OSI document to this path instead of the semantic-model layout dir')
+    .action(async (action, file, options) => {
       let exitCode = 1;
       try {
         exitCode = await commands.owl(action, file, options);
-      }
-      catch (err: any) {
+      } catch (err: any) {
         console.error('Error:', err.message || err);
         exitCode = 1;
       }
 
       process.exit(exitCode);
-   });
+    });
 
 
 cli.command('mcp', 'Run the Model Context Protocol (MCP) server')
-   .option('--path <path>', 'Path to the catalog snapshot root directory')
-   .action(async (options) => {
+    .option('--path <path>', 'Path to the catalog snapshot root directory')
+    .action(async (options) => {
       try {
         await mcp.startServer(options.path);
-      }
-      catch (err: any) {
+      } catch (err: any) {
         console.error('Error starting MCP server:', err.message || err);
         process.exit(1);
       }
-   });
+    });
 
 
 try {
   cli.parse();
-}
-catch (err: any) {
+} catch (err: any) {
   console.error('Error:', err.message || err);
   process.exit(1);
 }

--- a/toolbox/mdcode/tests/libts/semantic/deploy_spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy_spanner.test.ts
@@ -141,6 +141,12 @@ describe('deploySpanner', () => {
           expect(database).toBe('commerce');
           expect(statements[0])
               .toContain('CREATE OR REPLACE PROPERTY GRAPH sales_graph');
+          // Spanner's updateDatabaseDdl rejects a statement ending in ';'
+          // (verified live); the leg strips the generator's trailing semicolon
+          // for the wire, but the returned/printed DDL keeps it for
+          // readability.
+          expect(statements[0].trimEnd().endsWith(';')).toBe(false);
+          expect(res.ddl[0].trimEnd().endsWith(';')).toBe(true);
 
           // The returned operation was polled by name until done.
           expect(opSpy).toHaveBeenCalledTimes(1);

--- a/toolbox/mdcode/tests/libts/semantic/deploy_spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy_spanner.test.ts
@@ -1,0 +1,211 @@
+// Tests for the semantic-model Spanner deploy leg
+// (src/libts/semantic/deploy_spanner.ts).
+//
+// `spannerGraphTargets` is exercised as a pure function; `deploySpanner` is
+// exercised end to end over a fixture (loader -> IR -> generator -> target),
+// with the Spanner client stubbed so no network call is made.
+
+import {describe, expect, spyOn, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {ApiContext} from '../../../src/libts/gcp/context';
+import * as spannerClient from '../../../src/libts/gcp/spanner';
+import {deploySpanner} from '../../../src/libts/semantic/deploy_spanner';
+import {spannerGraphTargets} from '../../../src/libts/semantic/deployment_target';
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {loadSemanticModels} from '../../../src/libts/semantic/loader';
+
+const CTX = new ApiContext('test-project', 'us', 'test-token');
+
+function models(
+    docs: {name: string; text: string}[], defaultProject = 'test-project') {
+  const r = loadSemanticModels(docs, {defaultProject});
+  if (r.error) throw new Error(r.error);
+  return r.models;
+}
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+const SPANNER_URI =
+    '//spanner.googleapis.com/projects/demo/instances/prod/databases/commerce/propertyGraphs/sales_graph';
+const BQ_URI =
+    '//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph';
+
+const OSSIE = fs.readFileSync(
+    path.join(FIXTURES, 'sales_spanner_graph_target.yaml'), 'utf8');
+
+function modelWithExtension(data: string, vendor = 'GOOGLE'): SemanticModel {
+  return {
+    name: 'm',
+    entities: [],
+    relationships: [],
+    metrics: [],
+    customExtensions: [{vendorName: vendor, data}],
+  };
+}
+
+
+describe('spannerGraphTargets', () => {
+  test('parses a Spanner Graph deployment target', () => {
+    const {targets, malformed} = spannerGraphTargets(
+        modelWithExtension(JSON.stringify({deploymentTargets: [SPANNER_URI]})));
+    expect(targets).toEqual([
+      {
+        project: 'demo',
+        instance: 'prod',
+        database: 'commerce',
+        graphName: 'sales_graph',
+        uri: SPANNER_URI,
+      },
+    ]);
+    expect(malformed).toEqual([]);
+  });
+
+  test('a BigQuery target is not a Spanner target, and not malformed', () => {
+    // A BigQuery URI is a recognized destination, just not a Spanner one, so it
+    // is neither returned as a Spanner target nor flagged as a typo.
+    const {targets, malformed} = spannerGraphTargets(
+        modelWithExtension(JSON.stringify({deploymentTargets: [BQ_URI]})));
+    expect(targets).toEqual([]);
+    expect(malformed).toEqual([]);
+  });
+
+  test('an unsupported URI is collected as malformed', () => {
+    const bad = '//alloydb.googleapis.com/projects/p/whatever';
+    const {targets, malformed} = spannerGraphTargets(
+        modelWithExtension(JSON.stringify({deploymentTargets: [bad]})));
+    expect(targets).toEqual([]);
+    expect(malformed).toEqual([bad]);
+  });
+
+  test('rejects a graph name with an injection character', () => {
+    const evil =
+        '//spanner.googleapis.com/projects/demo/instances/prod/databases/commerce/propertyGraphs/g`;DROP';
+    const {targets, malformed} = spannerGraphTargets(
+        modelWithExtension(JSON.stringify({deploymentTargets: [evil]})));
+    expect(targets).toEqual([]);
+    expect(malformed).toEqual([evil]);
+  });
+});
+
+
+describe('deploySpanner', () => {
+  test('validateOnly returns the DDL without calling Spanner', async () => {
+    const ddlSpy =
+        spyOn(spannerClient.SpannerClient.prototype, 'updateDatabaseDdl');
+    try {
+      const res = await deploySpanner(
+          models([{name: 'sales', text: OSSIE}]), CTX, {validateOnly: true});
+      expect(res.success).toBe(true);
+      expect(res.deployed).toBe(0);
+      expect(ddlSpy).not.toHaveBeenCalled();
+
+      const ddl = res.ddl.join('\n');
+      expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH sales_graph');
+      // Bare table name, not the three-part BigQuery source.
+      expect(ddl).toContain('Orders AS orders');
+      // The metric is dropped (Spanner has no MEASURE).
+      expect(res.warnings.some(w => w.includes('total_revenue'))).toBe(true);
+    } finally {
+      ddlSpy.mockRestore();
+    }
+  });
+
+  test(
+      'applies the DDL to the target database and polls to completion',
+      async () => {
+        const ddlSpy =
+            spyOn(spannerClient.SpannerClient.prototype, 'updateDatabaseDdl')
+                .mockImplementation(async () => ({
+                                      status: 200,
+                                      result: {name: 'op-1', done: false},
+                                    }));
+        const opSpy =
+            spyOn(spannerClient.SpannerClient.prototype, 'getOperation')
+                .mockImplementation(
+                    async () => ({status: 200, result: {done: true}}));
+        try {
+          const res = await deploySpanner(
+              models([{name: 'sales', text: OSSIE}]), CTX, {pollBackoffMs: 0});
+          expect(res.success).toBe(true);
+          expect(res.deployed).toBe(1);
+          expect(ddlSpy).toHaveBeenCalledTimes(1);
+
+          // updateDatabaseDdl(project, instance, database, statements) -- the
+          // coords come from the deployment-target URI.
+          const [project, instance, database, statements] =
+              ddlSpy.mock.calls[0];
+          expect(project).toBe('demo');
+          expect(instance).toBe('prod');
+          expect(database).toBe('commerce');
+          expect(statements[0])
+              .toContain('CREATE OR REPLACE PROPERTY GRAPH sales_graph');
+
+          // The returned operation was polled by name until done.
+          expect(opSpy).toHaveBeenCalledTimes(1);
+          expect(opSpy.mock.calls[0][0]).toBe('op-1');
+        } finally {
+          ddlSpy.mockRestore();
+          opSpy.mockRestore();
+        }
+      });
+
+  test('a completed operation carrying an error fails the deploy', async () => {
+    const ddlSpy =
+        spyOn(spannerClient.SpannerClient.prototype, 'updateDatabaseDdl')
+            .mockImplementation(async () => ({
+                                  status: 200,
+                                  result: {
+                                    name: 'op-1',
+                                    done: true,
+                                    error: {code: 3, message: 'bad DDL'},
+                                  },
+                                }));
+    try {
+      const res = await deploySpanner(
+          models([{name: 'sales', text: OSSIE}]), CTX, {pollBackoffMs: 0});
+      expect(res.success).toBe(false);
+      expect(res.details).toContain('bad DDL');
+      expect(res.deployed).toBe(0);
+    } finally {
+      ddlSpy.mockRestore();
+    }
+  });
+
+  test(
+      'an operation that never completes fails after exhausting polls',
+      async () => {
+        const ddlSpy =
+            spyOn(spannerClient.SpannerClient.prototype, 'updateDatabaseDdl')
+                .mockImplementation(async () => ({
+                                      status: 200,
+                                      result: {name: 'op-1', done: false},
+                                    }));
+        const opSpy =
+            spyOn(spannerClient.SpannerClient.prototype, 'getOperation')
+                .mockImplementation(
+                    async () => ({status: 200, result: {done: false}}));
+        try {
+          const res = await deploySpanner(
+              models([{name: 'sales', text: OSSIE}]), CTX,
+              {pollBackoffMs: 0, maxOperationPolls: 3});
+          expect(res.success).toBe(false);
+          expect(res.details).toContain('did not complete after 3 polls');
+        } finally {
+          ddlSpy.mockRestore();
+          opSpy.mockRestore();
+        }
+      });
+
+  test('a model with no Spanner target fails clearly', async () => {
+    // A BigQuery-only model handed to the Spanner leg has nothing to deploy;
+    // commands.ts routes such models away, so this is the direct-call guard.
+    const bqDoc = fs.readFileSync(
+        path.join(FIXTURES, 'sales_bq_graph_target.yaml'), 'utf8');
+    const res = await deploySpanner(
+        models([{name: 'sales', text: bqDoc}]), CTX, {validateOnly: true});
+    expect(res.success).toBe(false);
+    expect(res.details).toContain('no Spanner Graph deploymentTarget');
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.spanner.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.spanner.golden.sql
@@ -1,0 +1,80 @@
+CREATE OR REPLACE PROPERTY GRAPH people
+NODE TABLES (
+  person AS Person
+    KEY(id)
+    DEFAULT LABEL
+    PROPERTIES(
+      id,
+      full_name,
+      email
+    ),
+  customer AS Customer
+    KEY(id)
+    DEFAULT LABEL
+    PROPERTIES(
+      id,
+      loyalty_tier,
+      full_name,
+      email
+    )
+    LABEL Person
+    PROPERTIES(
+      id,
+      full_name,
+      email
+    ),
+  employee AS Employee
+    KEY(id)
+    DEFAULT LABEL
+    PROPERTIES(
+      id,
+      department,
+      full_name,
+      email
+    )
+    LABEL Person
+    PROPERTIES(
+      id,
+      full_name,
+      email
+    ),
+  manager AS Manager
+    KEY(id)
+    DEFAULT LABEL
+    PROPERTIES(
+      id,
+      team_size,
+      department,
+      full_name,
+      email
+    )
+    LABEL Employee
+    PROPERTIES(
+      id,
+      department,
+      full_name,
+      email
+    )
+    LABEL Person
+    PROPERTIES(
+      id,
+      full_name,
+      email
+    ),
+  city AS City
+    KEY(id)
+    PROPERTIES(
+      id,
+      city_name
+    )
+)
+EDGE TABLES (
+  person AS livesIn
+    KEY(id)
+    SOURCE KEY(id) REFERENCES Person(id)
+    DESTINATION KEY(city_id) REFERENCES City(id)
+);
+
+-- warnings --
+-- note: no 'BIGQUERY' dialect for one or more expressions; using the portable 'ANSI_SQL' dialect verbatim ('BIGQUERY' accepts the ANSI core subset — supply 'BIGQUERY' variants only for BIGQUERY-specific SQL)
+-- metric 'total_cities' is not emitted: Spanner Graph has no MEASURE, so model-level metrics have no home in it

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_fanout.spanner.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_fanout.spanner.golden.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE PROPERTY GRAPH sales_graph
+NODE TABLES (
+  customers AS customers
+    KEY(customer_id)
+    PROPERTIES(
+      customer_id,
+      region
+    ),
+  orders AS orders
+    KEY(order_id)
+    PROPERTIES(
+      order_id,
+      customer_id
+    ),
+  order_items AS order_items
+    KEY(order_item_id)
+    PROPERTIES(
+      order_item_id,
+      order_id,
+      amount
+    )
+)
+EDGE TABLES (
+  orders AS orders_customers
+    KEY(order_id)
+    SOURCE KEY(order_id) REFERENCES orders(order_id)
+    DESTINATION KEY(customer_id) REFERENCES customers(customer_id),
+  order_items AS orderitems_orders
+    KEY(order_item_id)
+    SOURCE KEY(order_item_id) REFERENCES order_items(order_item_id)
+    DESTINATION KEY(order_id) REFERENCES orders(order_id)
+);
+
+-- warnings --
+-- metric 'total_revenue' is not emitted: Spanner Graph has no MEASURE, so model-level metrics have no home in it
+-- metric 'order_count' is not emitted: Spanner Graph has no MEASURE, so model-level metrics have no home in it

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_spanner_graph_target.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_spanner_graph_target.yaml
@@ -1,0 +1,37 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# A minimal, loader-valid model that declares a GOOGLE Spanner Graph deployment
+# target (a `//spanner.googleapis.com/.../propertyGraphs/...` URI). This is the
+# happy-path document for the Spanner deploy leg: loader -> IR -> generator ->
+# Spanner Graph. The target resolves to the graph `sales_graph` in the database
+# `commerce` of instance `prod` in project `demo`. The metric is dropped by the
+# Spanner generator (Spanner Graph has no MEASURE).
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: sales
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"deploymentTargets": ["//spanner.googleapis.com/projects/demo/instances/prod/databases/commerce/propertyGraphs/sales_graph"]}'
+    datasets:
+      - name: orders
+        source: demo.sales.Orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_totalprice
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/school_manytomany.spanner.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/school_manytomany.spanner.golden.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE PROPERTY GRAPH school_graph
+NODE TABLES (
+  students AS students
+    KEY(student_id)
+    PROPERTIES(
+      student_id,
+      name
+    ),
+  courses AS courses
+    KEY(course_id)
+    PROPERTIES(
+      course_id,
+      title
+    )
+)
+EDGE TABLES (
+  enrollment AS enrollment
+    KEY(enrollment_id)
+    SOURCE KEY(student_id) REFERENCES students(student_id)
+    DESTINATION KEY(course_id) REFERENCES courses(course_id)
+    PROPERTIES(
+      grade
+    )
+);

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.spanner.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.spanner.golden.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE PROPERTY GRAPH sales
+NODE TABLES (
+  orders AS orders
+    KEY(o_orderkey)
+    PROPERTIES(
+      o_orderkey,
+      o_custkey,
+      o_orderdate,
+      o_totalprice
+    ),
+  customer AS customer
+    KEY(c_custkey)
+    PROPERTIES(
+      c_custkey,
+      c_name
+    )
+)
+EDGE TABLES (
+  orders AS orders_to_customer
+    KEY(o_orderkey)
+    SOURCE KEY(o_orderkey) REFERENCES orders(o_orderkey)
+    DESTINATION KEY(o_custkey) REFERENCES customer(c_custkey)
+);
+
+-- warnings --
+-- note: no 'BIGQUERY' dialect for one or more expressions; using the portable 'ANSI_SQL' dialect verbatim ('BIGQUERY' accepts the ANSI core subset — supply 'BIGQUERY' variants only for BIGQUERY-specific SQL)
+-- metric 'total_revenue' is not emitted: Spanner Graph has no MEASURE, so model-level metrics have no home in it
+-- metric 'order_count' is not emitted: Spanner Graph has no MEASURE, so model-level metrics have no home in it

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
@@ -408,6 +408,53 @@ describe('model-level structure', () => {
             'model has no entities; only the semantic-model entry will be generated');
       });
 
+  test(
+      'a Spanner-targeted model records its Spanner URI in the semantic-model aspect',
+      () => {
+        // A model bound to Spanner Graph must not lose its deployment target in
+        // Knowledge Catalog (the aspect used to read only BigQuery targets, so a
+        // Spanner-only model round-tripped as UNBOUND).
+        const spannerUri =
+            '//spanner.googleapis.com/projects/p/instances/i/databases/db/propertyGraphs/g';
+        const model: SemanticModel = {
+          name: 'm',
+          relationships: [],
+          metrics: [],
+          entities: [{name: 'e', dataSource: 'p.d.t', keys: ['k'], fields: []}],
+          customExtensions: [{
+            vendorName: 'GOOGLE',
+            data: JSON.stringify({deploymentTargets: [spannerUri]}),
+          }],
+        };
+        const {entries} = generateCatalogResources(model, OPTS);
+        const anchor = entries[0];
+        expect(anchor.aspects!['dataplex-types.global.semantic-model'].data)
+            .toEqual({deploymentTargets: [spannerUri]});
+      });
+
+  test(
+      'a model targeting both BigQuery and Spanner records both URIs, BigQuery first',
+      () => {
+        const bqUri =
+            '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
+        const spannerUri =
+            '//spanner.googleapis.com/projects/p/instances/i/databases/db/propertyGraphs/g';
+        const model: SemanticModel = {
+          name: 'm',
+          relationships: [],
+          metrics: [],
+          entities: [{name: 'e', dataSource: 'p.d.t', keys: ['k'], fields: []}],
+          customExtensions: [{
+            vendorName: 'GOOGLE',
+            data: JSON.stringify({deploymentTargets: [spannerUri, bqUri]}),
+          }],
+        };
+        const {entries} = generateCatalogResources(model, OPTS);
+        const anchor = entries[0];
+        expect(anchor.aspects!['dataplex-types.global.semantic-model'].data)
+            .toEqual({deploymentTargets: [bqUri, spannerUri]});
+      });
+
   test('the anchor is emitted first and is the parent of every child', () => {
     const model: SemanticModel = {
       name: 'm',

--- a/toolbox/mdcode/tests/libts/semantic/spanner.e2e.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.e2e.test.ts
@@ -1,0 +1,118 @@
+// End-to-end tests for the Spanner destination: real-shaped fixtures run the
+// full file -> IR -> DDL path.
+//
+// Mirrors bigquery.e2e.test.ts. For every fixture below, the complete generated
+// DDL plus the emitted warnings are compared byte-for-byte against a committed
+// `<fixture>.spanner.golden.sql`. The goldens are the reviewable "big picture":
+// open a `.yaml` next to its `.spanner.golden.sql` to see the full input and
+// output. Note the corpus is shared with the BigQuery suite, so the two goldens
+// side by side show exactly how the same model lowers to each backend --
+// including what Spanner drops (measures, per-element OPTIONS) and how it
+// references bare table names.
+//
+//   Regenerate goldens after an intentional generator change:
+//     UPDATE_GOLDENS=1 npx bun test ./tests/libts/semantic/spanner.e2e.test.ts
+//   then read the diff before committing.
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {loadModels, LoadOptions} from '../../../src/libts/semantic/loader';
+import {generateSpannerPropertyGraph} from '../../../src/libts/semantic/spanner';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+// A subset of the BigQuery corpus that exercises the Spanner-relevant shapes:
+// a basic star (nodes + a direct-FK edge, with metrics that Spanner drops), a
+// class hierarchy (DEFAULT LABEL + inherited LABEL blocks), and a multi-edge
+// fan-out.
+const CORPUS = [
+  'star_orders_customer.yaml',
+  'hierarchy_graph.yaml',
+  'sales_fanout.yaml',
+];
+
+function loadFixture(fixture: string, load: LoadOptions = {}) {
+  const text = fs.readFileSync(path.join(FIXTURES, fixture), 'utf8');
+  return loadModels(
+      text,
+      {defaultProject: 'sqlgen-testing', defaultDataset: 'demo', ...load});
+}
+
+function build(fixture: string, load: LoadOptions = {}) {
+  const {models, warnings: loadWarnings} = loadFixture(fixture, load);
+  const {ddl, warnings: genWarnings} = generateSpannerPropertyGraph(models[0]);
+  return {models, ddl, loadWarnings, genWarnings};
+}
+
+// The exact artifact a golden captures: the full DDL, then every warning (load
+// + generate) as SQL comments so a reviewer sees dropped/flagged elements too.
+function render(fixture: string): string {
+  const {ddl, loadWarnings, genWarnings} = build(fixture);
+  const warnings = [...loadWarnings, ...genWarnings];
+  const warnBlock =
+      warnings.length ? warnings.map(w => `-- ${w}`).join('\n') : '-- (none)';
+  return `${ddl}\n-- warnings --\n${warnBlock}\n`;
+}
+
+const goldenPath = (fixture: string) =>
+    path.join(FIXTURES, fixture.replace(/\.yaml$/, '.spanner.golden.sql'));
+
+
+describe(
+    'golden DDL: each corpus fixture generates its exact expected Spanner property graph',
+    () => {
+      for (const fixture of CORPUS) {
+        test(fixture, () => {
+          const actual = render(fixture);
+          const golden = goldenPath(fixture);
+          if (process.env.UPDATE_GOLDENS) {
+            fs.writeFileSync(golden, actual);
+            return;
+          }
+          if (!fs.existsSync(golden)) {
+            throw new Error(`missing golden ${
+                path.basename(golden)} — run UPDATE_GOLDENS=1 to create it`);
+          }
+          expect(actual).toBe(fs.readFileSync(golden, 'utf8'));
+        });
+      }
+    });
+
+
+describe('Spanner Graph drops what it cannot express', () => {
+  test('model-level metrics are not emitted, and each is warned', () => {
+    // Spanner Graph has no MEASURE, so the star fixture's two metrics are
+    // dropped -- the graph structure (nodes, the edge) still generates.
+    const {ddl, genWarnings} = build('star_orders_customer.yaml');
+    expect(ddl).not.toContain('MEASURE');
+    expect(ddl).not.toContain('total_revenue');
+    expect(genWarnings)
+        .toContain(
+            'metric \'total_revenue\' is not emitted: Spanner Graph has no ' +
+            'MEASURE, so model-level metrics have no home in it');
+    expect(genWarnings)
+        .toContain(
+            'metric \'order_count\' is not emitted: Spanner Graph has no ' +
+            'MEASURE, so model-level metrics have no home in it');
+  });
+
+  test('no per-element OPTIONS clause is emitted', () => {
+    // BigQuery attaches description/synonyms as OPTIONS on labels/properties;
+    // Spanner Graph has no such clause, so none appears.
+    const {ddl} = build('star_orders_customer.yaml');
+    expect(ddl).not.toContain('OPTIONS(');
+  });
+
+  test(
+      'input tables are referenced by their bare name, not project.dataset',
+      () => {
+        // The star fixture's `orders` entity sources `samples.tpch.orders`; the
+        // Spanner graph names it by the final segment only.
+        const {ddl} = build('star_orders_customer.yaml');
+        expect(ddl).toContain('orders AS orders');
+        expect(ddl).not.toContain('samples.tpch.orders');
+        expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH sales');
+      });
+});

--- a/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
@@ -1,0 +1,200 @@
+// Behavior specification for the Spanner property-graph generator
+// (src/libts/semantic/spanner.ts).
+//
+// The readable "big picture" tests live in `spanner.e2e.test.ts`: a corpus of
+// `<fixture>.yaml` inputs, each with a committed `<fixture>.spanner.golden.sql`
+// showing the exact generated DDL and warnings. Prefer adding a fixture +
+// golden there.
+//
+// This file holds only what a loader fixture CANNOT express: an M:N association
+// edge (the open format has no association-table syntax, so its IR is
+// hand-built and checked against a committed golden), and degenerate/negative
+// inputs and pure GenerateOptions behavior (graph naming, bare table mapping).
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {GenerateOptions, generateSpannerPropertyGraph} from '../../../src/libts/semantic/spanner';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+
+describe(
+    'M:N association edge (no association-table syntax in the open format yet)',
+    () => {
+      // Hand-built because the loader's relationship schema is direct-FK only;
+      // it cannot express an edge backed by its own association table with its
+      // own KEY and edge properties. The expected DDL is a committed golden
+      // (`school_manytomany.spanner.golden.sql`), the Spanner counterpart to
+      // the BigQuery association golden, so the two shapes are reviewable side
+      // by side.
+      const SCHOOL: SemanticModel = {
+        name: 'school_graph',
+        entities: [
+          {
+            name: 'students',
+            dataSource: 'sqlgen-testing.bei_semantic_ir_verify.students',
+            keys: ['student_id'],
+            fields: [
+              {name: 'student_id', expression: 'students.student_id'},
+              {name: 'name', expression: 'students.name'}
+            ]
+          },
+          {
+            name: 'courses',
+            dataSource: 'sqlgen-testing.bei_semantic_ir_verify.courses',
+            keys: ['course_id'],
+            fields: [
+              {name: 'course_id', expression: 'courses.course_id'},
+              {name: 'title', expression: 'courses.title'}
+            ]
+          },
+        ],
+        relationships: [
+          {
+            name: 'enrollment',
+            source: {entity: 'students', columns: ['student_id']},
+            destination: {entity: 'courses', columns: ['course_id']},
+            association: {
+              dataSource: 'sqlgen-testing.bei_semantic_ir_verify.enrollment',
+              keys: ['enrollment_id'],
+              sourceColumns: ['student_id'],
+              destinationColumns: ['course_id'],
+              fields: [{
+                name: 'grade',
+                expression: 'enrollment.grade',
+                description: 'Letter grade'
+              }]
+            }
+          },
+        ],
+        metrics: [],
+      };
+
+      test('the association graph matches its committed golden DDL', () => {
+        const {ddl} = generateSpannerPropertyGraph(SCHOOL);
+        const golden =
+            path.join(FIXTURES, 'school_manytomany.spanner.golden.sql');
+        if (process.env.UPDATE_GOLDENS) {
+          fs.writeFileSync(golden, ddl);
+          return;
+        }
+        expect(ddl).toBe(fs.readFileSync(golden, 'utf8'));
+      });
+
+      test(
+          'an edge property carries no OPTIONS (Spanner has no per-element options)',
+          () => {
+            // The junction's `grade` field has a description; on BigQuery that
+            // becomes an OPTIONS clause, on Spanner it is dropped.
+            const {ddl} = generateSpannerPropertyGraph(SCHOOL);
+            expect(ddl).toContain('grade');
+            expect(ddl).not.toContain('OPTIONS');
+          });
+    });
+
+
+describe('graph naming', () => {
+  const oneEntity = (): SemanticModel => ({
+    name: 'my_model',
+    relationships: [],
+    metrics: [],
+    entities: [{
+      name: 'orders',
+      dataSource: 'proj.ds.orders',
+      keys: ['id'],
+      fields: [{name: 'id', expression: 'orders.id'}]
+    }],
+  });
+
+  test(
+      'the graph name defaults to the model name, bare (no project.dataset)',
+      () => {
+        const {ddl} = generateSpannerPropertyGraph(oneEntity());
+        expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH my_model');
+      });
+
+  test('opts.graphName overrides the model name', () => {
+    const {ddl} =
+        generateSpannerPropertyGraph(oneEntity(), {graphName: 'chosen'});
+    expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH chosen');
+  });
+
+  test('a non-simple graph name is backtick-quoted', () => {
+    // A hyphen is not a valid unquoted GoogleSQL identifier; the graph name
+    // from a deployment-target URI can contain one, so it must be quoted.
+    const opts: GenerateOptions = {graphName: 'sales-graph'};
+    const {ddl} = generateSpannerPropertyGraph(oneEntity(), opts);
+    expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `sales-graph`');
+  });
+});
+
+
+describe('bare table mapping', () => {
+  const withSource = (source: string): SemanticModel => ({
+    name: 'm',
+    relationships: [],
+    metrics: [],
+    entities: [{
+      name: 'orders',
+      dataSource: source,
+      keys: ['id'],
+      fields: [{name: 'id', expression: 'orders.id'}]
+    }],
+  });
+
+  test('a three-part source reduces to its final table segment', () => {
+    const {ddl} = generateSpannerPropertyGraph(withSource('proj.ds.Orders'));
+    expect(ddl).toContain('Orders AS orders');
+    expect(ddl).not.toContain('proj.ds.Orders');
+  });
+
+  test('a bare source is used as-is', () => {
+    const {ddl} = generateSpannerPropertyGraph(withSource('Orders'));
+    expect(ddl).toContain('Orders AS orders');
+  });
+
+  test(
+      'a query source is emitted verbatim (parenthesized) with a warning',
+      () => {
+        const {ddl, warnings} =
+            generateSpannerPropertyGraph(withSource('SELECT * FROM t'));
+        expect(ddl).toContain('(SELECT * FROM t) AS orders');
+        expect(warnings.some(w => w.includes('looks like a query'))).toBe(true);
+      });
+});
+
+
+describe('degenerate inputs', () => {
+  test(
+      'a model with no entities throws (an empty NODE TABLES is invalid DDL)',
+      () => {
+        expect(
+            () => generateSpannerPropertyGraph(
+                {name: 'm', entities: [], relationships: [], metrics: []}))
+            .toThrow(/at least one NODE TABLE/);
+      });
+
+  test('an entity with no KEY is skipped and warned', () => {
+    const model: SemanticModel = {
+      name: 'm',
+      relationships: [],
+      metrics: [],
+      entities: [
+        {
+          name: 'good',
+          dataSource: 'ds.good',
+          keys: ['id'],
+          fields: [{name: 'id', expression: 'good.id'}]
+        },
+        {name: 'bad', dataSource: 'ds.bad', keys: [], fields: []},
+      ],
+    };
+    const {ddl, warnings} = generateSpannerPropertyGraph(model);
+    expect(ddl).toContain('good AS good');
+    expect(ddl).not.toContain('AS bad');
+    expect(warnings.some(w => w.includes('empty KEY'))).toBe(true);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
@@ -156,6 +156,23 @@ describe('bare table mapping', () => {
     expect(ddl).toContain('Orders AS orders');
   });
 
+  test('a backtick-quoted final segment is unwrapped to its bare name', () => {
+    const {ddl} = generateSpannerPropertyGraph(withSource('proj.ds.`Orders`'));
+    expect(ddl).toContain('Orders AS orders');
+  });
+
+  test(
+      'a dot INSIDE a quoted final segment does not split the table name',
+      () => {
+        // The naive `split('.')` mangled `weird.name` into `name`; the quoted
+        // segment must survive whole (and be re-quoted, since it is not a
+        // simple identifier).
+        const {ddl} =
+            generateSpannerPropertyGraph(withSource('proj.ds.`weird.name`'));
+        expect(ddl).toContain('`weird.name` AS orders');
+        expect(ddl).not.toContain('name AS orders');
+      });
+
   test(
       'a query source is emitted verbatim (parenthesized) with a warning',
       () => {

--- a/toolbox/mdcode/tests/libts/semantic/target.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/target.test.ts
@@ -7,7 +7,7 @@
 
 import {describe, expect, test} from 'bun:test';
 
-import {resolveTargets} from '../../../src/tool/commands';
+import {isExplicitSelection, resolveTargets} from '../../../src/tool/commands';
 
 describe('resolveTargets', () => {
   test('defaults to every destination when no target is given', () => {
@@ -57,4 +57,31 @@ describe('resolveTargets', () => {
         // than throwing on `.toLowerCase()`.
         expect(resolveTargets(true as unknown as string)).toBeUndefined();
       });
+});
+
+
+describe('isExplicitSelection', () => {
+  test('the omitted default is not an explicit selection', () => {
+    // A leg pulled in only by the default should skip quietly, not hard-fail,
+    // when no model targets it.
+    expect(isExplicitSelection(undefined)).toBe(false);
+  });
+  test('the \'all\' keyword is not an explicit selection', () => {
+    expect(isExplicitSelection('all')).toBe(false);
+    expect(isExplicitSelection('ALL')).toBe(false);
+    // `all` anywhere in the list still means "every backend", so a missing
+    // model for one of them is a skip, not an error.
+    expect(isExplicitSelection('all,spanner')).toBe(false);
+  });
+  test('a named destination (or list) is an explicit selection', () => {
+    expect(isExplicitSelection('spanner')).toBe(true);
+    expect(isExplicitSelection('bq')).toBe(true);
+    expect(isExplicitSelection('bq,kc')).toBe(true);
+    expect(isExplicitSelection(' SPANNER ')).toBe(true);
+  });
+  test('a bare boolean --target is not an explicit selection', () => {
+    // Guarded so an invalid flag is reported by resolveTargets, not treated as
+    // a named target here.
+    expect(isExplicitSelection(true as unknown as string)).toBe(false);
+  });
 });

--- a/toolbox/mdcode/tests/libts/semantic/target.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/target.test.ts
@@ -11,29 +11,37 @@ import {resolveTargets} from '../../../src/tool/commands';
 
 describe('resolveTargets', () => {
   test('defaults to every destination when no target is given', () => {
-    expect(resolveTargets(undefined)).toEqual(['bigquery', 'kc']);
+    expect(resolveTargets(undefined)).toEqual(['bigquery', 'spanner', 'kc']);
   });
   test('\'bq\' and \'bigquery\' both select BigQuery', () => {
     expect(resolveTargets('bq')).toEqual(['bigquery']);
     expect(resolveTargets('bigquery')).toEqual(['bigquery']);
+  });
+  test('\'sp\' and \'spanner\' both select Spanner', () => {
+    expect(resolveTargets('sp')).toEqual(['spanner']);
+    expect(resolveTargets('spanner')).toEqual(['spanner']);
   });
   test('\'kc\' selects Knowledge Catalog', () => {
     expect(resolveTargets('kc')).toEqual(['kc']);
   });
   test('a comma-separated list selects each destination', () => {
     expect(resolveTargets('bq,kc')).toEqual(['bigquery', 'kc']);
+    expect(resolveTargets('bq,spanner')).toEqual(['bigquery', 'spanner']);
   });
   test('\'all\' selects every destination', () => {
-    expect(resolveTargets('all')).toEqual(['bigquery', 'kc']);
+    expect(resolveTargets('all')).toEqual(['bigquery', 'spanner', 'kc']);
   });
   test('the result is always in canonical order (BigQuery first)', () => {
     // Regardless of how the user orders the flag, fail-fast runs BigQuery
-    // first.
+    // first, then Spanner, then Knowledge Catalog.
     expect(resolveTargets('kc,bq')).toEqual(['bigquery', 'kc']);
+    expect(resolveTargets('kc,spanner,bq')).toEqual([
+      'bigquery', 'spanner', 'kc'
+    ]);
   });
   test('duplicate tokens are de-duplicated', () => {
     expect(resolveTargets('bq,bq,kc')).toEqual(['bigquery', 'kc']);
-    expect(resolveTargets('all,kc')).toEqual(['bigquery', 'kc']);
+    expect(resolveTargets('all,kc')).toEqual(['bigquery', 'spanner', 'kc']);
   });
   test('is case-insensitive and tolerates surrounding whitespace', () => {
     expect(resolveTargets(' BQ , KC ')).toEqual(['bigquery', 'kc']);

--- a/toolbox/mdcode/tests/libts/semantic/validate.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/validate.test.ts
@@ -12,17 +12,23 @@ import {BigQueryClientMock} from '../mocks';
 const BQ_TARGET =
     '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
 
+// A parsed Spanner Graph deployment target the strict matcher accepts.
+const SPANNER_TARGET =
+    '//spanner.googleapis.com/projects/p/instances/i/databases/db/propertyGraphs/g';
+
 function googleExt(targets: string[]): CustomExtension {
-  return {vendorName: 'GOOGLE', data: JSON.stringify({deploymentTargets: targets})};
+  return {
+    vendorName: 'GOOGLE',
+    data: JSON.stringify({deploymentTargets: targets})
+  };
 }
 
 function loaded(model: SemanticModel, document = 'doc'): LoadedModel {
   return {document, model};
 }
 
-function model(
-    over: Partial<SemanticModel> = {},
-    exts?: CustomExtension[]): SemanticModel {
+function model(over: Partial<SemanticModel> = {}, exts?: CustomExtension[]):
+    SemanticModel {
   return {
     name: 'm',
     entities: [],
@@ -36,7 +42,10 @@ function model(
 describe('validatePushRequirements', () => {
   test('a model with a deployment target and resolved metrics passes', () => {
     const m = model(
-        {metrics: [{name: 'rev', expression: 'SUM(o.p)', entity: 'o'} as Metric]},
+        {
+          metrics:
+              [{name: 'rev', expression: 'SUM(o.p)', entity: 'o'} as Metric]
+        },
         [googleExt([BQ_TARGET])]);
     expect(validatePushRequirements([loaded(m)])).toEqual([]);
   });
@@ -48,24 +57,36 @@ describe('validatePushRequirements', () => {
     expect(errs[0]).toContain('doc');
   });
 
-  test('a BigQuery-target metric that resolves to no entity is rejected', () => {
+  test(
+      'a BigQuery-target metric that resolves to no entity is rejected', () => {
+        const m = model(
+            {metrics: [{name: 'cnt', expression: 'COUNT(*)'} as Metric]},
+            [googleExt([BQ_TARGET])]);
+        const errs = validatePushRequirements([loaded(m)]);
+        expect(errs.length).toBe(1);
+        expect(errs[0]).toContain('metric \'cnt\'');
+        expect(errs[0]).toContain('single entity');
+      });
+
+  test('a model with a Spanner Graph deployment target passes', () => {
+    // Spanner Graph has no MEASURE, so a metric that does not resolve to one
+    // entity is NOT required to (unlike a BigQuery target); the model is valid
+    // with only a Spanner target declared.
     const m = model(
         {metrics: [{name: 'cnt', expression: 'COUNT(*)'} as Metric]},
-        [googleExt([BQ_TARGET])]);
-    const errs = validatePushRequirements([loaded(m)]);
-    expect(errs.length).toBe(1);
-    expect(errs[0]).toContain("metric 'cnt'");
-    expect(errs[0]).toContain('single entity');
+        [googleExt([SPANNER_TARGET])]);
+    expect(validatePushRequirements([loaded(m)])).toEqual([]);
   });
 
-  test('a non-BigQuery Graph deployment target is rejected as malformed', () => {
-    // We only support BigQuery Graph targets; a single, otherwise well-formed
-    // non-BigQuery URI still fails because it does not parse as one.
+  test('an unsupported deployment target is rejected as malformed', () => {
+    // A single, otherwise well-formed URI that is neither a BigQuery nor a
+    // Spanner Graph target fails because it does not parse as either.
     const m = model(
         {}, [googleExt(['//dataplex.googleapis.com/projects/p/locations/us'])]);
     const errs = validatePushRequirements([loaded(m)]);
     expect(errs.length).toBe(1);
-    expect(errs[0]).toContain('not a valid BigQuery Graph URI');
+    expect(errs[0]).toContain(
+        'not a valid BigQuery Graph or Spanner Graph URI');
   });
 
   test('more than one deployment target is rejected', () => {
@@ -99,7 +120,10 @@ function entity(name: string, dataSource: string): Entity {
 }
 
 function mockTable(project: string, dataset: string, tableId: string) {
-  return {id: tableId, tableReference: {projectId: project, datasetId: dataset, tableId}};
+  return {
+    id: tableId,
+    tableReference: {projectId: project, datasetId: dataset, tableId}
+  };
 }
 
 describe('validateBigQueryDataSources', () => {
@@ -107,36 +131,39 @@ describe('validateBigQueryDataSources', () => {
     const bq = new BigQueryClientMock();
     bq.addMockTable(mockTable('p', 'd', 'orders'));
     bq.addMockTable(mockTable('p', 'd', 'customer'));
-    const m = model(
-        {entities: [entity('orders', 'p.d.orders'),
-                    entity('customer', 'p.d.customer')]});
+    const m = model({
+      entities:
+          [entity('orders', 'p.d.orders'), entity('customer', 'p.d.customer')]
+    });
     expect(await validateBigQueryDataSources([loaded(m)], bq, 'p')).toEqual([]);
   });
 
-  test('reports a missing source table, naming the entity/model/document',
-     async () => {
-       const bq = new BigQueryClientMock();
-       bq.addMockTable(mockTable('p', 'd', 'orders'));
-       const m = model({
-         entities: [entity('orders', 'p.d.orders'),
-                    entity('gone', 'p.d.ghost')],
-       });
-       const errs = await validateBigQueryDataSources([loaded(m)], bq, 'p');
-       expect(errs.length).toBe(1);
-       expect(errs[0]).toContain('p.d.ghost');
-       expect(errs[0]).toContain('does not exist');
-       expect(errs[0]).toContain("entity 'gone'");
-       expect(errs[0]).toContain('doc');
-     });
+  test(
+      'reports a missing source table, naming the entity/model/document',
+      async () => {
+        const bq = new BigQueryClientMock();
+        bq.addMockTable(mockTable('p', 'd', 'orders'));
+        const m = model({
+          entities:
+              [entity('orders', 'p.d.orders'), entity('gone', 'p.d.ghost')],
+        });
+        const errs = await validateBigQueryDataSources([loaded(m)], bq, 'p');
+        expect(errs.length).toBe(1);
+        expect(errs[0]).toContain('p.d.ghost');
+        expect(errs[0]).toContain('does not exist');
+        expect(errs[0]).toContain('entity \'gone\'');
+        expect(errs[0]).toContain('doc');
+      });
 
   test('covers a four-part REST-catalog / Iceberg source', async () => {
     // A federated REST-catalog table (e.g. Iceberg via BigLake) is a four-part
-    // name that tables.get cannot address; the dry-run resolves it as the deploy
-    // will. A reachable one passes; a missing one is reported by name.
+    // name that tables.get cannot address; the dry-run resolves it as the
+    // deploy will. A reachable one passes; a missing one is reported by name.
     const bq = new BigQueryClientMock();
     bq.addMockSource('ice_cat.db.sales.orders');
     const ok = model({entities: [entity('orders', 'ice_cat.db.sales.orders')]});
-    expect(await validateBigQueryDataSources([loaded(ok)], bq, 'p')).toEqual([]);
+    expect(await validateBigQueryDataSources([loaded(ok)], bq, 'p'))
+        .toEqual([]);
 
     const missing =
         model({entities: [entity('lost', 'ice_cat.db.sales.ghost')]});
@@ -149,8 +176,8 @@ describe('validateBigQueryDataSources', () => {
   test('reports a permission-denied source table', async () => {
     const bq = new BigQueryClientMock();
     bq.query =
-        (async () => ({status: 403, message: 'Access Denied: no permission'})) as
-        any;
+        (async () =>
+             ({status: 403, message: 'Access Denied: no permission'})) as any;
     const m = model({entities: [entity('o', 'p.d.o')]});
     const errs = await validateBigQueryDataSources([loaded(m)], bq, 'p');
     expect(errs.length).toBe(1);
@@ -165,21 +192,22 @@ describe('validateBigQueryDataSources', () => {
     expect(await validateBigQueryDataSources([loaded(m)], bq, 'p')).toEqual([]);
   });
 
-  test('probes each distinct table once across entities and models',
-     async () => {
-       const bq = new BigQueryClientMock();
-       bq.addMockTable(mockTable('p', 'd', 'shared'));
-       let calls = 0;
-       const orig = bq.query.bind(bq);
-       bq.query = ((p: string, sql: string, loc?: string, dry?: boolean) => {
-         calls++;
-         return orig(p, sql, loc, dry);
-       }) as any;
-       const m1 = model({name: 'm1', entities: [entity('a', 'p.d.shared')]});
-       const m2 = model({name: 'm2', entities: [entity('b', 'p.d.shared')]});
-       const errs = await validateBigQueryDataSources(
-           [loaded(m1, 'd1'), loaded(m2, 'd2')], bq, 'p');
-       expect(errs).toEqual([]);
-       expect(calls).toBe(1);
-     });
+  test(
+      'probes each distinct table once across entities and models',
+      async () => {
+        const bq = new BigQueryClientMock();
+        bq.addMockTable(mockTable('p', 'd', 'shared'));
+        let calls = 0;
+        const orig = bq.query.bind(bq);
+        bq.query = ((p: string, sql: string, loc?: string, dry?: boolean) => {
+                     calls++;
+                     return orig(p, sql, loc, dry);
+                   }) as any;
+        const m1 = model({name: 'm1', entities: [entity('a', 'p.d.shared')]});
+        const m2 = model({name: 'm2', entities: [entity('b', 'p.d.shared')]});
+        const errs = await validateBigQueryDataSources(
+            [loaded(m1, 'd1'), loaded(m2, 'd2')], bq, 'p');
+        expect(errs).toEqual([]);
+        expect(calls).toBe(1);
+      });
 });


### PR DESCRIPTION
## What

Adds `--target spanner` to the semantic-model `kcmd push`, alongside the existing BigQuery Graph and Knowledge Catalog legs. A model deploys to Spanner Graph by declaring a `//spanner.googleapis.com/projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>` deployment target; the target's host selects the leg, so **the same authored model that deploys to BigQuery Graph deploys to Spanner Graph unchanged**.

```
kcmd push --target spanner        # deploy the Spanner-targeting model(s)
kcmd push --target bq,spanner     # both graph backends
kcmd push                         # all: bq, spanner, kc
kcmd push --target spanner --print --validate-only   # inspect the DDL, deploy nothing
```

This complements the binding-profiles work: a profile chooses the *physical binding*; `--target spanner` now provides the *Spanner deploy backend* a Spanner-bound profile lowers to.

## How Spanner Graph differs from BigQuery Graph (and how this handles it)

- **Bare table names.** A property graph lives inside one Spanner database and names tables in that same database, so the generator maps each entity's `dataSource` to its final segment (`proj.ds.Orders` → `Orders`); the graph name is bare too (from the URI's `propertyGraphs/<g>`).
- **No `MEASURE`.** Spanner Graph has no measures, so model-level metrics are dropped with a warning — the graph structure (nodes, edges, labels, properties, inheritance labels) still deploys.
- **No per-element `OPTIONS`.** description/synonyms are not emitted; they ride into Knowledge Catalog instead (mirroring how BigQuery's graph-level OPTIONS is dropped).
- **Async DDL.** Applied via the Spanner Admin `updateDatabaseDdl` long-running operation, polled to completion (vs BigQuery `jobs.query`).

## Structure

| File | Role |
|---|---|
| `deployment_target.ts` (new) | Shared GOOGLE deployment-target reader; classifies each URI as a BigQuery or Spanner Graph target. `deploy_bigquery.ts` re-exports the BQ views, so existing importers are unchanged. |
| `spanner.ts` (new) | Spanner Graph DDL generator — sibling to `bigquery.ts`. |
| `gcp/spanner.ts` (new) | `SpannerClient` (`updateDatabaseDdl` + `getOperation`). |
| `deploy_spanner.ts` (new) | Spanner deploy leg — sibling to `deploy_bigquery.ts`. |
| `commands.ts` | Routes each model to the leg matching its target; the BigQuery data-source pre-flight now runs only over BigQuery-targeting models. |
| `validate.ts` | Accepts a BigQuery **or** Spanner target; the metric-resolves-to-one-entity rule stays BigQuery-only. |

## Design decisions (flagging for review)

1. **A model declares exactly one deployment target** (unchanged rule); its host selects the leg. A model can't target both BQ and Spanner in one document today — that fits the one-binding-per-profile model. Easy to relax later.
2. **Source → Spanner table = final dotted segment.** The loader does not yet parse `//spanner.../tables/<T>` source URIs (that's the proposed profiles feature), so the existing `project.dataset.table` source is reduced to its table name. One authored model works for both backends.
3. **Metrics dropped, not errored,** for Spanner (warned per metric).

## Tests

- `spanner.test.ts` — generator units + M:N association golden.
- `spanner.e2e.test.ts` — golden DDL for star / hierarchy / fan-out fixtures (shared corpus with the BQ suite, so the two goldens sit side by side).
- `deploy_spanner.test.ts` — target parsing + deploy leg with a mocked client (op polling, error, exhaustion, no-target).
- `validate.test.ts` / `target.test.ts` — Spanner target acceptance and `--target` resolution.

`tsc --noEmit` clean; full `bun test` suite green (537 tests); CLI binary builds.

## Docs

This PR now also documents the Spanner Graph target across the semantic-model guide (it previously shipped code only):

- **Deploy guide** (`docs/semantic-model/README.md`) — push reframed as "a property graph (BigQuery **or** Spanner, selected by the target host) + Knowledge Catalog"; adds the Spanner target URI form, the bare-table `source` reduction, and `--target spanner`.
- **Reference** (`docs/semantic-model/reference.md`) — `--target bq|spanner|kc|all`; a new **What gets created in Spanner** section (bare names, no `MEASURE`, no `OPTIONS`, async `updateDatabaseDdl`); validation now accepts a BigQuery **or** Spanner target and scopes the metric-resolves-to-one-entity rule and the live source pre-flight to BigQuery-targeting models; Spanner IAM permissions.
- **Fidelity** (`docs/semantic-model/fidelity.md`) — a new **To Spanner Graph** section (structure kept, metrics/OPTIONS dropped) plus a note that the BigQuery-graph matrix column is BigQuery-specific.
- **Codelab** (`docs/semantic-model/codelab.md`) — a runnable step that swaps the same model's target to Spanner and prints the generated DDL under `--validate-only`.
- Top-level `toolbox/mdcode/README.md` and the `docs/semantic-model.md` index updated to match.

Docs-only commit; the code, tests, and `bun test` results above are unchanged.
