### PR TITLE
fix(mdcode): resolve Spanner graph KEY/REFERENCES to physical columns

### DIFF
--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -181,7 +181,12 @@ function renderNodeTable(
 
   const lines = [
     line(1, `${table} AS ${entity.name}`),
-    line(2, `KEY(${entity.keys.join(', ')})`),
+    line(
+        2,
+        `KEY(${
+            physicalColumns(
+                entity, entity.keys, warnings, `entity '${entity.name}'`)
+                .join(', ')})`),
   ];
 
   // A node participating in the hierarchy -- as a subclass (it declares
@@ -226,6 +231,7 @@ function renderEdgeTable(
   // columns; the edge is keyed by, and references its source node through, the
   // source entity's own key.
   const sourceEntity = entitiesByName.get(rel.source.entity);
+  const destEntity = entitiesByName.get(rel.destination.entity);
   let backing: string;
   let sourceKey: string[];
   if (!sourceEntity) {
@@ -239,15 +245,28 @@ function renderEdgeTable(
     sourceKey = sourceEntity.keys;
   }
 
-  const key = sourceKey.join(', ');
+  // Every key clause names physical columns: the edge is the source entity's
+  // own table, so its KEY / SOURCE KEY / the FK in DESTINATION KEY all resolve
+  // against the source entity, while the destination REFERENCES resolves
+  // against the destination entity's key. A profile that remaps any of these
+  // columns must reach the physical name here or Spanner rejects the DDL.
+  const relCtx = `relationship '${rel.name}'`;
+  const key =
+      physicalColumns(sourceEntity, sourceKey, warnings, relCtx).join(', ');
+  const destFk =
+      physicalColumns(sourceEntity, rel.source.columns, warnings, relCtx)
+          .join(', ');
+  const destRef =
+      physicalColumns(destEntity, rel.destination.columns, warnings, relCtx)
+          .join(', ');
   const lines = [
     line(1, `${backing} AS ${rel.name}`),
     line(2, `KEY(${key})`),
     line(2, `SOURCE KEY(${key}) REFERENCES ${rel.source.entity}(${key})`),
     line(
         2,
-        `DESTINATION KEY(${rel.source.columns.join(', ')}) REFERENCES ${
-            rel.destination.entity}(${rel.destination.columns.join(', ')})`),
+        `DESTINATION KEY(${destFk}) REFERENCES ${rel.destination.entity}(${
+            destRef})`),
   ];
   return lines.join('\n');
 }
@@ -275,7 +294,9 @@ function renderAssociationEdge(
           `relationship '${rel.name}': unknown entity '${end.entity}'`);
       return end.columns.join(', ');
     }
-    return entity.keys.join(', ');
+    return physicalColumns(
+               entity, entity.keys, warnings, `relationship '${rel.name}'`)
+        .join(', ');
   };
 
   const lines = [
@@ -313,6 +334,46 @@ function renderFieldProperty(field: Field, entity: string): string {
 // that is all the IR carries (see the Field expression-fidelity contract).
 function fieldExpression(f: Field): string|undefined {
   return f.expression ?? f.importedExpression;
+}
+
+
+// Resolves a logical field name to the physical column it binds to on
+// `entity`'s table. A structural key reference -- node KEY, edge KEY, SOURCE
+// KEY, DESTINATION KEY, and each REFERENCES target -- must name a real column,
+// never the property alias exposed under the field's name: Spanner rejects an
+// alias there ("Column '<alias>' not found in table"). A profile that binds a
+// field to a differently named column (a warehouse's `o_orderkey` vs an
+// operational store's `OrderId`) makes name != column common, so this mirrors
+// the BigQuery leg. Falls back to the name itself when it is not a declared
+// field (already a raw column) or the entity is unknown.
+function physicalColumn(entity: Entity|undefined, fieldName: string): string {
+  const field = entity?.fields.find(f => f.name === fieldName);
+  if (entity === undefined || field === undefined) return fieldName;
+  const expr = fieldExpression(field);
+  return expr !== undefined ? stripQualifier(expr, entity.name) : fieldName;
+}
+
+function physicalColumns(
+    entity: Entity|undefined, fieldNames: string[], warnings: string[],
+    context: string): string[] {
+  return fieldNames.map(n => {
+    const col = physicalColumn(entity, n);
+    // A structural site (KEY / SOURCE KEY / DESTINATION KEY / REFERENCES) must
+    // name a bare column. A field bound to a computed expression resolves to
+    // SQL, not a column, which Spanner rejects at deploy; warn here so the
+    // problem is named statically rather than surfacing as opaque DDL.
+    if (!isSimpleIdentifier(col)) {
+      warnings.push(
+          `${context}: field '${n}' is bound to a non-column expression (${
+              col}); a KEY/REFERENCES site requires a bare column, so Spanner ` +
+          `will reject the generated DDL`);
+    }
+    return col;
+  });
+}
+
+function isSimpleIdentifier(s: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(s);
 }
 
 

--- a/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
@@ -184,6 +184,82 @@ describe('bare table mapping', () => {
 });
 
 
+describe(
+    'remapped physical columns (a profile binds fields to differently named columns)',
+    () => {
+      // A binding profile can map a logical field onto a differently named
+      // physical column (a warehouse's `o_orderkey` vs an operational store's
+      // `OrderId`). Every structural site -- node KEY, edge KEY / SOURCE KEY /
+      // DESTINATION KEY, and each REFERENCES target -- must name the physical
+      // column, never the property alias exposed under the field name, or
+      // Spanner rejects the DDL
+      // ("Column 'o_orderkey' not found in table 'Orders'"). PROPERTIES still
+      // exposes the alias. Mirrors the BigQuery leg.
+      const remapped = (): SemanticModel => ({
+        name: 'sales',
+        metrics: [],
+        entities: [
+          {
+            name: 'orders',
+            dataSource: 'Orders',
+            keys: ['o_orderkey'],
+            fields: [
+              {name: 'o_orderkey', expression: 'OrderId'},
+              {name: 'o_custkey', expression: 'CustomerId'},
+            ],
+          },
+          {
+            name: 'customer',
+            dataSource: 'Customers',
+            keys: ['c_custkey'],
+            fields: [
+              {name: 'c_custkey', expression: 'CustomerId'},
+              {name: 'c_name', expression: 'FullName'},
+            ],
+          },
+        ],
+        relationships: [{
+          name: 'orders_to_customer',
+          source: {entity: 'orders', columns: ['o_custkey']},
+          destination: {entity: 'customer', columns: ['c_custkey']},
+        }],
+      });
+
+      test(
+          'node KEY names the physical column, PROPERTIES keeps the alias',
+          () => {
+            const {ddl} = generateSpannerPropertyGraph(remapped());
+            expect(ddl).toContain('KEY(OrderId)');
+            expect(ddl).not.toContain('KEY(o_orderkey)');
+            expect(ddl).toContain('OrderId AS o_orderkey');
+          });
+
+      test(
+          'edge SOURCE/DESTINATION KEY and REFERENCES name physical columns',
+          () => {
+            const {ddl} = generateSpannerPropertyGraph(remapped());
+            expect(ddl).toContain(
+                'SOURCE KEY(OrderId) REFERENCES orders(OrderId)');
+            expect(ddl).toContain(
+                'DESTINATION KEY(CustomerId) REFERENCES customer(CustomerId)');
+            // The FK's logical name may still appear as a PROPERTIES alias
+            // (`CustomerId AS o_custkey`); it must not appear at a key site.
+            expect(ddl).not.toContain('KEY(o_custkey)');
+          });
+
+      test(
+          'a key field bound to a non-column expression is warned (Spanner needs a bare column)',
+          () => {
+            const model = remapped();
+            model.entities[0].fields[0].expression = 'UPPER(OrderId)';
+            const {warnings} = generateSpannerPropertyGraph(model);
+            expect(warnings.some(
+                       w => w.includes('o_orderkey') &&
+                           w.includes('non-column expression')))
+                .toBe(true);
+          });
+    });
+
 describe('degenerate inputs', () => {
   test(
       'a model with no entities throws (an empty NODE TABLES is invalid DDL)',


### PR DESCRIPTION
## What

The Spanner property-graph generator emitted **logical field names** in every structural key site — node `KEY`, edge `KEY` / `SOURCE KEY` / `DESTINATION KEY`, and each `REFERENCES` target — even though `PROPERTIES` correctly aliased the physical column (`OrderId AS o_orderkey`). When a field's bound column differs from its logical name, Spanner rejects the DDL:

```
Column 'o_orderkey' not found in table 'Orders'
```

## Why it matters

This surfaces the moment you use **binding profiles** (#358) with Spanner (#361): an operational profile that maps `o_orderkey` → `OrderId` (the common warehouse-vs-operational naming split) generates a graph that fails at deploy. The `profiles.md` operational example itself remaps columns and would fail live.

The BigQuery leg already resolves these sites to physical columns via `physicalColumns()`. This mirrors that in the Spanner leg (`spanner.ts`) and adds a static warning when a key field binds to a non-column expression, rather than emitting DDL Spanner will reject.

## Verification

- 3 new unit tests in `spanner.test.ts` (node KEY, edge SOURCE/DESTINATION KEY + REFERENCES, non-column-expression warning); all 564 semantic tests pass.
- Deployed a fully-remapped operational profile to a **live ENTERPRISE Spanner Graph** and ran GQL traversals — correct results, using logical property names backed by remapped physical columns.

## Before / after

```
# before (rejected by Spanner)          # after
KEY(o_orderkey)                          KEY(OrderId)
SOURCE KEY(o_orderkey) ...               SOURCE KEY(OrderId) REFERENCES orders(OrderId)
DESTINATION KEY(o_custkey) ...           DESTINATION KEY(CustomerId) REFERENCES customer(CustomerId)
```