### PR TITLE
viewer: resolve bundle-relative markdown links in concept bodies

### DIFF
--- a/okf/src/reference_agent/viewer/static/viz.js
+++ b/okf/src/reference_agent/viewer/static/viz.js
@@ -250,7 +250,7 @@
     const html = marked.parse(body, { breaks: false, gfm: true });
     const bodyEl = document.getElementById("detail-body");
     bodyEl.innerHTML = html;
-    rewriteInternalLinks(bodyEl);
+    rewriteInternalLinks(bodyEl, conceptId);
 
     const bl = backlinks[conceptId] || [];
     const blSection = document.getElementById("detail-backlinks");
@@ -290,21 +290,42 @@
     return event.at ? `${event.by} · ${event.at}` : String(event.by);
   }
 
-  function rewriteInternalLinks(root) {
+  function resolveRelative(href, conceptId) {
+    // Resolve a bundle-relative href (e.g. ../entities/Foo%20Bar.md) against
+    // the directory of the current concept, returning a concept id or null.
+    try { href = decodeURIComponent(href); } catch (e) { /* keep raw */ }
+    const baseParts = conceptId.split("/");
+    baseParts.pop(); // drop the file name, keep the directory
+    const segs = href.split("/");
+    for (const seg of segs) {
+      if (seg === "." ) continue;
+      else if (seg === "..") baseParts.pop();
+      else baseParts.push(seg);
+    }
+    let id = baseParts.join("/");
+    if (id.endsWith(".md")) id = id.slice(0, -3);
+    return id;
+  }
+
+  function rewriteInternalLinks(root, conceptId) {
     root.querySelectorAll("a[href]").forEach((a) => {
       const href = a.getAttribute("href");
       if (!href) return;
+      let target = null;
       if (href.startsWith("/") && href.endsWith(".md")) {
-        const target = href.slice(1, -3);
-        if (nodeIndex[target]) {
-          a.className = "internal";
-          a.setAttribute("href", "javascript:void(0)");
-          a.addEventListener("click", (e) => {
-            e.preventDefault();
-            showDetail(target);
-          });
-          return;
-        }
+        target = href.slice(1, -3);
+      } else if (!href.startsWith("#") && !/^[a-z][a-z0-9+.-]*:/i.test(href) && href.endsWith(".md")) {
+        // relative link — resolve against the current concept's directory
+        target = resolveRelative(href, conceptId);
+      }
+      if (target && nodeIndex[target]) {
+        a.className = "internal";
+        a.setAttribute("href", "javascript:void(0)");
+        a.addEventListener("click", (e) => {
+          e.preventDefault();
+          showDetail(target);
+        });
+        return;
       }
       a.className = "external";
       a.setAttribute("target", "_blank");


### PR DESCRIPTION
## Problem

The detail panel's `rewriteInternalLinks` only rewires hrefs in OKF's **recommended absolute form** (`/tables/customers.md`). Bundles that use the **relative form explicitly allowed by SPEC §6.1** (e.g. `../entities/foo.md`) fall through to the external-link path. Following such a link in a browser produces `ERR_FILE_NOT_FOUND` instead of navigating within the graph.

Relative links are common in practice for bundles consumed by more than one tool — e.g. a bundle also read as an Obsidian vault, where relative links (with URL-encoded spaces, `../entities/My%20Concept.md`) are the form Obsidian itself generates and resolve natively.

Note the inconsistency this creates *within the viewer itself*: the Python side already handles relative hrefs correctly — `_extract_links` resolves them against the document directory when building graph edges — so **the graph edges exist and render, but the same links are dead in the detail panel**.

## Fix

- `rewriteInternalLinks` now receives the current concept id and resolves relative `.md` hrefs against its directory. A new `resolveRelative` helper handles `.`/`..` segments and decodes URL-encoded characters such as `%20`.
- A relative target that resolves to an existing concept now navigates within the graph, identical to absolute-form behavior.
- Unresolvable targets and non-`.md`/scheme/anchor hrefs keep the existing external-link behavior.

## Testing

- `node --check` passes on the patched file.
- Verified against a real 3-bundle corpus (574 concepts, ~1,900 edges) whose links are all relative-form: before the patch, every in-document link errored with `ERR_FILE_NOT_FOUND`; after, a sampled 178/178 relative hrefs resolve to concept ids and navigate correctly.
- Graph edges (built by `_extract_links`) were unchanged before/after the patch, confirming the body-link path now agrees with the edge path.
