### PR TITLE
fix(mdcode): correct the OWL-import UNBOUND push hint for --target kc

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -139,8 +139,8 @@ kcmd owl import /tmp/parts.ttl --out /tmp/parts_osi.yaml
 converted 2 classes, 1 object property, 2 datatype properties
 wrote /tmp/parts_osi.yaml
 note: this model is UNBOUND (placeholder `unbound:` sources, no deployment target).
-      `kcmd push` is rejected until you bind each entity's source table and add
-      a BigQuery deployment target -- validation needs both, for every --target.
+      `kcmd push --target kc` publishes it to Knowledge Catalog as-is. To deploy a
+      graph, bind each entity's source table and add a deployment target first.
 ```
 
 Look at what it produced:

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -952,8 +952,8 @@ export async function owl(
   console.log(`wrote ${writtenPath}`);
   console.log(
       `note: this model is UNBOUND (placeholder \`unbound:\` sources, no deployment target).\n` +
-      `      \`kcmd push\` is rejected until you bind each entity's source table and add\n` +
-      `      a BigQuery deployment target -- validation needs both, for every --target.`);
+      `      \`kcmd push --target kc\` publishes it to Knowledge Catalog as-is. To deploy a\n` +
+      `      graph, bind each entity's source table and add a deployment target first.`);
   return 0;
 }
 

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -6,9 +6,9 @@
 // the user-guide section "Importing an OWL ontology":
 //   1. the sales example produces exactly the documented OSI (golden), and
 //   2. that OSI loads through the OSI loader (the UNBOUND placeholders satisfy
-//      the schema, so the document is well-formed -- loadable, but not yet
-//      pushable: `kcmd push` rejects an unbound model, for every --target,
-//      until its sources are bound and a deployment target is set), and
+//      the schema, so the document is well-formed -- loadable, and pushable to
+//      Knowledge Catalog as-is (`kcmd push --target kc`), though a graph leg is
+//      rejected until its sources are bound and a deployment target is set), and
 //   3. each mapped construct behaves as documented.
 // The scope is exactly the user guide; richer OWL is out of scope by design.
 


### PR DESCRIPTION
## What

`#367` let a purely logical model push to Knowledge Catalog (`kcmd push --target kc`), but the `kcmd owl import` hint printed after conversion still said:

> `kcmd push` is rejected until you bind each entity's source table and add a BigQuery deployment target -- validation needs both, for every --target.

That is now false for `--target kc`. This corrects the printed note and the two places that reproduce it verbatim:

- `src/tool/commands.ts` — the note printed by `owl import`.
- `docs/semantic-model/codelab.md` — the reproduced console output (which otherwise contradicts the same codelab's "govern the model right now with `--target kc`" step).
- `tests/libts/semantic/owl_converter.test.ts` — the behavior-spec comment.

New wording:

> `kcmd push --target kc` publishes it to Knowledge Catalog as-is. To deploy a graph, bind each entity's source table and add a deployment target first.

## Notes

- No logic change — only a printed string, a doc block, and a comment.
- The developer-guide prose for this (`owl-import.md`, `reference.md`) is corrected separately in the docs PR #365.
- Dependencies were not installed in this environment, so the suite was not run locally; the change touches no code paths.