### PR TITLE
docs(mdcode): give each codelab step subsections named by its sub-steps

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -54,6 +54,8 @@ Author the model in two parts — this is what lets one model serve many stores:
   each field is. You write one when you deploy to BigQuery (step 3) and another
   for Spanner (step 4); the logical model never changes.
 
+### Author by hand
+
 Write the logical model — declarations only, no sources, no columns, no
 deployment target:
 
@@ -99,7 +101,7 @@ semantic_model:
 YAML
 ```
 
-### Import existing semantics instead of authoring
+### Import from an OWL ontology
 
 You can also start from an existing OWL ontology instead of hand-authoring this
 YAML. `kcmd owl import` converts an ontology (`.ttl`) into a semantic model:
@@ -199,8 +201,11 @@ The rest of this codelab uses the hand-authored `sales` model above.
 ## 2. Govern it in Knowledge Catalog
 
 You can govern the model right now — the push writes the logical model straight
-to the catalog as entries, so there is nothing to bind or load first. Preview
-the plan without writing anything:
+to the catalog as entries, so there is nothing to bind or load first.
+
+### Preview the plan
+
+Preview the plan without writing anything:
 
 ```bash
 kcmd push --target kc --validate-only --print
@@ -229,6 +234,8 @@ them: relationship names come back from a `kcmd pull` lowercased and hyphenated
 (`orders-to-customer`), because Knowledge Catalog keeps the name only in the
 normalized link id. Nothing is wrong — the graph itself keeps the authored
 `orders_to_customer`.
+
+### Write the entries
 
 Then drop `--validate-only` to perform the write:
 
@@ -260,6 +267,8 @@ too.
 Governing the model created catalog entries but no tables. Deploying it to a
 query engine creates the tables and the graph. You add a **binding profile**,
 create the data, and deploy.
+
+### Write the binding profile
 
 Write the **analytical** binding: the BigQuery table each entity reads, the
 column each field maps to, and the BigQuery graph to deploy to. The
@@ -329,6 +338,8 @@ echo 'default_profile: analytical' >> catalog.yaml
 > This codelab splits them because step 4 adds a second store, and that split is
 > what lets one model back both.
 
+### Create the tables
+
 Now create the data. An ontology-driven data-engineering agent would produce it
 from raw sources; for a self-contained run, create the three tables directly.
 `net_amount` is materialized on `orders` (the measure aggregates it), and each
@@ -360,6 +371,8 @@ SELECT * FROM UNNEST([                 -- order 100: 2 lines, 101: 1, 102: 3
 > resolves in BigQuery — even under `--validate-only` — and builds the graph over
 > these tables. So the tables must exist first. (Step 2 needed none of this: it
 > governed the logical model, no tables required.)
+
+### Deploy the graph
 
 Now deploy the bound model to BigQuery. `--print` shows the generated DDL:
 
@@ -412,6 +425,8 @@ EDGE TABLES (
 Deployed 1 BigQuery Graph(s).
 ```
 
+### View the graph in the console
+
 The graph is now a resource in your dataset, and the console draws its schema as
 a diagram of node and edge tables — easier to read than the DDL above. Print the
 BigQuery Studio link to the dataset:
@@ -424,6 +439,8 @@ printf 'https://console.cloud.google.com/bigquery?project=%s&ws=!1m4!1m3!3m2!1s%
 Open the link, expand the `$DATASET` dataset in the Explorer, and click the
 `$GRAPH` property graph. Its schema renders as a visual graph of the nodes and
 the edges that connect them.
+
+### Query the graph two ways
 
 Now ask the same question — revenue by customer — two ways.
 
@@ -498,6 +515,8 @@ Spanner database holds the same business, but its tables are named differently
 (`Customers`, `Orders`, `LineItems`), its columns are named differently
 (`FullName`, `OrderId`), and it does not carry `net_amount` — a settled figure
 the warehouse computes rather than one the live store keeps.
+
+### Write the operational binding
 
 Add a **second profile** beside the first. Like the `analytical` one, it changes
 only where each entity reads from and which column each field binds to; it never
@@ -578,6 +597,8 @@ from the bindings rather than declared. The `analytical` profile binds `net_amou
 the same metric is available under the binding step 3 used. One model; each store
 answers the part of it that its data can back.
 
+### Preview the generated DDL
+
 Preview the Spanner DDL the profile generates (`--validate-only` runs the
 generator without touching a database):
 
@@ -642,6 +663,8 @@ BigQuery DDL in step 3:
 - **No `OPTIONS`.** Descriptions and synonyms are not written into the Spanner
   DDL; they live in Knowledge Catalog instead.
 
+### Create the tables and deploy
+
 To apply it for real, create the operational tables in a Spanner
 ENTERPRISE-edition database (Graph requires ENTERPRISE), load a little data, and
 drop `--validate-only`. The Spanner leg applies the DDL through the
@@ -669,6 +692,8 @@ kcmd push --profile operational --target spanner
 > the Spanner leg. Step 2 governed the *logical* model, and adding a binding
 > profile changes nothing logical — bindings are not governed in Knowledge
 > Catalog. The single set of entries from step 2 already describes this graph too.
+
+### Query the graph
 
 Query it with Spanner's Graph Query Language. The query names the model's
 properties (`c_name`, `o_orderkey`); the profile's column bindings are invisible

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -440,7 +440,7 @@ Open the link, expand the `$DATASET` dataset in the Explorer, and click the
 `$GRAPH` property graph. Its schema renders as a visual graph of the nodes and
 the edges that connect them.
 
-### Query the semantic model
+### Core Semantic Model: Metrics
 
 Now ask the same question — revenue by customer — two ways.
 
@@ -504,6 +504,34 @@ query, so the correct answer is the default one.
 > **Tips.** Use `--nouse_cache` — `GRAPH_EXPAND` result caches are not
 > invalidated by graph edits. To see the exact output column names for a graph:
 > `DECLARE s STRING; CALL BQ.SHOW_GRAPH_EXPAND_SCHEMA("$PROJECT.$DATASET.$GRAPH", s); SELECT s;`
+
+### Core Semantic Model: GQL
+
+Metrics answer aggregate questions. To follow the relationships between entities,
+query the graph with graph pattern matching (GQL). This walks the
+`orders_to_customer` edge to count each customer's orders:
+
+```bash
+bq query --use_legacy_sql=false --nouse_cache '
+GRAPH `'"$PROJECT.$DATASET.$GRAPH"'`
+MATCH (o:orders)-[:orders_to_customer]->(c:customer)
+RETURN c.c_name AS customer, COUNT(o.o_orderkey) AS orders
+GROUP BY customer ORDER BY customer'
+```
+
+```
++----------+--------+
+| customer | orders |
++----------+--------+
+| Acme     |      2 |
+| Globex   |      1 |
++----------+--------+
+```
+
+This is the same GQL query you run against Spanner in step 4. The pattern, the
+model's property names, and the result are identical. Only the graph reference
+changes: BigQuery takes the fully qualified `$PROJECT.$DATASET.$GRAPH`, Spanner
+the bare `sales`.
 
 ---
 
@@ -693,11 +721,12 @@ kcmd push --profile operational --target spanner
 > profile changes nothing logical — bindings are not governed in Knowledge
 > Catalog. The single set of entries from step 2 already describes this graph too.
 
-### Query the semantic model
+### Core Semantic Model: GQL
 
-Query it with Spanner's Graph Query Language. The query names the model's
-properties (`c_name`, `o_orderkey`); the profile's column bindings are invisible
-to it:
+Query it with graph pattern matching. This is the same GQL query you ran on
+BigQuery in step 3, now against the bare `sales` graph. The query names the
+model's properties (`c_name`, `o_orderkey`); the profile's column bindings are
+invisible to it:
 
 ```bash
 gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -440,7 +440,7 @@ Open the link, expand the `$DATASET` dataset in the Explorer, and click the
 `$GRAPH` property graph. Its schema renders as a visual graph of the nodes and
 the edges that connect them.
 
-### Core Semantic Model: Metrics
+### Query Semantic Model: Metrics
 
 Now ask the same question — revenue by customer — two ways.
 
@@ -505,7 +505,7 @@ query, so the correct answer is the default one.
 > invalidated by graph edits. To see the exact output column names for a graph:
 > `DECLARE s STRING; CALL BQ.SHOW_GRAPH_EXPAND_SCHEMA("$PROJECT.$DATASET.$GRAPH", s); SELECT s;`
 
-### Core Semantic Model: GQL
+### Query Semantic Model: GQL
 
 Metrics answer aggregate questions. To follow the relationships between entities,
 query the graph with graph pattern matching (GQL). This walks the
@@ -721,7 +721,7 @@ kcmd push --profile operational --target spanner
 > profile changes nothing logical — bindings are not governed in Knowledge
 > Catalog. The single set of entries from step 2 already describes this graph too.
 
-### Core Semantic Model: GQL
+### Query Semantic Model: GQL
 
 Query it with graph pattern matching. This is the same GQL query you ran on
 BigQuery in step 3, now against the bare `sales` graph. The query names the

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -508,8 +508,9 @@ query, so the correct answer is the default one.
 ### Query Semantic Model: GQL
 
 Metrics answer aggregate questions. To follow the relationships between entities,
-query the graph with graph pattern matching (GQL). This walks the
-`orders_to_customer` edge to count each customer's orders:
+query the graph with graph query language (GQL), which matches a pattern of nodes
+and edges. This walks the `orders_to_customer` edge to count each customer's
+orders:
 
 ```bash
 bq query --use_legacy_sql=false --nouse_cache '
@@ -723,8 +724,8 @@ kcmd push --profile operational --target spanner
 
 ### Query Semantic Model: GQL
 
-Query it with graph pattern matching. This is the same GQL query you ran on
-BigQuery in step 3, now against the bare `sales` graph. The query names the
+Query it with the same GQL query you ran on BigQuery in step 3, now against the
+bare `sales` graph. The query names the
 model's properties (`c_name`, `o_orderkey`); the profile's column bindings are
 invisible to it:
 

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -545,7 +545,7 @@ Spanner database holds the same business, but its tables are named differently
 (`FullName`, `OrderId`), and it does not carry `net_amount` — a settled figure
 the warehouse computes rather than one the live store keeps.
 
-### Write the operational binding
+### Write the binding profile
 
 Add a **second profile** beside the first. Like the `analytical` one, it changes
 only where each entity reads from and which column each field binds to; it never
@@ -626,18 +626,41 @@ from the bindings rather than declared. The `analytical` profile binds `net_amou
 the same metric is available under the binding step 3 used. One model; each store
 answers the part of it that its data can back.
 
-### Preview the generated DDL
+### Create the tables
 
-Preview the Spanner DDL the profile generates (`--validate-only` runs the
-generator without touching a database):
+Create the operational tables in a Spanner ENTERPRISE-edition database. Spanner
+Graph requires the ENTERPRISE edition. Create the database with its three tables,
+then load a little data:
 
 ```bash
-kcmd push --profile operational --target spanner --validate-only --print
+gcloud spanner databases create $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --ddl='CREATE TABLE Customers (CustomerId INT64 NOT NULL, FullName STRING(MAX)) PRIMARY KEY(CustomerId)' \
+  --ddl='CREATE TABLE Orders (OrderId INT64 NOT NULL, CustomerId INT64) PRIMARY KEY(OrderId)' \
+  --ddl='CREATE TABLE LineItems (LineId INT64 NOT NULL, OrderId INT64) PRIMARY KEY(LineId)'
+
+gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --sql="INSERT INTO Customers (CustomerId, FullName) VALUES (1,'Acme'),(2,'Globex')"
+gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --sql="INSERT INTO Orders (OrderId, CustomerId) VALUES (100,1),(101,1),(102,2)"
+gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
+  --sql="INSERT INTO LineItems (LineId, OrderId) VALUES (1,100),(2,100),(3,101),(4,102),(5,102),(6,102)"
+```
+
+> **Why the tables come before the Spanner push.** `kcmd push --target spanner`
+> applies the DDL through the `updateDatabaseDdl` long-running operation; it does
+> not create or pre-check the tables. So the tables must exist first.
+
+### Deploy the semantic model
+
+Now deploy the bound model to Spanner. `--print` shows the generated DDL:
+
+```bash
+kcmd push --profile operational --target spanner --print
 ```
 
 ```
 Note: profile 'operational' leaves 1 field(s) unbound; 0 entity(ies), 1 metric(s) and 0 relationship(s) unavailable.
-Validating semantic model for Spanner Graph...
+Pushing semantic model (Spanner Graph)...
 -- Spanner Graph --
 -- //spanner.googleapis.com/projects/$PROJECT/instances/$SPANNER_INSTANCE/databases/$SPANNER_DB/propertyGraphs/sales
 CREATE OR REPLACE PROPERTY GRAPH sales
@@ -672,7 +695,7 @@ EDGE TABLES (
     DESTINATION KEY(OrderId) REFERENCES orders(OrderId)
 );
 
-Validation complete; no changes applied.
+Deployed 1 Spanner Graph(s).
 ```
 
 The graph still speaks the model's vocabulary — the properties are `o_orderkey`,
@@ -691,31 +714,6 @@ BigQuery DDL in step 3:
   them.
 - **No `OPTIONS`.** Descriptions and synonyms are not written into the Spanner
   DDL; they live in Knowledge Catalog instead.
-
-### Create the tables and deploy
-
-To apply it for real, create the operational tables in a Spanner
-ENTERPRISE-edition database (Graph requires ENTERPRISE), load a little data, and
-drop `--validate-only`. The Spanner leg applies the DDL through the
-`updateDatabaseDdl` long-running operation and does not create or pre-check the
-tables, so they must exist first:
-
-```bash
-gcloud spanner databases create $SPANNER_DB --instance=$SPANNER_INSTANCE \
-  --ddl='CREATE TABLE Customers (CustomerId INT64 NOT NULL, FullName STRING(MAX)) PRIMARY KEY(CustomerId)' \
-  --ddl='CREATE TABLE Orders (OrderId INT64 NOT NULL, CustomerId INT64) PRIMARY KEY(OrderId)' \
-  --ddl='CREATE TABLE LineItems (LineId INT64 NOT NULL, OrderId INT64) PRIMARY KEY(LineId)'
-
-gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
-  --sql="INSERT INTO Customers (CustomerId, FullName) VALUES (1,'Acme'),(2,'Globex')"
-gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
-  --sql="INSERT INTO Orders (OrderId, CustomerId) VALUES (100,1),(101,1),(102,2)"
-gcloud spanner databases execute-sql $SPANNER_DB --instance=$SPANNER_INSTANCE \
-  --sql="INSERT INTO LineItems (LineId, OrderId) VALUES (1,100),(2,100),(3,101),(4,102),(5,102),(6,102)"
-
-kcmd push --profile operational --target spanner
-# -> Deployed 1 Spanner Graph(s).
-```
 
 > **Knowledge Catalog is unchanged.** You do not re-push to Knowledge Catalog for
 > the Spanner leg. Step 2 governed the *logical* model, and adding a binding

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -372,7 +372,7 @@ SELECT * FROM UNNEST([                 -- order 100: 2 lines, 101: 1, 102: 3
 > these tables. So the tables must exist first. (Step 2 needed none of this: it
 > governed the logical model, no tables required.)
 
-### Deploy the graph
+### Deploy the semantic model
 
 Now deploy the bound model to BigQuery. `--print` shows the generated DDL:
 
@@ -425,7 +425,7 @@ EDGE TABLES (
 Deployed 1 BigQuery Graph(s).
 ```
 
-### View the graph in the console
+### View the semantic model
 
 The graph is now a resource in your dataset, and the console draws its schema as
 a diagram of node and edge tables — easier to read than the DDL above. Print the
@@ -440,7 +440,7 @@ Open the link, expand the `$DATASET` dataset in the Explorer, and click the
 `$GRAPH` property graph. Its schema renders as a visual graph of the nodes and
 the edges that connect them.
 
-### Query the graph two ways
+### Query the semantic model
 
 Now ask the same question — revenue by customer — two ways.
 
@@ -693,7 +693,7 @@ kcmd push --profile operational --target spanner
 > profile changes nothing logical — bindings are not governed in Knowledge
 > Catalog. The single set of entries from step 2 already describes this graph too.
 
-### Query the graph
+### Query the semantic model
 
 Query it with Spanner's Graph Query Language. The query names the model's
 properties (`c_name`, `o_orderkey`); the profile's column bindings are invisible


### PR DESCRIPTION
Follow-up to the semantic-model codelab. The longer steps ran as one continuous block; this breaks them into `###` subsections whose titles name the job each sub-step does, so the flow is scannable.

- **Step 1** — `Author by hand` / `Import from an OWL ontology` (the second heading renamed for parallelism).
- **Step 2** — `Preview the plan` / `Write the entries`.
- **Step 3** — `Write the binding profile` / `Create the tables` / `Deploy the graph` / `View the graph in the console` / `Query the graph two ways` (mirrors the step's "add a binding profile, create the data, and deploy" opener).
- **Step 4** — `Write the operational binding` / `Preview the generated DDL` / `Create the tables and deploy` / `Query the graph`.

Headings only; no prose or command changes (one sentence split so a heading could sit between the orientation and the preview command).