### PR TITLE
fix(mdcode): emit an empty source for a logical-only KC entity

### DIFF
--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -335,15 +335,15 @@ function modelAspectData(model: SemanticModel): Record<string, any> {
 // semantic-entity: the base table(s) backing the entity. importedSystem/
 // importedResource have no IR source today and are left unset.
 function entityAspectData(entity: Entity): Record<string, any> {
-  // A logical-only entity has no physical table (empty dataSource). Omit the
-  // `source` block entirely rather than emit an empty (or bogus ['']) resources
-  // array: like the semantic-model aspect's deploymentTargets, empty aspect data
-  // is valid and the aspect is still attached to satisfy required_aspects. The
-  // reader treats an absent source the same as an empty one (dataSource
-  // becomes '').
+  // A logical-only entity has no physical table (empty dataSource). Still emit
+  // the `source` block with an empty `resources` array rather than a bogus
+  // ['']: the semantic-entity template requires `source` (with its `resources`
+  // list), so omitting it is rejected server-side. An empty list is the honest
+  // "no binding yet"; the reader treats it the same as an absent source
+  // (dataSource becomes '').
   const path = resourcePath(entity.dataSource);
   return compact({
-    source: path ? {resources: [path]} : undefined,
+    source: {resources: path ? [path] : []},
   });
 }
 

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
@@ -645,14 +645,13 @@ describe('a purely logical model (no physical binding) emits cleanly', () => {
     expect(warnings).toEqual([]);
   });
 
-  test('a logical entity omits the physical source block (no bogus empty element)', () => {
+  test('a logical entity emits an empty source (no bogus empty element)', () => {
     const {entries} = generateCatalogResources(logicalModel(), OPTS);
     const orders = entries.find(e => e.entryType.endsWith('/semantic-entity'))!;
-    // No table -> no `source` at all (empty aspect data is valid, like the
-    // model aspect's deploymentTargets), rather than source:{resources:[]} or
-    // the old bogus source:{resources:['']}.
+    // No table -> `source.resources` is [], not the old omitted source (which
+    // the semantic-entity template rejects) or a bogus source:{resources:['']}.
     const data = orders.aspects!['dataplex-types.global.semantic-entity'].data!;
-    expect(data.source).toBeUndefined();
+    expect(data.source).toEqual({resources: []});
   });
 
   test(


### PR DESCRIPTION
## Problem

A logical-only semantic model (no bindings, no deployment target) pushed to Knowledge Catalog is **rejected by the live server**:

```
INVALID_ARGUMENT: Failed to parse the data provided in Aspect
  projects/.../aspectTypes/semantic-entity against its template:
  Required field missing source.
```

The `semantic-entity` aspect template requires the `source` record (with its `resources` list). The emitter omitted the `source` block entirely for an entity with an empty `dataSource`, so the write failed.

#367 (logical-only KC push) was verified only with `--validate-only` and offline unit tests — one of which explicitly asserted `source` is `undefined` — so the live write path was never exercised and this slipped through.

## Fix

Emit `source: {resources: []}` for a logical-only entity instead of omitting it. An empty list is the honest "no binding yet"; the pull reader already treats it the same as an absent source (`dataSource` becomes `''`). Output is **unchanged for a bound entity**.

Updated the one unit test that pinned the old omit behavior.

## Verification

- 577 semantic tests green; `tsc` clean.
- **Live against the autopush Knowledge Catalog instance:** `kcmd push --target kc` on a purely logical model now writes all 5 entries + 2 links, and `kcmd pull` round-trips.

## Context

Prerequisite for the semantic-model codelab's "govern the logical model before you bind it" step (docs PR #364), which could not run live without this.