### PR TITLE
fix(mdcode): reduce a resource-name URI Spanner source to its final path segment

### DIFF
--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -381,9 +381,12 @@ function isSimpleIdentifier(s: string): boolean {
 // references. A property graph names input tables within its own database, so
 // only the final segment of a qualified `project.dataset.table` (or any dotted
 // source) is meaningful; the leading qualifiers name where a BigQuery copy
-// lives and have no bearing on the Spanner table. A verbatim query (contains
-// whitespace) cannot back a graph element table, so it is passed through
-// parenthesized with a warning.
+// lives and have no bearing on the Spanner table. A resource-name URI
+// (`//spanner.googleapis.com/.../tables/<t>`, or any other `scheme://.../<t>`)
+// names its table by the final PATH segment for the same reason — the leading
+// path locates the store, not the table. A verbatim query (contains whitespace)
+// cannot back a graph element table, so it is passed through parenthesized with
+// a warning.
 function spannerTable(
     dataSource: string, warnings: string[], context: string): string {
   const trimmed = (dataSource ?? '').trim();
@@ -399,8 +402,28 @@ function spannerTable(
         `emitting it verbatim (a graph element table requires a table)`);
     return `(${trimmed})`;
   }
-  const last = splitDotted(trimmed).map(unquote).pop() ?? trimmed;
+  // A BigQuery resource URI is rewritten to `project.dataset.table` upstream in
+  // the loader, but a Spanner-native (or other `scheme://`) URI is kept
+  // verbatim there, so reduce it to its final path segment here before the
+  // dotted reduction below.
+  const source = isResourceUri(trimmed) ? finalPathSegment(trimmed) : trimmed;
+  const last = splitDotted(source).map(unquote).pop() ?? source;
   return quoteIdent(last);
+}
+
+
+// A Google Cloud resource name (`//host/...`) or any `scheme://...` URI, as
+// opposed to a bare or dotted table reference. Mirrors the loader's source
+// parsing so the two agree on what counts as a URI.
+function isResourceUri(source: string): boolean {
+  return source.startsWith('//') || /^[a-z][\w+.-]*:\/\//i.test(source);
+}
+
+// The final non-empty path segment of a URI (`.../tables/Customer` →
+// `Customer`).
+function finalPathSegment(uri: string): string {
+  const segments = uri.split('/').filter(s => s.length > 0);
+  return segments.pop() ?? uri;
 }
 
 

--- a/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
@@ -161,6 +161,24 @@ describe('bare table mapping', () => {
     expect(ddl).toContain('Orders AS orders');
   });
 
+  test('a Spanner resource-name URI reduces to its final path segment', () => {
+    // A binding profile may name a Spanner source by its AIP-122 resource
+    // name; the loader keeps it verbatim, so the generator must reduce it to
+    // the bare table (the naive dotted split left `com/.../tables/Orders`).
+    const {ddl} = generateSpannerPropertyGraph(withSource(
+        '//spanner.googleapis.com/projects/p/instances/i/databases/d/tables/Orders'));
+    expect(ddl).toContain('Orders AS orders');
+    expect(ddl).not.toContain('googleapis');
+    expect(ddl).not.toContain('tables/Orders');
+  });
+
+  test('a scheme:// source URI reduces to its final path segment', () => {
+    const {ddl} =
+        generateSpannerPropertyGraph(withSource('iceberg://cat/db/Orders'));
+    expect(ddl).toContain('Orders AS orders');
+    expect(ddl).not.toContain('iceberg');
+  });
+
   test(
       'a dot INSIDE a quoted final segment does not split the table name',
       () => {


### PR DESCRIPTION
## What

`spannerTable()` reduced a Spanner node/edge source to its final **dotted**
segment. That is correct for a `project.dataset.table` source, but a binding
profile may name a Spanner source by its AIP-122 resource name
(`//spanner.googleapis.com/projects/p/instances/i/databases/d/tables/Orders`),
which the loader keeps verbatim. Splitting *that* on `.` yielded
`` `com/projects/.../tables/Orders` `` — invalid DDL that Spanner rejects.

The fix reduces a resource-name / `scheme://` URI by its final **path** segment
first, then applies the existing dotted reduction. Localized to the Spanner leg,
so Knowledge Catalog still records the full resource name.

This is the same family of bug as #363 (Spanner sources needing the physical
name, not the logical one), surfaced while auditing the binding-profiles guide.

## Test

Added two unit tests in `spanner.test.ts` (`bare table mapping`):
- a `//spanner.googleapis.com/...` resource URI reduces to bare `Orders`
- a generic `iceberg://cat/db/Orders` scheme URI reduces to bare `Orders`

Full semantic suite green (`test:libts`).
