### PR TITLE
docs(mdcode): codelab deploys to Spanner via a binding profile

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -1,9 +1,10 @@
 # End-to-end codelab: one semantic model, from authoring to query
 
-A self-contained walkthrough. You author one semantic model, govern it in
-Knowledge Catalog, hydrate its data, and query a metric through BigQuery Graph.
-The metric is defined once and computed the same way at every step. The expected
-output is shown after each command so you can check as you go.
+A self-contained walkthrough. You author one *logical* semantic model, govern it
+in Knowledge Catalog, then bind it to physical stores — BigQuery and Spanner —
+and query the same metric in each. The metric is defined once and computed the
+same way at every step. The expected output is shown after each command so you
+can check as you go.
 
 For the deploy mechanics on their own (author, push, update, pull), see the
 [deploy guide](README.md); for every flag and permission, see the
@@ -32,7 +33,7 @@ export DATASET=datacloud_demo                       # BigQuery dataset + KC entr
 export GRAPH=sales                                  # property-graph name
 ```
 
-The Knowledge Catalog step (step 3) writes the `semantic-model` /
+The Knowledge Catalog step (step 2) writes the `semantic-model` /
 `semantic-entity` / `semantic-metric` entry types. These are not yet generally
 available on production Dataplex, so point `kcmd` at the staging (autopush)
 instance where they already exist. Once the types reach GA, delete this block —
@@ -46,7 +47,7 @@ export KC_TYPE_PROJECT=dataplex-autopush-types                             # pro
 
 ---
 
-## 1. Author the semantic model
+## 1. Author the logical model
 
 `init` provisions the Knowledge Catalog entry group and a local workspace:
 
@@ -57,15 +58,16 @@ kcmd init --semantic-model $PROJECT.$LOCATION.$DATASET
 ```
 
 Author the model in two parts — this is what lets one model serve many stores.
-The **logical model** declares the business: three entities (`orders`,
-`customer`, `lineitem`), the relationships between them, and one metric
-(`revenue`). It names nothing physical. A **binding profile** then says where
-each entity reads from and which column each field is. Section 5 adds a second
-profile for a different store; the logical model never changes. (A real sales
-schema fans each order out into many line-item rows, so the model includes
-`lineitem` — step 4 uses that fan-out to show where hand-written SQL goes wrong.)
+The **logical model** (this step) declares the business: three entities
+(`orders`, `customer`, `lineitem`), the relationships between them, and one
+metric (`revenue`). It names nothing physical. A **binding profile** then says
+where each entity reads from and which column each field is — you write one when
+you deploy to BigQuery (step 3) and another for Spanner (step 4); the logical
+model never changes. (A real sales schema fans each order out into many
+line-item rows, so the model includes `lineitem` — step 3 uses that fan-out to
+show where hand-written SQL goes wrong.)
 
-Write the logical model first — declarations only, no sources, no columns, no
+Write the logical model — declarations only, no sources, no columns, no
 deployment target:
 
 ```bash
@@ -113,75 +115,13 @@ YAML
 > **Metric constraint.** A BigQuery Graph measure can only aggregate a
 > **single column** — `SUM(orders.net_amount)` is fine, but
 > `SUM(o_extendedprice * (1 - o_discount))` is rejected at deploy. Any arithmetic
-> must be materialized into a column first (step 2 does that for `net_amount`).
+> must be materialized into a column first (the Deploy-to-BigQuery step does that
+> for `net_amount`).
 
-Now write the **analytical** binding: the BigQuery table each entity reads, the
-column each field maps to, and the BigQuery Graph to deploy to. The
-`deployment_target` key names that graph. A binding lives beside the model in
-`sales.profiles/`:
-
-```bash
-# BigQuery Graph deployment target, named by the profile's deployment_target key.
-BQ_DS=projects/$PROJECT/datasets/$DATASET
-TARGET=//bigquery.googleapis.com/$BQ_DS/propertyGraphs/$GRAPH
-
-mkdir -p catalog/EntryGroups/$DATASET/sales.profiles
-cat > catalog/EntryGroups/$DATASET/sales.profiles/analytical.yaml <<YAML
-version: "0.2.0.dev0"
-semantic_model:
-  - name: sales
-    deployment_target: $TARGET
-    datasets:
-      - name: orders
-        source: $PROJECT.$DATASET.orders
-        fields:
-          - { name: o_orderkey, expression: o_orderkey }
-          - { name: o_custkey,  expression: o_custkey }
-          - { name: net_amount, expression: net_amount }
-      - name: customer
-        source: $PROJECT.$DATASET.customer
-        fields:
-          - { name: c_custkey, expression: c_custkey }
-          - { name: c_name,    expression: c_name }
-      - name: lineitem
-        source: $PROJECT.$DATASET.lineitem
-        fields:
-          - { name: l_linekey,  expression: l_linekey }
-          - { name: l_orderkey, expression: l_orderkey }
-YAML
-```
-
-The binding restates no relationship, no metric, and no grain — those are logical
-and live once in the model. It carries only bindings: each entity's table and
-each field's column. Make it the default so a bare `kcmd push` selects it (steps
-3–4 rely on this); section 5 selects the other profile explicitly with
-`--profile`:
-
-```bash
-echo 'default_profile: analytical' >> catalog.yaml
-```
-
-> **Simple case — one binding, one file.** If a model only ever binds to one
-> store, you don't need a separate profile. Put the `deployment_target`, each
-> entity's `source`, and each field's `expression` directly on the model in
-> `sales.yaml` — that is the `default` profile — and run a bare `kcmd push`. An
-> `orders` entity then reads:
->
-> ```yaml
-> semantic_model:
->   - name: sales
->     deployment_target: //bigquery.googleapis.com/.../propertyGraphs/sales
->     datasets:
->       - name: orders
->         source: $PROJECT.$DATASET.orders
->         primary_key: [o_orderkey]
->         fields:
->           - { name: o_orderkey, datatype: Integer, expression: o_orderkey }
->           # ...
-> ```
->
-> This codelab splits them from the start because section 5 adds a second store,
-> and that split is what lets one model back both.
+That is the whole model — enough to govern in Knowledge Catalog. It carries no
+`source` table, no field `expression`, and no `deployment_target`: those are
+physical bindings, and Knowledge Catalog governs meaning, not storage. You add a
+binding only when you deploy to a query engine (steps 3 and 4).
 
 ### Import existing semantics instead of authoring
 
@@ -269,57 +209,22 @@ The classes became `Part` and `Supplier` entities, the datatype properties
 became `Part`'s fields, and the object property became the `suppliedBy`
 relationship. The `source: unbound:*` and `TODO_BIND` join columns are
 placeholders: the import gives you structure, and you bind it to physical tables
-and a deployment target before pushing — which is exactly what the `analytical`
-binding above adds to the hand-authored `sales` model. For the full OWL mapping — class hierarchies, unique
-keys, and the constructs carried as custom extensions — see
-[Importing an OWL ontology](owl-import.md).
+and a deployment target before deploying to a query engine — which is exactly
+what the `analytical` binding adds to the hand-authored `sales` model in step 3.
+For the full OWL mapping — class hierarchies, unique keys, and the constructs
+carried as custom extensions — see [Importing an OWL ontology](owl-import.md).
 
 The rest of this codelab uses the hand-authored `sales` model above.
 
 ---
 
-## 2. Hydrate the data
+## 2. Govern it in Knowledge Catalog
 
-An ontology-driven data-engineering agent would produce this data from raw
-sources. For a self-contained run, create the three tables directly. `net_amount`
-is materialized on `orders` (the measure aggregates it), and each order fans out
-into several `lineitem` rows:
-
-```bash
-bq mk -f --dataset $PROJECT:$DATASET
-
-bq query --use_legacy_sql=false '
-CREATE OR REPLACE TABLE `'"$PROJECT.$DATASET"'.customer` AS
-SELECT * FROM UNNEST([STRUCT(1 AS c_custkey, "Acme" AS c_name),
-                      STRUCT(2, "Globex")]);
-CREATE OR REPLACE TABLE `'"$PROJECT.$DATASET"'.orders` AS
-SELECT * FROM UNNEST([
-  STRUCT(100 AS o_orderkey, 1 AS o_custkey,  90.0 AS net_amount),
-  STRUCT(101, 1, 200.0),
-  STRUCT(102, 2,  40.0)
-]);
-CREATE OR REPLACE TABLE `'"$PROJECT.$DATASET"'.lineitem` AS
-SELECT * FROM UNNEST([                 -- order 100: 2 lines, 101: 1, 102: 3
-  STRUCT(1 AS l_linekey, 100 AS l_orderkey), STRUCT(2, 100),
-  STRUCT(3, 101),
-  STRUCT(4, 102), STRUCT(5, 102), STRUCT(6, 102)
-]);'
-```
-
-> **Why data comes before the pushes.** `kcmd push` does more than register the
-> model. It validates that every entity's `source` table resolves in BigQuery,
-> even under `--validate-only`, and the BigQuery graph is built over these
-> tables. So the tables must exist before the Knowledge Catalog push (step 3) and
-> the BigQuery push (step 4).
-
----
-
-## 3. Govern it in Knowledge Catalog
-
-The same model becomes governed catalog entries. Steps 3 and 4 deploy the
-`analytical` binding — the default profile you set in step 1 — so a bare `kcmd
-push` selects it; you never repeat `--profile` until section 5 needs the other
-one. First preview the plan without writing anything:
+Knowledge Catalog governs *meaning*, which is entirely logical — so you can
+govern the model right now, before binding it to any store or loading a single
+row. The push writes the logical model as catalog entries; it needs no `source`
+tables, no column bindings, and no data. First preview the plan without writing
+anything:
 
 ```bash
 kcmd push --target kc --validate-only --print
@@ -352,7 +257,8 @@ Wrote 5 new and 0 updated Knowledge Catalog entries; linked 2 relationships.
 Each entity, the metric, and the model itself are now governed entries, joined by
 a schema-join link — discoverable, access-controlled, and the single definition
 every downstream step reads from. `kcmd pull` reconstructs the model YAML from
-these entries, confirming the round-trip.
+these entries, confirming the round-trip. None of this required a physical store:
+the model is governed first, then bound.
 
 > This write needs the `semantic-model` / `semantic-entity` / `semantic-metric`
 > entry types and write access to the entry group. See
@@ -360,9 +266,113 @@ these entries, confirming the round-trip.
 
 ---
 
-## 4. Get reliable insights with BigQuery
+## 3. Deploy to BigQuery and get reliable insights
 
-Deploy the model to BigQuery Graph. `--print` shows the generated DDL:
+Governing the model didn't touch a table. Deploying it to a query engine does:
+you add a **binding profile** — the table each entity reads and the column each
+field maps to — then create the data and deploy.
+
+Write the **analytical** binding: the BigQuery table each entity reads, the
+column each field maps to, and the BigQuery graph to deploy to. The
+`deployment_target` key names that graph. A binding lives beside the model in
+`sales.profiles/`:
+
+```bash
+# BigQuery deployment target, named by the profile's deployment_target key.
+BQ_DS=projects/$PROJECT/datasets/$DATASET
+TARGET=//bigquery.googleapis.com/$BQ_DS/propertyGraphs/$GRAPH
+
+mkdir -p catalog/EntryGroups/$DATASET/sales.profiles
+cat > catalog/EntryGroups/$DATASET/sales.profiles/analytical.yaml <<YAML
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    deployment_target: $TARGET
+    datasets:
+      - name: orders
+        source: $PROJECT.$DATASET.orders
+        fields:
+          - { name: o_orderkey, expression: o_orderkey }
+          - { name: o_custkey,  expression: o_custkey }
+          - { name: net_amount, expression: net_amount }
+      - name: customer
+        source: $PROJECT.$DATASET.customer
+        fields:
+          - { name: c_custkey, expression: c_custkey }
+          - { name: c_name,    expression: c_name }
+      - name: lineitem
+        source: $PROJECT.$DATASET.lineitem
+        fields:
+          - { name: l_linekey,  expression: l_linekey }
+          - { name: l_orderkey, expression: l_orderkey }
+YAML
+```
+
+The binding restates no relationship, no metric, and no grain — those are logical
+and live once in the model. It carries only bindings: each entity's table and
+each field's column. Make it the default so a bare `kcmd push` selects it (the
+rest of this step relies on this); step 4 selects the other profile explicitly
+with `--profile`:
+
+```bash
+echo 'default_profile: analytical' >> catalog.yaml
+```
+
+> **Simple case — one binding, one file.** If a model only ever binds to one
+> store, you don't need a separate profile. Put the `deployment_target`, each
+> entity's `source`, and each field's `expression` directly on the model in
+> `sales.yaml` — that is the `default` profile — and run a bare `kcmd push`. An
+> `orders` entity then reads:
+>
+> ```yaml
+> semantic_model:
+>   - name: sales
+>     deployment_target: //bigquery.googleapis.com/.../propertyGraphs/sales
+>     datasets:
+>       - name: orders
+>         source: $PROJECT.$DATASET.orders
+>         primary_key: [o_orderkey]
+>         fields:
+>           - { name: o_orderkey, datatype: Integer, expression: o_orderkey }
+>           # ...
+> ```
+>
+> This codelab splits them because step 4 adds a second store, and that split is
+> what lets one model back both.
+
+Now create the data. An ontology-driven data-engineering agent would produce it
+from raw sources; for a self-contained run, create the three tables directly.
+`net_amount` is materialized on `orders` (the measure aggregates it), and each
+order fans out into several `lineitem` rows:
+
+```bash
+bq mk -f --dataset $PROJECT:$DATASET
+
+bq query --use_legacy_sql=false '
+CREATE OR REPLACE TABLE `'"$PROJECT.$DATASET"'.customer` AS
+SELECT * FROM UNNEST([STRUCT(1 AS c_custkey, "Acme" AS c_name),
+                      STRUCT(2, "Globex")]);
+CREATE OR REPLACE TABLE `'"$PROJECT.$DATASET"'.orders` AS
+SELECT * FROM UNNEST([
+  STRUCT(100 AS o_orderkey, 1 AS o_custkey,  90.0 AS net_amount),
+  STRUCT(101, 1, 200.0),
+  STRUCT(102, 2,  40.0)
+]);
+CREATE OR REPLACE TABLE `'"$PROJECT.$DATASET"'.lineitem` AS
+SELECT * FROM UNNEST([                 -- order 100: 2 lines, 101: 1, 102: 3
+  STRUCT(1 AS l_linekey, 100 AS l_orderkey), STRUCT(2, 100),
+  STRUCT(3, 101),
+  STRUCT(4, 102), STRUCT(5, 102), STRUCT(6, 102)
+]);'
+```
+
+> **Why the tables come before the BigQuery push.** Unlike the Knowledge Catalog
+> step, `kcmd push --target bq` validates that every entity's `source` table
+> resolves in BigQuery — even under `--validate-only` — and builds the graph over
+> these tables. So the tables must exist first. (Step 2 needed none of this: it
+> governed the logical model, no tables required.)
+
+Now deploy the bound model to BigQuery. `--print` shows the generated DDL:
 
 ```bash
 kcmd push --target bq --print
@@ -488,10 +498,10 @@ query, so the correct answer is the default one.
 
 ---
 
-## 5. Deploy the same model to Spanner Graph
+## 4. Deploy the same model to Spanner
 
-The same customers and orders usually live in more than one store. Steps 1–4
-deployed the `analytical` profile — the BigQuery warehouse. An operational
+The same customers and orders usually live in more than one store. Step 3 bound
+and deployed the `analytical` profile — the BigQuery warehouse. An operational
 Spanner database holds the same business, but its tables are named differently
 (`Customers`, `Orders`, `LineItems`), its columns are named differently
 (`FullName`, `OrderId`), and it does not carry `net_amount` — a settled figure
@@ -573,8 +583,8 @@ DDL below shows.)
 `revenue` is `SUM(orders.net_amount)`, and the operational store does not bind
 `net_amount`, so the profile reports `revenue` as unavailable there — computed
 from the bindings, not declared. The `analytical` profile binds `net_amount`, so
-the same metric is available under the binding steps 1–4 used. One model; each
-store answers the part of it that its data can back.
+the same metric is available under the binding step 3 used. One model; each store
+answers the part of it that its data can back.
 
 Preview the Spanner DDL the profile generates (`--validate-only` runs the
 generator without touching a database):
@@ -628,7 +638,7 @@ The graph still speaks the model's vocabulary — the properties are `o_orderkey
 (`OrderId AS o_orderkey`, `FullName AS c_name`). The key and reference clauses
 name the physical columns (`KEY(OrderId)`), because a Spanner graph keys on the
 table's real column, not the property alias. Three things also differ from the
-BigQuery DDL in step 4:
+BigQuery DDL in step 3:
 
 - **Bare table and graph names.** A Spanner property graph names tables inside
   one database, so there is no backticked `project.dataset.` qualifier — each
@@ -663,6 +673,11 @@ kcmd push --profile operational --target spanner
 # -> Deployed 1 Spanner Graph(s).
 ```
 
+> **Knowledge Catalog is unchanged.** You do not re-push to Knowledge Catalog for
+> the Spanner leg. Step 2 governed the *logical* model, and adding a binding
+> profile changes nothing logical — bindings are not governed in Knowledge
+> Catalog. The single set of entries from step 2 already describes this graph too.
+
 Query it with Spanner's Graph Query Language. The query names the model's
 properties (`c_name`, `o_orderkey`); the profile's column bindings are invisible
 to it:
@@ -680,7 +695,7 @@ Acme      2
 Globex    1
 ```
 
-The one model now backs two stores: the BigQuery warehouse from steps 1–4, where
+The one model now backs two stores: the BigQuery warehouse from step 3, where
 `revenue` is a measure, and this operational Spanner graph, where the same
 entities and relationships are queried live and `revenue` is computed in SQL or
 the application rather than by the graph. `Customer`, `orders_to_customer`, and
@@ -688,7 +703,7 @@ every field mean the same thing in both; only the bindings differ.
 
 ---
 
-## 6. Clean up
+## 5. Clean up
 
 Drop the BigQuery dataset (tables + property graph):
 
@@ -696,7 +711,7 @@ Drop the BigQuery dataset (tables + property graph):
 bq rm -r -f -d $PROJECT:$DATASET
 ```
 
-Drop the Spanner database from section 5 (its tables and the graph go with it):
+Drop the Spanner database from step 4 (its tables and the graph go with it):
 
 ```bash
 gcloud spanner databases delete $SPANNER_DB --instance=$SPANNER_INSTANCE --quiet

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -118,10 +118,12 @@ YAML
 > must be materialized into a column first (the Deploy-to-BigQuery step does that
 > for `net_amount`).
 
-That is the whole model — enough to govern in Knowledge Catalog. It carries no
-`source` table, no field `expression`, and no `deployment_target`: those are
-physical bindings, and Knowledge Catalog governs meaning, not storage. You add a
-binding only when you deploy to a query engine (steps 3 and 4).
+That is already enough to govern in Knowledge Catalog. It carries no `source`
+table, no field `expression`, and no `deployment_target` yet — those are physical
+bindings, which you add when you deploy to a query engine (steps 3 and 4). This
+codelab governs the logical model first and binds it afterward, but that is just
+the order it happens to take: Knowledge Catalog can hold the physical bindings
+too once you have them.
 
 ### Import existing semantics instead of authoring
 
@@ -220,11 +222,12 @@ The rest of this codelab uses the hand-authored `sales` model above.
 
 ## 2. Govern it in Knowledge Catalog
 
-Knowledge Catalog governs *meaning*, which is entirely logical — so you can
+A Knowledge Catalog push does not require any physical binding — so you can
 govern the model right now, before binding it to any store or loading a single
 row. The push writes the logical model as catalog entries; it needs no `source`
-tables, no column bindings, and no data. First preview the plan without writing
-anything:
+tables, no column bindings, and no data. (Once you do bind it, those bindings can
+be governed here too; this step just shows the earliest point at which governance
+is possible.) First preview the plan without writing anything:
 
 ```bash
 kcmd push --target kc --validate-only --print

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -119,11 +119,8 @@ YAML
 > for `net_amount`).
 
 That is already enough to govern in Knowledge Catalog. It carries no `source`
-table, no field `expression`, and no `deployment_target` yet — those are physical
-bindings, which you add when you deploy to a query engine (steps 3 and 4). This
-codelab governs the logical model first and binds it afterward, but that is just
-the order it happens to take: Knowledge Catalog can hold the physical bindings
-too once you have them.
+table, no field `expression`, and no `deployment_target` yet — you add those
+physical bindings when you deploy to a query engine (steps 3 and 4).
 
 ### Import existing semantics instead of authoring
 
@@ -222,12 +219,10 @@ The rest of this codelab uses the hand-authored `sales` model above.
 
 ## 2. Govern it in Knowledge Catalog
 
-A Knowledge Catalog push does not require any physical binding — so you can
-govern the model right now, before binding it to any store or loading a single
-row. The push writes the logical model as catalog entries; it needs no `source`
-tables, no column bindings, and no data. (Once you do bind it, those bindings can
-be governed here too; this step just shows the earliest point at which governance
-is possible.) First preview the plan without writing anything:
+You can govern the model right now, before binding it to any store or loading a
+single row. The push writes the logical model as catalog entries; it needs no
+`source` tables, no column bindings, and no data. First preview the plan without
+writing anything:
 
 ```bash
 kcmd push --target kc --validate-only --print
@@ -260,8 +255,9 @@ Wrote 5 new and 0 updated Knowledge Catalog entries; linked 2 relationships.
 Each entity, the metric, and the model itself are now governed entries, joined by
 a schema-join link — discoverable, access-controlled, and the single definition
 every downstream step reads from. `kcmd pull` reconstructs the model YAML from
-these entries, confirming the round-trip. None of this required a physical store:
-the model is governed first, then bound.
+these entries, confirming the round-trip. You develop the model, govern it here,
+and bind it in the sections that follow — and those physical bindings can be
+governed in Knowledge Catalog too.
 
 > This write needs the `semantic-model` / `semantic-entity` / `semantic-metric`
 > entry types and write access to the entry group. See

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -118,10 +118,6 @@ YAML
 > must be materialized into a column first (the Deploy-to-BigQuery step does that
 > for `net_amount`).
 
-That is already enough to govern in Knowledge Catalog. It carries no `source`
-table, no field `expression`, and no `deployment_target` yet — you add those
-physical bindings when you deploy to a query engine (steps 3 and 4).
-
 ### Import existing semantics instead of authoring
 
 You can also start from an existing OWL ontology instead of hand-authoring this

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -56,64 +56,41 @@ kcmd init --semantic-model $PROJECT.$LOCATION.$DATASET
 # -> scope: semantic-model.$PROJECT.$LOCATION.$DATASET
 ```
 
-Author the model: three entities (`orders`, `customer`, `lineitem`), the
-relationships between them, and one metric (`revenue`). A real sales schema fans
-each order out into many line-item rows, so the model includes `lineitem`. Step
-4 uses that fan-out to show where hand-written SQL goes wrong. The
-`deployment_target` key names the BigQuery Graph the model deploys to.
+Author the model in two parts — this is what lets one model serve many stores.
+The **logical model** declares the business: three entities (`orders`,
+`customer`, `lineitem`), the relationships between them, and one metric
+(`revenue`). It names nothing physical. A **binding profile** then says where
+each entity reads from and which column each field is. Section 5 adds a second
+profile for a different store; the logical model never changes. (A real sales
+schema fans each order out into many line-item rows, so the model includes
+`lineitem` — step 4 uses that fan-out to show where hand-written SQL goes wrong.)
+
+Write the logical model first — declarations only, no sources, no columns, no
+deployment target:
 
 ```bash
-# BigQuery Graph deployment target, named by the model's deployment_target key.
-BQ_DS=projects/$PROJECT/datasets/$DATASET
-TARGET=//bigquery.googleapis.com/$BQ_DS/propertyGraphs/$GRAPH
-
-cat > catalog/EntryGroups/$DATASET/sales.yaml <<YAML
+cat > catalog/EntryGroups/$DATASET/sales.yaml <<'YAML'
 version: "0.2.0.dev0"
 semantic_model:
   - name: sales
     description: Orders, line items, and customers for the codelab
-    deployment_target: $TARGET
     datasets:
       - name: orders
-        source: $PROJECT.$DATASET.orders
         primary_key: [o_orderkey]
         fields:
-          - name: o_orderkey
-            datatype: Integer
-            expression:
-              dialects: [{ dialect: BIGQUERY, expression: o_orderkey }]
-          - name: o_custkey
-            datatype: Integer
-            expression:
-              dialects: [{ dialect: BIGQUERY, expression: o_custkey }]
-          - name: net_amount
-            datatype: Decimal
-            expression:
-              dialects: [{ dialect: BIGQUERY, expression: net_amount }]
+          - { name: o_orderkey, datatype: Integer }
+          - { name: o_custkey,  datatype: Integer }
+          - { name: net_amount, datatype: Decimal }
       - name: customer
-        source: $PROJECT.$DATASET.customer
         primary_key: [c_custkey]
         fields:
-          - name: c_custkey
-            datatype: Integer
-            expression:
-              dialects: [{ dialect: BIGQUERY, expression: c_custkey }]
-          - name: c_name
-            datatype: String
-            expression:
-              dialects: [{ dialect: BIGQUERY, expression: c_name }]
+          - { name: c_custkey, datatype: Integer }
+          - { name: c_name,    datatype: String }
       - name: lineitem
-        source: $PROJECT.$DATASET.lineitem
         primary_key: [l_linekey]
         fields:
-          - name: l_linekey
-            datatype: Integer
-            expression:
-              dialects: [{ dialect: BIGQUERY, expression: l_linekey }]
-          - name: l_orderkey
-            datatype: Integer
-            expression:
-              dialects: [{ dialect: BIGQUERY, expression: l_orderkey }]
+          - { name: l_linekey,  datatype: Integer }
+          - { name: l_orderkey, datatype: Integer }
     relationships:
       - name: orders_to_customer
         from: orders
@@ -137,6 +114,74 @@ YAML
 > **single column** — `SUM(orders.net_amount)` is fine, but
 > `SUM(o_extendedprice * (1 - o_discount))` is rejected at deploy. Any arithmetic
 > must be materialized into a column first (step 2 does that for `net_amount`).
+
+Now write the **analytical** binding: the BigQuery table each entity reads, the
+column each field maps to, and the BigQuery Graph to deploy to. The
+`deployment_target` key names that graph. A binding lives beside the model in
+`sales.profiles/`:
+
+```bash
+# BigQuery Graph deployment target, named by the profile's deployment_target key.
+BQ_DS=projects/$PROJECT/datasets/$DATASET
+TARGET=//bigquery.googleapis.com/$BQ_DS/propertyGraphs/$GRAPH
+
+mkdir -p catalog/EntryGroups/$DATASET/sales.profiles
+cat > catalog/EntryGroups/$DATASET/sales.profiles/analytical.yaml <<YAML
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    deployment_target: $TARGET
+    datasets:
+      - name: orders
+        source: $PROJECT.$DATASET.orders
+        fields:
+          - { name: o_orderkey, expression: o_orderkey }
+          - { name: o_custkey,  expression: o_custkey }
+          - { name: net_amount, expression: net_amount }
+      - name: customer
+        source: $PROJECT.$DATASET.customer
+        fields:
+          - { name: c_custkey, expression: c_custkey }
+          - { name: c_name,    expression: c_name }
+      - name: lineitem
+        source: $PROJECT.$DATASET.lineitem
+        fields:
+          - { name: l_linekey,  expression: l_linekey }
+          - { name: l_orderkey, expression: l_orderkey }
+YAML
+```
+
+The binding restates no relationship, no metric, and no grain — those are logical
+and live once in the model. It carries only bindings: each entity's table and
+each field's column. Make it the default so a bare `kcmd push` selects it (steps
+3–4 rely on this); section 5 selects the other profile explicitly with
+`--profile`:
+
+```bash
+echo 'default_profile: analytical' >> catalog.yaml
+```
+
+> **Simple case — one binding, one file.** If a model only ever binds to one
+> store, you don't need a separate profile. Put the `deployment_target`, each
+> entity's `source`, and each field's `expression` directly on the model in
+> `sales.yaml` — that is the `default` profile — and run a bare `kcmd push`. An
+> `orders` entity then reads:
+>
+> ```yaml
+> semantic_model:
+>   - name: sales
+>     deployment_target: //bigquery.googleapis.com/.../propertyGraphs/sales
+>     datasets:
+>       - name: orders
+>         source: $PROJECT.$DATASET.orders
+>         primary_key: [o_orderkey]
+>         fields:
+>           - { name: o_orderkey, datatype: Integer, expression: o_orderkey }
+>           # ...
+> ```
+>
+> This codelab splits them from the start because section 5 adds a second store,
+> and that split is what lets one model back both.
 
 ### Import existing semantics instead of authoring
 
@@ -224,8 +269,8 @@ The classes became `Part` and `Supplier` entities, the datatype properties
 became `Part`'s fields, and the object property became the `suppliedBy`
 relationship. The `source: unbound:*` and `TODO_BIND` join columns are
 placeholders: the import gives you structure, and you bind it to physical tables
-and a deployment target before pushing, which is what the hand-authored `sales`
-model above already has. For the full OWL mapping — class hierarchies, unique
+and a deployment target before pushing — which is exactly what the `analytical`
+binding above adds to the hand-authored `sales` model. For the full OWL mapping — class hierarchies, unique
 keys, and the constructs carried as custom extensions — see
 [Importing an OWL ontology](owl-import.md).
 
@@ -271,8 +316,10 @@ SELECT * FROM UNNEST([                 -- order 100: 2 lines, 101: 1, 102: 3
 
 ## 3. Govern it in Knowledge Catalog
 
-The same model becomes governed catalog entries. First preview the plan without
-writing anything:
+The same model becomes governed catalog entries. Steps 3 and 4 deploy the
+`analytical` binding — the default profile you set in step 1 — so a bare `kcmd
+push` selects it; you never repeat `--profile` until section 5 needs the other
+one. First preview the plan without writing anything:
 
 ```bash
 kcmd push --target kc --validate-only --print
@@ -444,17 +491,17 @@ query, so the correct answer is the default one.
 ## 5. Deploy the same model to Spanner Graph
 
 The same customers and orders usually live in more than one store. Steps 1–4
-used the model's built-in binding — the BigQuery warehouse. An operational
+deployed the `analytical` profile — the BigQuery warehouse. An operational
 Spanner database holds the same business, but its tables are named differently
 (`Customers`, `Orders`, `LineItems`), its columns are named differently
 (`FullName`, `OrderId`), and it does not carry `net_amount` — a settled figure
 the warehouse computes, not something the live store keeps.
 
-A **binding profile** maps the one logical model onto that store. It changes only
-where each entity reads from and which column each field binds to; it never
+Add a **second profile** beside the first. Like the `analytical` one, it changes
+only where each entity reads from and which column each field binds to; it never
 changes what an entity, a relationship, or a metric *means* (for the full
 contract, see [binding profiles](profiles.md)). Write the operational binding
-beside the model, in `sales.profiles/`:
+into the same `sales.profiles/` directory:
 
 ```bash
 export SPANNER_INSTANCE=<your-spanner-instance>   # a Spanner ENTERPRISE-edition instance
@@ -497,9 +544,16 @@ kcmd profiles
 ```
 
 ```
-Model 'sales' (kcmd_codelab):
+Model 'sales' ($DATASET):
+  profile 'analytical' (default)
+    target: //bigquery.googleapis.com/projects/$PROJECT/datasets/$DATASET/propertyGraphs/sales
+    sources:
+      orders -> $PROJECT.$DATASET.orders
+      customer -> $PROJECT.$DATASET.customer
+      lineitem -> $PROJECT.$DATASET.lineitem
+    cannot answer: nothing withheld.
   profile 'operational'
-    target: //spanner.googleapis.com/projects/.../databases/.../propertyGraphs/sales
+    target: //spanner.googleapis.com/projects/$PROJECT/instances/$SPANNER_INSTANCE/databases/$SPANNER_DB/propertyGraphs/sales
     sources:
       orders -> $PROJECT.Orders
       customer -> $PROJECT.Customers
@@ -509,14 +563,17 @@ Model 'sales' (kcmd_codelab):
       metric revenue (field orders.net_amount is unbound)
 ```
 
-(`kcmd profiles` resolves each source against your project for display; the
-Spanner graph itself references the bare table — `Orders` — as the DDL below
-shows.)
+Both profiles now show side by side: `analytical` binds every field, so it
+withholds nothing; `operational` leaves `net_amount` unbound. (`kcmd profiles`
+resolves each source against your project for display — the `analytical` sources
+are fully qualified, and each `operational` bare table such as `Orders` is shown
+project-prefixed; the Spanner graph itself references the bare `Orders`, as the
+DDL below shows.)
 
 `revenue` is `SUM(orders.net_amount)`, and the operational store does not bind
 `net_amount`, so the profile reports `revenue` as unavailable there — computed
-from the bindings, not declared. The warehouse binds `net_amount`, so the same
-metric is available under the default binding steps 1–4 used. One model; each
+from the bindings, not declared. The `analytical` profile binds `net_amount`, so
+the same metric is available under the binding steps 1–4 used. One model; each
 store answers the part of it that its data can back.
 
 Preview the Spanner DDL the profile generates (`--validate-only` runs the

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -1,10 +1,10 @@
 # End-to-end codelab: one semantic model, from authoring to query
 
-A self-contained walkthrough. You author one *logical* semantic model, govern it
-in Knowledge Catalog, then bind it to physical stores — BigQuery and Spanner —
-and query it in each. The model is defined once and every store reads from that
-single definition. The expected output is shown after each command so you can
-check as you go.
+A self-contained walkthrough. You author a semantic model, govern it in Knowledge
+Catalog, and bind it to physical stores — BigQuery and Spanner — to query it in
+each. The model is defined once and every store reads from that single
+definition. The expected output is shown after each command so you can check as
+you go.
 
 For the deploy mechanics on their own (author, push, update, pull), see the
 [deploy guide](README.md); for every flag and permission, see the

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -76,7 +76,7 @@ version: "0.2.0.dev0"
 semantic_model:
   - name: sales
     description: Orders, line items, and customers for the codelab
-    datasets:
+    entities:
       - name: orders
         primary_key: [o_orderkey]
         fields:
@@ -202,7 +202,9 @@ semantic_model:
 
 The classes became `Part` and `Supplier` entities, the datatype properties
 became `Part`'s fields, and the object property became the `suppliedBy`
-relationship. The `source: unbound:*` and `TODO_BIND` join columns are
+relationship. (The importer writes them under `datasets:`, the original spelling
+of the `entities:` key this codelab uses — the two are interchangeable.) The
+`source: unbound:*` and `TODO_BIND` join columns are
 placeholders: the import gives you structure, and you bind it to physical tables
 and a deployment target before deploying to a query engine — which is exactly
 what the `analytical` binding adds to the hand-authored `sales` model in step 3.
@@ -225,6 +227,10 @@ kcmd push --target kc --validate-only --print
 ```
 
 ```
+Validating semantic model for Knowledge Catalog...
+Warning: [sales] relationship 'orders_to_customer': Knowledge Catalog stores the name only in the normalized link id, so a pull returns it lowercased/hyphenated (e.g. 'orders-to-customer'), not 'orders_to_customer'.
+Warning: [sales] relationship 'lineitem_to_orders': Knowledge Catalog stores the name only in the normalized link id, so a pull returns it lowercased/hyphenated (e.g. 'lineitem-to-orders'), not 'lineitem_to_orders'.
+-- Knowledge Catalog --
 Knowledge Catalog plan for 'sales' (destination $PROJECT.$LOCATION.$DATASET):
   5 entries:
     - sales (semantic-model)
@@ -235,7 +241,14 @@ Knowledge Catalog plan for 'sales' (destination $PROJECT.$LOCATION.$DATASET):
   2 schema-join links:
     - sales-orders-to-customer
     - sales-lineitem-to-orders
+Validation complete; no changes applied.
 ```
+
+The two warnings are informational, and every Knowledge Catalog push repeats
+them: relationship names come back from a `kcmd pull` lowercased and hyphenated
+(`orders-to-customer`), because Knowledge Catalog keeps the name only in the
+normalized link id. Nothing is wrong — the graph itself keeps the authored
+`orders_to_customer`.
 
 Then drop `--validate-only` to perform the write:
 
@@ -248,12 +261,13 @@ Pushing semantic model (Knowledge Catalog)...
 Wrote 5 new and 0 updated Knowledge Catalog entries; linked 2 relationships.
 ```
 
-Each entity, the metric, and the model itself are now governed entries, joined by
-a schema-join link — discoverable, access-controlled, and the single definition
-every downstream step reads from. `kcmd pull` reconstructs the model YAML from
-these entries, confirming the round-trip. You develop the model, govern it here,
-and bind it in the sections that follow — and those physical bindings can be
-governed in Knowledge Catalog too.
+(The write repeats the same two warnings, dropped here.) Each entity, the metric,
+and the model itself are now governed entries, joined by a schema-join link —
+discoverable, access-controlled, and the single definition every downstream step
+reads from. `kcmd pull` reconstructs the model YAML from these entries, confirming
+the round-trip. You develop the model, govern it here, and bind it in the sections
+that follow — and those physical bindings can be governed in Knowledge Catalog
+too.
 
 > This write needs the `semantic-model` / `semantic-entity` / `semantic-metric`
 > entry types and write access to the entry group. See
@@ -283,7 +297,7 @@ version: "0.2.0.dev0"
 semantic_model:
   - name: sales
     deployment_target: $TARGET
-    datasets:
+    entities:
       - name: orders
         source: $PROJECT.$DATASET.orders
         fields:
@@ -323,7 +337,7 @@ echo 'default_profile: analytical' >> catalog.yaml
 > semantic_model:
 >   - name: sales
 >     deployment_target: //bigquery.googleapis.com/.../propertyGraphs/sales
->     datasets:
+>     entities:
 >       - name: orders
 >         source: $PROJECT.$DATASET.orders
 >         primary_key: [o_orderkey]
@@ -378,6 +392,9 @@ edge, and the metric into a measure (your `$PROJECT`/`$DATASET` appear in the fu
 qualified names):
 
 ```sql
+Pushing semantic model (BigQuery Graph)...
+-- BigQuery Graph --
+-- //bigquery.googleapis.com/projects/$PROJECT/datasets/$DATASET/propertyGraphs/$GRAPH
 CREATE OR REPLACE PROPERTY GRAPH `$PROJECT.$DATASET.$GRAPH`
 NODE TABLES (
   `$PROJECT.$DATASET.orders` AS orders
@@ -519,7 +536,7 @@ version: "0.2.0.dev0"
 semantic_model:
   - name: sales
     deployment_target: $SPANNER_TARGET
-    datasets:
+    entities:
       - name: orders
         source: Orders                       # a bare table in the Spanner database
         fields:

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -59,11 +59,11 @@ kcmd init --semantic-model $PROJECT.$LOCATION.$DATASET
 Author the model: three entities (`orders`, `customer`, `lineitem`), the
 relationships between them, and one metric (`revenue`). A real sales schema fans
 each order out into many line-item rows, so the model includes `lineitem`. Step
-4 uses that fan-out to show where hand-written SQL goes wrong. The `GOOGLE`
-extension names the BigQuery Graph deployment target.
+4 uses that fan-out to show where hand-written SQL goes wrong. The
+`deployment_target` key names the BigQuery Graph the model deploys to.
 
 ```bash
-# BigQuery Graph deployment target named by the GOOGLE extension below.
+# BigQuery Graph deployment target, named by the model's deployment_target key.
 BQ_DS=projects/$PROJECT/datasets/$DATASET
 TARGET=//bigquery.googleapis.com/$BQ_DS/propertyGraphs/$GRAPH
 
@@ -72,9 +72,7 @@ version: "0.2.0.dev0"
 semantic_model:
   - name: sales
     description: Orders, line items, and customers for the codelab
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["$TARGET"]}'
+    deployment_target: $TARGET
     datasets:
       - name: orders
         source: $PROJECT.$DATASET.orders
@@ -445,98 +443,191 @@ query, so the correct answer is the default one.
 
 ## 5. Deploy the same model to Spanner Graph
 
-The model you authored is backend-agnostic — the one BigQuery-specific choice in
-it is the deployment target. Swap that target for a Spanner Graph URI and the
-**same document** deploys to Spanner Graph. You can inspect the generated DDL
-without a Spanner database, because the generator runs under `--validate-only`:
+The same customers and orders usually live in more than one store. Steps 1–4
+used the model's built-in binding — the BigQuery warehouse. An operational
+Spanner database holds the same business, but its tables are named differently
+(`Customers`, `Orders`, `LineItems`), its columns are named differently
+(`FullName`, `OrderId`), and it does not carry `net_amount` — a settled figure
+the warehouse computes, not something the live store keeps.
+
+A **binding profile** maps the one logical model onto that store. It changes only
+where each entity reads from and which column each field binds to; it never
+changes what an entity, a relationship, or a metric *means* (for the full
+contract, see [binding profiles](profiles.md)). Write the operational binding
+beside the model, in `sales.profiles/`:
 
 ```bash
-# Point $GRAPH at a Spanner Graph target instead of the BigQuery one from step 1.
-export SPANNER_INSTANCE=<your-spanner-instance>
+export SPANNER_INSTANCE=<your-spanner-instance>   # a Spanner ENTERPRISE-edition instance
 export SPANNER_DB=<your-googlesql-database>
 SPANNER_TARGET=//spanner.googleapis.com/projects/$PROJECT/instances/$SPANNER_INSTANCE/databases/$SPANNER_DB/propertyGraphs/$GRAPH
 
-# Rewrite the deployment target in place (cleanup in step 6 removes the workspace).
-sed -i "s#//bigquery.googleapis.com/[^\"]*#$SPANNER_TARGET#" catalog/EntryGroups/$DATASET/sales.yaml
+mkdir -p catalog/EntryGroups/$DATASET/sales.profiles
+cat > catalog/EntryGroups/$DATASET/sales.profiles/operational.yaml <<YAML
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    deployment_target: $SPANNER_TARGET
+    datasets:
+      - name: orders
+        source: Orders                       # a bare table in the Spanner database
+        fields:
+          - { name: o_orderkey, expression: OrderId }
+          - { name: o_custkey,  expression: CustomerId }
+          - { name: net_amount, unbound: true }   # the operational store has no settled total
+      - name: customer
+        source: Customers
+        fields:
+          - { name: c_custkey, expression: CustomerId }
+          - { name: c_name,    expression: FullName }
+      - name: lineitem
+        source: LineItems
+        fields:
+          - { name: l_linekey,  expression: LineId }
+          - { name: l_orderkey, expression: OrderId }
+YAML
+```
 
-kcmd push --target spanner --validate-only --print
+The profile restates no relationship, no metric, no label, and no grain — those
+are logical and live once in the model. It carries only bindings: each entity's
+Spanner table, each field's Spanner column, and the one field the store does not
+have. `kcmd profiles` reports what each binding can answer:
+
+```bash
+kcmd profiles
 ```
 
 ```
+Model 'sales' (kcmd_codelab):
+  profile 'operational'
+    target: //spanner.googleapis.com/projects/.../databases/.../propertyGraphs/sales
+    sources:
+      orders -> $PROJECT.Orders
+      customer -> $PROJECT.Customers
+      lineitem -> $PROJECT.LineItems
+    cannot answer:
+      field orders.net_amount (unbound)
+      metric revenue (field orders.net_amount is unbound)
+```
+
+(`kcmd profiles` resolves each source against your project for display; the
+Spanner graph itself references the bare table — `Orders` — as the DDL below
+shows.)
+
+`revenue` is `SUM(orders.net_amount)`, and the operational store does not bind
+`net_amount`, so the profile reports `revenue` as unavailable there — computed
+from the bindings, not declared. The warehouse binds `net_amount`, so the same
+metric is available under the default binding steps 1–4 used. One model; each
+store answers the part of it that its data can back.
+
+Preview the Spanner DDL the profile generates (`--validate-only` runs the
+generator without touching a database):
+
+```bash
+kcmd push --profile operational --target spanner --validate-only --print
+```
+
+```
+Note: profile 'operational' leaves 1 field(s) unbound; 0 entity(ies), 1 metric(s) and 0 relationship(s) unavailable.
 Validating semantic model for Spanner Graph...
-Warning: metric 'revenue' is not emitted: Spanner Graph has no MEASURE, so model-level metrics have no home in it
 -- Spanner Graph --
+-- //spanner.googleapis.com/projects/$PROJECT/instances/$SPANNER_INSTANCE/databases/$SPANNER_DB/propertyGraphs/sales
 CREATE OR REPLACE PROPERTY GRAPH sales
 NODE TABLES (
-  orders AS orders
-    KEY(o_orderkey)
+  Orders AS orders
+    KEY(OrderId)
     PROPERTIES(
-      o_orderkey,
-      o_custkey,
-      net_amount
+      OrderId AS o_orderkey,
+      CustomerId AS o_custkey
     ),
-  customer AS customer
-    KEY(c_custkey)
+  Customers AS customer
+    KEY(CustomerId)
     PROPERTIES(
-      c_custkey,
-      c_name
+      CustomerId AS c_custkey,
+      FullName AS c_name
     ),
-  lineitem AS lineitem
-    KEY(l_linekey)
+  LineItems AS lineitem
+    KEY(LineId)
     PROPERTIES(
-      l_linekey,
-      l_orderkey
+      LineId AS l_linekey,
+      OrderId AS l_orderkey
     )
 )
 EDGE TABLES (
-  orders AS orders_to_customer
-    KEY(o_orderkey)
-    SOURCE KEY(o_orderkey) REFERENCES orders(o_orderkey)
-    DESTINATION KEY(o_custkey) REFERENCES customer(c_custkey),
-  lineitem AS lineitem_to_orders
-    KEY(l_linekey)
-    SOURCE KEY(l_linekey) REFERENCES lineitem(l_linekey)
-    DESTINATION KEY(l_orderkey) REFERENCES orders(o_orderkey)
+  Orders AS orders_to_customer
+    KEY(OrderId)
+    SOURCE KEY(OrderId) REFERENCES orders(OrderId)
+    DESTINATION KEY(CustomerId) REFERENCES customer(CustomerId),
+  LineItems AS lineitem_to_orders
+    KEY(LineId)
+    SOURCE KEY(LineId) REFERENCES lineitem(LineId)
+    DESTINATION KEY(OrderId) REFERENCES orders(OrderId)
 );
 
 Validation complete; no changes applied.
 ```
 
-Three things differ from the BigQuery DDL in step 4, and nothing else:
+The graph still speaks the model's vocabulary — the properties are `o_orderkey`,
+`c_name`, and the rest — but each is now backed by the profile's Spanner column
+(`OrderId AS o_orderkey`, `FullName AS c_name`). The key and reference clauses
+name the physical columns (`KEY(OrderId)`), because a Spanner graph keys on the
+table's real column, not the property alias. Three things also differ from the
+BigQuery DDL in step 4:
 
 - **Bare table and graph names.** A Spanner property graph names tables inside
   one database, so there is no backticked `project.dataset.` qualifier — each
-  `source`'s final segment (`$PROJECT.$DATASET.orders` → `orders`) is the table.
-- **No `MEASURE`.** Spanner Graph has no measures, so `revenue` is dropped with
-  the warning above rather than emitted onto the `orders` node. Author metrics as
-  usual — a BigQuery target still emits them, and step 3's Knowledge Catalog
-  entries still record `revenue`.
+  `source` is a bare table (`Orders`) in the target database.
+- **No `MEASURE`.** Spanner Graph has no measures. `revenue` is already withheld
+  here because `net_amount` is unbound, but even a bound metric is not emitted
+  onto a Spanner node; author metrics as usual and a BigQuery target still emits
+  them.
 - **No `OPTIONS`.** Descriptions and synonyms are not written into the Spanner
   DDL; they live in Knowledge Catalog instead.
 
-The nodes, edges, and keys are identical to the BigQuery graph.
-
-To actually apply it, drop `--validate-only` and point the target at a Spanner
-database that already holds `orders`, `customer`, and `lineitem` — the Spanner
-leg applies the DDL through the `updateDatabaseDdl` long-running operation and
-does not create or pre-check those tables:
+To apply it for real, create the operational tables in a Spanner
+ENTERPRISE-edition database (Graph requires ENTERPRISE), load a little data, and
+drop `--validate-only`. The Spanner leg applies the DDL through the
+`updateDatabaseDdl` long-running operation and does not create or pre-check the
+tables, so they must exist first:
 
 ```bash
-kcmd push --target spanner
+gcloud spanner databases create $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --ddl='CREATE TABLE Customers (CustomerId INT64 NOT NULL, FullName STRING(MAX)) PRIMARY KEY(CustomerId)' \
+  --ddl='CREATE TABLE Orders (OrderId INT64 NOT NULL, CustomerId INT64) PRIMARY KEY(OrderId)' \
+  --ddl='CREATE TABLE LineItems (LineId INT64 NOT NULL, OrderId INT64) PRIMARY KEY(LineId)'
+
+gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --sql="INSERT INTO Customers (CustomerId, FullName) VALUES (1,'Acme'),(2,'Globex')"
+gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --sql="INSERT INTO Orders (OrderId, CustomerId) VALUES (100,1),(101,1),(102,2)"
+gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --sql="INSERT INTO LineItems (LineId, OrderId) VALUES (1,100),(2,100),(3,101),(4,102),(5,102),(6,102)"
+
+kcmd push --profile operational --target spanner
 # -> Deployed 1 Spanner Graph(s).
 ```
 
-Then query it with Spanner's Graph Query Language, for example
-`GRAPH sales MATCH (o:orders)-[:orders_to_customer]->(c:customer) RETURN c.c_name, o.net_amount`.
-Aggregates like `revenue` are computed in your application or in SQL, not by the
-graph, since Spanner Graph has no measure.
-
-Restore the BigQuery target before the rest of the codelab, if you kept the
-workspace:
+Query it with Spanner's Graph Query Language. The query names the model's
+properties (`c_name`, `o_orderkey`); the profile's column bindings are invisible
+to it:
 
 ```bash
-sed -i "s#//spanner.googleapis.com/[^\"]*#//bigquery.googleapis.com/$BQ_DS/propertyGraphs/$GRAPH#" catalog/EntryGroups/$DATASET/sales.yaml
+gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --sql="GRAPH sales MATCH (o:orders)-[:orders_to_customer]->(c:customer)
+         RETURN c.c_name AS customer, COUNT(o.o_orderkey) AS orders
+         GROUP BY customer ORDER BY customer"
 ```
+
+```
+customer  orders
+Acme      2
+Globex    1
+```
+
+The one model now backs two stores: the BigQuery warehouse from steps 1–4, where
+`revenue` is a measure, and this operational Spanner graph, where the same
+entities and relationships are queried live and `revenue` is computed in SQL or
+the application rather than by the graph. `Customer`, `orders_to_customer`, and
+every field mean the same thing in both; only the bindings differ.
 
 ---
 
@@ -546,6 +637,12 @@ Drop the BigQuery dataset (tables + property graph):
 
 ```bash
 bq rm -r -f -d $PROJECT:$DATASET
+```
+
+Drop the Spanner database from section 5 (its tables and the graph go with it):
+
+```bash
+gcloud spanner databases delete $SPANNER_DB --instance=$SPANNER_INSTANCE --quiet
 ```
 
 Remove the Knowledge Catalog entries and entry group via REST:

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -2,9 +2,9 @@
 
 A self-contained walkthrough. You author one *logical* semantic model, govern it
 in Knowledge Catalog, then bind it to physical stores — BigQuery and Spanner —
-and query the same metric in each. The metric is defined once and computed the
-same way at every step. The expected output is shown after each command so you
-can check as you go.
+and query it in each. The model is defined once and every store reads from that
+single definition. The expected output is shown after each command so you can
+check as you go.
 
 For the deploy mechanics on their own (author, push, update, pull), see the
 [deploy guide](README.md); for every flag and permission, see the

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -1,11 +1,9 @@
 # One logical model, many physical bindings
 
-> **Scope.** `kcmd` deploys a merged model to BigQuery Graph, Spanner Graph, and
-> Knowledge Catalog. A profile may bind an entity to any store — BigQuery,
-> Spanner, AlloyDB, a lake table — and `kcmd` merges it and reports its
-> availability; a profile whose deployment target is a BigQuery or Spanner graph
-> also deploys. Deploying a binding to another store (AlloyDB, a lake) is not yet
-> supported — the merge and the availability report still run.
+> **Scope.** `kcmd` deploys a merged model to BigQuery Graph and Knowledge
+> Catalog only. A profile may bind an entity to any store — BigQuery, Spanner,
+> AlloyDB, a lake table — and `kcmd` merges it and reports its availability, but
+> deploying a binding to a non-BigQuery store is not yet supported.
 
 A semantic model describes a business logically — its entities, the
 relationships between them, and the metrics over them — independent of where the
@@ -69,13 +67,6 @@ source is an [AIP-122](https://google.aip.dev/122) resource name —
 resolves to an endpoint. A profile moves an entity between stores by swapping
 this URI, and — when the two stores shape the data differently — the column each
 field reads.
-
-One exception follows from how a graph names its inputs. A **Spanner** property
-graph references tables *within its own database* (the database named by the
-deployment target), so a Spanner-bound entity names its table by bare name
-(`source: Customer`), not a full `//spanner.googleapis.com/…/tables/Customer`
-resource URI. A **BigQuery** source may be either the `//bigquery.googleapis.com/…`
-resource URI or the equivalent `project.dataset.table`.
 
 ## What a profile may change — the contract
 
@@ -252,14 +243,14 @@ semantic_model:
     deployment_target: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/propertyGraphs/commerce
     entities:
       - name: Customer
-        source: Customer                 # a bare table in the target Spanner database
+        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Customer
         fields:
           - { name: key,             expression: CustomerId }
           - { name: name,            expression: FullName }
           - { name: availableCredit, expression: AvailableCredit }
           - { name: lifetimeValue,   unbound: true }
       - name: Order
-        source: Orders
+        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Orders
         fields:
           - { name: key,         expression: OrderId }
           - { name: customerKey, expression: CustomerId }
@@ -268,9 +259,9 @@ semantic_model:
 
 Neither binding restates the grain, the `PlacedBy` relationship, the labels, or
 the metric definitions; those live once in the logical model. `kcmd push
---profile operational` merges the operational bindings, reports what they answer,
-and deploys the Spanner graph; `--profile analytical` deploys the BigQuery one.
-The two bindings answer different parts of the same model:
+--profile operational` merges the operational bindings and reports what they
+answer; today only the BigQuery-bound `analytical` profile deploys (see
+**Scope** above). The two bindings answer different parts of the same model:
 
 - `order_count` depends only on `Order.key`, bound under both bindings, so it is
   available under either.
@@ -300,19 +291,17 @@ The two bindings answer different parts of the same model:
 ## Command line
 
 ```bash
-kcmd push --profile analytical            # merge the analytical bindings and deploy the BigQuery graph
-kcmd push --profile operational --target spanner  # merge the operational bindings and deploy the Spanner graph
+kcmd push --profile analytical            # merge the analytical (BigQuery) bindings and deploy
+kcmd push --profile operational           # merge the operational bindings and report availability
 kcmd push --profile analytical --target kc # profile and destination-type are independent
 kcmd push                                 # uses default_profile from catalog.yaml
 kcmd profiles                             # list profiles, their resolved sources, and what each cannot answer
 ```
 
 `--profile` chooses **which physical binding**. The existing `--target
-bq|spanner|kc|all` chooses **which destination type** (BigQuery Graph, Spanner
-Graph, Knowledge Catalog, or all). They are orthogonal — though a graph target
-must match the store the profile binds: a profile with a Spanner
-`deployment_target` deploys under `--target spanner`, one with a BigQuery target
-under `--target bq`, and either under `--target kc`.
+bq|kc|all` chooses **which destination type** (BigQuery Graph, Knowledge
+Catalog, or both). They are orthogonal — any profile can go to either
+destination.
 
 Set the default so a bare `kcmd push` in CI does the right thing, in
 `catalog.yaml`:

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -1,9 +1,11 @@
 # One logical model, many physical bindings
 
-> **Scope.** `kcmd` deploys a merged model to BigQuery Graph and Knowledge
-> Catalog only. A profile may bind an entity to any store — BigQuery, Spanner,
-> AlloyDB, a lake table — and `kcmd` merges it and reports its availability, but
-> deploying a binding to a non-BigQuery store is not yet supported.
+> **Scope.** `kcmd` deploys a merged model to BigQuery Graph, Spanner Graph, and
+> Knowledge Catalog. A profile may bind an entity to any store — BigQuery,
+> Spanner, AlloyDB, a lake table — and `kcmd` merges it and reports its
+> availability; a profile whose deployment target is a BigQuery or Spanner graph
+> also deploys. Deploying a binding to another store (AlloyDB, a lake) is not yet
+> supported — the merge and the availability report still run.
 
 A semantic model describes a business logically — its entities, the
 relationships between them, and the metrics over them — independent of where the
@@ -67,6 +69,13 @@ source is an [AIP-122](https://google.aip.dev/122) resource name —
 resolves to an endpoint. A profile moves an entity between stores by swapping
 this URI, and — when the two stores shape the data differently — the column each
 field reads.
+
+One exception follows from how a graph names its inputs. A **Spanner** property
+graph references tables *within its own database* (the database named by the
+deployment target), so a Spanner-bound entity names its table by bare name
+(`source: Customer`), not a full `//spanner.googleapis.com/…/tables/Customer`
+resource URI. A **BigQuery** source may be either the `//bigquery.googleapis.com/…`
+resource URI or the equivalent `project.dataset.table`.
 
 ## What a profile may change — the contract
 
@@ -243,14 +252,14 @@ semantic_model:
     deployment_target: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/propertyGraphs/commerce
     entities:
       - name: Customer
-        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Customer
+        source: Customer                 # a bare table in the target Spanner database
         fields:
           - { name: key,             expression: CustomerId }
           - { name: name,            expression: FullName }
           - { name: availableCredit, expression: AvailableCredit }
           - { name: lifetimeValue,   unbound: true }
       - name: Order
-        source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Orders
+        source: Orders
         fields:
           - { name: key,         expression: OrderId }
           - { name: customerKey, expression: CustomerId }
@@ -259,9 +268,9 @@ semantic_model:
 
 Neither binding restates the grain, the `PlacedBy` relationship, the labels, or
 the metric definitions; those live once in the logical model. `kcmd push
---profile operational` merges the operational bindings and reports what they
-answer; today only the BigQuery-bound `analytical` profile deploys (see
-**Scope** above). The two bindings answer different parts of the same model:
+--profile operational` merges the operational bindings, reports what they answer,
+and deploys the Spanner graph; `--profile analytical` deploys the BigQuery one.
+The two bindings answer different parts of the same model:
 
 - `order_count` depends only on `Order.key`, bound under both bindings, so it is
   available under either.
@@ -291,17 +300,19 @@ answer; today only the BigQuery-bound `analytical` profile deploys (see
 ## Command line
 
 ```bash
-kcmd push --profile analytical            # merge the analytical (BigQuery) bindings and deploy
-kcmd push --profile operational           # merge the operational bindings and report availability
+kcmd push --profile analytical            # merge the analytical bindings and deploy the BigQuery graph
+kcmd push --profile operational --target spanner  # merge the operational bindings and deploy the Spanner graph
 kcmd push --profile analytical --target kc # profile and destination-type are independent
 kcmd push                                 # uses default_profile from catalog.yaml
 kcmd profiles                             # list profiles, their resolved sources, and what each cannot answer
 ```
 
 `--profile` chooses **which physical binding**. The existing `--target
-bq|kc|all` chooses **which destination type** (BigQuery Graph, Knowledge
-Catalog, or both). They are orthogonal — any profile can go to either
-destination.
+bq|spanner|kc|all` chooses **which destination type** (BigQuery Graph, Spanner
+Graph, Knowledge Catalog, or all). They are orthogonal — though a graph target
+must match the store the profile binds: a profile with a Spanner
+`deployment_target` deploys under `--target spanner`, one with a BigQuery target
+under `--target bq`, and either under `--target kc`.
 
 Set the default so a bare `kcmd push` in CI does the right thing, in
 `catalog.yaml`:


### PR DESCRIPTION
Reworks the semantic-model codelab and binding-profiles guide to show the Spanner Graph target (#361) and binding profiles (#358) working together.

> **Depends on #363** (now merged into `main`): the Spanner physical-column fix that lets remapped key/join columns deploy. This branch contains the docs commit only.

## Codelab (`docs/semantic-model/codelab.md`)

- **Step 1** names the deployment target with the first-class `deployment_target:` key instead of a `GOOGLE custom_extensions` JSON string.
- **Section 5** replaces the `sed` deployment-target swap with a real **binding profile** (`sales.profiles/operational.yaml`): a Spanner store with different table names, remapped columns (including keys), and an unbound `net_amount` so `revenue` is withheld operationally. It shows `kcmd profiles`' availability report, the generated Spanner DDL, a live deploy, and a GQL query.
- **Cleanup** drops the Spanner database.

Every command output in section 5 was captured from a live run against an ENTERPRISE Spanner instance.

## Binding profiles (`docs/semantic-model/profiles.md`)

- Scope note updated: Spanner graphs now deploy (was "non-BigQuery not yet supported").
- Spanner sources use **bare table names**, not `//spanner.../tables/X` resource URIs (which a Spanner graph cannot reference); added a note on the rule in "Sources are URIs".
- `--target` documented as `bq|spanner|kc|all`; command examples deploy the operational (Spanner) profile.

## Why now

The codelab previously swapped backends with `sed`, which is exactly the manual step binding profiles remove. This makes the codelab demonstrate the feature as intended: one logical model, an analytical (BigQuery) binding and an operational (Spanner) binding, switched with `--profile`.