### PR TITLE
docs(semantic-model): audit the deploy guide for binding profiles + Spanner Graph

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -64,13 +64,10 @@ version: "0.2.0.dev0"
 
 semantic_model:
   - name: sales                              # keep equal to the <model>.yaml filename (pull round-trips to that name)
-    # Required: the deployment target, in a GOOGLE custom extension. `data` is a
-    # JSON string whose deploymentTargets holds the target graph URI (for now,
-    # exactly one).
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/my-project/datasets/sales/propertyGraphs/sales_graph"]}'
-    datasets:                                # each dataset becomes an entity
+    # The graph this model deploys to. `deployment_target` is a model key whose
+    # value is the target graph URI — its host selects the backend (see below).
+    deployment_target: //bigquery.googleapis.com/projects/my-project/datasets/sales/propertyGraphs/sales_graph
+    entities:                                # each entity is backed by one table
       - name: orders
         source: my-project.sales.orders      # the backing BigQuery table
         primary_key: [o_orderkey]
@@ -91,9 +88,9 @@ rules.
 
 ### Deployment targets (required)
 
-Every model must declare exactly one **deployment target** — the property graph
-it deploys to — in a `GOOGLE` custom extension, as shown above. The target's
-**host selects the graph backend**:
+Every model that deploys a graph declares exactly one **deployment target** — the
+property graph it deploys to — with the model-level `deployment_target` key, as
+shown above. The target's **host selects the graph backend**:
 
 ```
 # BigQuery Graph
@@ -109,7 +106,10 @@ other is all it takes to deploy the same model to the other backend. The target
 is also recorded on the model's Knowledge Catalog entry. Deploying a graph needs
 exactly one target: a model with none, or more than one, is rejected when a graph
 leg runs. A Knowledge-Catalog-only push (`--target kc`) deploys no graph, so the
-target is optional there (see [Validation](reference.md#validation)).
+target is optional there (see [Validation](reference.md#validation)). The
+equivalent `GOOGLE` `custom_extensions` block with a `deploymentTargets` list
+still works and means the same thing — see [profiles](profiles.md) for both
+forms.
 
 ### Table sources
 

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -7,9 +7,9 @@ model to two destinations at once:
 
 * **A property graph** — a queryable `CREATE OR REPLACE PROPERTY GRAPH` over the
   model's tables, so the model can be traversed (and, on BigQuery, its metrics
-  computed) in SQL. The graph backend is **BigQuery Graph** or **Spanner
-  Graph**, chosen by the deployment target you declare — the same authored model
-  deploys to either (see [Deployment targets](#deployment-targets-required)).
+  computed) in SQL. The graph runs in **BigQuery** or **Spanner**, chosen by the
+  deployment target you declare — the same authored model deploys to either (see
+  [Deployment targets](#deployment-targets-required)).
 * **Knowledge Catalog** — catalog entries and links that make the
   model discoverable as metadata.
 
@@ -139,7 +139,7 @@ kcmd push
 ```
 
 With no flags this deploys to **every** destination — the model's graph backend
-(BigQuery Graph or Spanner Graph, whichever its target names) and Knowledge
+(BigQuery or Spanner, whichever its target names) and Knowledge
 Catalog — the graph first. The most common flags:
 
 ```bash
@@ -158,7 +158,7 @@ that gate it are in [Validation](reference.md#validation).
 GRAPH` per deployment target: each entity becomes a node table, each relationship
 an edge table, each metric a measure. In **Spanner**, the same
 `CREATE OR REPLACE PROPERTY GRAPH` with bare table names and no measures —
-Spanner Graph has no `MEASURE`, so metrics are dropped with a warning while the
+Spanner has no `MEASURE`, so metrics are dropped with a warning while the
 graph structure (nodes, edges, labels, inheritance) still deploys. In
 **Knowledge Catalog**, one entry per model, entity, and metric, plus
 `schema-join` links for relationships. The exact mapping — and the
@@ -172,7 +172,7 @@ survives the trip (and what doesn't) is in
 
 Your model document is the source of truth. To change what is deployed, edit
 the document and run `kcmd push` again — you never edit the catalog or the
-BigQuery Graph by hand. Re-running is safe: each push makes the destinations
+deployed graph by hand. Re-running is safe: each push makes the destinations
 match the document as it stands now.
 
 **When you edit an entity, metric, or relationship** — push overwrites the

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -126,9 +126,11 @@ the deploy does (see [Validation](reference.md#validation)).
 
 For a **Spanner** target, the graph and its tables live inside the one Spanner
 database the target names, so a `source` is reduced to its **final segment** —
-the table name in that database (`demo.sales.Orders` → `Orders`). That lets one
-authored `source` serve both backends; a Spanner-native `source` form is a
-planned [profiles](profiles.md) feature.
+the table name in that database. That final segment is taken the same way from a
+dotted `demo.sales.Orders` or a Spanner-native resource name
+(`//spanner.googleapis.com/…/tables/Orders`), so one authored `source` serves
+both backends. Binding a differently named Spanner source per environment is a
+[profiles](profiles.md) feature.
 
 ## 2. Push
 

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -26,6 +26,7 @@ back. For the Ossie document format itself, see
 |---|---|
 | **This page** | author a model and deploy it |
 | [End-to-end codelab](codelab.md) | see the whole lifecycle: author, govern, hydrate, query |
+| [One model, many bindings](profiles.md) | bind one logical model to several stores or environments with profiles |
 | [Reference](reference.md) | look up a flag, what push creates, validation, or permissions |
 | [What push and pull preserve](fidelity.md) | understand why something changed or wasn't recovered |
 | [Importing an OWL ontology](owl-import.md) | start from an OWL ontology instead of hand-authoring |

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -106,13 +106,16 @@ it deploys to — in a `GOOGLE` custom extension, as shown above. The target's
 A BigQuery target's project and dataset are where the property graph is created;
 a Spanner target's instance and database are. Swapping one target URI for the
 other is all it takes to deploy the same model to the other backend. The target
-is also recorded on the model's Knowledge Catalog entry. A model with no
-deployment target — or with more than one — is rejected at push time (see
-[Validation](reference.md#validation)).
+is also recorded on the model's Knowledge Catalog entry. Deploying a graph needs
+exactly one target: a model with none, or more than one, is rejected when a graph
+leg runs. A Knowledge-Catalog-only push (`--target kc`) deploys no graph, so the
+target is optional there (see [Validation](reference.md#validation)).
 
 ### Table sources
 
-Each entity's `source` is its backing table.
+Each entity's `source` is its backing table. Sources bind the model to a store
+for a graph deploy; a `--target kc` push governs the logical model and needs
+none.
 
 For a **BigQuery** target, `source` is the BigQuery table. A `source` written as
 `dataset.table` (two parts) is qualified with the scope's project — the
@@ -247,6 +250,7 @@ your authored document as the source of truth.
 Already have an OWL ontology? `kcmd owl import` converts it into a semantic model
 once — classes → entities, object properties → relationships, datatype
 properties → fields. The converted model is **unbound** (placeholder sources, no
-deployment target), so bind each entity's `source`, fill the relationship join
-columns, and add a deployment target before `kcmd push` will deploy it — then it
-rides the normal push / pull above. See [Importing an OWL ontology](owl-import.md).
+deployment target). `kcmd push --target kc` can publish it to Knowledge Catalog
+as-is; to deploy a graph, bind each entity's `source`, fill the relationship join
+columns, and add a deployment target first. Either way it rides the normal push /
+pull above. See [Importing an OWL ontology](owl-import.md).

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -12,7 +12,7 @@ Rows are what you authored; columns are its fate in each direction. `✓` = come
 back as authored; `—` = not present in that destination. Footnotes carry the
 nuances that don't fit a cell. The **→ BigQuery graph** column describes a
 BigQuery target; a Spanner target keeps the same graph *structure* but no
-measures and no `OPTIONS` metadata — see [To Spanner Graph](#to-spanner-graph).
+measures and no `OPTIONS` metadata — see [To Spanner](#to-spanner).
 
 | Authored element | → BigQuery graph | → Knowledge Catalog | Recovered by `pull` |
 |---|---|---|---|
@@ -70,7 +70,7 @@ as a separate form: the graph builds from the canonical `expression` when
 present, and falls back to the imported vendor SQL verbatim only when the model
 was never transpiled to a canonical form.
 
-## To Spanner Graph
+## To Spanner
 
 A Spanner target keeps the queryable **structure** and drops the descriptive
 metadata. The node tables, edge tables, and labels (including the `extends`
@@ -78,12 +78,12 @@ hierarchy, with fields flattened down) deploy exactly as they do for BigQuery,
 but with bare table and graph names. Two things do not make the trip, both by
 design:
 
-- **Metrics.** Spanner Graph has no `MEASURE`, so every model-level metric is
+- **Metrics.** Spanner has no `MEASURE`, so every model-level metric is
   dropped with a warning. The BigQuery-only rule that a metric resolve to one
   entity does not apply. Author your metrics as usual — a BigQuery target still
   emits them, and Knowledge Catalog still records each `semantic-metric` entry —
   they simply have no home in the Spanner graph.
-- **`OPTIONS` metadata.** Spanner Graph carries no per-element `OPTIONS`, so
+- **`OPTIONS` metadata.** Spanner carries no per-element `OPTIONS`, so
   `description`, `synonyms`, `instructions`, `examples`, and field `label` are not
   written into the Spanner DDL. They still reach Knowledge Catalog on the same
   push (the model's / entities' / metrics' descriptions and `instructions` land

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -6,7 +6,7 @@ does not learn a second format — it **converts OWL into a semantic model** onc
 then the ontology rides the normal [`kcmd push` / `kcmd pull`](README.md)
 workflow. The semantic model stays the single canonical form.
 
-The converter maps the OWL constructs that have a clean BigQuery Graph shape to
+The converter maps the OWL constructs that have a clean BigQuery shape to
 **native** semantic-model fields — class → node, object property → edge,
 datatype property → property, plus **class hierarchies** (`rdfs:subClassOf` →
 entity `extends`, see [Class hierarchies](#class-hierarchies-rdfssubclassof)).
@@ -286,7 +286,7 @@ onto one logical type:
 
 A temporal field (`Date` / `Time` / `DateTime` / `DateTimeTz`) is additionally
 marked a **time dimension** (`dimension: { is_time: true }`), so downstream
-BigQuery Graph / BI treats it as one.
+BigQuery / BI treats it as one.
 
 ### Keys (`owl:hasKey`, `owl:InverseFunctionalProperty`)
 
@@ -403,7 +403,7 @@ they describe. Carriage is a holding pattern with three deliberate properties:
   Knowledge Catalog, though, so a `kcmd pull` does not return these facts today
   (push writes no aspect for them — see
   [What push and pull preserve](fidelity.md)).
-- **Inert.** A carried fact changes **nothing** downstream — the BigQuery Graph
+- **Inert.** A carried fact changes **nothing** downstream — the BigQuery
   push and the Knowledge Catalog push read none of it, so it never alters a node,
   an edge, or a query. (Contrast `extends`, which *does* change the graph by
   adding node labels — that is why it earned a native slot and these have not.)

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -133,8 +133,8 @@ $ kcmd owl import sales.owl.ttl
 converted 2 classes, 1 object property, 9 datatype properties
 wrote catalog/EntryGroups/<entryGroup>/sales.yaml
 note: this model is UNBOUND (placeholder `unbound:` sources, no deployment target).
-      `kcmd push` is rejected until you bind each entity's source table and add
-      a BigQuery deployment target -- validation needs both, for every --target.
+      `kcmd push --target kc` publishes it to Knowledge Catalog as-is. To deploy a
+      graph, bind each entity's source table and add a deployment target first.
 ```
 
 The model name comes from the file (`sales.owl.ttl` → `sales`). By default the
@@ -626,18 +626,18 @@ is out of scope (see [Limitations](#limitations)).
 ## 4. Going from ontology to a running graph (binding)
 
 The import gets you an **unbound** model — placeholder `unbound:<Name>` sources,
-`TODO_BIND` join columns, and no deployment target — so it is **not deployable
-yet**. `kcmd push` is rejected for *any* `--target` (including `kc`) until the
-model passes [validation](reference.md#validation): every entity `source` must
-resolve to a real BigQuery table, and the model must declare exactly one BigQuery
-deployment target. Both checks run before either destination leg, so there is no
-Knowledge-Catalog-only shortcut around them today.
+`TODO_BIND` join columns, and no deployment target. You can **publish it to
+Knowledge Catalog right away**: `kcmd push --target kc` governs the logical model
+(entities, relationships, metrics, descriptions) and needs no bindings or
+deployment target. **Deploying a graph** is what requires binding — `kcmd push`
+with a graph leg (`bq`/`spanner`/`all`) is rejected until every entity `source`
+resolves to a real table and the model declares exactly one deployment target
+(see [validation](reference.md#validation)).
 
-> **Known limitation — no KC-only publish before binding.** Even
-> `kcmd push --target kc` runs the BigQuery deployment-target and live-source
-> checks first, so you cannot publish the ontology as catalog metadata while the
-> model is still unbound. Letting `--target kc` publish an unbound model is a
-> possible follow-up (see [Limitations](#limitations)).
+> **Governance before binding.** The catalog governs *meaning*, so an unbound
+> ontology can be published as catalog metadata and bound to a physical store
+> later. One caveat: a `--target kc` push records each entity's `source` as its
+> `unbound:<Name>` placeholder verbatim, until you bind a real table below.
 
 To make the model deployable, bind each class to a real table. A
 declared key does half of this for you: an edge into a class that has a key
@@ -678,10 +678,9 @@ in this first cut.
 
 ## Limitations
 
-Four different situations hide in "not covered": constructs already read but not
-yet resolved all the way downstream, constructs not read but reachable next,
-constructs out of scope, and one item that is a push limitation rather than a
-converter gap.
+Three situations hide in "not covered": constructs already read but not yet
+resolved all the way downstream, constructs not read but reachable next, and
+constructs out of scope.
 
 **Read now — only downstream resolution is pending.** These are not dropped; the
 importer handles them today, and the remaining work is a later step, not in the
@@ -724,10 +723,3 @@ converter targets:
   instances), and `owl:sameAs` / `owl:differentFrom` (which relate individuals).
 - OWL serializations other than Turtle (`.ttl`), and the reverse direction —
   semantic model → OWL export. Import is one-way.
-
-**A push limitation, not a converter gap: no Knowledge-Catalog-only publish of an
-unbound model.** A freshly imported model cannot `kcmd push --target kc` until its
-sources are bound and a deployment target is set: push validates the BigQuery
-deployment target and probes every source table before any leg runs (for every
-`--target`), so there is no KC-only path around those checks. Decoupling the KC
-leg from the BigQuery checks is a possible follow-up.

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -96,12 +96,14 @@ computes, the grain, and the graph shape. The logical model owns all of it.
 **Binding** is physical: which store each entity reads from, and which column
 each field reads. A profile sets binding and leaves declaration alone.
 
-| A profile **may** set (physical binding) | A profile **may not** touch (logical, in the model) |
-|---|---|
-| an entity's `source` (its store URI) | which entities, fields, relationships, or metrics exist, and what each means |
-| a field's column (its `expression`, a bare column reference) | a field's `label`, `description`, `dimension`, `datatype` |
-| whether a field is bound at all under this profile | the grain (`primary_key` / `unique_keys`) and graph shape (`from`/`to`, `from_columns`/`to_columns`) |
-| the deployment target | a field `expression` that is arbitrary SQL, which changes the computation; any `metric` definition; any `ai_context` / synonyms; a relationship or its junction `source` |
+| Model element | Physical — a profile **may** bind | Logical — a profile **may not** change |
+|---|---|---|
+| Entity | its `source` (store URI) | that it exists and what it means; its grain (`primary_key` / `unique_keys`) |
+| Field | its column — `expression` as a bare column reference; whether it is bound at all | `label`, `description`, `dimension`, `datatype`; an `expression` that is arbitrary SQL (the computation itself) |
+| Relationship | — | that it exists; its join columns (`from`/`to`, `from_columns`/`to_columns`); its junction `source` |
+| Metric | — | its definition (refers to field *names*, stable across profiles) |
+| Deployment target | the target URI | — |
+| AI metadata | — | `ai_context`, synonyms |
 
 An element's `name` is not overridden — it is the key that pairs a profile
 element with the model element it binds. The grain and the join columns name

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -105,18 +105,15 @@ each field reads. A profile sets binding and leaves declaration alone.
 | Deployment target | the target URI | — |
 | AI metadata | — | `ai_context`, synonyms |
 
-An element's `name` is not overridden — it is the key that pairs a profile
-element with the model element it binds. The grain and the join columns name
-*fields* rather than physical columns, so they belong to the logical model; each
-field's column is resolved per profile from its `expression`.
-
-**Why metrics never appear in a profile.** A metric like
-`SUM(OrderedAs.extendedPrice * (1 - OrderedAs.discount))` references field
-*names* rather than columns. Field names are stable across profiles — only their
-column bindings change — so the metric is correct under every profile where its
-fields are bound, without being restated. Where a field it references is not
-bound, the metric is unavailable under that profile; the next section explains
-why.
+An element's `name` is never bound — it is the key that pairs a profile's binding
+to the model element it applies to. Everything logical is defined in terms of
+these names, not physical columns: a metric like `AVG(Customer.lifetimeValue)`,
+the grain, and a relationship's join columns all reference *field names*, which
+are identical under every profile. A profile changes only the column each name
+resolves to. That is why a metric is never restated in a profile: it stays
+correct wherever its fields are bound, and simply becomes unavailable under a
+profile that leaves one of them unbound — the next section explains how that
+propagates.
 
 ## Availability follows the bindings
 

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -1,9 +1,11 @@
 # One logical model, many physical bindings
 
-> **Scope.** `kcmd` deploys a merged model to BigQuery Graph and Knowledge
-> Catalog only. A profile may bind an entity to any store — BigQuery, Spanner,
-> AlloyDB, a lake table — and `kcmd` merges it and reports its availability, but
-> deploying a binding to a non-BigQuery store is not yet supported.
+> **Scope.** `kcmd` deploys a merged model to a property graph — **BigQuery
+> Graph or Spanner Graph**, whichever the profile's deployment target names — and
+> to Knowledge Catalog. A profile may bind an entity to any store — BigQuery,
+> Spanner, AlloyDB, a lake table — and `kcmd` merges it and reports its
+> availability; a binding to a store with no graph backend yet (AlloyDB, a SaaS
+> API, a lake table) is merged and reported, not deployed.
 
 A semantic model describes a business logically — its entities, the
 relationships between them, and the metrics over them — independent of where the
@@ -67,6 +69,14 @@ source is an [AIP-122](https://google.aip.dev/122) resource name —
 resolves to an endpoint. A profile moves an entity between stores by swapping
 this URI, and — when the two stores shape the data differently — the column each
 field reads.
+
+A graph references a source by its **final segment** — the table name in the
+target store. A **BigQuery** `source` may be written as this resource name or as
+a plain `project.dataset.table`; both resolve identically. A **Spanner** graph
+lives inside one database and names its tables directly, so both
+`//spanner.googleapis.com/…/tables/Customer` and the equivalent dotted
+`acme.commerce.Customer` resolve to the table `Customer`. One authored form
+therefore serves either backend.
 
 ## What a profile may change — the contract
 
@@ -138,10 +148,12 @@ column for it has it until one binds it. Alternatively, a profile that would
 otherwise inherit a column sets `unbound: true` on the field to drop it. Silently
 omitting a field that another profile binds does neither — the field stays
 declared and simply has no column under the omitting profile, which is caught if
-a metric needs it. When the source table a profile binds is missing or
-inaccessible, validation fails and names it; a mistyped column name resolves to a
-real table and so surfaces at deploy, when BigQuery rejects the generated graph.
-So a forgotten binding is caught, and an intentional non-binding is written down.
+a metric needs it. When a BigQuery source table a profile binds is missing or
+inaccessible, validation fails and names it (the live source probe is
+BigQuery-only; a Spanner source is not probed, so a bad Spanner table surfaces at
+deploy instead); a mistyped column name resolves to a real table and so surfaces
+at deploy, when the graph backend rejects the generated graph. So a forgotten
+binding is caught, and an intentional non-binding is written down.
 
 ## File layout
 
@@ -259,9 +271,11 @@ semantic_model:
 
 Neither binding restates the grain, the `PlacedBy` relationship, the labels, or
 the metric definitions; those live once in the logical model. `kcmd push
---profile operational` merges the operational bindings and reports what they
-answer; today only the BigQuery-bound `analytical` profile deploys (see
-**Scope** above). The two bindings answer different parts of the same model:
+--profile analytical` deploys to BigQuery Graph and `kcmd push --profile
+operational` deploys to Spanner Graph — each profile routes to the backend its
+deployment target names (see **Scope** above); on Spanner the metrics are
+dropped, since Spanner Graph has no `MEASURE`. The two bindings answer different
+parts of the same model:
 
 - `order_count` depends only on `Order.key`, bound under both bindings, so it is
   available under either.
@@ -291,8 +305,8 @@ answer; today only the BigQuery-bound `analytical` profile deploys (see
 ## Command line
 
 ```bash
-kcmd push --profile analytical            # merge the analytical (BigQuery) bindings and deploy
-kcmd push --profile operational           # merge the operational bindings and report availability
+kcmd push --profile analytical            # merge the analytical bindings and deploy to BigQuery Graph
+kcmd push --profile operational           # merge the operational bindings and deploy to Spanner Graph
 kcmd push --profile analytical --target kc # profile and destination-type are independent
 kcmd push                                 # uses default_profile from catalog.yaml
 kcmd profiles                             # list profiles, their resolved sources, and what each cannot answer
@@ -326,10 +340,12 @@ writes nothing.
   offending path.
 - **Unknown name** — a profile element whose `name` is not in the logical model
   is rejected. Profiles bind declarations; they do not add them.
-- **Unresolvable source** — the BigQuery table a profile binds is probed with a
-  dry run; a table that is missing or inaccessible fails and names it. Column
-  names are not probed here — a mistyped column resolves to a real table and is
-  caught at deploy, when BigQuery rejects the generated graph.
+- **Unresolvable source** — a BigQuery table a profile binds is probed with a
+  dry run; a table that is missing or inaccessible fails and names it. The probe
+  is BigQuery-only: a Spanner source is not probed, so a bad Spanner table
+  surfaces at deploy rather than in validation. Column names are not probed
+  either — a mistyped column resolves to a real table and is caught at deploy,
+  when the graph backend rejects the generated graph.
 - **Availability summary** — push resolves the dependency graph and prints, per
   profile, how many entities, metrics, and relationships the binding leaves
   unavailable. `kcmd profiles` lists each one with the unbound field that stops

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -5,7 +5,7 @@ between them, and the metrics over them — independent of where the data
 physically lives. A **binding profile** maps that one logical model onto a
 concrete set of sources. You author the model once as a single canonical
 definition and pick a profile per scenario; a profile changes only *where* each
-entity reads from, never *what* the model means, so `Customer`, `revenue`, and
+entity reads from, never *what* the model means, so `Customer`, `order_count`, and
 every relationship mean the same thing whichever profile serves them.
 
 It works like a class hierarchy (the same way an entity `extends` a supertype):
@@ -31,7 +31,7 @@ model to one of them:
 - **Different backends for different consumers.** A live operational store
   (Spanner) holds the `Customer` an agent reads and writes as it acts; an
   analytics warehouse (BigQuery) holds a scaled copy the dashboards read. Each is
-  a profile, and both inherit the same metric definitions, so `revenue` is
+  a profile, and both inherit the same metric definitions, so `order_count` is
   computed the same way wherever it is asked.
 - **Different environments.** Dev, staging, and prod are three profiles that
   differ only in the project they point at.

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -1,11 +1,13 @@
 # One logical model, many physical bindings
 
-> **Scope.** `kcmd` deploys a merged model to a property graph — **BigQuery
-> Graph or Spanner Graph**, whichever the profile's deployment target names — and
-> to Knowledge Catalog. A profile may bind an entity to any store — BigQuery,
-> Spanner, AlloyDB, a lake table — and `kcmd` merges it and reports its
-> availability; a binding to a store with no graph backend yet (AlloyDB, a SaaS
-> API, a lake table) is merged and reported, not deployed.
+> **Scope.** `kcmd push --profile <name>` merges a binding onto the logical model
+> and deploys the result to the graph backend the profile's deployment target
+> names — **BigQuery Graph or Spanner Graph**, the two graph backends today — and
+> to Knowledge Catalog. A profile rebinds each entity's `source` and columns and
+> may leave fields unbound; `kcmd` reports, per profile, what the binding can and
+> cannot answer. The deployment target must name one of the two graph backends; a
+> binding whose data lives elsewhere (an operational store reached over another
+> engine, a SaaS API) is a modeling direction, not a deploy target yet.
 
 A semantic model describes a business logically — its entities, the
 relationships between them, and the metrics over them — independent of where the
@@ -316,15 +318,19 @@ parts of the same model:
 ```bash
 kcmd push --profile analytical            # merge the analytical bindings and deploy to BigQuery Graph
 kcmd push --profile operational           # merge the operational bindings and deploy to Spanner Graph
-kcmd push --profile analytical --target kc # profile and destination-type are independent
+kcmd push --profile analytical --target kc # write only Knowledge Catalog, skip the graph
 kcmd push                                 # uses default_profile from catalog.yaml
 kcmd profiles                             # list profiles, their resolved sources, and what each cannot answer
 ```
 
-`--profile` chooses **which physical binding**. The existing `--target
-bq|kc|all` chooses **which destination type** (BigQuery Graph, Knowledge
-Catalog, or both). They are orthogonal — any profile can go to either
-destination.
+`--profile` chooses **which binding** to merge, and that binding's
+`deployment_target` fixes its **graph backend** — BigQuery Graph for the
+analytical binding above, Spanner Graph for the operational one. `--target`
+chooses **which destinations to write**: `bq`, `spanner`, `kc`, or `all` (the
+default). The two are not interchangeable. `--target kc` writes only the catalog
+under any profile, but naming a graph leg the profile does not target — say
+`--target bq` on the Spanner-bound `operational` — is an error, not a redirect:
+the backend is set by the profile's target, never by the flag.
 
 Set the default so a bare `kcmd push` in CI does the right thing, in
 `catalog.yaml`:
@@ -371,7 +377,9 @@ the same thing.
 string (`expression: c_name`) instead of the full per-dialect object. The two
 forms mean the same thing and expand to the same wire representation.
 
-**Dialect comes from the store.** A profile carries no SQL dialect. The dialect
-follows from the store a profile binds to; the engine lowers each `expression` to
-that store's query language when it runs. A profile chooses the data, and the
-execution engine chooses the dialect.
+**Dialect comes from the store, not the profile.** A profile carries no SQL
+dialect. Expressions are GoogleSQL — the language of both BigQuery Graph and
+Spanner Graph — and are emitted into the generated graph as written; the optional
+`kcmd push --transpile` pass converts vendor SQL to GoogleSQL at push time when a
+source was authored in another dialect. A profile chooses the data, and the
+backend it targets fixes the dialect.

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -70,13 +70,23 @@ resolves to an endpoint. A profile moves an entity between stores by swapping
 this URI, and — when the two stores shape the data differently — the column each
 field reads.
 
-A graph references a source by its **final segment** — the table name in the
-target store. A **BigQuery** `source` may be written as this resource name or as
-a plain `project.dataset.table`; both resolve identically. A **Spanner** graph
-lives inside one database and names its tables directly, so both
-`//spanner.googleapis.com/…/tables/Customer` and the equivalent dotted
-`acme.commerce.Customer` resolve to the table `Customer`. One authored form
-therefore serves either backend.
+How that `source` becomes a table reference in the generated graph depends on
+the backend:
+
+* **BigQuery** keeps the source **fully qualified**. The resource name
+  `//bigquery.googleapis.com/projects/acme/datasets/commerce/tables/Customer` and
+  the plain `acme.commerce.Customer` name the same table, and the graph
+  references it as `acme.commerce.Customer` — a BigQuery graph can read tables
+  across projects and datasets, so the whole path is kept.
+* **Spanner** keeps only the **table name**. The graph and all its tables live in
+  the one database the deployment target names, so the source is reduced to its
+  last segment: both
+  `//spanner.googleapis.com/…/databases/…/tables/Customer` and a dotted
+  `acme.commerce.Customer` become the bare table `Customer`.
+
+Either URI form works for either backend, so the same authored `source` can
+target both — and a profile can swap it for a differently named table when a
+store doesn't line up.
 
 ## What a profile may change — the contract
 

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -17,7 +17,7 @@ deployment target. `kcmd push --profile <name>` merges the two **by name** and
 deploys the result; a profile is never deployed alone.
 
 > **Scope.** A profile deploys to the graph backend its `deployment_target`
-> names — **BigQuery Graph or Spanner Graph**, the two graph backends today —
+> names — **BigQuery or Spanner**, the two backends today —
 > plus Knowledge Catalog. It rebinds sources and columns and may leave fields
 > unbound; `kcmd` reports, per profile, what the binding can and cannot answer. A
 > store with no graph backend (an operational engine reached another way, a SaaS
@@ -227,8 +227,8 @@ kcmd profiles                             # list profiles, their resolved source
 ```
 
 `--profile` chooses **which binding** to merge, and that binding's
-`deployment_target` fixes its **graph backend** — BigQuery Graph for the
-analytical binding above, Spanner Graph for the operational one. `--target`
+`deployment_target` fixes its **backend** — BigQuery for the
+analytical binding above, Spanner for the operational one. `--target`
 chooses **which destinations to write**: `bq`, `spanner`, `kc`, or `all` (the
 default). The two are not interchangeable. `--target kc` writes only the catalog
 under any profile, but naming a graph leg the profile does not target — say
@@ -337,8 +337,8 @@ string (`expression: c_name`) instead of the full per-dialect object. The two
 forms mean the same thing and expand to the same wire representation.
 
 **Dialect comes from the store, not the profile.** A profile carries no SQL
-dialect. Expressions are GoogleSQL — the language of both BigQuery Graph and
-Spanner Graph — and are emitted into the generated graph as written; the optional
+dialect. Expressions are GoogleSQL — the language of both BigQuery and
+Spanner — and are emitted into the generated graph as written; the optional
 `kcmd push --transpile` pass converts vendor SQL to GoogleSQL at push time when a
 source was authored in another dialect. A profile chooses the data, and the
 backend it targets fixes the dialect.

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -1,178 +1,46 @@
 # One logical model, many physical bindings
 
-> **Scope.** `kcmd push --profile <name>` merges a binding onto the logical model
-> and deploys the result to the graph backend the profile's deployment target
-> names — **BigQuery Graph or Spanner Graph**, the two graph backends today — and
-> to Knowledge Catalog. A profile rebinds each entity's `source` and columns and
-> may leave fields unbound; `kcmd` reports, per profile, what the binding can and
-> cannot answer. The deployment target must name one of the two graph backends; a
-> binding whose data lives elsewhere (an operational store reached over another
-> engine, a SaaS API) is a modeling direction, not a deploy target yet.
+A semantic model describes a business logically — its entities, the relationships
+between them, and the metrics over them — independent of where the data
+physically lives. A **binding profile** maps that one logical model onto a
+concrete set of sources. You author the model once as a single canonical
+definition and pick a profile per scenario; a profile changes only *where* each
+entity reads from, never *what* the model means, so `Customer`, `revenue`, and
+every relationship mean the same thing whichever profile serves them.
 
-A semantic model describes a business logically — its entities, the
-relationships between them, and the metrics over them — independent of where the
-data physically lives. A **binding profile** maps that one logical model onto a
-concrete set of sources. You keep the model as a single canonical definition and
-select a profile per scenario; a profile changes only where each entity reads
-from, never what the model means. Because every profile shares one model,
-`Customer`, `revenue`, and each relationship mean the same thing whichever
-profile serves them.
+It works like a class hierarchy (the same way an entity `extends` a supertype):
+the logical model (`<model>.yaml`) is the **base** — the complete declaration of
+entities, fields, relationships, metrics, the grain, and the graph shape, with no
+physical binding — and each profile is a **subclass** that fills in the facets
+the base leaves open: each entity's `source`, each field's column, and the
+deployment target. `kcmd push --profile <name>` merges the two **by name** and
+deploys the result; a profile is never deployed alone.
+
+> **Scope.** A profile deploys to the graph backend its `deployment_target`
+> names — **BigQuery Graph or Spanner Graph**, the two graph backends today —
+> plus Knowledge Catalog. It rebinds sources and columns and may leave fields
+> unbound; `kcmd` reports, per profile, what the binding can and cannot answer. A
+> store with no graph backend (an operational engine reached another way, a SaaS
+> API) is a modeling direction, not a deploy target yet.
 
 ## Why a model gets more than one binding
 
 The same concept usually lives in more than one system, and a profile binds the
-model to one of them. The systems differ along whatever axis matters to you:
+model to one of them:
 
-- **Different backends for different consumers.** A live operational store —
-  AlloyDB, Spanner, a SaaS API — holds the `Customer` an agent reads to check
-  current state before it acts, and writes back to. An analytics warehouse such
-  as BigQuery holds a copy of that same `Customer`, scaled for reporting, that
-  dashboards and conversational-analytics agents read. One profile binds each,
-  and every consumer inherits the same metric definitions, so `revenue` is
+- **Different backends for different consumers.** A live operational store
+  (Spanner) holds the `Customer` an agent reads and writes as it acts; an
+  analytics warehouse (BigQuery) holds a scaled copy the dashboards read. Each is
+  a profile, and both inherit the same metric definitions, so `revenue` is
   computed the same way wherever it is asked.
-- **Different environments of one backend.** A dev, staging, and prod copy of one
-  store are three profiles that differ only in the project they point at.
-- **Different physical layouts.** The same model can bind a table exported to
-  files in a lake, an Iceberg copy, or a partner's differently-named schema.
+- **Different environments.** Dev, staging, and prod are three profiles that
+  differ only in the project they point at.
+- **Different layouts.** The same model can bind a table exported to a lake, an
+  Iceberg copy, or a partner's differently-named schema.
 
-A profile is a named binding, and its meaning is yours to decide; the cases above
-only illustrate the range. You author the model once and choose the profile when
-you deploy or query.
+You author the model once and choose the profile when you deploy or query.
 
-## How it works: a logical model and its bindings
-
-A model and its profiles form a class hierarchy, the same way an entity
-`extends` a supertype:
-
-- The **logical model** (`<model>.yaml`) is the **base**: the complete
-  declaration — entities, fields, relationships, metrics, the grain, and the
-  graph shape — with no physical binding.
-- A **binding profile** is a **subclass**: a document in the *identical schema*
-  that supplies the physical facets the logical model leaves open — each entity's
-  `source`, each field's column, and the deployment target.
-- `kcmd push --profile <name>` **merges** the profile onto the logical model —
-  matching entities, fields, relationships, and metrics **by name** — and
-  deploys the result. A profile is never deployed alone: the logical model
-  supplies every declaration, and the profile supplies the bindings its store
-  provides.
-
-Because the two share one schema, a binding may also sit inline in the logical
-model as a profile named `default`. The layout on this page keeps the logical
-model standalone and each binding in its own file, so the split between logical
-and physical is visible on disk.
-
-## Sources are URIs
-
-Each entity names where its data lives with `source`, a URI. A Google Cloud
-source is an [AIP-122](https://google.aip.dev/122) resource name —
-`//bigquery.googleapis.com/…`, `//spanner.googleapis.com/…`,
-`//alloydb.googleapis.com/…` — read with ambient IAM. Anything else is a
-`scheme://…` URI, such as an `iceberg://…` table that the deployment manifest
-resolves to an endpoint. A profile moves an entity between stores by swapping
-this URI, and — when the two stores shape the data differently — the column each
-field reads.
-
-How that `source` becomes a table reference in the generated graph depends on
-the backend:
-
-* **BigQuery** keeps the source **fully qualified**. The resource name
-  `//bigquery.googleapis.com/projects/acme/datasets/commerce/tables/Customer` and
-  the plain `acme.commerce.Customer` name the same table, and the graph
-  references it as `acme.commerce.Customer` — a BigQuery graph can read tables
-  across projects and datasets, so the whole path is kept.
-* **Spanner** keeps only the **table name**. The graph and all its tables live in
-  the one database the deployment target names, so the source is reduced to its
-  last segment: both
-  `//spanner.googleapis.com/…/databases/…/tables/Customer` and a dotted
-  `acme.commerce.Customer` become the bare table `Customer`.
-
-Either URI form works for either backend, so the same authored `source` can
-target both — and a profile can swap it for a differently named table when a
-store doesn't line up.
-
-## What a profile may change — the contract
-
-A model separates two things. **Declaration** is logical: which entities,
-fields, relationships, and metrics exist, what each means, how each metric
-computes, the grain, and the graph shape. The logical model owns all of it.
-**Binding** is physical: which store each entity reads from, and which column
-each field reads. A profile sets binding and leaves declaration alone.
-
-| Model element | Physical — a profile **may** bind | Logical — a profile **may not** change |
-|---|---|---|
-| Entity | its `source` (store URI) | that it exists and what it means; its grain (`primary_key` / `unique_keys`) |
-| Field | its column — `expression` as a bare column reference; whether it is bound at all | `label`, `description`, `dimension`, `datatype`; an `expression` that is arbitrary SQL (the computation itself) |
-| Relationship | — | that it exists; its join columns (`from`/`to`, `from_columns`/`to_columns`); its junction `source` |
-| Metric | — | its definition (refers to field *names*, stable across profiles) |
-| Deployment target | the target URI | — |
-| AI metadata | — | `ai_context`, synonyms |
-
-An element's `name` is never bound — it is the key that pairs a profile's binding
-to the model element it applies to. Everything logical is defined in terms of
-these names, not physical columns: a metric like `AVG(Customer.lifetimeValue)`,
-the grain, and a relationship's join columns all reference *field names*, which
-are identical under every profile. A profile changes only the column each name
-resolves to. That is why a metric is never restated in a profile: it stays
-correct wherever its fields are bound, and simply becomes unavailable under a
-profile that leaves one of them unbound — the next section explains how that
-propagates.
-
-## Availability follows the bindings
-
-A store holds what it holds. An operational database keeps a customer's live
-credit; a warehouse keeps a modeled lifetime value; neither carries the other's
-column. A profile binds whatever subset its store serves, and leaves the rest
-unbound.
-
-What a profile can answer is therefore derived from what it binds, by one rule.
-**A building block is available under a profile when every field it depends on is
-bound there. When any input is unbound, the block is unbound too, and so is
-anything built on it.** Availability propagates up the dependency graph from the
-fields a profile binds. The chain runs as far as the model does:
-
-- a field is bound when the profile gives its column;
-- an entity is available when its key fields are bound — a graph node must be
-  keyed, so an entity whose key is unbound is dropped whole, and every
-  relationship and metric that touches it falls with it;
-- a metric is available when every field its expression references is bound and
-  every entity it spans is available;
-- a relationship is available when both endpoint entities are available and the
-  join columns on both ends are bound; a cross-entity metric over it is available
-  only when the relationship is.
-
-So an operational-only field such as live credit carries its operational-only
-metrics with it, and a warehouse-only field such as lifetime value carries its
-reports; each is present where its inputs are, and unavailable everywhere else.
-The logical model still declares each thing once; a profile answers the part of
-it that its store can back.
-
-**Unbound is not null.** A bound field whose data happens to be empty — a
-customer with no phone on file — is null: the field exists and the value is
-missing. An unbound field does not exist under that profile at all, and anything
-that reads it is unavailable there rather than reading a null. Keeping the two
-apart is what lets a query fail against a store that cannot answer it instead of
-returning a blank that reads like real data.
-
-**Leaving a field unbound is explicit.** A profile leaves a field unbound in one
-of two ways. The logical model declares the field, and no profile that omits a
-column for it has it until one binds it. Alternatively, a profile that would
-otherwise inherit a column sets `unbound: true` on the field to drop it. Silently
-omitting a field that another profile binds does neither — the field stays
-declared and simply has no column under the omitting profile, which is caught if
-a metric needs it. When a BigQuery source table a profile binds is missing or
-inaccessible, validation fails and names it (the live source probe is
-BigQuery-only; a Spanner source is not probed, so a bad Spanner table surfaces at
-deploy instead); a mistyped column name resolves to a real table and so surfaces
-at deploy, when the graph backend rejects the generated graph. So a forgotten
-binding is caught, and an intentional non-binding is written down.
-
-## File layout
-
-A binding may also sit inline in the logical model — logical and physical in a
-single file — which is how the `default` profile works, and a model with one
-binding needs nothing more. Keeping them in separate files, as below, is one
-layout among several: it keeps the logical model reusable across bindings and
-lets each binding be reviewed and owned on its own.
+## Walkthrough: one model, two bindings
 
 The logical model is one file, and its bindings live beside it, one file per
 profile:
@@ -185,14 +53,11 @@ catalog/EntryGroups/commerce_eg/
     operational.yaml             # bindings for the operational store
 ```
 
-Each binding file is a `semantic_model` document in the same schema as the
-logical model, carrying only physical facets. `--profile analytical` reads
-`commerce.yaml` plus `analytical.yaml`, so nothing in one binding can affect
-another.
+A binding can also sit inline in the logical model as a profile named `default`;
+keeping them in separate files, as here, lets each binding be reviewed and owned
+on its own.
 
-## Example — one model, an analytical and an operational binding
-
-The logical model declares the business and nothing physical: no sources, no
+The logical model declares the business and nothing physical — no sources, no
 columns, no deployment target. `lifetimeValue` and `availableCredit` are both
 declared here, though no single store carries both:
 
@@ -228,8 +93,8 @@ semantic_model:
         expression: AVG(Customer.lifetimeValue)
 ```
 
-The analytical binding points the model at the BigQuery warehouse. The warehouse
-carries the modeled `lifetimeValue` and does not hold live credit, so
+The **analytical** binding points the model at the BigQuery warehouse. The
+warehouse carries the modeled `lifetimeValue` and not live credit, so
 `availableCredit` is `unbound`:
 
 ```yaml
@@ -254,9 +119,9 @@ semantic_model:
           - { name: orderDate,   expression: o_orderdate }
 ```
 
-The operational binding points the same model at the live Spanner store. Spanner
-holds the same customers under different table and column names, binds the live
-`availableCredit`, and does not carry the modeled `lifetimeValue`:
+The **operational** binding points the same model at the live Spanner store.
+Spanner holds the same customers under different table and column names, binds the
+live `availableCredit`, and does not carry the modeled `lifetimeValue`:
 
 ```yaml
 # commerce.profiles/operational.yaml — Spanner bindings
@@ -281,37 +146,75 @@ semantic_model:
 ```
 
 Neither binding restates the grain, the `PlacedBy` relationship, the labels, or
-the metric definitions; those live once in the logical model. `kcmd push
+the metric definitions — those live once in the logical model. `kcmd push
 --profile analytical` deploys to BigQuery Graph and `kcmd push --profile
-operational` deploys to Spanner Graph — each profile routes to the backend its
-deployment target names (see **Scope** above); on Spanner the metrics are
-dropped, since Spanner Graph has no `MEASURE`. The two bindings answer different
-parts of the same model:
+operational` deploys to Spanner Graph, each routing to the backend its deployment
+target names; on Spanner the metrics are dropped, since Spanner Graph has no
+`MEASURE`. The two bindings answer different parts of the same model:
 
-- `order_count` depends only on `Order.key`, bound under both bindings, so it is
-  available under either.
-- `avg_lifetime_value` depends on `Customer.lifetimeValue`. The warehouse binds
-  it, so the metric is available analytically; the operational store marks it
-  unbound, so the metric is unavailable there.
-- `availableCredit` is bound only operationally, so it — and any metric written
-  on top of it — is available under the operational binding and absent under the
-  analytical one.
+- `order_count` depends only on `Order.key`, bound under both, so it is available
+  either way.
+- `avg_lifetime_value` needs `Customer.lifetimeValue` — the warehouse binds it,
+  the operational store marks it `unbound`, so it is available analytically and
+  absent operationally.
+- `availableCredit`, and any metric on top of it, is available only operationally.
 
-## Merge rules
+That last effect — a field a store can't back becomes `unbound`, and everything
+depending on it becomes unavailable there rather than returning nulls — is the
+[availability rule](#availability-what-a-binding-can-answer). The `source` forms
+(resource name vs. dotted table name) are in [Source URIs](#source-uris), and the
+push flags in [Command line](#command-line).
 
-- A profile carries only `entities` (its alias `datasets` also works) and their
-  `fields`; these merge onto the logical model **by `name`**. A profile never
-  carries a `relationship` or a `metric` — those are logical, so they live once
-  in the model and a profile that sets one is rejected.
-- An entity or field named only in the logical model is carried through
-  unchanged; a profile element whose `name` is not in the logical model is
-  rejected.
-- Scalars — `source`, `expression`, `deployment_target` — **replace**.
-- A field with `unbound: true` in a profile **drops** any column for that field
-  under that profile.
-- Profiles are **binding-only**: a profile sets physical facets and may leave a
-  field unbound. It cannot add or remove entities, fields, or metrics, change
-  the grain or graph shape, or change what anything means.
+## What a profile may change — the contract
+
+A profile sets physical **binding** and leaves the logical **declaration** alone:
+
+| Model element | Physical — a profile **may** bind | Logical — a profile **may not** change |
+|---|---|---|
+| Entity | its `source` (store URI) | that it exists and what it means; its grain (`primary_key` / `unique_keys`) |
+| Field | its column — `expression` as a bare column reference; whether it is bound at all | `label`, `description`, `dimension`, `datatype`; an `expression` that is arbitrary SQL (the computation itself) |
+| Relationship | — | that it exists; its join columns (`from`/`to`, `from_columns`/`to_columns`); its junction `source` |
+| Metric | — | its definition (refers to field *names*, stable across profiles) |
+| Deployment target | the target URI | — |
+| AI metadata | — | `ai_context`, synonyms |
+
+An element's `name` is never bound — it is the key that pairs a profile's binding
+to the model element it applies to. Everything logical is defined in terms of
+these names, not physical columns: a metric like `AVG(Customer.lifetimeValue)`,
+the grain, and a relationship's join columns all reference *field names*, which
+are identical under every profile. A profile changes only the column each name
+resolves to. That is why a metric is never restated in a profile: it stays
+correct wherever its fields are bound, and simply becomes unavailable under a
+profile that leaves one of them unbound.
+
+## Availability: what a binding can answer
+
+A store holds what it holds — an operational database keeps a customer's live
+credit, a warehouse keeps a modeled lifetime value, neither carries the other's
+column. A profile binds whatever subset its store serves and leaves the rest
+unbound. What it can answer follows by one rule:
+
+**A building block is available under a profile when every field it depends on is
+bound there. When any input is unbound, the block is unbound too, and so is
+anything built on it.**
+
+Availability propagates up the dependency graph, as far as the model runs:
+
+- a field is bound when the profile gives its column;
+- an entity is available when its key fields are bound — a graph node must be
+  keyed, so an entity whose key is unbound is dropped whole, and every
+  relationship and metric that touches it falls with it;
+- a metric is available when every field its expression references is bound and
+  every entity it spans is available;
+- a relationship is available when both endpoint entities are available and the
+  join columns on both ends are bound; a cross-entity metric over it is available
+  only when the relationship is.
+
+So an operational-only field such as live credit carries its operational-only
+metrics with it, and a warehouse-only field such as lifetime value carries its
+reports; each is present where its inputs are, and unavailable everywhere else.
+The logical model still declares each thing once; a profile answers the part of
+it that its store can back.
 
 ## Command line
 
@@ -340,6 +243,48 @@ scope: semantic-model.acme.us.commerce_eg
 default_profile: analytical
 ```
 
+## Source URIs
+
+Each entity names where its data lives with `source`, a URI. A Google Cloud
+source is an [AIP-122](https://google.aip.dev/122) resource name —
+`//bigquery.googleapis.com/…`, `//spanner.googleapis.com/…`,
+`//alloydb.googleapis.com/…` — read with ambient IAM. Anything else is a
+`scheme://…` URI, such as an `iceberg://…` table that the deployment manifest
+resolves to an endpoint. A profile moves an entity between stores by swapping
+this URI, and — when the two stores shape the data differently — the column each
+field reads.
+
+How that `source` becomes a table reference in the generated graph depends on
+the backend:
+
+* **BigQuery** keeps the source **fully qualified**. The resource name
+  `//bigquery.googleapis.com/projects/acme/datasets/commerce/tables/Customer` and
+  the plain `acme.commerce.Customer` name the same table, and the graph
+  references it as `acme.commerce.Customer` — a BigQuery graph can read tables
+  across projects and datasets, so the whole path is kept.
+* **Spanner** keeps only the **table name**. The graph and all its tables live in
+  the one database the deployment target names, so the source is reduced to its
+  last segment: both
+  `//spanner.googleapis.com/…/databases/…/tables/Customer` and a dotted
+  `acme.commerce.Customer` become the bare table `Customer`.
+
+Either URI form works for either backend, so the same authored `source` can
+target both — and a profile can swap it for a differently named table when a
+store doesn't line up.
+
+## Merge rules
+
+- A profile carries only `entities` (its alias `datasets` also works) and their
+  `fields`; these merge onto the logical model **by `name`**. A profile never
+  carries a `relationship` or a `metric` — those are logical, so they live once
+  in the model and a profile that sets one is rejected.
+- An entity or field named only in the logical model is carried through
+  unchanged; a profile element whose `name` is not in the logical model is
+  rejected.
+- Scalars — `source`, `expression`, `deployment_target` — **replace**.
+- A field with `unbound: true` in a profile **drops** any column for that field
+  under that profile.
+
 ## Validation
 
 Profiles are checked as part of push; `--validate-only` runs the checks and
@@ -366,7 +311,21 @@ writes nothing.
   unavailable. `kcmd profiles` lists each one with the unbound field that stops
   it, so withheld coverage is stated rather than discovered later.
 
-## Notes
+## Details
+
+**Unbound is not null.** A bound field whose data happens to be empty — a
+customer with no phone on file — is null: the field exists and the value is
+missing. An unbound field does not exist under that profile at all, and anything
+that reads it is unavailable there rather than reading a null. Keeping the two
+apart is what lets a query fail against a store that cannot answer it instead of
+returning a blank that reads like real data.
+
+**Leaving a field unbound is explicit.** A profile leaves a field unbound in one
+of two ways: the logical model declares a field and no profile binds a column for
+it, or a profile that would otherwise inherit a column sets `unbound: true` to
+drop it. Either way the field stays declared and simply has no column under that
+profile, caught if a metric needs it. So a forgotten binding surfaces, and an
+intentional non-binding is written down.
 
 **The deployment target is a first-class key.** So a profile can set it readably,
 `deployment_target:` is a model key rather than a JSON string inside a `GOOGLE

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -28,7 +28,8 @@ Knowledge Catalog — the graph first.
 
 | Flag | Effect |
 |------|--------|
-| `--target <bq\|spanner\|kc\|all>` | Which destination(s) to deploy to; accepts a comma-separated list (`bq,kc`). Default `all`. `bq` and `spanner` are the two graph backends; each model routes to whichever its deployment target names, so `--target spanner` on a BigQuery-targeting model reports it has nothing to do. |
+| `--target <bq\|spanner\|kc\|all>` | Which destination(s) to deploy to; accepts a comma-separated list (`bq,kc`). Default `all`. `bq` and `spanner` are the two graph backends; each model routes to whichever its deployment target names. Naming a graph backend that **no** model targets depends on how you asked: an explicit `--target spanner` (or `bq`) with no matching model is an error (nothing to deploy), while the same backend pulled in only by `all`/the default is skipped quietly, since the model is simply bound to the other backend. |
+| `--profile <name>` | Merge the named [binding profile](profiles.md) onto the logical model before deploying — chooses which physical binding is used, independent of `--target`. Defaults to `default_profile` from `catalog.yaml`, then to the inline (`default`) binding. |
 | `--validate-only` | Run every validation check and report pass/fail, but write nothing. |
 | `--print` | Print each destination's generated artifact (BigQuery or Spanner Graph SQL DDL, Knowledge Catalog entry plan). Combine with `--validate-only` to preview without deploying. |
 | `--force-remove` | Delete models in the entry group that this push no longer includes (see [Updating and removing models](README.md#updating-and-removing-models)). |

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -90,7 +90,7 @@ You author only each entity's **own** fields plus the one `extends` keyword; the
 push does the rest:
 
 ```yaml
-datasets:
+entities:
   - name: Person
     source: proj.ds.person
     primary_key: [id]

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -205,6 +205,13 @@ Each element of your model maps to one catalog resource. Every resource type
 below is a built-in system type under `dataplex-types/global` — push references
 them, it never creates them.
 
+A `--target kc` push accepts a **logical-only model** — entities, relationships,
+and metrics with no source bindings, field expressions, or deployment target —
+because the catalog governs meaning, not physical storage. Bindings and a target
+are required only for a graph leg. (An entity with no `source` publishes with no
+linked resource; one whose `source` is still an `unbound:<Name>` placeholder
+publishes that placeholder verbatim until you bind a real table.)
+
 > Set `KC_TYPE_PROJECT` to read these system types from another project, and
 > `DATAPLEX_ENDPOINT` to target a non-prod Dataplex host; both default to
 > production (`dataplex-types` / `https://dataplex.googleapis.com`).
@@ -233,17 +240,19 @@ of your model. For exactly what is stored, what is gated behind
 `push` and `--validate-only` run the same checks, **before either destination is
 touched**, so a model that cannot deploy fails fast instead of half-deploying:
 
-* **Exactly one deployment target per model, and it must be a valid BigQuery
-  or Spanner URI.** A model with no target — or with more than one —
-  is rejected, and so is a single target whose URI matches neither
+* **A graph push declares exactly one deployment target, a valid BigQuery or
+  Spanner URI.** When the push has a graph leg (`bq`/`spanner`/`all`), a model
+  with no target — or with more than one — is rejected, and so is a single target
+  whose URI matches neither
   `//bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>` nor
   `//spanner.googleapis.com/projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>`
   (for example a `propertyGraph`/`propertyGraphs` typo, or a
   `…/entryGroups/@bigquery/entries/…` entry form). The error names the offending
-  URI and the expected forms. This gate runs before any destination leg and for
-  every `--target`, so a malformed target writes **nothing** — not to the graph
-  and **not to Knowledge Catalog**; the push aborts with a non-zero exit and no
-  entries are created. *(static)*
+  URI and the expected forms, and the gate runs before any leg, so a malformed
+  target writes **nothing**. A **Knowledge-Catalog-only push** (`--target kc`)
+  deploys no graph, so the deployment target is optional and, when present, not
+  checked — a logical model with no target still publishes to the catalog.
+  *(static)*
 * **Every metric on a BigQuery model resolves to exactly one entity** —
   otherwise it would be dropped from the BigQuery graph. Set the metric's attach
   entity, or scope its expression to a single entity. This rule is
@@ -259,10 +268,11 @@ touched**, so a model that cannot deploy fails fast instead of half-deploying:
   (a different system) and are **not** probed here. *(live — needs BigQuery
   access)*
 
-The live table check runs for **every** `--target` over the BigQuery-targeting
-models, because the same tables back both a BigQuery graph and its Knowledge
-Catalog entries — so even a Knowledge-Catalog-only push of a BigQuery-targeting
-model confirms it could deploy to BigQuery.
+The live table check runs only when the push actually touches BigQuery — a graph
+leg is requested (`bq`, or `all`/the default) and a model targets BigQuery. A
+**Spanner-only** or **Knowledge-Catalog-only** push queries no BigQuery tables,
+so it runs no live probe: a `--target kc` push writes catalog metadata without
+reaching any source, and a logical model has no sources to probe.
 
 ## Permissions
 

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -31,7 +31,7 @@ Knowledge Catalog — the graph first.
 | `--target <bq\|spanner\|kc\|all>` | Which destination(s) to deploy to; accepts a comma-separated list (`bq,kc`). Default `all`. `bq` and `spanner` are the two graph backends; each model routes to whichever its deployment target names. Naming a graph backend that **no** model targets depends on how you asked: an explicit `--target spanner` (or `bq`) with no matching model is an error (nothing to deploy), while the same backend pulled in only by `all`/the default is skipped quietly, since the model is simply bound to the other backend. |
 | `--profile <name>` | Merge the named [binding profile](profiles.md) onto the logical model before deploying — chooses which physical binding is used, independent of `--target`. Defaults to `default_profile` from `catalog.yaml`, then to the inline (`default`) binding. |
 | `--validate-only` | Run every validation check and report pass/fail, but write nothing. |
-| `--print` | Print each destination's generated artifact (BigQuery or Spanner Graph SQL DDL, Knowledge Catalog entry plan). Combine with `--validate-only` to preview without deploying. |
+| `--print` | Print each destination's generated artifact (BigQuery or Spanner SQL DDL, Knowledge Catalog entry plan). Combine with `--validate-only` to preview without deploying. |
 | `--force-remove` | Delete models in the entry group that this push no longer includes (see [Updating and removing models](README.md#updating-and-removing-models)). |
 | `--emit-expressions` | Also write the SQL-expression fields (per-field `schema.semantics` and `semantic-metric.expression`) to Knowledge Catalog. Off by default: the published system-type templates do not carry them yet. Knowledge Catalog push only. |
 
@@ -79,7 +79,7 @@ labels, …) lands in the graph and which is dropped, see
 
 ### Class hierarchies (`extends` → labels)
 
-An entity that declares `extends: [Parent]` is a **subclass**. BigQuery Graph has
+An entity that declares `extends: [Parent]` is a **subclass**. BigQuery has
 no inheritance keyword, so the push expresses the hierarchy with **labels**: a
 subclass node table declares its own default label **plus one `LABEL <Ancestor>`
 per supertype**, walking the full transitive chain. A node then matches its
@@ -167,16 +167,16 @@ published normally.
 
 ## What gets created in Spanner
 
-When the deployment target is a Spanner Graph URI, `push` executes the same
-`CREATE OR REPLACE PROPERTY GRAPH` — but generated for Spanner Graph, which
-differs from BigQuery Graph in four ways:
+When the deployment target is a Spanner URI, `push` executes the same
+`CREATE OR REPLACE PROPERTY GRAPH` — but generated for Spanner, which
+differs from BigQuery in four ways:
 
 | Model element | Spanner construct | Notes |
 |---|---|---|
 | Model | `PROPERTY GRAPH` | named by the URI's `propertyGraphs/<g>` segment, **bare** (no backticked `project.dataset.` prefix) |
 | Entity | `NODE TABLE` | backed by the entity's `source` reduced to its final segment (`proj.ds.Orders` → `Orders`), a table in the target database |
 | Relationship | `EDGE TABLE` | connects the two entities' node tables |
-| Metric | — dropped | Spanner Graph has no `MEASURE`, so every model-level metric is skipped with a warning; the graph structure still deploys |
+| Metric | — dropped | Spanner has no `MEASURE`, so every model-level metric is skipped with a warning; the graph structure still deploys |
 | Entity `extends` | extra `LABEL` clauses on the subclass node table | same label-and-flatten handling as BigQuery (see [Class hierarchies](#class-hierarchies-extends--labels)) |
 
 - **Bare table and graph names.** A Spanner property graph lives inside one
@@ -188,7 +188,7 @@ differs from BigQuery Graph in four ways:
 - **No per-element `OPTIONS`.** `description` / `synonyms` are not emitted into
   the Spanner DDL; they ride into Knowledge Catalog instead — mirroring how
   BigQuery's graph-level `OPTIONS` is dropped. See
-  [What push and pull preserve](fidelity.md#to-spanner-graph).
+  [What push and pull preserve](fidelity.md#to-spanner).
 - **Async DDL.** The statement is applied through the Spanner Admin
   `updateDatabaseDdl` long-running operation, polled to completion (BigQuery runs
   its DDL through `jobs.query`). No region detection is needed — the DDL runs in
@@ -234,7 +234,7 @@ of your model. For exactly what is stored, what is gated behind
 touched**, so a model that cannot deploy fails fast instead of half-deploying:
 
 * **Exactly one deployment target per model, and it must be a valid BigQuery
-  Graph or Spanner Graph URI.** A model with no target — or with more than one —
+  or Spanner URI.** A model with no target — or with more than one —
   is rejected, and so is a single target whose URI matches neither
   `//bigquery.googleapis.com/projects/<p>/datasets/<d>/propertyGraphs/<g>` nor
   `//spanner.googleapis.com/projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>`
@@ -244,10 +244,10 @@ touched**, so a model that cannot deploy fails fast instead of half-deploying:
   every `--target`, so a malformed target writes **nothing** — not to the graph
   and **not to Knowledge Catalog**; the push aborts with a non-zero exit and no
   entries are created. *(static)*
-* **Every metric on a BigQuery Graph model resolves to exactly one entity** —
-  otherwise it would be dropped from the BigQuery Graph. Set the metric's attach
+* **Every metric on a BigQuery model resolves to exactly one entity** —
+  otherwise it would be dropped from the BigQuery graph. Set the metric's attach
   entity, or scope its expression to a single entity. This rule is
-  BigQuery-only: Spanner Graph has no `MEASURE`, so a Spanner target drops its
+  BigQuery-only: Spanner has no `MEASURE`, so a Spanner target drops its
   metrics by design and imposes no such requirement. *(static)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it


### PR DESCRIPTION
## What

Holistic audit + revision of the non-codelab semantic-model user guide against
the semantic-model / Spanner-deploy PRs merged today (#357/#358 binding
profiles, #361 Spanner Graph target, #363 physical-column KEYs, #366 source-URI
reduction). **Docs only.** Rebased onto `main` (includes #366), so every claim
is backed by landed code.

**README / reference.md**
- Link the binding-profiles guide; document `--profile`; correct `--target`
  (an explicit `--target spanner`/`bq` with no matching model is a hard error,
  not a quiet no-op); state the Spanner-native resource-name `source` is
  supported, not "planned."

**profiles.md — reconciled with Spanner deployment**
- **Scope**: removed a "bind to a non-graph store → merged and reported, not
  deployed" path that has no implementation. A deployment target must name a
  BigQuery Graph or Spanner Graph URI (`validate.ts:38-53`); those are the two
  graph backends.
- **Command line**: added `--target spanner`; corrected the orthogonality
  framing — the graph backend is fixed by the profile's `deployment_target`, so
  `--target bq` on a Spanner-bound profile is an error, not a redirect; only
  `--target kc` is universal.
- **Sources / notes**: clarified how a `source` URI resolves per backend
  (BigQuery keeps the full path; Spanner reduces to the bare table name);
  replaced the aspirational "engine lowers each expression at runtime" with what
  actually happens (GoogleSQL emitted as written; `--transpile` converts vendor
  SQL at push).
- **Contract table**: reorganized by model element (physical vs logical per row);
  consolidated the follow-on prose and fixed an off-example metric to the doc's
  own `AVG(Customer.lifetimeValue)`.

## Verification

Claim-by-claim audit against the code (commands.ts, loader.ts, validate.ts,
resolve_profiles.ts, spanner.ts, bigquery.ts). Everything else in the guide
verified CONFIRMED. Spanner unit tests 17/17 on the rebased branch.
