### PR TITLE
feat(mdcode): allow a logical-only model to push to Knowledge Catalog

### DIFF
--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -625,8 +625,23 @@ function renderNodeTable(
   // Order: declared fields, then any operand properties synthesized for
   // measures, then the measures themselves (which reference those operand
   // properties).
+  // Defense in depth: availability pruning normally strips every unbound field
+  // (it has no column) before generation, and fieldBinding is the shared
+  // "is bound" oracle both it and this generator consult so the two never
+  // disagree. But a caller that generates DDL straight from a bindingOptional
+  // load without pruning could still reach here with an unbound (e.g. purely
+  // logical) field. Skip it with a warning rather than emit `<name>` as a
+  // phantom bare column the source table does not have.
+  const boundFields = entity.fields.filter(f => {
+    if (fieldBinding(f) !== undefined) return true;
+    warnings.push(
+        `entity '${entity.name}': field '${f.name}' has no column under this ` +
+        `binding; omitted from the node table (bind it, or govern the logical ` +
+        `model in Knowledge Catalog instead)`);
+    return false;
+  });
   const properties = [
-    ...entity.fields.map(renderOwn),
+    ...boundFields.map(renderOwn),
     ...derivedProperties,
     ...measures,
   ];

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -332,18 +332,19 @@ function modelAspectData(model: SemanticModel): Record<string, any> {
   });
 }
 
-// semantic-entity: the base table(s) backing the entity. `source` and its
-// `resources` array are required by the aspect type. importedSystem/
+// semantic-entity: the base table(s) backing the entity. importedSystem/
 // importedResource have no IR source today and are left unset.
 function entityAspectData(entity: Entity): Record<string, any> {
-  // A logical-only entity has no physical table (empty dataSource); emit an
-  // empty resources array rather than a bogus [''] element.
+  // A logical-only entity has no physical table (empty dataSource). Omit the
+  // `source` block entirely rather than emit an empty (or bogus ['']) resources
+  // array: like the semantic-model aspect's deploymentTargets, empty aspect data
+  // is valid and the aspect is still attached to satisfy required_aspects. The
+  // reader treats an absent source the same as an empty one (dataSource
+  // becomes '').
   const path = resourcePath(entity.dataSource);
-  return {
-    source: compact({
-      resources: path ? [path] : [],
-    }),
-  };
+  return compact({
+    source: path ? {resources: [path]} : undefined,
+  });
 }
 
 // The built-in schema aspect, carrying each field's column type and display

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -286,11 +286,18 @@ function schemaJoinAspectData(
   return {
     joins: [compact({
       source: {
-        name: srcEntity ? srcEntity.dataSource : rel.source.entity,
+        // Name each side by its SQL table (dataSource); fall back to the entity
+        // name when the model is logical-only (no binding, so dataSource is
+        // empty), matching the entity-not-found fallback.
+        name: srcEntity && srcEntity.dataSource ?
+            srcEntity.dataSource :
+            rel.source.entity,
         fields: rel.source.columns,
       },
       target: {
-        name: dstEntity ? dstEntity.dataSource : rel.destination.entity,
+        name: dstEntity && dstEntity.dataSource ?
+            dstEntity.dataSource :
+            rel.destination.entity,
         fields: rel.destination.columns,
       },
       description: rel.description,
@@ -329,9 +336,12 @@ function modelAspectData(model: SemanticModel): Record<string, any> {
 // `resources` array are required by the aspect type. importedSystem/
 // importedResource have no IR source today and are left unset.
 function entityAspectData(entity: Entity): Record<string, any> {
+  // A logical-only entity has no physical table (empty dataSource); emit an
+  // empty resources array rather than a bogus [''] element.
+  const path = resourcePath(entity.dataSource);
   return {
     source: compact({
-      resources: [resourcePath(entity.dataSource)],
+      resources: path ? [path] : [],
     }),
   };
 }

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -21,6 +21,13 @@ export interface LoadOptions {
   dialect?: string;         // preferred expression dialect; default 'BIGQUERY'
   defaultProject?: string;  // fallback when a dataset `source` omits the project
   defaultDataset?: string;  // fallback when a dataset `source` omits the dataset
+  // Accept a purely logical model: do not require a `source` on each concrete
+  // dataset or an `expression` on each field. Set for a Knowledge-Catalog-only
+  // push, which governs the logical model (meaning) and needs no physical
+  // binding. Graph legs (BigQuery/Spanner) never set it -- they cannot generate
+  // a graph without bindings. Contradiction checks (unbound+expression,
+  // abstract+source) stay enforced regardless.
+  bindingOptional?: boolean;
 }
 
 export interface LoadResult {
@@ -84,12 +91,17 @@ const dimensionSchema = z.object({
   is_time: z.boolean().optional(),
 });
 
-const fieldSchema = z.object({
+// The field object shape, WITHOUT the binding-completeness refinement. The
+// refinement is applied per-load by makeDocumentSchema, so a
+// Knowledge-Catalog-only push (bindingOptional) can accept a purely logical
+// field. A superRefine does not change a schema's inferred type, so FieldDoc is
+// inferred from this base.
+const fieldBase = z.object({
   name: z.string(),
   // A bound field names its physical column via `expression`; an `unbound`
-  // field has no column under this binding. Exactly one of the two holds
-  // (enforced below), so a field is never both, and a field that is neither -- a
-  // forgotten binding -- is caught here rather than silently dropped.
+  // field has no column under this binding. Whether a field must be bound (or
+  // explicitly `unbound`) is decided per-load by makeDocumentSchema; a purely
+  // logical field carries neither.
   expression: expressionSchema.optional(),
   unbound: z.boolean().optional(),
   datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
@@ -98,30 +110,16 @@ const fieldSchema = z.object({
   dimension: dimensionSchema.optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
-}).superRefine((f, ctx) => {
-  if (f.unbound && f.expression !== undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['expression'],
-      message: `field '${f.name}': an unbound field has no column; remove ` +
-          `'expression', or drop 'unbound: true' to bind it to that column`,
-    });
-  }
-  if (!f.unbound && f.expression === undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['expression'],
-      message: `field '${f.name}': requires an expression; set 'expression', ` +
-          `or mark it 'unbound: true' if this binding has no column for it`,
-    });
-  }
 });
 
-const datasetSchema = z.object({
+// The dataset object shape, WITHOUT the source-required refinement (applied
+// per-load by makeDocumentSchema). DatasetDoc is inferred from this base.
+const datasetBase = z.object({
   name: z.string(),
   // A concrete dataset is backed by a physical `source` table; an `abstract`
-  // one has no table, so `source` is optional here and required-unless-abstract
-  // by the refinement below.
+  // one has no table. Whether a non-abstract dataset must name a `source` is
+  // decided per-load by makeDocumentSchema (a KC-only push accepts a logical
+  // dataset with none); the abstract+source contradiction is always rejected.
   source: z.string().optional(),
   primary_key: z.array(z.string()).optional(),
   unique_keys: z.array(z.array(z.string())).optional(),
@@ -135,32 +133,8 @@ const datasetSchema = z.object({
   abstract: z.boolean().optional(),
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
-  fields: z.array(fieldSchema).optional(),
+  fields: z.array(fieldBase).optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
-}).superRefine((ds, ctx) => {
-  // A concrete (non-abstract) dataset must name its backing table; only an
-  // abstract one may omit `source`.
-  if (!ds.abstract && ds.source === undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['source'],
-      message: `dataset '${ds.name}': a non-abstract dataset requires a ` +
-          `source; set 'source', or mark it 'abstract: true' if it has no table`,
-    });
-  }
-  // The converse: an abstract dataset has no physical table, so declaring a
-  // `source` on it is contradictory -- the BigQuery leg forms no node table for
-  // an abstract entity and would silently ignore the source, dropping a table
-  // the author clearly intended. Reject it so the ambiguity is resolved
-  // explicitly rather than lost.
-  if (ds.abstract && ds.source !== undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['source'],
-      message: `dataset '${ds.name}': an abstract dataset has no table; ` +
-          `remove 'source', or drop 'abstract: true' to bind it to that table`,
-    });
-  }
 });
 
 const relationshipSchema = z.object({
@@ -183,27 +157,80 @@ const metricSchema = z.object({
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
 
-const modelSchema = z.object({
+const modelBase = z.object({
   name: z.string(),
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
-  datasets: z.array(datasetSchema).min(1),
+  datasets: z.array(datasetBase).min(1),
   relationships: z.array(relationshipSchema).optional(),
   metrics: z.array(metricSchema).optional(),
 });
 
-const documentSchema = z.object({
-  version: z.string().optional(),
-  semantic_model: z.array(modelSchema).min(1),
-});
+// Builds the document schema with the binding-completeness refinement applied
+// according to `bindingOptional`. When false (the default -- any push that
+// includes a graph leg), each concrete dataset must name a `source` and each
+// field must be bound or explicitly `unbound`. When true (a
+// Knowledge-Catalog-only push, which governs the logical model), those two
+// requirements are dropped so a purely logical model loads. The contradiction
+// checks (unbound+expression, abstract+source) are enforced either way.
+function makeDocumentSchema(bindingOptional: boolean) {
+  const field = fieldBase.superRefine((f, ctx) => {
+    if (f.unbound && f.expression !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expression'],
+        message: `field '${f.name}': an unbound field has no column; remove ` +
+            `'expression', or drop 'unbound: true' to bind it to that column`,
+      });
+    }
+    if (!bindingOptional && !f.unbound && f.expression === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expression'],
+        message: `field '${f.name}': requires an expression; set 'expression', ` +
+            `or mark it 'unbound: true' if this binding has no column for it`,
+      });
+    }
+  });
+  const dataset = datasetBase.extend({ fields: z.array(field).optional() })
+    .superRefine((ds, ctx) => {
+      // A concrete (non-abstract) dataset must name its backing table; only an
+      // abstract one may omit `source`. Relaxed under bindingOptional, where a
+      // logical dataset has no source.
+      if (!bindingOptional && !ds.abstract && ds.source === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['source'],
+          message: `dataset '${ds.name}': a non-abstract dataset requires a ` +
+              `source; set 'source', or mark it 'abstract: true' if it has no table`,
+        });
+      }
+      // The converse is always contradictory: an abstract dataset has no
+      // physical table, so a `source` on it would be silently ignored by the
+      // BigQuery leg. Reject it regardless of bindingOptional.
+      if (ds.abstract && ds.source !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['source'],
+          message: `dataset '${ds.name}': an abstract dataset has no table; ` +
+              `remove 'source', or drop 'abstract: true' to bind it to that table`,
+        });
+      }
+    });
+  const model = modelBase.extend({ datasets: z.array(dataset).min(1) });
+  return z.object({
+    version: z.string().optional(),
+    semantic_model: z.array(model).min(1),
+  });
+}
 
 type ExpressionDoc = z.infer<typeof expressionSchema>;
-type DatasetDoc = z.infer<typeof datasetSchema>;
-type FieldDoc = z.infer<typeof fieldSchema>;
+type DatasetDoc = z.infer<typeof datasetBase>;
+type FieldDoc = z.infer<typeof fieldBase>;
 type RelationshipDoc = z.infer<typeof relationshipSchema>;
 type MetricDoc = z.infer<typeof metricSchema>;
-type ModelDoc = z.infer<typeof modelSchema>;
+type ModelDoc = z.infer<typeof modelBase>;
 type CustomExtensionDoc = z.infer<typeof customExtensionSchema>;
 type AiContextDoc = z.infer<typeof aiContextSchema>;
 
@@ -354,7 +381,8 @@ export function loadModels(text: string, opts: LoadOptions = {}): LoadResult {
  */
 export function fromDocument(doc: unknown, opts: LoadOptions = {}): LoadResult {
   const normalized = normalizeDocumentSugars(doc);
-  const result = documentSchema.safeParse(normalized);
+  const result =
+      makeDocumentSchema(opts.bindingOptional ?? false).safeParse(normalized);
   if (!result.success) {
     throw new Error(`Semantic model load error: ${result.error.message}`);
   }
@@ -460,15 +488,18 @@ function convertField(f: FieldDoc, entityName: string, warnings: string[], diale
     // Declared but not bound under this binding: no column, no expression (the
     // schema guarantees `expression` is absent here). See Field.unbound.
     field.unbound = true;
-  } else {
+  } else if (f.expression !== undefined) {
     const picked = pickDialect(
-      f.expression!, dialect, `field '${entityName}.${f.name}'`, warnings);
+      f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
     if (picked.expression !== undefined) field.expression = picked.expression;
     if (picked.importedExpression !== undefined) {
       field.importedExpression = picked.importedExpression;
       field.importedDialect = picked.importedDialect;
     }
   }
+  // else: a purely logical field (no expression, not explicitly unbound). Only
+  // reachable under bindingOptional -- strict loading requires one or the other
+  // -- so the field carries meaning with no physical column for a KC-only push.
   if (f.datatype) field.type = f.datatype;
   if (f.label) field.label = f.label;
   if (f.dimension) {

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -174,7 +174,7 @@ const modelBase = z.object({
 // Knowledge-Catalog-only push, which governs the logical model), those two
 // requirements are dropped so a purely logical model loads. The contradiction
 // checks (unbound+expression, abstract+source) are enforced either way.
-function makeDocumentSchema(bindingOptional: boolean) {
+function buildDocumentSchema(bindingOptional: boolean) {
   const field = fieldBase.superRefine((f, ctx) => {
     if (f.unbound && f.expression !== undefined) {
       ctx.addIssue({
@@ -223,6 +223,16 @@ function makeDocumentSchema(bindingOptional: boolean) {
     version: z.string().optional(),
     semantic_model: z.array(model).min(1),
   });
+}
+
+// Only two schema shapes exist (strict vs binding-optional) and each is
+// immutable, so build both once at module load and select between them rather
+// than reconstructing the whole field/dataset/model/document graph -- with fresh
+// superRefine closures -- on every fromDocument call.
+const strictDocumentSchema = buildDocumentSchema(false);
+const logicalDocumentSchema = buildDocumentSchema(true);
+function makeDocumentSchema(bindingOptional: boolean) {
+  return bindingOptional ? logicalDocumentSchema : strictDocumentSchema;
 }
 
 type ExpressionDoc = z.infer<typeof expressionSchema>;

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -176,8 +176,22 @@ function renderNodeTable(
   const table =
       spannerTable(entity.dataSource, warnings, `entity '${entity.name}'`);
 
+  // Defense in depth: availability pruning normally strips every unbound field
+  // (it has no column) before generation. A caller that generates DDL straight
+  // from a bindingOptional load without pruning could still reach here with an
+  // unbound (e.g. purely logical) field; skip it with a warning rather than emit
+  // `<name>` as a phantom bare column the source table does not have.
   const properties =
-      entity.fields.map(f => renderFieldProperty(f, entity.name));
+      entity.fields
+          .filter(f => {
+            if (fieldExpression(f) !== undefined) return true;
+            warnings.push(
+                `entity '${entity.name}': field '${f.name}' has no column ` +
+                `under this binding; omitted from the node table (bind it, or ` +
+                `govern the logical model in Knowledge Catalog instead)`);
+            return false;
+          })
+          .map(f => renderFieldProperty(f, entity.name));
 
   const lines = [
     line(1, `${table} AS ${entity.name}`),

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -17,7 +17,14 @@ import {LoadedModel} from './loader';
 // Checks every model against the push requirements and returns the collected
 // error messages (empty when all models pass), each tagged with the model's
 // source document so the author can find it.
-export function validatePushRequirements(models: LoadedModel[]): string[] {
+//
+// `targetOptional` permits a model with NO deployment target -- the case for a
+// Knowledge-Catalog-only push, which governs the logical model and deploys no
+// graph. A graph leg never sets it, so a bq/spanner/all push still requires
+// exactly one target. A model that declares more than one target is a
+// misconfiguration either way.
+export function validatePushRequirements(
+    models: LoadedModel[], opts: {targetOptional?: boolean} = {}): string[] {
   const errors: string[] = [];
   for (const {document, model} of models) {
     let deployInfo: ReturnType<typeof googleDeploymentTargets>;
@@ -33,23 +40,26 @@ export function validatePushRequirements(models: LoadedModel[]): string[] {
     }
 
     // Every model must declare exactly one deployment target -- a single
-    // BigQuery Graph OR Spanner Graph URI (we do not support zero or several
-    // graphs per model). The target's host selects which deploy leg runs.
-    if (deployInfo.uris.length !== 1) {
+    // BigQuery Graph OR Spanner Graph URI (we do not support several graphs per
+    // model). The target's host selects which deploy leg runs. A KC-only push
+    // (targetOptional) also accepts zero targets, since it deploys no graph.
+    if (deployInfo.uris.length === 1) {
+      if (deployInfo.bigQuery.length + deployInfo.spanner.length === 0) {
+        // The single target is present but is not a supported graph URI.
+        errors.push(
+            `model '${model.name}' (${document}) deploymentTarget '${
+                deployInfo.malformed[0]}' is not a valid BigQuery Graph or ` +
+            `Spanner Graph URI; expected //bigquery.googleapis.com/projects/` +
+            `<p>/datasets/<d>/propertyGraphs/<g> or //spanner.googleapis.com/` +
+            `projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>.`);
+      }
+    } else if (!(opts.targetOptional && deployInfo.uris.length === 0)) {
       errors.push(
           `model '${model.name}' (${document}) declares ${
               deployInfo.uris
                   .length} deploymentTargets; exactly one BigQuery ` +
           `Graph or Spanner Graph target is required under its GOOGLE ` +
           `custom_extension.`);
-    } else if (deployInfo.bigQuery.length + deployInfo.spanner.length === 0) {
-      // The single target is present but is not a supported graph URI.
-      errors.push(
-          `model '${model.name}' (${document}) deploymentTarget '${
-              deployInfo.malformed[0]}' is not a valid BigQuery Graph or ` +
-          `Spanner Graph URI; expected //bigquery.googleapis.com/projects/<p>/` +
-          `datasets/<d>/propertyGraphs/<g> or //spanner.googleapis.com/` +
-          `projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>.`);
     }
 
     // A model that targets a BigQuery graph must have every metric resolve to a

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -21,8 +21,8 @@ import {LoadedModel} from './loader';
 // `targetOptional` permits a model with NO deployment target -- the case for a
 // Knowledge-Catalog-only push, which governs the logical model and deploys no
 // graph. A graph leg never sets it, so a bq/spanner/all push still requires
-// exactly one target. A model that declares more than one target is a
-// misconfiguration either way.
+// exactly one target. A KC-only push ignores its deployment target entirely --
+// it deploys no graph.
 export function validatePushRequirements(
     models: LoadedModel[], opts: {targetOptional?: boolean} = {}): string[] {
   const errors: string[] = [];
@@ -39,12 +39,23 @@ export function validatePushRequirements(
       continue;
     }
 
-    // Every model must declare exactly one deployment target -- a single
-    // BigQuery Graph OR Spanner Graph URI (we do not support several graphs per
-    // model). The target's host selects which deploy leg runs. A KC-only push
-    // (targetOptional) also accepts zero targets, since it deploys no graph.
-    if (deployInfo.uris.length === 1) {
-      if (deployInfo.bigQuery.length + deployInfo.spanner.length === 0) {
+    // A graph push must declare exactly one deployment target -- a single
+    // BigQuery Graph OR Spanner Graph URI (we do not support zero or several
+    // graphs per model). The target's host selects which deploy leg runs.
+    //
+    // A KC-only push (targetOptional) deploys no graph, so its deployment target
+    // is irrelevant: skip the check entirely. Such a push may carry no target (a
+    // logical model), one, or even both backends (whose KC aspect records both)
+    // -- none of that affects the Knowledge Catalog write.
+    if (!opts.targetOptional) {
+      if (deployInfo.uris.length !== 1) {
+        errors.push(
+            `model '${model.name}' (${document}) declares ${
+                deployInfo.uris
+                    .length} deploymentTargets; exactly one BigQuery ` +
+            `Graph or Spanner Graph target is required under its GOOGLE ` +
+            `custom_extension.`);
+      } else if (deployInfo.bigQuery.length + deployInfo.spanner.length === 0) {
         // The single target is present but is not a supported graph URI.
         errors.push(
             `model '${model.name}' (${document}) deploymentTarget '${
@@ -53,13 +64,6 @@ export function validatePushRequirements(
             `<p>/datasets/<d>/propertyGraphs/<g> or //spanner.googleapis.com/` +
             `projects/<p>/instances/<i>/databases/<db>/propertyGraphs/<g>.`);
       }
-    } else if (!(opts.targetOptional && deployInfo.uris.length === 0)) {
-      errors.push(
-          `model '${model.name}' (${document}) declares ${
-              deployInfo.uris
-                  .length} deploymentTargets; exactly one BigQuery ` +
-          `Graph or Spanner Graph target is required under its GOOGLE ` +
-          `custom_extension.`);
     }
 
     // A model that targets a BigQuery graph must have every metric resolve to a

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -300,6 +300,12 @@ export async function push(options: PushOptions): Promise<number> {
       return 1;
     }
 
+    // A push whose only destination is Knowledge Catalog governs the logical
+    // model (its meaning) and deploys no graph, so it neither needs physical
+    // bindings nor a deployment target. Relax both requirements for that case;
+    // any push that includes a graph leg keeps requiring them.
+    const kcOnly = targets.length === 1 && targets[0] === 'kc';
+
     // Load + validate every model ONCE, then fan the parsed models out to each
     // destination leg. Both legs consume the same IR, so a `--target all` push
     // parses each document a single time instead of once per leg. A parse error
@@ -342,7 +348,8 @@ export async function push(options: PushOptions): Promise<number> {
       docs = merged;
     }
     const loaded = loadSemanticModels(
-        docs, {defaultProject: source.project ?? ctx.project});
+        docs,
+        {defaultProject: source.project ?? ctx.project, bindingOptional: kcOnly});
     if (loaded.error) {
       console.error('Error:', loaded.error);
       return 1;
@@ -375,26 +382,32 @@ export async function push(options: PushOptions): Promise<number> {
     // whose join column is unbound), so the deployed graph presents only what
     // the profile binds. Availability propagates up the dependency graph. Runs
     // for every profile, including 'default' (a no-op when nothing is unbound).
-    const availability: AvailabilityReport[] = [];
-    models = models.map(({document, model}) => {
-      const {model: pruned, report} = pruneUnavailable(model, profileName);
-      availability.push(report);
-      return {document, model: pruned};
-    });
-    for (const r of availability) {
-      const dropped = r.droppedEntities.length + r.droppedMetrics.length +
-          r.droppedRelationships.length;
-      if (r.unboundFields.length || dropped) {
-        console.warn(
-            `Note: profile '${r.profile}' leaves ${
-                r.unboundFields.length} field(s) unbound` +
-            (dropped ?
-                 `; ${r.droppedEntities.length} entity(ies), ${
-                     r.droppedMetrics.length} metric(s) and ${
-                     r.droppedRelationships.length} relationship(s) ` +
-                     `unavailable` :
-                 '') +
-            '.');
+    //
+    // A KC-only push governs the whole logical model -- meaning, not a physical
+    // binding -- so pruning would wrongly drop every unbound entity/metric the
+    // author declared. Skip it: Knowledge Catalog publishes the full model.
+    if (!kcOnly) {
+      const availability: AvailabilityReport[] = [];
+      models = models.map(({document, model}) => {
+        const {model: pruned, report} = pruneUnavailable(model, profileName);
+        availability.push(report);
+        return {document, model: pruned};
+      });
+      for (const r of availability) {
+        const dropped = r.droppedEntities.length + r.droppedMetrics.length +
+            r.droppedRelationships.length;
+        if (r.unboundFields.length || dropped) {
+          console.warn(
+              `Note: profile '${r.profile}' leaves ${
+                  r.unboundFields.length} field(s) unbound` +
+              (dropped ?
+                   `; ${r.droppedEntities.length} entity(ies), ${
+                       r.droppedMetrics.length} metric(s) and ${
+                       r.droppedRelationships.length} relationship(s) ` +
+                       `unavailable` :
+                   '') +
+              '.');
+        }
       }
     }
 
@@ -403,7 +416,8 @@ export async function push(options: PushOptions): Promise<number> {
     // BigQuery-graph-targeting model's metrics must each resolve to one entity.
     // This is also the --validate-only path, so a dry run reports the same
     // failures.
-    const validationErrors = validatePushRequirements(models);
+    const validationErrors =
+        validatePushRequirements(models, {targetOptional: kcOnly});
     if (validationErrors.length) {
       for (const e of validationErrors) {
         console.error(`Error: ${e}`);

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -160,6 +160,21 @@ describe('IR-contract metric cases the loader cannot produce', () => {
   });
 
   test(
+      'an unbound field (no column) is omitted from the node table with a warning',
+      () => {
+        // Availability pruning normally removes unbound fields; generating DDL
+        // without pruning (e.g. straight from a bindingOptional load) must not
+        // emit the field as a phantom bare column.
+        const model = orders();
+        model.entities[0].fields.push({name: 'notes'});  // no expression/binding
+        const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
+        expect(ddl).not.toContain('notes');
+        expect(warnings.some(
+                   w => w.includes('notes') && w.includes('no column')))
+            .toBe(true);
+      });
+
+  test(
       'a metric whose declared entity disagrees with its expression is reported',
       () => {
         // Declared entity:'orders' but the expression aggregates a different

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
@@ -605,6 +605,68 @@ describe('relationships map to schema-join entry links', () => {
 });
 
 
+describe('a purely logical model (no physical binding) emits cleanly', () => {
+  // A Knowledge-Catalog-only model governs meaning with no binding: every
+  // entity has an empty dataSource and its fields carry no expression. The
+  // emitter must publish it without inventing a bogus physical resource, and a
+  // relationship's join endpoints fall back to the entity name (there is no
+  // table to name).
+  function logicalModel(): SemanticModel {
+    return {
+      name: 'm',
+      metrics: [],
+      entities: [
+        {
+          name: 'orders',
+          dataSource: '',
+          keys: ['o_key'],
+          fields: [{name: 'amount'}]
+        },
+        {
+          name: 'customer',
+          dataSource: '',
+          keys: ['c_key'],
+          fields: [{name: 'name'}]
+        },
+      ],
+      relationships: [{
+        name: 'orders-to-customer',
+        source: {entity: 'orders', columns: ['custkey']},
+        destination: {entity: 'customer', columns: ['c_key']},
+      }],
+    };
+  }
+
+  test('every entity is published (anchor + 2 entities), no warnings', () => {
+    const {entries, warnings} = generateCatalogResources(logicalModel(), OPTS);
+    const kinds = entries.map(e => e.entryType.replace(/.*\//, ''));
+    expect(kinds).toEqual(
+        ['semantic-model', 'semantic-entity', 'semantic-entity']);
+    expect(warnings).toEqual([]);
+  });
+
+  test('a logical entity emits an empty resources array (no bogus empty element)', () => {
+    const {entries} = generateCatalogResources(logicalModel(), OPTS);
+    const orders = entries.find(e => e.entryType.endsWith('/semantic-entity'))!;
+    expect(orders.aspects!['dataplex-types.global.semantic-entity'].data!.source)
+        .toEqual({resources: []});
+  });
+
+  test(
+      'the schema-join endpoints fall back to the entity name when there is no table',
+      () => {
+        const {entryLinks} = generateCatalogResources(logicalModel(), OPTS);
+        expect(entryLinks.length).toBe(1);
+        const join = entryLinks[0]
+                         .aspects!['dataplex-types.global.schema-join']
+                         .data!.joins[0];
+        // No dataSource to name, so the endpoint `name` is the entity name.
+        expect(join.source).toEqual({name: 'orders', fields: ['custkey']});
+        expect(join.target).toEqual({name: 'customer', fields: ['c_key']});
+      });
+});
+
+
 describe('abstract entities are skipped for Knowledge Catalog', () => {
   // The KC leg does not model inheritance (that is BigQuery-only today), and an
   // abstract entity has no physical table, so it must not be published as an

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
@@ -645,11 +645,14 @@ describe('a purely logical model (no physical binding) emits cleanly', () => {
     expect(warnings).toEqual([]);
   });
 
-  test('a logical entity emits an empty resources array (no bogus empty element)', () => {
+  test('a logical entity omits the physical source block (no bogus empty element)', () => {
     const {entries} = generateCatalogResources(logicalModel(), OPTS);
     const orders = entries.find(e => e.entryType.endsWith('/semantic-entity'))!;
-    expect(orders.aspects!['dataplex-types.global.semantic-entity'].data!.source)
-        .toEqual({resources: []});
+    // No table -> no `source` at all (empty aspect data is valid, like the
+    // model aspect's deploymentTargets), rather than source:{resources:[]} or
+    // the old bogus source:{resources:['']}.
+    const data = orders.aspects!['dataplex-types.global.semantic-entity'].data!;
+    expect(data.source).toBeUndefined();
   });
 
   test(

--- a/toolbox/mdcode/tests/libts/semantic/loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/loader.test.ts
@@ -1113,3 +1113,63 @@ describe('fields may be declared unbound (no physical column)', () => {
     })).toThrow(/field 'credit': requires an expression/);
   });
 });
+
+
+describe('a purely logical model loads only under bindingOptional', () => {
+  // A logical-only model declares meaning (entities, fields, keys) with no
+  // physical binding: no dataset `source`, no field `expression`. It is the
+  // Knowledge-Catalog-only push case -- KC governs the logical layer and needs
+  // no table or column to point at.
+  const logicalOnly = {
+    semantic_model: [{
+      name: 'm',
+      datasets: [{
+        name: 'orders', primary_key: ['id'],
+        fields: [{ name: 'amount' }, { name: 'status' }],
+      }],
+    }],
+  };
+
+  test('under bindingOptional it loads with an empty source and unbound fields', () => {
+    const { models } = fromDocument(logicalOnly, { bindingOptional: true });
+    const orders = models[0].entities[0];
+    // No source -> empty dataSource (the emitter tolerates this); the fields
+    // carry no expression because there is no binding.
+    expect(orders.dataSource).toBe('');
+    expect(orders.keys).toEqual(['id']);
+    expect(orders.fields.map(f => f.name)).toEqual(['amount', 'status']);
+    expect(orders.fields.every(f => f.expression === undefined)).toBe(true);
+  });
+
+  test('without bindingOptional the same model fails for the missing source and expression', () => {
+    let message = '';
+    try {
+      fromDocument(logicalOnly);
+    } catch (e: any) {
+      message = String(e.message ?? e);
+    }
+    // Both binding-completeness checks fire in the default (strict) mode.
+    expect(message).toContain("dataset 'orders': a non-abstract dataset requires a source");
+    expect(message).toContain("field 'amount': requires an expression");
+  });
+
+  test('bindingOptional still rejects an unbound field that also has an expression', () => {
+    // The contradiction check is independent of binding-completeness, so it
+    // fires even when a source/expression is otherwise optional.
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'a', fields: [{ name: 'c', unbound: true, expression: 'c' }] }],
+      }],
+    }, { bindingOptional: true })).toThrow(/an unbound field has no column/);
+  });
+
+  test('bindingOptional still rejects an abstract dataset that also names a source', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'Party', abstract: true, source: 'p.d.party', fields: [] }],
+      }],
+    }, { bindingOptional: true })).toThrow(/an abstract dataset has no table/);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
@@ -129,6 +129,21 @@ describe('graph naming', () => {
     const {ddl} = generateSpannerPropertyGraph(oneEntity(), opts);
     expect(ddl).toContain('CREATE OR REPLACE PROPERTY GRAPH `sales-graph`');
   });
+
+  test(
+      'an unbound field (no column) is omitted from the node table with a warning',
+      () => {
+        // Pruning normally removes unbound fields; generating DDL without
+        // pruning (e.g. straight from a bindingOptional load) must not emit the
+        // field as a phantom bare column.
+        const model = oneEntity();
+        model.entities[0].fields.push({name: 'notes'});  // no expression/binding
+        const {ddl, warnings} = generateSpannerPropertyGraph(model);
+        expect(ddl).not.toContain('notes');
+        expect(warnings.some(
+                   w => w.includes('notes') && w.includes('no column')))
+            .toBe(true);
+      });
 });
 
 

--- a/toolbox/mdcode/tests/libts/semantic/validate.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/validate.test.ts
@@ -125,15 +125,21 @@ describe('validatePushRequirements', () => {
         expect(validatePushRequirements([loaded(m)]).length).toBe(1);
       });
 
-  test('targetOptional still rejects more than one deployment target', () => {
-    // Optional means zero-or-one; a model that declares two targets is a
-    // misconfiguration regardless of the destination.
+  test('targetOptional ignores the deployment target entirely (KC-only)', () => {
+    // A KC-only push deploys no graph, so its deployment target is irrelevant:
+    // more than one target -- and even a single malformed one -- is accepted,
+    // where a graph push rejects both. (Zero targets is covered above.)
     const other =
         '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g2';
-    const m = model({}, [googleExt([BQ_TARGET, other])]);
-    const errs = validatePushRequirements([loaded(m)], {targetOptional: true});
-    expect(errs.length).toBe(1);
-    expect(errs[0]).toContain('exactly one');
+    const many = model({}, [googleExt([BQ_TARGET, other])]);
+    expect(validatePushRequirements([loaded(many)], {targetOptional: true}))
+        .toEqual([]);
+    expect(validatePushRequirements([loaded(many)]).length).toBe(1);
+
+    const malformed = model({}, [googleExt(['//example.com/not/a/graph'])]);
+    expect(validatePushRequirements([loaded(malformed)], {targetOptional: true}))
+        .toEqual([]);
+    expect(validatePushRequirements([loaded(malformed)]).length).toBe(1);
   });
 });
 

--- a/toolbox/mdcode/tests/libts/semantic/validate.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/validate.test.ts
@@ -111,6 +111,30 @@ describe('validatePushRequirements', () => {
     const errs = validatePushRequirements([a, b]);
     expect(errs.length).toBe(2);
   });
+
+  test(
+      'targetOptional accepts a model with no deployment target (KC-only)',
+      () => {
+        // A Knowledge-Catalog-only push governs the logical model and deploys
+        // no graph, so it needs no deployment target. The same model without
+        // the option is rejected (proving the option is what relaxed it).
+        const m = model();
+        expect(validatePushRequirements([loaded(m)], {
+          targetOptional: true
+        })).toEqual([]);
+        expect(validatePushRequirements([loaded(m)]).length).toBe(1);
+      });
+
+  test('targetOptional still rejects more than one deployment target', () => {
+    // Optional means zero-or-one; a model that declares two targets is a
+    // misconfiguration regardless of the destination.
+    const other =
+        '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g2';
+    const m = model({}, [googleExt([BQ_TARGET, other])]);
+    const errs = validatePushRequirements([loaded(m)], {targetOptional: true});
+    expect(errs.length).toBe(1);
+    expect(errs[0]).toContain('exactly one');
+  });
 });
 
 


### PR DESCRIPTION
## What

Knowledge Catalog governs **meaning** — entities, metrics, relationships, grain, descriptions — which is the *logical* layer of a semantic model. Physical bindings (a dataset's source table, a field's column expression) and a graph deployment target are a **graph-deploy** concern for BigQuery and Spanner, not for KC.

Today `kcmd push --target kc` rejects a purely logical model on three fronts: the loader demands a `source` on every concrete dataset and an `expression` on every field, and the push path demands exactly one graph `deployment_target`. So a model cannot be governed in KC until it has already been bound to a physical store — which is backwards.

This change lets a logical-only model be governed in KC directly.

## Governing rule

For a push whose resolved targets are **exactly `kc`**, bindings and a deployment target are **optional** — a logical model is accepted, and a fully-bound one still works unchanged. For `--target bq | spanner | all`, full bindings + a valid graph target stay **required** (a graph cannot be generated without them). The change only *widens* what a KC-only push accepts; every existing path is untouched.

## Changes

- **loader** (`loader.ts`): a `bindingOptional` load option builds the document schema so the two binding-completeness checks (dataset-requires-source, field-requires-expression) are skipped. The contradiction checks (unbound+expression, abstract+source) stay enforced regardless. `convertField` tolerates a field with no expression.
- **validate** (`validate.ts`): a `targetOptional` option lets a KC-only push declare zero deployment targets; more than one is still rejected.
- **push** (`commands.ts`): a KC-only push (`--target kc`) sets both flags and skips the binding-availability prune, so KC publishes the whole logical model rather than dropping every unbound entity/metric.
- **KC emitter** (`knowledge_catalog.ts`): tolerate an empty `dataSource` — emit an empty `resources` array (not a bogus `['']` element) and fall back to the entity name for a schema-join endpoint.

## Tests

- loader: a logical-only document loads under `bindingOptional`, and still fails with the same two messages without it; the contradiction checks still fire under `bindingOptional`.
- validate: `targetOptional` accepts zero targets and still rejects more than one.
- KC emitter: a logical-only model emits the full anchor + entities + schema-join link with entity-name endpoints and no empty `resources`.

`npm run build` and `npm test` (596 tests) pass.

## Verification (live)

Against a logical-only `sales.yaml` (no bindings, no deployment target) with the scope pointed at `sqlgen-testing`:

- `kcmd push --target kc --validate-only` → clean 4-entry + 1 schema-join-link plan, no binding/target errors.
- `kcmd push --target bq --validate-only` → still errors on the missing source/expression (regression guard).

A live `kcmd push --target kc` reaches the API and is gated only by the `semantic-*` entry-type permission on the staging project (unrelated to this change).