### PR TITLE
feat(mdcode): OWL import produces a purely logical model

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -103,85 +103,141 @@ YAML
 
 ### Import from an OWL ontology
 
-You can also start from an existing OWL ontology instead of hand-authoring this
-YAML. `kcmd owl import` converts an ontology (`.ttl`) into a semantic model:
-classes become entities, datatype properties become fields, and object
-properties become relationships. Write a tiny ontology and import it:
+You do not have to write that YAML by hand. If you already describe this domain
+in an OWL ontology, `kcmd owl import` converts it to the same kind of logical
+model: classes become entities, datatype properties become fields, object
+properties become relationships, and an `owl:hasKey` becomes a primary key. Here
+is the sales domain as a small ontology:
 
 ```bash
-cat > /tmp/parts.ttl <<'TTL'
+cat > /tmp/sales.ttl <<'TTL'
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
-@prefix ex:   <http://example.com/commerce#> .
+@prefix ex:   <http://example.com/sales#> .
 
-ex:Part a owl:Class ;
-    rdfs:label "Part" ;
-    rdfs:comment "A sellable part" .
-ex:Supplier a owl:Class ;
-    rdfs:label "Supplier" .
+<http://example.com/sales> a owl:Ontology ;
+    rdfs:comment "Orders, line items, and customers for the codelab." .
 
-ex:partName a owl:DatatypeProperty ;
-    rdfs:domain ex:Part ;
-    rdfs:range xsd:string .
-ex:partPrice a owl:DatatypeProperty ;
-    rdfs:domain ex:Part ;
+ex:orders a owl:Class ;
+    owl:hasKey ( ex:o_orderkey ) .
+ex:customer a owl:Class ;
+    owl:hasKey ( ex:c_custkey ) .
+ex:lineitem a owl:Class ;
+    owl:hasKey ( ex:l_linekey ) .
+
+ex:o_orderkey a owl:DatatypeProperty ;
+    rdfs:domain ex:orders ;
+    rdfs:range xsd:integer .
+ex:o_custkey a owl:DatatypeProperty ;
+    rdfs:domain ex:orders ;
+    rdfs:range xsd:integer .
+ex:net_amount a owl:DatatypeProperty ;
+    rdfs:domain ex:orders ;
     rdfs:range xsd:decimal .
-ex:suppliedBy a owl:ObjectProperty ;
-    rdfs:domain ex:Part ;
-    rdfs:range ex:Supplier .
+
+ex:c_custkey a owl:DatatypeProperty ;
+    rdfs:domain ex:customer ;
+    rdfs:range xsd:integer .
+ex:c_name a owl:DatatypeProperty ;
+    rdfs:domain ex:customer ;
+    rdfs:range xsd:string .
+
+ex:l_linekey a owl:DatatypeProperty ;
+    rdfs:domain ex:lineitem ;
+    rdfs:range xsd:integer .
+ex:l_orderkey a owl:DatatypeProperty ;
+    rdfs:domain ex:lineitem ;
+    rdfs:range xsd:integer .
+
+ex:orders_to_customer a owl:ObjectProperty ;
+    rdfs:domain ex:orders ;
+    rdfs:range ex:customer .
+ex:lineitem_to_orders a owl:ObjectProperty ;
+    rdfs:domain ex:lineitem ;
+    rdfs:range ex:orders .
 TTL
 
-kcmd owl import /tmp/parts.ttl --out /tmp/parts_osi.yaml
+kcmd owl import /tmp/sales.ttl --out /tmp/sales_from_owl.yaml
 ```
 
 ```
-converted 2 classes, 1 object property, 2 datatype properties
-wrote /tmp/parts_osi.yaml
+converted 3 classes, 2 object properties, 7 datatype properties
+wrote /tmp/sales_from_owl.yaml
 note: this is a LOGICAL model (no physical binding).
       `kcmd push --target kc` publishes it to Knowledge Catalog as-is.
       A BigQuery or Spanner Graph deploy needs a binding profile (sources,
       field and join columns) and a deployment target added on top.
 ```
 
-Look at what it produced:
-
-```bash
-cat /tmp/parts_osi.yaml
-```
+The imported model:
 
 ```yaml
 version: 0.2.0.dev0
 semantic_model:
-  - name: parts
-    description: Imported from OWL ontology http://example.com/commerce#
+  - name: sales
+    description: Orders, line items, and customers for the codelab.
     datasets:
-      - name: Part
-        description: A sellable part
+      - name: orders
+        primary_key:
+          - o_orderkey
         fields:
-          - name: partName
-            datatype: String
-          - name: partPrice
+          - name: o_orderkey
+            datatype: Integer
+          - name: o_custkey
+            datatype: Integer
+          - name: net_amount
             datatype: Decimal
-      - name: Supplier
+      - name: customer
+        primary_key:
+          - c_custkey
+        fields:
+          - name: c_custkey
+            datatype: Integer
+          - name: c_name
+            datatype: String
+      - name: lineitem
+        primary_key:
+          - l_linekey
+        fields:
+          - name: l_linekey
+            datatype: Integer
+          - name: l_orderkey
+            datatype: Integer
     relationships:
-      - name: suppliedBy
-        from: Part
-        to: Supplier
+      - name: orders_to_customer
+        from: orders
+        to: customer
+      - name: lineitem_to_orders
+        from: lineitem
+        to: orders
 ```
 
-The classes became `Part` and `Supplier` entities, the datatype properties
-became `Part`'s fields, and the object property became the `suppliedBy`
-relationship. (The importer writes them under `datasets:`, the original spelling
-of the `entities:` key this codelab uses — the two are interchangeable.) The
-result is a purely **logical model**: an ontology declares meaning, not physical
-tables, so entities carry no `source`, fields no `expression`, and the edge no
-join columns. `kcmd push --target kc` publishes it to Knowledge Catalog as-is; a
-BigQuery or Spanner Graph deploy adds those physical facts through a
-[binding profile](profiles.md) — exactly what the `analytical` binding adds to
-the hand-authored `sales` model in step 3. For the full OWL mapping — class
-hierarchies, unique keys, and the constructs carried as custom extensions — see
-[Importing an OWL ontology](owl-import.md).
+This is the hand-authored `sales` model above, reproduced from the ontology: the
+same three entities, the same fields and datatypes, the same primary keys, and
+the same two relationships. (The importer writes entities under `datasets:`, the
+original spelling of the `entities:` key this codelab uses — the two are
+interchangeable.)
+
+Two things from the hand-authored model are missing, and both are inherent —
+an ontology has no way to state either:
+
+- **The `revenue` metric.** OWL describes structure — classes, properties,
+  relationships — not aggregations, so the importer emits no metrics. Add the
+  metric to the model by hand.
+- **The relationship join columns.** An object property states a direction
+  (`orders` → `customer`), not which foreign-key column joins to which key, so
+  each edge arrives as a pure logical edge — `from`/`to` only. Add the
+  `from_columns`/`to_columns` to each relationship by hand, as in the
+  hand-authored model above.
+
+Both gaps are logical facts you fill in on the model itself. The *physical*
+facts — the table each entity reads, the column each field maps to — stay out of
+the logical model entirely; a [binding profile](profiles.md) supplies them at
+deploy time (step 3), which is why neither model carries a `source`. `kcmd push
+--target kc` publishes the logical model to Knowledge Catalog as-is. For the full
+OWL mapping — class hierarchies, unique keys, and the constructs carried as
+custom extensions — see [Importing an OWL ontology](owl-import.md).
 
 The rest of this codelab uses the hand-authored `sales` model above.
 

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -119,22 +119,43 @@ cat > /tmp/sales.ttl <<'TTL'
 <http://example.com/sales> a owl:Ontology ;
     rdfs:comment "Orders, line items, and customers for the codelab." .
 
-ex:orders   a owl:Class ; owl:hasKey ( ex:o_orderkey ) .
-ex:customer a owl:Class ; owl:hasKey ( ex:c_custkey ) .
-ex:lineitem a owl:Class ; owl:hasKey ( ex:l_linekey ) .
+ex:orders a owl:Class ;
+    owl:hasKey ( ex:o_orderkey ) .
+ex:customer a owl:Class ;
+    owl:hasKey ( ex:c_custkey ) .
+ex:lineitem a owl:Class ;
+    owl:hasKey ( ex:l_linekey ) .
 
-ex:o_orderkey a owl:DatatypeProperty ; rdfs:domain ex:orders ; rdfs:range xsd:integer .
-ex:o_custkey  a owl:DatatypeProperty ; rdfs:domain ex:orders ; rdfs:range xsd:integer .
-ex:net_amount a owl:DatatypeProperty ; rdfs:domain ex:orders ; rdfs:range xsd:decimal .
+ex:o_orderkey a owl:DatatypeProperty ;
+    rdfs:domain ex:orders ;
+    rdfs:range xsd:integer .
+ex:o_custkey a owl:DatatypeProperty ;
+    rdfs:domain ex:orders ;
+    rdfs:range xsd:integer .
+ex:net_amount a owl:DatatypeProperty ;
+    rdfs:domain ex:orders ;
+    rdfs:range xsd:decimal .
 
-ex:c_custkey a owl:DatatypeProperty ; rdfs:domain ex:customer ; rdfs:range xsd:integer .
-ex:c_name    a owl:DatatypeProperty ; rdfs:domain ex:customer ; rdfs:range xsd:string .
+ex:c_custkey a owl:DatatypeProperty ;
+    rdfs:domain ex:customer ;
+    rdfs:range xsd:integer .
+ex:c_name a owl:DatatypeProperty ;
+    rdfs:domain ex:customer ;
+    rdfs:range xsd:string .
 
-ex:l_linekey  a owl:DatatypeProperty ; rdfs:domain ex:lineitem ; rdfs:range xsd:integer .
-ex:l_orderkey a owl:DatatypeProperty ; rdfs:domain ex:lineitem ; rdfs:range xsd:integer .
+ex:l_linekey a owl:DatatypeProperty ;
+    rdfs:domain ex:lineitem ;
+    rdfs:range xsd:integer .
+ex:l_orderkey a owl:DatatypeProperty ;
+    rdfs:domain ex:lineitem ;
+    rdfs:range xsd:integer .
 
-ex:orders_to_customer a owl:ObjectProperty ; rdfs:domain ex:orders   ; rdfs:range ex:customer .
-ex:lineitem_to_orders a owl:ObjectProperty ; rdfs:domain ex:lineitem ; rdfs:range ex:orders .
+ex:orders_to_customer a owl:ObjectProperty ;
+    rdfs:domain ex:orders ;
+    rdfs:range ex:customer .
+ex:lineitem_to_orders a owl:ObjectProperty ;
+    rdfs:domain ex:lineitem ;
+    rdfs:range ex:orders .
 TTL
 
 kcmd owl import /tmp/sales.ttl --out /tmp/sales_from_owl.yaml

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -138,9 +138,10 @@ kcmd owl import /tmp/parts.ttl --out /tmp/parts_osi.yaml
 ```
 converted 2 classes, 1 object property, 2 datatype properties
 wrote /tmp/parts_osi.yaml
-note: this model is UNBOUND (placeholder `unbound:` sources, no deployment target).
-      `kcmd push` is rejected until you bind each entity's source table and add
-      a BigQuery deployment target -- validation needs both, for every --target.
+note: this is a LOGICAL model (no physical binding).
+      `kcmd push --target kc` publishes it to Knowledge Catalog as-is.
+      A BigQuery or Spanner Graph deploy needs a binding profile (sources,
+      field and join columns) and a deployment target added on top.
 ```
 
 Look at what it produced:
@@ -156,43 +157,31 @@ semantic_model:
     description: Imported from OWL ontology http://example.com/commerce#
     datasets:
       - name: Part
-        source: unbound:Part
         description: A sellable part
         fields:
           - name: partName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: partName
             datatype: String
           - name: partPrice
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: partPrice
             datatype: Decimal
       - name: Supplier
-        source: unbound:Supplier
     relationships:
       - name: suppliedBy
         from: Part
         to: Supplier
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - TODO_BIND
 ```
 
 The classes became `Part` and `Supplier` entities, the datatype properties
 became `Part`'s fields, and the object property became the `suppliedBy`
 relationship. (The importer writes them under `datasets:`, the original spelling
 of the `entities:` key this codelab uses — the two are interchangeable.) The
-`source: unbound:*` and `TODO_BIND` join columns are
-placeholders: the import gives you structure, and you bind it to physical tables
-and a deployment target before deploying to a query engine — which is exactly
-what the `analytical` binding adds to the hand-authored `sales` model in step 3.
-For the full OWL mapping — class hierarchies, unique keys, and the constructs
-carried as custom extensions — see [Importing an OWL ontology](owl-import.md).
+result is a purely **logical model**: an ontology declares meaning, not physical
+tables, so entities carry no `source`, fields no `expression`, and the edge no
+join columns. `kcmd push --target kc` publishes it to Knowledge Catalog as-is; a
+BigQuery or Spanner Graph deploy adds those physical facts through a
+[binding profile](profiles.md) — exactly what the `analytical` binding adds to
+the hand-authored `sales` model in step 3. For the full OWL mapping — class
+hierarchies, unique keys, and the constructs carried as custom extensions — see
+[Importing an OWL ontology](owl-import.md).
 
 The rest of this codelab uses the hand-authored `sales` model above.
 

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -119,43 +119,22 @@ cat > /tmp/sales.ttl <<'TTL'
 <http://example.com/sales> a owl:Ontology ;
     rdfs:comment "Orders, line items, and customers for the codelab." .
 
-ex:orders a owl:Class ;
-    owl:hasKey ( ex:o_orderkey ) .
-ex:customer a owl:Class ;
-    owl:hasKey ( ex:c_custkey ) .
-ex:lineitem a owl:Class ;
-    owl:hasKey ( ex:l_linekey ) .
+ex:orders   a owl:Class ; owl:hasKey ( ex:o_orderkey ) .
+ex:customer a owl:Class ; owl:hasKey ( ex:c_custkey ) .
+ex:lineitem a owl:Class ; owl:hasKey ( ex:l_linekey ) .
 
-ex:o_orderkey a owl:DatatypeProperty ;
-    rdfs:domain ex:orders ;
-    rdfs:range xsd:integer .
-ex:o_custkey a owl:DatatypeProperty ;
-    rdfs:domain ex:orders ;
-    rdfs:range xsd:integer .
-ex:net_amount a owl:DatatypeProperty ;
-    rdfs:domain ex:orders ;
-    rdfs:range xsd:decimal .
+ex:o_orderkey a owl:DatatypeProperty ; rdfs:domain ex:orders ; rdfs:range xsd:integer .
+ex:o_custkey  a owl:DatatypeProperty ; rdfs:domain ex:orders ; rdfs:range xsd:integer .
+ex:net_amount a owl:DatatypeProperty ; rdfs:domain ex:orders ; rdfs:range xsd:decimal .
 
-ex:c_custkey a owl:DatatypeProperty ;
-    rdfs:domain ex:customer ;
-    rdfs:range xsd:integer .
-ex:c_name a owl:DatatypeProperty ;
-    rdfs:domain ex:customer ;
-    rdfs:range xsd:string .
+ex:c_custkey a owl:DatatypeProperty ; rdfs:domain ex:customer ; rdfs:range xsd:integer .
+ex:c_name    a owl:DatatypeProperty ; rdfs:domain ex:customer ; rdfs:range xsd:string .
 
-ex:l_linekey a owl:DatatypeProperty ;
-    rdfs:domain ex:lineitem ;
-    rdfs:range xsd:integer .
-ex:l_orderkey a owl:DatatypeProperty ;
-    rdfs:domain ex:lineitem ;
-    rdfs:range xsd:integer .
+ex:l_linekey  a owl:DatatypeProperty ; rdfs:domain ex:lineitem ; rdfs:range xsd:integer .
+ex:l_orderkey a owl:DatatypeProperty ; rdfs:domain ex:lineitem ; rdfs:range xsd:integer .
 
-ex:orders_to_customer a owl:ObjectProperty ;
-    rdfs:domain ex:orders ;
-    rdfs:range ex:customer .
-ex:lineitem_to_orders a owl:ObjectProperty ;
-    rdfs:domain ex:lineitem ;
-    rdfs:range ex:orders .
+ex:orders_to_customer a owl:ObjectProperty ; rdfs:domain ex:orders   ; rdfs:range ex:customer .
+ex:lineitem_to_orders a owl:ObjectProperty ; rdfs:domain ex:lineitem ; rdfs:range ex:orders .
 TTL
 
 kcmd owl import /tmp/sales.ttl --out /tmp/sales_from_owl.yaml
@@ -179,38 +158,24 @@ semantic_model:
     description: Orders, line items, and customers for the codelab.
     datasets:
       - name: orders
-        primary_key:
-          - o_orderkey
+        primary_key: [o_orderkey]
         fields:
-          - name: o_orderkey
-            datatype: Integer
-          - name: o_custkey
-            datatype: Integer
-          - name: net_amount
-            datatype: Decimal
+          - { name: o_orderkey, datatype: Integer }
+          - { name: o_custkey,  datatype: Integer }
+          - { name: net_amount, datatype: Decimal }
       - name: customer
-        primary_key:
-          - c_custkey
+        primary_key: [c_custkey]
         fields:
-          - name: c_custkey
-            datatype: Integer
-          - name: c_name
-            datatype: String
+          - { name: c_custkey, datatype: Integer }
+          - { name: c_name,    datatype: String }
       - name: lineitem
-        primary_key:
-          - l_linekey
+        primary_key: [l_linekey]
         fields:
-          - name: l_linekey
-            datatype: Integer
-          - name: l_orderkey
-            datatype: Integer
+          - { name: l_linekey,  datatype: Integer }
+          - { name: l_orderkey, datatype: Integer }
     relationships:
-      - name: orders_to_customer
-        from: orders
-        to: customer
-      - name: lineitem_to_orders
-        from: lineitem
-        to: orders
+      - { name: orders_to_customer, from: orders,   to: customer }
+      - { name: lineitem_to_orders, from: lineitem, to: orders }
 ```
 
 This is the hand-authored `sales` model above, reproduced from the ontology: the

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -166,8 +166,9 @@ converted 3 classes, 2 object properties, 7 datatype properties
 wrote /tmp/sales_from_owl.yaml
 note: this is a LOGICAL model (no physical binding).
       `kcmd push --target kc` publishes it to Knowledge Catalog as-is.
-      A BigQuery or Spanner Graph deploy needs a binding profile (sources,
-      field and join columns) and a deployment target added on top.
+      A BigQuery or Spanner Graph deploy needs each relationship's join
+      columns added to the model, plus a binding profile (sources, field
+      columns) and a deployment target.
 ```
 
 The imported model:

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -132,9 +132,10 @@ literal types that become each field's `datatype`.
 $ kcmd owl import sales.owl.ttl
 converted 2 classes, 1 object property, 9 datatype properties
 wrote catalog/EntryGroups/<entryGroup>/sales.yaml
-note: this model is UNBOUND (placeholder `unbound:` sources, no deployment target).
-      `kcmd push` is rejected until you bind each entity's source table and add
-      a BigQuery deployment target -- validation needs both, for every --target.
+note: this is a LOGICAL model (no physical binding).
+      `kcmd push --target kc` publishes it to Knowledge Catalog as-is.
+      A BigQuery or Spanner Graph deploy needs a binding profile (sources,
+      field and join columns) and a deployment target added on top.
 ```
 
 The model name comes from the file (`sales.owl.ttl` → `sales`). By default the
@@ -160,8 +161,7 @@ semantic_model:
       examples:
         - How many orders did each customer place last month?
     datasets:
-      - name: Customer
-        source: unbound:Customer        # placeholder — bind to a table for BigQuery Graph
+      - name: Customer                   # no source: a logical entity
         primary_key:
           - customerId                   # from owl:hasKey
         unique_keys:
@@ -171,56 +171,36 @@ semantic_model:
           synonyms:
             - Buyer
         fields:
-          - name: customerId
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: customerId
+          - name: customerId             # no expression: a logical field
             datatype: String
           - name: email
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: email
             datatype: String
             description: The customer's unique email address.
           - name: customerName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: customerName
             datatype: String
             label: name
           - name: signupDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: signupDate
             datatype: Date
             dimension:
               is_time: true              # a temporal field is a time dimension
           - name: isVip
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: isVip
             datatype: Boolean
             description: Whether the customer is in the loyalty program.
       # ... Order dataset: orderId, orderAmount, quantity, orderDate ...
     relationships:
       - name: placedBy
-        from: Order
+        from: Order                      # logical edge: direction only, no columns
         to: Customer
-        from_columns:
-          - TODO_BIND                    # source FK — fill in when you bind sources
-        to_columns:
-          - customerId                   # already bound to Customer's key
         ai_context:
           instructions: Links an order to the customer who placed it.
 ```
 
-This is the **clean mapping**: every construct here has a native semantic-model
-home, so the output carries no term IRIs and no `custom_extensions`. Two kinds of
+This is a purely **logical model**: an ontology declares meaning, not physical
+tables, so entities carry no `source`, fields no `expression`, and relationships
+no join columns — a [binding profile](profiles.md) supplies those before a graph
+deploy. It is also the **clean mapping**: every construct here has a native
+semantic-model home, so the output carries no term IRIs and no
+`custom_extensions`. Two kinds of
 ontology go further — a **class hierarchy** (`rdfs:subClassOf`) and constructs
 with **no native home yet** (inverses, equivalences, property characteristics,
 …). Both are supported; the rest of this page shows them as extensions of *this
@@ -243,9 +223,9 @@ appears nowhere above.
 | OWL | Semantic model | Notes |
 |---|---|---|
 | `owl:Ontology` header | model `description`, `ai_context`, version | comment → `description`; labels → `ai_context.synonyms`; `skos:example` → `ai_context.examples`; `owl:versionInfo` → appended to `description` |
-| `owl:Class` | `datasets[]` entry | `source` = `unbound:<Name>` placeholder until bound |
-| `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; `expression` defaults to the property's local name (a valid column ref once bound) |
-| `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; join columns bound to the destination key when it has one, else `TODO_BIND` (see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
+| `owl:Class` | `datasets[]` entry | a logical entity — **no `source`** (a binding profile adds one before a graph deploy) |
+| `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; a logical field — **no `expression`** (a binding profile maps it to a column) |
+| `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; a **logical edge with no join columns** (a binding profile supplies them, see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
 | `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, `owl:AllDisjointClasses`, `owl:AllDisjointProperties`, `owl:AllDifferent`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
@@ -305,7 +285,10 @@ BigQuery Graph / BI treats it as one.
   (with a warning) so the dataset has a grain; ambiguous cases (several unique
   keys, or a composite one) are left without a `primary_key`.
 
-Keys also make relationships half-bindable — see the next section.
+Keys are **logical grain**, not a binding — they are the entity's identity, so
+they come across even though the model has no physical binding. A binding profile
+uses them later to fill an edge's destination join columns; see
+[binding](#4-going-from-ontology-to-a-running-graph-binding).
 
 ### Class hierarchies (`rdfs:subClassOf`)
 
@@ -334,19 +317,13 @@ the `Person` and `Customer` datasets come out as (`Customer` carrying
 ```yaml
   # Person is its own dataset:
   - name: Person
-    source: unbound:Person
     description: A human being.
     fields:
       - name: fullName
-        expression:
-          dialects:
-            - dialect: BIGQUERY
-              expression: fullName
         datatype: String
   # Customer records that it extends Person and keeps ONLY its own fields;
   # Person's fullName is NOT flattened down.
   - name: Customer
-    source: unbound:Customer
     extends:
       - Person
     primary_key:
@@ -354,10 +331,6 @@ the `Person` and `Customer` datasets come out as (`Customer` carrying
     description: A person or organization that places orders.
     fields:
       - name: customerId
-        expression:
-          dialects:
-            - dialect: BIGQUERY
-              expression: customerId
         datatype: String
       # ... email, customerName, signupDate, isVip (Customer's own) ...
 ```
@@ -625,63 +598,65 @@ is out of scope (see [Limitations](#limitations)).
 
 ## 4. Going from ontology to a running graph (binding)
 
-The import gets you an **unbound** model — placeholder `unbound:<Name>` sources,
-`TODO_BIND` join columns, and no deployment target — so it is **not deployable
-yet**. `kcmd push` is rejected for *any* `--target` (including `kc`) until the
-model passes [validation](reference.md#validation): every entity `source` must
-resolve to a real BigQuery table, and the model must declare exactly one BigQuery
-deployment target. Both checks run before either destination leg, so there is no
-Knowledge-Catalog-only shortcut around them today.
-
-> **Known limitation — no KC-only publish before binding.** Even
-> `kcmd push --target kc` runs the BigQuery deployment-target and live-source
-> checks first, so you cannot publish the ontology as catalog metadata while the
-> model is still unbound. Letting `--target kc` publish an unbound model is a
-> possible follow-up (see [Limitations](#limitations)).
-
-To make the model deployable, bind each class to a real table. A
-declared key does half of this for you: an edge into a class that has a key
-already has its **destination** columns bound to that key, so you only fill each
-dataset's `source` table and the relationship's **source** foreign-key columns
-(the `TODO_BIND` placeholders):
-
-```yaml
-datasets:
-  - name: Customer
-    source: myproj.sales.customers        # was unbound:Customer
-    primary_key:
-      - customerId                        # already set from owl:hasKey
-    # ... fields, each expression bound to its real column ...
-  - name: Order
-    source: myproj.sales.orders           # was unbound:Order
-    # ... fields ...
-relationships:
-  - name: placedBy
-    from: Order
-    to: Customer
-    from_columns:
-      - customer_id                       # fill in the source FK (was TODO_BIND)
-    to_columns:
-      - customerId                        # already bound to Customer's key
-```
-
-Add a [deployment target](README.md#deployment-targets-required) on the model as
-well. With every `source` bound and one deployment target set, the model passes
-validation, and a single `kcmd push` deploys both destinations:
+The import gives you a **logical model**: what the domain means, with no physical
+binding. That is directly useful — `kcmd push --target kc` publishes it to
+Knowledge Catalog as-is, so the ontology becomes catalog metadata (entities,
+fields, keys, and edges) with nothing more to fill in:
 
 ```console
-$ kcmd push                  # CREATE OR REPLACE PROPERTY GRAPH (Customer/Order nodes, placedBy edge), then KC entries
+$ kcmd push --target kc      # publishes the logical model to Knowledge Catalog
 ```
 
-Binding the `source` tables and the source foreign-key columns is a manual edit
-in this first cut.
+A **BigQuery or Spanner Graph** deploy needs the physical facts an ontology does
+not carry: which table each entity reads, which column each field reads, the join
+columns on each edge, and a deployment target. You supply those in a
+[binding profile](profiles.md) — a document in the same schema, kept beside the
+model as `<model>.profiles/<name>.yaml`, that adds *only* the binding and leaves
+the logical model untouched. The logical model and the profile merge by name at
+push time:
+
+```yaml
+# sales.profiles/warehouse.yaml — physical binding for the sales model
+version: 0.2.0.dev0
+semantic_model:
+  - name: sales
+    deployment_target: //bigquery.googleapis.com/projects/myproj/datasets/sales/propertyGraphs/sales
+    datasets:
+      - name: Customer
+        source: //bigquery.googleapis.com/projects/myproj/datasets/sales/tables/customers
+        fields:
+          - { name: customerId, expression: c_custkey }
+          - { name: email,      expression: c_email }
+          # ... the remaining Customer fields ...
+      - name: Order
+        source: //bigquery.googleapis.com/projects/myproj/datasets/sales/tables/orders
+        fields:
+          - { name: orderId, expression: o_orderkey }
+          # ... the remaining Order fields ...
+    relationships:
+      - name: placedBy
+        from_columns: [o_custkey]        # the Order-side foreign key
+        to_columns: [customerId]         # Customer's key column
+```
+
+The keys the import already recovered (`primary_key`, `unique_keys`) tell you
+which columns an edge's `to_columns` must reference — here `placedBy.to_columns`
+targets Customer's `customerId` key. With the profile in place, a single push
+deploys the graph:
+
+```console
+$ kcmd push --profile warehouse   # merges the binding, then CREATE OR REPLACE PROPERTY GRAPH + KC entries
+```
+
+See [One logical model, many physical bindings](profiles.md) for the full profile
+contract — what a profile may and may not set, how merge and prune work, and how
+one logical model binds to several stores.
 
 ## Limitations
 
-Four different situations hide in "not covered": constructs already read but not
-yet resolved all the way downstream, constructs not read but reachable next,
-constructs out of scope, and one item that is a push limitation rather than a
-converter gap.
+Three different situations hide in "not covered": constructs already read but not
+yet resolved all the way downstream, constructs not read but reachable next, and
+constructs out of scope.
 
 **Read now — only downstream resolution is pending.** These are not dropped; the
 importer handles them today, and the remaining work is a later step, not in the
@@ -724,10 +699,3 @@ converter targets:
   instances), and `owl:sameAs` / `owl:differentFrom` (which relate individuals).
 - OWL serializations other than Turtle (`.ttl`), and the reverse direction —
   semantic model → OWL export. Import is one-way.
-
-**A push limitation, not a converter gap: no Knowledge-Catalog-only publish of an
-unbound model.** A freshly imported model cannot `kcmd push --target kc` until its
-sources are bound and a deployment target is set: push validates the BigQuery
-deployment target and probes every source table before any leg runs (for every
-`--target`), so there is no KC-only path around those checks. Decoupling the KC
-leg from the BigQuery checks is a possible follow-up.

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -134,8 +134,9 @@ converted 2 classes, 1 object property, 9 datatype properties
 wrote catalog/EntryGroups/<entryGroup>/sales.yaml
 note: this is a LOGICAL model (no physical binding).
       `kcmd push --target kc` publishes it to Knowledge Catalog as-is.
-      A BigQuery or Spanner Graph deploy needs a binding profile (sources,
-      field and join columns) and a deployment target added on top.
+      A BigQuery or Spanner Graph deploy needs each relationship's join
+      columns added to the model, plus a binding profile (sources, field
+      columns) and a deployment target.
 ```
 
 The model name comes from the file (`sales.owl.ttl` → `sales`). By default the
@@ -197,8 +198,9 @@ semantic_model:
 
 This is a purely **logical model**: an ontology declares meaning, not physical
 tables, so entities carry no `source`, fields no `expression`, and relationships
-no join columns — a [binding profile](profiles.md) supplies those before a graph
-deploy. It is also the **clean mapping**: every construct here has a native
+no join columns. Before a graph deploy a [binding profile](profiles.md) supplies
+the sources and field expressions, and you add each edge's join columns to the
+model (they are logical, not a binding). It is also the **clean mapping**: every construct here has a native
 semantic-model home, so the output carries no term IRIs and no
 `custom_extensions`. Two kinds of
 ontology go further — a **class hierarchy** (`rdfs:subClassOf`) and constructs
@@ -225,7 +227,7 @@ appears nowhere above.
 | `owl:Ontology` header | model `description`, `ai_context`, version | comment → `description`; labels → `ai_context.synonyms`; `skos:example` → `ai_context.examples`; `owl:versionInfo` → appended to `description` |
 | `owl:Class` | `datasets[]` entry | a logical entity — **no `source`** (a binding profile adds one before a graph deploy) |
 | `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; a logical field — **no `expression`** (a binding profile maps it to a column) |
-| `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; a **logical edge with no join columns** (a binding profile supplies them, see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
+| `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; a **logical edge with no join columns** (you add `from_columns`/`to_columns` to the model before a graph deploy, see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
 | `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, `owl:AllDisjointClasses`, `owl:AllDisjointProperties`, `owl:AllDifferent`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
@@ -286,9 +288,9 @@ BigQuery Graph / BI treats it as one.
   keys, or a composite one) are left without a `primary_key`.
 
 Keys are **logical grain**, not a binding — they are the entity's identity, so
-they come across even though the model has no physical binding. A binding profile
-uses them later to fill an edge's destination join columns; see
-[binding](#4-going-from-ontology-to-a-running-graph-binding).
+they come across even though the model has no physical binding. They also tell
+you which columns an edge's `to_columns` must reference when you add join columns
+to the model; see [binding](#4-going-from-ontology-to-a-running-graph-binding).
 
 ### Class hierarchies (`rdfs:subClassOf`)
 
@@ -601,47 +603,66 @@ is out of scope (see [Limitations](#limitations)).
 The import gives you a **logical model**: what the domain means, with no physical
 binding. That is directly useful — `kcmd push --target kc` publishes it to
 Knowledge Catalog as-is, so the ontology becomes catalog metadata (entities,
-fields, keys, and edges) with nothing more to fill in:
+fields, and keys) with nothing more to fill in:
 
 ```console
 $ kcmd push --target kc      # publishes the logical model to Knowledge Catalog
 ```
 
-A **BigQuery or Spanner Graph** deploy needs the physical facts an ontology does
-not carry: which table each entity reads, which column each field reads, the join
-columns on each edge, and a deployment target. You supply those in a
-[binding profile](profiles.md) — a document in the same schema, kept beside the
-model as `<model>.profiles/<name>.yaml`, that adds *only* the binding and leaves
-the logical model untouched. The logical model and the profile merge by name at
-push time:
+A relationship publishes as a catalog link only once it has join columns (added
+to the model, below); a column-less edge is skipped with a warning, so the
+entities and fields still publish while the edge waits.
 
-```yaml
-# sales.profiles/warehouse.yaml — physical binding for the sales model
-version: 0.2.0.dev0
-semantic_model:
-  - name: sales
-    deployment_target: //bigquery.googleapis.com/projects/myproj/datasets/sales/propertyGraphs/sales
-    datasets:
-      - name: Customer
-        source: //bigquery.googleapis.com/projects/myproj/datasets/sales/tables/customers
-        fields:
-          - { name: customerId, expression: c_custkey }
-          - { name: email,      expression: c_email }
-          # ... the remaining Customer fields ...
-      - name: Order
-        source: //bigquery.googleapis.com/projects/myproj/datasets/sales/tables/orders
-        fields:
-          - { name: orderId, expression: o_orderkey }
-          # ... the remaining Order fields ...
-    relationships:
-      - name: placedBy
-        from_columns: [o_custkey]        # the Order-side foreign key
-        to_columns: [customerId]         # Customer's key column
-```
+A **BigQuery or Spanner Graph** deploy needs two things the import leaves open,
+and they belong in different places:
 
-The keys the import already recovered (`primary_key`, `unique_keys`) tell you
-which columns an edge's `to_columns` must reference — here `placedBy.to_columns`
-targets Customer's `customerId` key. With the profile in place, a single push
+1. **The join columns on each edge — in the model.** The import gives every
+   relationship its endpoints (`from`/`to`) but no join columns; which columns an
+   edge joins on is a *logical* fact the model owns, not a physical binding, so
+   you add it to the imported model itself. The keys the import already recovered
+   (`primary_key`, `unique_keys`) tell you which columns an edge's `to_columns`
+   must reference:
+
+   ```yaml
+   # sales.yaml — add the join columns to the imported relationship
+   relationships:
+     - name: placedBy
+       from: Order
+       to: Customer
+       from_columns: [o_custkey]   # the Order-side foreign key
+       to_columns: [customerId]    # Customer's key column
+   ```
+
+2. **The physical binding — in a profile.** Which table each entity reads, which
+   column each field reads, and the deployment target go in a
+   [binding profile](profiles.md): a document in the same schema, kept beside the
+   model as `<model>.profiles/<name>.yaml`, that adds *only* the binding and
+   leaves the logical model untouched. A profile may set `source`, field
+   `expression`, `unbound`, and `deployment_target` — nothing logical (a
+   `relationships` block in a profile is rejected). The model and the profile
+   merge by name at push time:
+
+   ```yaml
+   # sales.profiles/warehouse.yaml — physical binding for the sales model
+   version: 0.2.0.dev0
+   semantic_model:
+     - name: sales
+       deployment_target: //bigquery.googleapis.com/projects/myproj/datasets/sales/propertyGraphs/sales
+       datasets:
+         - name: Customer
+           source: //bigquery.googleapis.com/projects/myproj/datasets/sales/tables/customers
+           fields:
+             - { name: customerId, expression: c_custkey }
+             - { name: email,      expression: c_email }
+             # ... the remaining Customer fields ...
+         - name: Order
+           source: //bigquery.googleapis.com/projects/myproj/datasets/sales/tables/orders
+           fields:
+             - { name: orderId, expression: o_orderkey }
+             # ... the remaining Order fields ...
+   ```
+
+With the join columns in the model and the profile in place, a single push
 deploys the graph:
 
 ```console

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/convert.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/convert.ts
@@ -27,8 +27,9 @@ export interface ConvertResult {
  * Converts a Turtle (.ttl) OWL ontology to an OSI YAML document.
  *
  * `modelName` names the resulting semantic model (the CLI derives it from the
- * source filename). The output is UNBOUND -- see to_ir.ts and the user guide --
- * but loads and pushes to Knowledge Catalog as-is.
+ * source filename). The output is a purely LOGICAL model -- see to_ir.ts and
+ * the user guide -- with no physical binding; it loads and pushes to Knowledge
+ * Catalog as-is, and a graph deploy adds bindings on top.
  *
  * Throws only on malformed Turtle (the parser's error); mapping gaps are
  * reported as warnings, not failures.
@@ -37,7 +38,10 @@ export function convertOwlToOsi(
     turtle: string, modelName: string): ConvertResult {
   const owl = parseOwl(turtle);
   const {model, warnings: mapWarnings, stats} = owlToIr(owl, modelName);
-  const {yaml, warnings: serializeWarnings} = serializeModel(model);
+  // An OWL import is always logical (no source/expression), so tell the
+  // serializer not to warn about the missing physical binding.
+  const {yaml, warnings: serializeWarnings} =
+      serializeModel(model, {logical: true});
   return {
     yaml,
     stats,

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -46,10 +46,11 @@
 // physical tables, so entities carry no source, fields no expression, and
 // relationships no join columns -- only the logical shape (entities, fields,
 // keys, and edges by direction). `kcmd push --target kc` publishes it as-is.
-// A BigQuery or Spanner Graph deploy needs physical binding (sources, field
-// columns, edge join columns) and a deployment target added on top; that is a
-// separate step (a binding profile, see the user guide, "Going from ontology
-// to a running graph").
+// A BigQuery or Spanner Graph deploy needs each edge's join columns added to
+// the model (logical grain the model owns) plus a physical binding (sources,
+// field columns) and a deployment target; that binding is a separate step (a
+// binding profile, see the user guide, "Going from ontology to a running
+// graph").
 
 import {AiContext, CustomExtension, Entity, Field, Relationship, SemanticModel,} from '../../ir';
 
@@ -519,8 +520,8 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
 
   // Object properties -> relationships (edges). Both endpoints must be known
   // classes. The edge is logical: it carries only its direction (source entity
-  // -> destination entity), no join columns. The physical foreign-key / key
-  // columns are supplied by a binding profile before a graph deploy.
+  // -> destination entity), no join columns. The foreign-key / key columns are
+  // added to the model (logical grain, not a binding) before a graph deploy.
   const relationships: Relationship[] = [];
   for (const p of owl.objectProperties) {
     const domain = p.domains[0];
@@ -606,9 +607,9 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
 
     const relationship: Relationship = {
       name: p.localName,
-      // A logical edge: direction only, no join columns. A binding profile
-      // supplies the source foreign-key and destination key columns before a
-      // graph deploy.
+      // A logical edge: direction only, no join columns. The source
+      // foreign-key and destination key columns are added to the model (logical
+      // grain, not a binding) before a graph deploy.
       source: {entity: domain, columns: []},
       destination: {entity: range, columns: []},
       // No `description`: the OSI relationship has no such slot, so the comment

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -6,7 +6,7 @@
 //
 // The mapping (see the user guide's table). Each line is one construct, kept
 // short so a comment reflow cannot run the columns together:
-//   owl:Class                     -> dataset (entity) + unbound source
+//   owl:Class                     -> dataset (entity), no source (logical)
 //   owl:DatatypeProperty          -> field on each domain class's dataset
 //   owl:ObjectProperty            -> relationship (edge), domain -> range
 //   rdfs:range xsd:*              -> field datatype (see XSD_DATATYPES)
@@ -42,13 +42,14 @@
 // A carried cross-reference keeps the full referent IRI unless it is in this
 // ontology's own namespace, when it shortens to a local name (see refValue).
 //
-// The result is UNBOUND: entities carry an `unbound:<Name>` source placeholder
-// and relationships carry `TODO_BIND` join columns, because an ontology has no
-// physical tables. A declared key sharpens this -- an edge into a class with a
-// key binds its destination columns to that key, leaving only the source
-// foreign-key columns to fill. The model loads and pushes to Knowledge Catalog
-// as-is; binding real sources/columns is a manual follow-up before a BigQuery
-// push (see the user guide, "Going from ontology to a running graph").
+// The result is a purely LOGICAL model: an ontology declares meaning, not
+// physical tables, so entities carry no source, fields no expression, and
+// relationships no join columns -- only the logical shape (entities, fields,
+// keys, and edges by direction). `kcmd push --target kc` publishes it as-is.
+// A BigQuery or Spanner Graph deploy needs physical binding (sources, field
+// columns, edge join columns) and a deployment target added on top; that is a
+// separate step (a binding profile, see the user guide, "Going from ontology
+// to a running graph").
 
 import {AiContext, CustomExtension, Entity, Field, Relationship, SemanticModel,} from '../../ir';
 
@@ -155,18 +156,6 @@ function commonTerms(a: OwlCommonAnnotations): Record<string, unknown> {
   if (a.versionInfo) terms['owl:versionInfo'] = a.versionInfo;
   return terms;
 }
-
-// The placeholder source for an unbound entity: an ontology class has no
-// backing table, so the entity is emitted with this sentinel until a real
-// source is bound. Chosen so it is obviously not a real table reference.
-function unboundSource(name: string): string {
-  return `unbound:${name}`;
-}
-
-// The placeholder join column for an unbound relationship: the real foreign-key
-// / key columns are unknown until sources are bound. The loader requires at
-// least one column per endpoint, so a sentinel stands in until binding.
-const TODO_BIND = 'TODO_BIND';
 
 // --- Datatype mapping. ------------------------------------------------------
 
@@ -372,7 +361,9 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     }
     const entity: Entity = {
       name: c.localName,
-      dataSource: unboundSource(c.localName),
+      // No source: a class is a logical entity. A binding profile supplies the
+      // backing table before a graph deploy; KC push needs none.
+      dataSource: '',
       keys: dedupe(c.keys),  // owl:hasKey -> primary_key (grain)
       description: c.comment,
       aiContext: synonymAiContext(c.label, c.localName, c.synonyms, c.examples),
@@ -467,9 +458,8 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       const type = datatypeFor(p.rangeIri);
       const field: Field = {
         name: p.localName,
-        // The property's local name is a valid column reference once the entity
-        // is bound to a real table; it is the default binding target.
-        expression: p.localName,
+        // No expression: the field is logical. A binding profile maps it to a
+        // column when a real source is bound.
         type,
         // A temporal field is a time dimension by OSI's own rule; mark it so
         // downstream (BigQuery Graph, BI) treats it as one.
@@ -528,9 +518,9 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
   }
 
   // Object properties -> relationships (edges). Both endpoints must be known
-  // classes. When the destination class declares a key, the edge's destination
-  // columns bind to it and only the source foreign-key columns stay unbound;
-  // otherwise both ends are placeholders.
+  // classes. The edge is logical: it carries only its direction (source entity
+  // -> destination entity), no join columns. The physical foreign-key / key
+  // columns are supplied by a binding profile before a graph deploy.
   const relationships: Relationship[] = [];
   for (const p of owl.objectProperties) {
     const domain = p.domains[0];
@@ -614,22 +604,13 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     if (p.asymmetric) relTerms['owl:AsymmetricProperty'] = true;
     Object.assign(relTerms, commonTerms(p));
 
-    const destKeys = entitiesByName.get(range)?.keys ?? [];
-    const bound = destKeys.length > 0;
     const relationship: Relationship = {
       name: p.localName,
-      // Source FK columns are unknown until binding; keep the count aligned
-      // with the destination key so the positional join is well-formed.
-      source: {
-        entity: domain,
-        columns: bound ? destKeys.map(() => TODO_BIND) : [TODO_BIND],
-      },
-      destination: {
-        // Copy the key so the destination columns render inline rather than as
-        // a YAML alias of the entity's primary_key (same array object).
-        entity: range,
-        columns: bound ? [...destKeys] : [TODO_BIND],
-      },
+      // A logical edge: direction only, no join columns. A binding profile
+      // supplies the source foreign-key and destination key columns before a
+      // graph deploy.
+      source: {entity: domain, columns: []},
+      destination: {entity: range, columns: []},
       // No `description`: the OSI relationship has no such slot, so the comment
       // rides in ai_context.instructions (see relationshipAiContext).
       aiContext: relationshipAiContext(

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -213,11 +213,13 @@ export function generateCatalogResources(
 
 
 // Builds the schema-join entry link for one relationship, or undefined when it
-// cannot be published. A many-to-many (association) edge is skipped -- a junction
-// is two joins, which the single source/target schema-join does not model -- and
-// so is an edge whose endpoint entity was not emitted (e.g. skipped for a
-// duplicate id). Both cases warn; the BigQuery property graph still carries the
-// edge.
+// cannot be published. Skipped, each with a warning: a many-to-many
+// (association) edge -- a junction is two joins, which the single source/target
+// schema-join does not model; an edge whose endpoint entity was not emitted
+// (e.g. skipped for a duplicate id); and a column-less (purely logical) edge,
+// whose join columns must be added to the model before it can publish. The
+// BigQuery property graph still carries the association and (once bound) direct
+// edges.
 function relationshipLink(
     names: Namer, model: SemanticModel, rel: Relationship,
     entityEntryName: Map<string, string>, seenLinks: Set<string>,
@@ -236,6 +238,19 @@ function relationshipLink(
     warnings.push(
         `relationship '${rel.name}': endpoint entity '${missing}' is not a ` +
         `published entity; the relationship link is skipped.`);
+    return undefined;
+  }
+  // A purely logical edge (an OWL import) carries no join columns. schema-join
+  // is a server-defined CLOSED metadataTemplate whose `fields` requirement we
+  // cannot depend on, so rather than risk a rejected aspect on a KC push we skip
+  // the link until the edge is bound. Add the relationship's from_columns /
+  // to_columns to the model and it publishes; the edge still lives in the model
+  // (and, once bound, the BigQuery/Spanner graph).
+  if (!rel.source.columns.length || !rel.destination.columns.length) {
+    warnings.push(
+        `relationship '${rel.name}': no join columns, so it is not published ` +
+        `to Knowledge Catalog yet; add its from_columns and to_columns to the ` +
+        `relationship in the model to publish the link.`);
     return undefined;
   }
   const linkId = names.linkId(model, rel);
@@ -280,11 +295,10 @@ function relationshipLink(
 // overwriting it. Field names/nesting mirror the schema-join aspect type's
 // metadataTemplate.
 //
-// A purely logical edge (an OWL import) carries no join columns; each endpoint
-// then omits `fields` and names the entity, so the aspect records the join's
-// direction and endpoints without a column binding. (schema-join is a server
-// CLOSED metadataTemplate; if it REQUIRES `fields`, skip the link for a
-// column-less edge with a warning instead -- see the PR's open item.)
+// Only bound edges reach here -- relationshipLink skips a column-less (logical)
+// edge -- so `fields` is always present. The `name` still falls back to the
+// entity name when the model is logical-only for KC (columns set but no
+// dataSource binding), matching the entity-not-found fallback.
 function schemaJoinAspectData(
     model: SemanticModel, rel: Relationship): Record<string, any> {
   const srcEntity = entityByName(model, rel.source.entity);
@@ -292,21 +306,16 @@ function schemaJoinAspectData(
   return {
     joins: [compact({
       source: compact({
-        // Name each side by its SQL table (dataSource); fall back to the entity
-        // name when the model is logical-only (no binding, so dataSource is
-        // empty), matching the entity-not-found fallback. `fields` is omitted
-        // for a column-less (logical) edge rather than emitted empty.
         name: srcEntity && srcEntity.dataSource ?
             srcEntity.dataSource :
             rel.source.entity,
-        fields: rel.source.columns.length ? rel.source.columns : undefined,
+        fields: rel.source.columns,
       }),
       target: compact({
         name: dstEntity && dstEntity.dataSource ?
             dstEntity.dataSource :
             rel.destination.entity,
-        fields: rel.destination.columns.length ? rel.destination.columns :
-                                                 undefined,
+        fields: rel.destination.columns,
       }),
       description: rel.description,
       type: 'FOREIGN_KEY',

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -279,27 +279,35 @@ function relationshipLink(
 // because the join is author-declared, and `userManaged` stops Dataplex from
 // overwriting it. Field names/nesting mirror the schema-join aspect type's
 // metadataTemplate.
+//
+// A purely logical edge (an OWL import) carries no join columns; each endpoint
+// then omits `fields` and names the entity, so the aspect records the join's
+// direction and endpoints without a column binding. (schema-join is a server
+// CLOSED metadataTemplate; if it REQUIRES `fields`, skip the link for a
+// column-less edge with a warning instead -- see the PR's open item.)
 function schemaJoinAspectData(
     model: SemanticModel, rel: Relationship): Record<string, any> {
   const srcEntity = entityByName(model, rel.source.entity);
   const dstEntity = entityByName(model, rel.destination.entity);
   return {
     joins: [compact({
-      source: {
+      source: compact({
         // Name each side by its SQL table (dataSource); fall back to the entity
         // name when the model is logical-only (no binding, so dataSource is
-        // empty), matching the entity-not-found fallback.
+        // empty), matching the entity-not-found fallback. `fields` is omitted
+        // for a column-less (logical) edge rather than emitted empty.
         name: srcEntity && srcEntity.dataSource ?
             srcEntity.dataSource :
             rel.source.entity,
-        fields: rel.source.columns,
-      },
-      target: {
+        fields: rel.source.columns.length ? rel.source.columns : undefined,
+      }),
+      target: compact({
         name: dstEntity && dstEntity.dataSource ?
             dstEntity.dataSource :
             rel.destination.entity,
-        fields: rel.destination.columns,
-      },
+        fields: rel.destination.columns.length ? rel.destination.columns :
+                                                 undefined,
+      }),
       description: rel.description,
       type: 'FOREIGN_KEY',
       inferenceSource: 'USER',

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -141,11 +141,26 @@ const relationshipSchema = z.object({
   name: z.string(),
   from: z.string(),
   to: z.string(),
-  from_columns: z.array(z.string()).min(1),
-  to_columns: z.array(z.string()).min(1),
+  // Join columns are the physical binding of the edge and are OPTIONAL, so a
+  // purely logical relationship (an ontology edge, direction only) loads. When
+  // present they must be non-empty; either both endpoints are bound or neither
+  // is (a half-bound edge is a malformed join, caught below). A graph push still
+  // requires both (see validatePushRequirements).
+  from_columns: z.array(z.string()).min(1).optional(),
+  to_columns: z.array(z.string()).min(1).optional(),
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
+}).superRefine((r, ctx) => {
+  if ((r.from_columns === undefined) !== (r.to_columns === undefined)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        `relationship '${r.name}': from_columns and to_columns must be given ` +
+        `together (both bind the edge) or both omitted (a logical edge); one ` +
+        `without the other is a half-bound join.`,
+    });
+  }
 });
 
 const metricSchema = z.object({
@@ -527,6 +542,8 @@ function convertField(f: FieldDoc, entityName: string, warnings: string[], diale
 // Maps an OSI foreign-key relationship onto the IR edge. `source.columns` are the
 // FK columns on the `from` table (`from_columns`); `destination.columns` are the
 // referenced key columns on the `to` table (`to_columns`), paired positionally.
+// A logical relationship carries no columns (both endpoints empty); a graph
+// push requires them and rejects a column-less edge (see validatePushRequirements).
 // The source entity's own primary key is not duplicated here -- downstream
 // consumers look it up from the entity. A malformed relationship (an endpoint not
 // declared in the model, or mismatched column arity) is a hard error, not a
@@ -539,16 +556,18 @@ function convertRelationship(r: RelationshipDoc, entityNames: Set<string>): Rela
   if (!entityNames.has(r.to)) {
     throw new Error(`${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
   }
-  if (r.from_columns.length !== r.to_columns.length) {
+  const fromColumns = r.from_columns ?? [];
+  const toColumns = r.to_columns ?? [];
+  if (fromColumns.length !== toColumns.length) {
     throw new Error(
-      `${ctx}: from_columns (${r.from_columns.length}) and to_columns ` +
-      `(${r.to_columns.length}) have different lengths; the join keys are mismatched`);
+      `${ctx}: from_columns (${fromColumns.length}) and to_columns ` +
+      `(${toColumns.length}) have different lengths; the join keys are mismatched`);
   }
 
   const relationship: Relationship = {
     name: r.name,
-    source: { entity: r.from, columns: r.from_columns },
-    destination: { entity: r.to, columns: r.to_columns },
+    source: { entity: r.from, columns: fromColumns },
+    destination: { entity: r.to, columns: toColumns },
   };
   const description = composeDescription(r.description);
   if (description) relationship.description = description;

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -74,10 +74,19 @@ export interface SerializeResult {
  *
  * Warnings flag IR content that has no loadable representation (an association
  * relationship's junction detail), so the caller can surface the lossy edge.
+ *
+ * `logical` marks the model as a purely logical one (no physical binding), so
+ * the missing-source and missing-expression warnings -- which flag a lossy pull
+ * of a bound model -- are suppressed. An OWL import sets it; `pull` does not.
  */
-export function serializeModel(model: SemanticModel): SerializeResult {
+export interface SerializeOptions {
+  logical?: boolean;
+}
+
+export function serializeModel(
+    model: SemanticModel, opts: SerializeOptions = {}): SerializeResult {
   const warnings: string[] = [];
-  const text = yaml.stringify(modelDocument(model, warnings));
+  const text = yaml.stringify(modelDocument(model, warnings, opts.logical));
   return {yaml: text, warnings: [...new Set(warnings)]};
 }
 
@@ -85,23 +94,26 @@ export function serializeModel(model: SemanticModel): SerializeResult {
 // renders. Kept separate so tests can assert the structure without parsing
 // YAML.
 export function modelDocument(
-    model: SemanticModel, warnings: string[] = []): Record<string, any> {
+    model: SemanticModel, warnings: string[] = [],
+    logical = false): Record<string, any> {
   return {
     version: SERIALIZED_VERSION,
-    semantic_model: [modelDoc(model, warnings)],
+    semantic_model: [modelDoc(model, warnings, logical)],
   };
 }
 
-function modelDoc(
-    model: SemanticModel, warnings: string[]): Record<string, any> {
+function modelDoc(model: SemanticModel, warnings: string[], logical: boolean):
+    Record<string, any> {
   // `datasets` is required (min 1) by the loader. A reconstructed model with no
   // entities (e.g. every entity fetch failed during a pull) would serialize to
   // a document the loader rejects; emit the (empty) array but flag it so the
   // lossy edge is visible rather than surfacing later as an opaque load error.
-  const datasets = (model.entities ?? []).map(e => datasetDoc(e, warnings));
+  const datasets =
+      (model.entities ?? []).map(e => datasetDoc(e, warnings, logical));
   if (!datasets.length) {
     warnings.push(
-        `model '${model.name}': no datasets (entities); the document requires ` +
+        `model '${
+            model.name}': no datasets (entities); the document requires ` +
         `at least one and will not load until an entity is present.`);
   }
   return compact({
@@ -117,21 +129,23 @@ function modelDoc(
 }
 
 function datasetDoc(
-    entity: Entity, warnings: string[]): Record<string, any> {
+    entity: Entity, warnings: string[], logical: boolean): Record<string, any> {
   // A concrete (non-abstract) entity with no source cannot be reloaded -- the
   // loader requires `source` unless the dataset is abstract -- so surface the
   // gap at write time instead of emitting a document that fails to load. This
   // never fires for a well-formed IR; it catches a lossy pull that dropped a
-  // binding without marking the entity abstract.
-  if (!entity.abstract && !entity.dataSource) {
+  // binding without marking the entity abstract. Suppressed for a logical
+  // model, where a missing source is intended (a binding profile supplies it
+  // later).
+  if (!logical && !entity.abstract && !entity.dataSource) {
     warnings.push(
         `entity '${entity.name}' has no source and is not abstract; the ` +
         `serialized document will not reload until a source is set`);
   }
   return compact({
     name: entity.name,
-    // An abstract entity has no physical table, so its source is empty; omit the
-    // key rather than emit `source: ""` (which the loader reads as a
+    // An abstract entity has no physical table, so its source is empty; omit
+    // the key rather than emit `source: ""` (which the loader reads as a
     // concrete-but-empty reference).
     source: entity.dataSource || undefined,
     // Supertype entities (entity-level inheritance); omitted when none.
@@ -142,15 +156,20 @@ function datasetDoc(
     unique_keys: nonEmpty(entity.uniqueKeys),
     description: entity.description,
     ai_context: aiContextDoc(entity.aiContext),
-    fields: nonEmpty((entity.fields ?? []).map(f => fieldDoc(f, warnings))),
+    fields: nonEmpty(
+        (entity.fields ?? []).map(f => fieldDoc(f, warnings, logical))),
     custom_extensions: customExtensionsDoc(entity.customExtensions),
   });
 }
 
-function fieldDoc(field: Field, warnings: string[]): Record<string, any> {
+function fieldDoc(
+    field: Field, warnings: string[], logical: boolean): Record<string, any> {
   const expression = expressionDoc(
       field.expression, field.importedExpression, field.importedDialect);
-  if (!expression) {
+  // A logical field intentionally has no expression (a binding profile maps it
+  // to a column later), so the missing-expression warning is suppressed there;
+  // for a bound model it still flags a lossy pull.
+  if (!logical && !expression) {
     warnings.push(
         `field '${field.name}': no expression; the loader requires one per ` +
         `field and the document will not load until it is set.`);

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -95,12 +95,17 @@ export function validatePushRequirements(
     // target (both arrays empty), so this is skipped.
     if (deployInfo.bigQuery.length + deployInfo.spanner.length > 0) {
       for (const rel of model.relationships ?? []) {
+        // An M:N edge binds through its junction table (association), so its
+        // direct source/destination columns are empty by design -- bigquery.ts
+        // renders it from `rel.association`. Only a plain FK edge needs direct
+        // join columns.
+        if (rel.association) continue;
         if (!rel.source.columns.length || !rel.destination.columns.length) {
           errors.push(
               `relationship '${rel.name}' in model '${model.name}' (${
-                  document}) targets a graph but has no join columns; bind its ` +
-              `source and destination columns (via a binding profile) before a ` +
-              `BigQuery or Spanner Graph deploy.`);
+                  document}) targets a graph but has no join columns; add its ` +
+              `from_columns and to_columns to the relationship in the model ` +
+              `before a BigQuery or Spanner Graph deploy.`);
         }
       }
     }

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -43,9 +43,10 @@ export function validatePushRequirements(
     // BigQuery Graph OR Spanner Graph URI (we do not support zero or several
     // graphs per model). The target's host selects which deploy leg runs.
     //
-    // A KC-only push (targetOptional) deploys no graph, so its deployment target
-    // is irrelevant: skip the check entirely. Such a push may carry no target (a
-    // logical model), one, or even both backends (whose KC aspect records both)
+    // A KC-only push (targetOptional) deploys no graph, so its deployment
+    // target is irrelevant: skip the check entirely. Such a push may carry no
+    // target (a logical model), one, or even both backends (whose KC aspect
+    // records both)
     // -- none of that affects the Knowledge Catalog write.
     if (!opts.targetOptional) {
       if (deployInfo.uris.length !== 1) {
@@ -81,6 +82,25 @@ export function validatePushRequirements(
                   document}) targets a BigQuery graph but does not resolve to a ` +
               `single entity; set its attach entity or scope its expression to ` +
               `one entity.`);
+        }
+      }
+    }
+
+    // A model that targets a graph (BigQuery OR Spanner) must have every
+    // relationship's join columns bound. The loader accepts a column-less
+    // relationship so a purely logical model (an OWL import) loads and pushes
+    // to Knowledge Catalog, but a graph deploy would emit an invalid
+    // `DESTINATION KEY () REFERENCES Dest ()` for such an edge -- so reject it
+    // here rather than generate broken DDL. A KC-only push declares no graph
+    // target (both arrays empty), so this is skipped.
+    if (deployInfo.bigQuery.length + deployInfo.spanner.length > 0) {
+      for (const rel of model.relationships ?? []) {
+        if (!rel.source.columns.length || !rel.destination.columns.length) {
+          errors.push(
+              `relationship '${rel.name}' in model '${model.name}' (${
+                  document}) targets a graph but has no join columns; bind its ` +
+              `source and destination columns (via a binding profile) before a ` +
+              `BigQuery or Spanner Graph deploy.`);
         }
       }
     }

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -873,8 +873,9 @@ const OWL_EXTENSIONS = /\.owl\.ttl$|\.ttl$|\.owl$/i;
 // Turtle OWL ontology into an OSI model document that then rides the normal
 // `kcmd push` / `kcmd pull`. The converted model is purely LOGICAL (see the OWL
 // converter): `kcmd push --target kc` publishes it as-is; a BigQuery or Spanner
-// Graph deploy needs a binding profile (sources, field and join columns) and a
-// deployment target added on top. Returns a process exit code.
+// Graph deploy needs each relationship's join columns added to the model (a
+// logical fact the model owns) plus a binding profile (sources, field columns)
+// and a deployment target. Returns a process exit code.
 export async function owl(
     action: string, file: string, options: OwlImportOptions): Promise<number> {
   if (action !== 'import') {
@@ -953,8 +954,9 @@ export async function owl(
   console.log(
       `note: this is a LOGICAL model (no physical binding).\n` +
       `      \`kcmd push --target kc\` publishes it to Knowledge Catalog as-is.\n` +
-      `      A BigQuery or Spanner Graph deploy needs a binding profile (sources,\n` +
-      `      field and join columns) and a deployment target added on top.`);
+      `      A BigQuery or Spanner Graph deploy needs each relationship's join\n` +
+      `      columns added to the model, plus a binding profile (sources, field\n` +
+      `      columns) and a deployment target.`);
   return 0;
 }
 

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -871,10 +871,10 @@ const OWL_EXTENSIONS = /\.owl\.ttl$|\.ttl$|\.owl$/i;
 
 // Handles `kcmd owl <action> <file>`. The only action is `import`: convert a
 // Turtle OWL ontology into an OSI model document that then rides the normal
-// `kcmd push` / `kcmd pull`. The converted model is UNBOUND (see the OWL
-// converter): its sources / join columns must be bound and a BigQuery
-// deployment target added before `kcmd push` will deploy it (to either
-// destination). Returns a process exit code.
+// `kcmd push` / `kcmd pull`. The converted model is purely LOGICAL (see the OWL
+// converter): `kcmd push --target kc` publishes it as-is; a BigQuery or Spanner
+// Graph deploy needs a binding profile (sources, field and join columns) and a
+// deployment target added on top. Returns a process exit code.
 export async function owl(
     action: string, file: string, options: OwlImportOptions): Promise<number> {
   if (action !== 'import') {
@@ -951,9 +951,10 @@ export async function owl(
 
   console.log(`wrote ${writtenPath}`);
   console.log(
-      `note: this model is UNBOUND (placeholder \`unbound:\` sources, no deployment target).\n` +
-      `      \`kcmd push\` is rejected until you bind each entity's source table and add\n` +
-      `      a BigQuery deployment target -- validation needs both, for every --target.`);
+      `note: this is a LOGICAL model (no physical binding).\n` +
+      `      \`kcmd push --target kc\` publishes it to Knowledge Catalog as-is.\n` +
+      `      A BigQuery or Spanner Graph deploy needs a binding profile (sources,\n` +
+      `      field and join columns) and a deployment target added on top.`);
   return 0;
 }
 

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
@@ -29,28 +29,15 @@ semantic_model:
           }
     datasets:
       - name: Person
-        source: unbound:Person
         primary_key:
           - personId
         description: A human being.
         fields:
           - name: personId
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: personId
             datatype: String
           - name: name
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: name
             datatype: String
           - name: legalName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: legalName
             datatype: String
             custom_extensions:
               - vendor_name: GOOGLE
@@ -87,10 +74,8 @@ semantic_model:
                 ]
               }
       - name: Robot
-        source: unbound:Robot
         description: A machine, never a person.
       - name: LifeStage
-        source: unbound:LifeStage
         custom_extensions:
           - vendor_name: GOOGLE
             data: |-
@@ -104,10 +89,6 @@ semantic_model:
       - name: ancestorOf
         from: Person
         to: Person
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - personId
         custom_extensions:
           - vendor_name: GOOGLE
             data: |-
@@ -129,10 +110,6 @@ semantic_model:
       - name: relatedTo
         from: Person
         to: Person
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - personId
         custom_extensions:
           - vendor_name: GOOGLE
             data: |-
@@ -146,10 +123,6 @@ semantic_model:
       - name: uncleOf
         from: Person
         to: Person
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - personId
         custom_extensions:
           - vendor_name: GOOGLE
             data: |-

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
@@ -10,30 +10,16 @@ semantic_model:
           }
     datasets:
       - name: Person
-        source: unbound:Person
         description: A human being.
         fields:
           - name: fullName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: fullName
             datatype: String
       - name: Employee
-        source: unbound:Employee
         description: A person employed by the organization.
         fields:
           - name: employeeId
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: employeeId
             datatype: String
           - name: legalName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: legalName
             datatype: String
             custom_extensions:
               - vendor_name: GOOGLE
@@ -44,19 +30,13 @@ semantic_model:
                     ]
                   }
       - name: Customer
-        source: unbound:Customer
         extends:
           - Person
         description: A person who buys.
         fields:
           - name: loyaltyTier
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: loyaltyTier
             datatype: String
       - name: Manager
-        source: unbound:Manager
         extends:
           - Person
           - Employee
@@ -65,10 +45,6 @@ semantic_model:
       - name: managedBy
         from: Employee
         to: Manager
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - TODO_BIND
         custom_extensions:
           - vendor_name: GOOGLE
             data: |-
@@ -80,7 +56,3 @@ semantic_model:
       - name: worksWith
         from: Employee
         to: Employee
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - TODO_BIND

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.osi.golden.yaml
@@ -5,7 +5,6 @@ semantic_model:
       projects they staff."
     datasets:
       - name: Employee
-        source: unbound:Employee
         primary_key:
           - employeeId
         description: A person employed by the organization.
@@ -15,69 +14,32 @@ semantic_model:
             - Worker
         fields:
           - name: employeeId
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: employeeId
             datatype: String
             description: The employee's unique staff number.
           - name: fullName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: fullName
             datatype: String
             label: name
           - name: hireDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: hireDate
             datatype: Date
             dimension:
               is_time: true
           - name: salary
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: salary
             datatype: Decimal
           - name: fteRatio
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: fteRatio
             datatype: Float
           - name: level
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: level
             datatype: Integer
           - name: isManager
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: isManager
             datatype: Boolean
           - name: lastLogin
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: lastLogin
             datatype: DateTime
             dimension:
               is_time: true
           - name: startDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: startDate
             datatype: Date
             dimension:
               is_time: true
       - name: Department
-        source: unbound:Department
         primary_key:
           - deptCode
         description: A functional unit that employees belong to.
@@ -86,58 +48,29 @@ semantic_model:
             - Org unit
         fields:
           - name: deptCode
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: deptCode
             datatype: String
           - name: budget
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: budget
             datatype: Decimal
       - name: Project
-        source: unbound:Project
         primary_key:
           - portfolio
           - projectNo
         description: A body of work staffed by employees.
         fields:
           - name: portfolio
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: portfolio
             datatype: String
           - name: projectNo
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: projectNo
             datatype: Integer
           - name: startDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: startDate
             datatype: Date
             dimension:
               is_time: true
           - name: notes
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: notes
             datatype: Opaque
     relationships:
       - name: worksIn
         from: Employee
         to: Department
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - deptCode
         ai_context:
           instructions: The department an employee belongs to.
           synonyms:
@@ -145,18 +78,8 @@ semantic_model:
       - name: reportsTo
         from: Employee
         to: Employee
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - employeeId
         ai_context:
           instructions: The manager an employee reports to.
       - name: worksOn
         from: Employee
         to: Project
-        from_columns:
-          - TODO_BIND
-          - TODO_BIND
-        to_columns:
-          - portfolio
-          - projectNo

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales-advanced.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales-advanced.osi.golden.yaml
@@ -14,14 +14,9 @@ semantic_model:
           }
     datasets:
       - name: Person
-        source: unbound:Person
         description: A human being.
         fields:
           - name: fullName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: fullName
             datatype: String
         custom_extensions:
           - vendor_name: GOOGLE
@@ -32,7 +27,6 @@ semantic_model:
                 ]
               }
       - name: Customer
-        source: unbound:Customer
         extends:
           - Person
         primary_key:
@@ -45,16 +39,8 @@ semantic_model:
             - Buyer
         fields:
           - name: customerId
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: customerId
             datatype: String
           - name: email
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: email
             datatype: String
             description: The customer's unique email address.
             custom_extensions:
@@ -64,10 +50,6 @@ semantic_model:
                     "owl:FunctionalProperty": true
                   }
           - name: customerName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: customerName
             datatype: String
             label: name
             custom_extensions:
@@ -82,43 +64,22 @@ semantic_model:
                     ]
                   }
           - name: signupDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: signupDate
             datatype: Date
             dimension:
               is_time: true
           - name: isVip
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: isVip
             datatype: Boolean
             description: Whether the customer is in the loyalty program.
       - name: Order
-        source: unbound:Order
         primary_key:
           - orderId
         description: A purchase placed by a customer.
         fields:
           - name: orderId
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: orderId
             datatype: String
           - name: orderAmount
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: orderAmount
             datatype: Decimal
           - name: orderDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: orderDate
             datatype: Date
             dimension:
               is_time: true
@@ -126,10 +87,6 @@ semantic_model:
       - name: placedBy
         from: Order
         to: Customer
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - customerId
         ai_context:
           instructions: Links an order to the customer who placed it.
         custom_extensions:
@@ -141,10 +98,6 @@ semantic_model:
       - name: referredBy
         from: Customer
         to: Customer
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - customerId
         ai_context:
           instructions: The customer who referred this one.
         custom_extensions:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.osi.golden.yaml
@@ -10,7 +10,6 @@ semantic_model:
         - How many orders did each customer place last month?
     datasets:
       - name: Customer
-        source: unbound:Customer
         primary_key:
           - customerId
         unique_keys:
@@ -21,72 +20,35 @@ semantic_model:
             - Buyer
         fields:
           - name: customerId
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: customerId
             datatype: String
           - name: email
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: email
             datatype: String
             description: The customer's unique email address.
           - name: customerName
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: customerName
             datatype: String
             label: name
           - name: signupDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: signupDate
             datatype: Date
             dimension:
               is_time: true
           - name: isVip
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: isVip
             datatype: Boolean
             description: Whether the customer is in the loyalty program.
       - name: Order
-        source: unbound:Order
         primary_key:
           - orderId
         description: A purchase placed by a customer.
         fields:
           - name: orderId
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: orderId
             datatype: String
           - name: orderAmount
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: orderAmount
             datatype: Decimal
             ai_context:
               examples:
                 - "19.99"
           - name: quantity
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: quantity
             datatype: Integer
           - name: orderDate
-            expression:
-              dialects:
-                - dialect: BIGQUERY
-                  expression: orderDate
             datatype: Date
             dimension:
               is_time: true
@@ -94,9 +56,5 @@ semantic_model:
       - name: placedBy
         from: Order
         to: Customer
-        from_columns:
-          - TODO_BIND
-        to_columns:
-          - customerId
         ai_context:
           instructions: Links an order to the customer who placed it.

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.test.ts
@@ -587,6 +587,23 @@ describe('relationships map to schema-join entry links', () => {
         .toBe(true);
   });
 
+  test('a column-less (purely logical) edge is skipped and warned, no link',
+       () => {
+         // An OWL import leaves an edge with no join columns. schema-join is a
+         // server CLOSED template, so rather than risk a rejected column-less
+         // aspect the emitter skips the link (the edge publishes once join
+         // columns are added to the model).
+         const model = directFkModel();
+         model.relationships[0].source.columns = [];
+         model.relationships[0].destination.columns = [];
+         const {entryLinks, warnings} = generateCatalogResources(model, OPTS);
+         expect(entryLinks.length).toBe(0);
+         expect(warnings.some(
+                    w => w.includes('orders-to-customer') &&
+                        w.includes('no join columns')))
+             .toBe(true);
+       });
+
   test(
       'a relationship name that is not link-id-clean warns it will normalize',
       () => {

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -89,9 +89,10 @@ function onlyExtendsExtension(errors: typeof validate.errors): boolean {
 // The OWL import goldens (.osi.golden.yaml) are purely LOGICAL models -- a
 // deliberate pre-OSI superset, the same shape the profiles/ subtree is exempted
 // for: an ontology has no physical tables, so they omit every binding facet the
-// released schema requires (dataset `source`, field `expression`, relationship
-// `from_columns`/`to_columns`; a binding profile supplies them later) and also
-// carry the `extends`/`abstract` dataset supersets. Tolerate EXACTLY those
+// released schema requires (dataset `source` and field `expression`, supplied
+// by a binding profile later; relationship `from_columns`/`to_columns`, added
+// to the model later) and also carry the `extends`/`abstract` dataset
+// supersets. Tolerate EXACTLY those
 // omissions and extra properties on these goldens and nothing else, so real
 // drift (a bad enum, a misspelled key, an unexpected shape) still fails.
 function onlyLogicalGoldenDeviations(errors: typeof validate.errors): boolean {

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -86,6 +86,34 @@ function onlyExtendsExtension(errors: typeof validate.errors): boolean {
         /\/datasets\/\d+$/.test(e.instancePath));
 }
 
+// The OWL import goldens (.osi.golden.yaml) are purely LOGICAL models -- a
+// deliberate pre-OSI superset, the same shape the profiles/ subtree is exempted
+// for: an ontology has no physical tables, so they omit every binding facet the
+// released schema requires (dataset `source`, field `expression`, relationship
+// `from_columns`/`to_columns`; a binding profile supplies them later) and also
+// carry the `extends`/`abstract` dataset supersets. Tolerate EXACTLY those
+// omissions and extra properties on these goldens and nothing else, so real
+// drift (a bad enum, a misspelled key, an unexpected shape) still fails.
+function onlyLogicalGoldenDeviations(errors: typeof validate.errors): boolean {
+  const missingOk = new Set(
+    ['source', 'expression', 'from_columns', 'to_columns']);
+  const extraOk = new Set(['extends', 'abstract']);
+  return !!errors && errors.length > 0 &&
+    errors.every(e => {
+      if (e.keyword === 'required') {
+        return missingOk.has(
+          (e.params as {missingProperty?: string}).missingProperty ?? '');
+      }
+      if (e.keyword === 'additionalProperties') {
+        return extraOk.has(
+          (e.params as {additionalProperty?: string}).additionalProperty ??
+          '') &&
+          /\/datasets\/\d+$/.test(e.instancePath);
+      }
+      return false;
+    });
+}
+
 describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () => {
   test('at least one fixture is discovered', () => {
     expect(fixtures.length).toBeGreaterThan(0);
@@ -104,14 +132,17 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
             onlyMissingExpression(validate.errors)) {
           return;
         }
-        // A dataset `extends`/`abstract` is a deliberate superset of released
-        // OSI (OWL rdfs:subClassOf -> entity-level inheritance, plus the
-        // abstract marker); tolerate exactly those extra properties and nothing
-        // else, and only on the OWL import goldens (.osi.golden.yaml) and the
-        // hand-authored hierarchy fixture that legitimately carry them -- so a
-        // stray `extends` slipping into any other fixture still fails.
-        if ((rel.endsWith('.osi.golden.yaml') ||
-             rel === 'hierarchy_graph.yaml') &&
+        // The OWL import goldens are purely logical models (a pre-OSI superset,
+        // like profiles/): they omit source/expression/join-columns and carry
+        // the extends/abstract supersets. Tolerate exactly those deviations on
+        // them, so any other drift still fails.
+        if (rel.endsWith('.osi.golden.yaml') &&
+            onlyLogicalGoldenDeviations(validate.errors)) {
+          return;
+        }
+        // The hand-authored bound graph fixture carries only the
+        // extends/abstract superset (its sources/expressions are present).
+        if (rel === 'hierarchy_graph.yaml' &&
             onlyExtendsExtension(validate.errors)) {
           return;
         }

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -16,6 +16,7 @@
 import {describe, expect, test} from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as yaml from 'yaml';
 
 import {convertOwlToOsi} from '../../../src/libts/semantic/converters/owl/convert';
 import {googleOntologyExtension} from '../../../src/libts/semantic/converters/owl/to_ir';
@@ -103,8 +104,8 @@ describe('sales ontology matches the user-guide CUJ', () => {
     expect(customer.keys).toEqual(['customerId']);
     expect(customer.uniqueKeys).toEqual([['email']]);
 
-    // The edge is logical: direction only, no join columns (a binding profile
-    // supplies them before a graph deploy).
+    // The edge is logical: direction only, no join columns (added to the model
+    // before a graph deploy).
     const placedBy = model.relationships.find(r => r.name === 'placedBy')!;
     expect(placedBy.source.entity).toBe('Order');
     expect(placedBy.destination.entity).toBe('Customer');
@@ -119,14 +120,26 @@ describe('the OWL import is a purely logical model', () => {
 
   // The emitted document carries no physical binding at all: no dataset
   // `source`, no field `expression`, and no relationship `from_columns` /
-  // `to_columns`. These are the facets a binding profile supplies later; an
-  // ontology has none.
-  test('the emitted YAML has no source, expression, or join columns', () => {
-    const {yaml} = convertOwlToOsi(ttl, 'sales');
-    expect(yaml).not.toContain('source:');
-    expect(yaml).not.toContain('expression:');
-    expect(yaml).not.toContain('from_columns:');
-    expect(yaml).not.toContain('to_columns:');
+  // `to_columns`. Asserted structurally on the parsed document (not a substring
+  // scan, which would false-positive on those words inside a description) so the
+  // guarantee holds regardless of formatting. Sources and expressions come from
+  // a binding profile later; join columns are added to the model; an ontology
+  // has none of the three.
+  test('the emitted document has no source, expression, or join columns', () => {
+    const {yaml: text} = convertOwlToOsi(ttl, 'sales');
+    const doc = yaml.parse(text);
+    for (const model of doc.semantic_model ?? []) {
+      for (const ds of model.datasets ?? []) {
+        expect(ds).not.toHaveProperty('source');
+        for (const f of ds.fields ?? []) {
+          expect(f).not.toHaveProperty('expression');
+        }
+      }
+      for (const rel of model.relationships ?? []) {
+        expect(rel).not.toHaveProperty('from_columns');
+        expect(rel).not.toHaveProperty('to_columns');
+      }
+    }
   });
 
   // The counterpart to the "loads under bindingOptional" test: the STRICT

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -5,10 +5,11 @@
 // that then rides the normal kcmd push/pull. The guarantees pinned here mirror
 // the user-guide section "Importing an OWL ontology":
 //   1. the sales example produces exactly the documented OSI (golden), and
-//   2. that OSI loads through the OSI loader (the UNBOUND placeholders satisfy
-//      the schema, so the document is well-formed -- loadable, but not yet
-//      pushable: `kcmd push` rejects an unbound model, for every --target,
-//      until its sources are bound and a deployment target is set), and
+//   2. that OSI loads as a purely LOGICAL model (no sources, no field
+//      expressions, no relationship join columns): it loads under
+//      bindingOptional and `kcmd push --target kc` publishes it as-is, while
+//      the strict loader (a graph push) rejects it until a binding profile adds
+//      sources/columns and a deployment target, and
 //   3. each mapped construct behaves as documented.
 // The scope is exactly the user guide; richer OWL is out of scope by design.
 
@@ -27,10 +28,17 @@ function readFixture(name: string): string {
   return fs.readFileSync(path.join(FIXTURES, name), 'utf8');
 }
 
+// Loads an OSI document as the logical model an OWL import produces: no sources
+// or field expressions, so bindingOptional is required (the strict loader would
+// reject it -- pinned by 'the OWL import is a purely logical model' below).
+function load(yaml: string) {
+  return loadModels(yaml, {bindingOptional: true});
+}
+
 // Converts an inline ontology and loads the result, the common path for the
 // focused rule tests below.
 function loadOwl(ttl: string) {
-  return loadModels(convertOwlToOsi(ttl, 'x').yaml).models[0];
+  return load(convertOwlToOsi(ttl, 'x').yaml).models[0];
 }
 
 // The carried OWL facts on an IR object: the parsed payload of its single
@@ -73,10 +81,10 @@ describe('sales ontology matches the user-guide CUJ', () => {
 
   test('the generated OSI loads and carries the guide highlights', () => {
     const {yaml} = convertOwlToOsi(ttl, 'sales');
-    // loadModels throws on a schema violation; a clean return proves the model
-    // is schema-valid and loadable -- not that it is pushable, since an unbound
-    // model still fails push validation until its sources are bound.
-    const model = loadModels(yaml).models[0];
+    // load() throws on a schema violation; a clean return proves the logical
+    // model is schema-valid and loadable (under bindingOptional). It is not yet
+    // graph-pushable -- a binding profile must add sources/columns first.
+    const model = load(yaml).models[0];
     expect(model.name).toBe('sales');
     expect(model.entities.map(e => e.name)).toEqual(['Customer', 'Order']);
 
@@ -95,11 +103,39 @@ describe('sales ontology matches the user-guide CUJ', () => {
     expect(customer.keys).toEqual(['customerId']);
     expect(customer.uniqueKeys).toEqual([['email']]);
 
-    // The edge's destination binds to Customer's key; only the source FK stays
-    // a placeholder.
+    // The edge is logical: direction only, no join columns (a binding profile
+    // supplies them before a graph deploy).
     const placedBy = model.relationships.find(r => r.name === 'placedBy')!;
-    expect(placedBy.destination.columns).toEqual(['customerId']);
-    expect(placedBy.source.columns).toEqual(['TODO_BIND']);
+    expect(placedBy.source.entity).toBe('Order');
+    expect(placedBy.destination.entity).toBe('Customer');
+    expect(placedBy.destination.columns).toEqual([]);
+    expect(placedBy.source.columns).toEqual([]);
+  });
+});
+
+
+describe('the OWL import is a purely logical model', () => {
+  const ttl = readFixture('sales.owl.ttl');
+
+  // The emitted document carries no physical binding at all: no dataset
+  // `source`, no field `expression`, and no relationship `from_columns` /
+  // `to_columns`. These are the facets a binding profile supplies later; an
+  // ontology has none.
+  test('the emitted YAML has no source, expression, or join columns', () => {
+    const {yaml} = convertOwlToOsi(ttl, 'sales');
+    expect(yaml).not.toContain('source:');
+    expect(yaml).not.toContain('expression:');
+    expect(yaml).not.toContain('from_columns:');
+    expect(yaml).not.toContain('to_columns:');
+  });
+
+  // The counterpart to the "loads under bindingOptional" test: the STRICT
+  // loader (what a BigQuery/Spanner graph push uses) rejects the same document,
+  // because a graph cannot be generated without sources/expressions. This is
+  // what makes it a logical model rather than a half-bound one.
+  test('the strict loader rejects it (no bindings)', () => {
+    const {yaml} = convertOwlToOsi(ttl, 'sales');
+    expect(() => loadModels(yaml)).toThrow();
   });
 });
 
@@ -126,7 +162,7 @@ describe('sales-advanced is the user-guide unified advanced example', () => {
 
   test(
       'carries the guide highlights: extends, carriage, both ref forms', () => {
-        const model = loadModels(convertOwlToOsi(ttl, 'sales').yaml).models[0];
+        const model = load(convertOwlToOsi(ttl, 'sales').yaml).models[0];
         const byName = Object.fromEntries(model.entities.map(e => [e.name, e]));
 
         // Class hierarchy: Customer extends Person, own fields only (Person's
@@ -185,7 +221,7 @@ describe('org ontology exercises datatypes, keys, and binding', () => {
   });
 
   test('the generated OSI loads and covers the mapping', () => {
-    const model = loadModels(convertOwlToOsi(ttl, 'org').yaml).models[0];
+    const model = load(convertOwlToOsi(ttl, 'org').yaml).models[0];
     expect(model.entities.map(e => e.name)).toEqual([
       'Employee', 'Department', 'Project'
     ]);
@@ -232,20 +268,16 @@ describe('org ontology exercises datatypes, keys, and binding', () => {
     expect(isTimeDimension(employee.fields.find(f => f.name === 'salary')!))
         .toBe(false);
 
-    // Edges bind their destination columns to the destination's key: single,
-    // self-referential, and composite (two columns, two source placeholders).
+    // Edges are logical: direction only, no join columns -- including the
+    // self-referential reportsTo. A binding profile fills the columns later.
     const byName =
         Object.fromEntries(model.relationships.map(r => [r.name, r]));
-    expect(byName['worksIn'].destination.columns).toEqual(['deptCode']);
+    expect(byName['worksIn'].destination.columns).toEqual([]);
     expect(byName['reportsTo'].source.entity).toBe('Employee');
     expect(byName['reportsTo'].destination.entity).toBe('Employee');
-    expect(byName['reportsTo'].destination.columns).toEqual(['employeeId']);
-    expect(byName['worksOn'].destination.columns).toEqual([
-      'portfolio', 'projectNo'
-    ]);
-    expect(byName['worksOn'].source.columns).toEqual([
-      'TODO_BIND', 'TODO_BIND'
-    ]);
+    expect(byName['reportsTo'].destination.columns).toEqual([]);
+    expect(byName['worksOn'].source.columns).toEqual([]);
+    expect(byName['worksOn'].destination.columns).toEqual([]);
   });
 });
 
@@ -266,7 +298,7 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
         // throw or drop it; a clean reload with the parents present proves the
         // round trip.
         const {yaml} = convertOwlToOsi(ttl, 'hierarchy');
-        const model = loadModels(yaml).models[0];
+        const model = load(yaml).models[0];
         const byName = Object.fromEntries(model.entities.map(e => [e.name, e]));
         // Single-parent subclass.
         expect(byName['Customer'].extends).toEqual(['Person']);
@@ -282,7 +314,7 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
     // This cut only RECORDS the hierarchy; it does not resolve it. A subclass
     // keeps exactly its own fields -- Person's fullName does NOT appear on
     // Customer. Resolving inherited fields is a follow-on.
-    const model = loadModels(convertOwlToOsi(ttl, 'hierarchy').yaml).models[0];
+    const model = load(convertOwlToOsi(ttl, 'hierarchy').yaml).models[0];
     const customer = model.entities.find(e => e.name === 'Customer')!;
     expect(customer.fields.map(f => f.name)).toEqual(['loyaltyTier']);
     const manager = model.entities.find(e => e.name === 'Manager')!;
@@ -298,8 +330,7 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
         // warning, nothing lost.
         const {warnings} = convertOwlToOsi(ttl, 'hierarchy');
         expect(warnings).toEqual([]);
-        const model =
-            loadModels(convertOwlToOsi(ttl, 'hierarchy').yaml).models[0];
+        const model = load(convertOwlToOsi(ttl, 'hierarchy').yaml).models[0];
 
         // The field survives AND carries its superproperty as a fact.
         const employee = model.entities.find(e => e.name === 'Employee')!;
@@ -334,7 +365,7 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
         .toBe(true);
     // Still recorded as declared -- the warning does not drop the link.
     const customer =
-        loadModels(yaml).models[0].entities.find(e => e.name === 'Customer')!;
+        load(yaml).models[0].entities.find(e => e.name === 'Customer')!;
     expect(customer.extends).toEqual(['Persn']);
   });
 
@@ -353,7 +384,7 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
         const {yaml, warnings} = convertOwlToOsi(ttl, 'top');
         expect(warnings).toEqual([]);
         const person =
-            loadModels(yaml).models[0].entities.find(e => e.name === 'Person')!;
+            load(yaml).models[0].entities.find(e => e.name === 'Person')!;
         expect(person.extends).toBeUndefined();
       });
 });
@@ -465,31 +496,37 @@ describe('keys and edge binding', () => {
     expect(person.uniqueKeys).toBeUndefined();
   });
 
-  // An edge into a class with a key binds its destination columns to that
-  // key; the source foreign-key columns stay placeholders (one per key
-  // column).
-  test('an edge binds its destination to the destination key', () => {
+  // An edge is a logical edge regardless of whether the destination declares a
+  // key: neither end carries join columns (a binding profile fills them before
+  // a graph deploy). The destination's own key is unaffected -- it is entity
+  // grain, not a binding -- so a keyed destination still exposes its
+  // primary_key.
+  test('an edge carries no join columns, keyed destination or not', () => {
     const ttl = `${PREFIXES}
       ex:Order a owl:Class .
       ex:Customer a owl:Class ; owl:hasKey ( ex:cid ) .
       ex:cid a owl:DatatypeProperty ; rdfs:domain ex:Customer ; rdfs:range xsd:string .
       ex:placedBy a owl:ObjectProperty ; rdfs:domain ex:Order ; rdfs:range ex:Customer .
     `;
-    const edge = loadOwl(ttl).relationships[0];
-    expect(edge.destination.columns).toEqual(['cid']);
-    expect(edge.source.columns).toEqual(['TODO_BIND']);
+    const model = loadOwl(ttl);
+    const edge = model.relationships[0];
+    expect(edge.source.columns).toEqual([]);
+    expect(edge.destination.columns).toEqual([]);
+    // The keyed destination keeps its grain (owl:hasKey -> primary_key).
+    const customer = model.entities.find(e => e.name === 'Customer')!;
+    expect(customer.keys).toEqual(['cid']);
   });
 
-  // Without a key on the destination, both ends stay fully unbound.
-  test('an edge into a keyless class is fully unbound', () => {
+  // A keyless destination is no different: the edge is still column-less.
+  test('an edge into a keyless class is also column-less', () => {
     const ttl = `${PREFIXES}
       ex:Order a owl:Class .
       ex:Customer a owl:Class .
       ex:placedBy a owl:ObjectProperty ; rdfs:domain ex:Order ; rdfs:range ex:Customer .
     `;
     const edge = loadOwl(ttl).relationships[0];
-    expect(edge.destination.columns).toEqual(['TODO_BIND']);
-    expect(edge.source.columns).toEqual(['TODO_BIND']);
+    expect(edge.destination.columns).toEqual([]);
+    expect(edge.source.columns).toEqual([]);
   });
 
   // A relationship maps ONE source to ONE destination. An object property with
@@ -754,7 +791,7 @@ describe('mapping table rules (labels, comments, skips)', () => {
     expect(warnings).toHaveLength(2);
     expect(warnings.some(w => w.includes('orphan'))).toBe(true);
     expect(warnings.some(w => w.includes('danglingEdge'))).toBe(true);
-    const model = loadModels(yaml).models[0];
+    const model = load(yaml).models[0];
     expect(model.entities[0].fields).toHaveLength(0);
     expect(model.relationships).toHaveLength(0);
   });
@@ -818,9 +855,7 @@ describe('mapping table rules (labels, comments, skips)', () => {
     const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
     expect(warnings.some(w => w.includes('stray') && w.includes('NotAClass')))
         .toBe(true);
-    expect(
-        loadModels(yaml).models[0].entities.find(
-                                               e => e.name === 'Thing')!.fields)
+    expect(load(yaml).models[0].entities.find(e => e.name === 'Thing')!.fields)
         .toHaveLength(0);
   });
 
@@ -841,7 +876,7 @@ describe('mapping table rules (labels, comments, skips)', () => {
     expect(warnings.some(
                w => w.includes('Customer') && w.includes('more than once')))
         .toBe(true);
-    const model = loadModels(yaml).models[0];
+    const model = load(yaml).models[0];
     expect(model.entities.map(e => e.name)).toEqual(['Customer']);
     expect(model.entities[0].description).toBe('from a');
   });
@@ -909,8 +944,8 @@ describe('OWL constructs carried as custom extensions', () => {
         expect(stats).toEqual(
             {classes: 3, datatypeProperties: 3, objectProperties: 3});
         // And the result stays schema-valid and loadable with the blocks
-        // attached (loadable, not yet pushable -- sources are still unbound).
-        expect(() => loadModels(yaml)).not.toThrow();
+        // attached (a logical model, loaded under bindingOptional).
+        expect(() => load(yaml)).not.toThrow();
       });
 
   test('owl:inverseOf on an object property -> relationship', () => {
@@ -935,7 +970,7 @@ describe('OWL constructs carried as custom extensions', () => {
     const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
     expect(warnings.some(w => w.includes('inverseOf') && w.includes('inv1')))
         .toBe(true);
-    const rel = loadModels(yaml).models[0].relationships[0];
+    const rel = load(yaml).models[0].relationships[0];
     expect(ontologyTerms(rel.customExtensions)).toEqual({
       'owl:inverseOf': 'inv1'
     });
@@ -951,7 +986,7 @@ describe('OWL constructs carried as custom extensions', () => {
           owl:inverseOf ex:inv ; owl:inverseOf ex:inv .`;
     const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
     expect(warnings.some(w => w.includes('inverseOf'))).toBe(false);
-    const rel = loadModels(yaml).models[0].relationships[0];
+    const rel = load(yaml).models[0].relationships[0];
     expect(ontologyTerms(rel.customExtensions)).toEqual({
       'owl:inverseOf': 'inv'
     });
@@ -1038,7 +1073,7 @@ describe('OWL constructs carried as custom extensions', () => {
       ex:Person a owl:Class ; owl:equivalentClass ex:Human .
       ex:Human a owl:Class .`;
     const yaml = convertOwlToOsi(ttl, 'x').yaml;
-    const reloaded = loadModels(yaml).models[0];
+    const reloaded = load(yaml).models[0];
     const person = reloaded.entities.find(e => e.name === 'Person')!;
     expect(ontologyTerms(person.customExtensions)).toEqual({
       'owl:equivalentClass': ['Human']


### PR DESCRIPTION
## What

`kcmd owl import` now produces a **purely logical** semantic model instead of a
hybrid one.

The converter used to emit physical-binding placeholders even though the repo
had already separated logical models from physical binding profiles and added a
logical-only Knowledge Catalog push:

- `source: unbound:<Name>` on every entity,
- `expression: <localName>` on every field,
- `TODO_BIND` (or the destination key) join columns on every relationship.

An ontology declares *meaning*, not physical tables, so the import is now:

- entities with **no `source`**,
- fields with **no `expression`**,
- relationships as **pure logical edges** (`from`/`to` only, no join columns).

`kcmd push --target kc` publishes it as-is. A BigQuery or Spanner Graph deploy
adds the sources, field columns, join columns, and deployment target through a
[binding profile](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/toolbox/mdcode/docs/semantic-model/profiles.md).

## Changes

| File | Change |
|---|---|
| `converters/owl/to_ir.ts` | Drop the unbound-source / expression / `TODO_BIND` synthesis; emit empty `dataSource`, no field expression, column-less edges. Keys (`owl:hasKey` → primary_key) stay — they are logical grain. |
| `loader.ts` | `from_columns`/`to_columns` optional; a `superRefine` requires both or neither (a half-bound edge is an error). |
| `osi_converter.ts` + `converters/owl/convert.ts` | A `{ logical }` serialize option suppresses the no-source / no-expression warnings; the OWL converter sets it, `pull` does not. |
| `validate.ts` | A graph-target push rejects a column-less edge (which would emit an invalid `DESTINATION KEY () REFERENCES ()` DDL). A KC-only push has no graph target, so it is unaffected. |
| `knowledge_catalog.ts` | A column-less edge yields an endpoint-only `schema-join` (omit empty `fields`). |
| `commands.ts` | The import note describes a logical model and the KC-publish / binding-profile path. |
| tests / fixtures / docs | Regenerate the 5 OWL goldens (pure deletions); update the OWL import tests (load under `bindingOptional`, add a logical-shape + strict-rejection test, consolidate the keyed/keyless edge tests); relax the OSI-schema guardrail to tolerate the logical-model omissions on OWL goldens; rewrite the binding sections of `owl-import.md` and `codelab.md`. |

## Testing

- `npm test` green (scenarios 21, layouts 2, semantic 579).
- `npx tsc --noEmit` clean.
- Built `kcmd` and ran `kcmd owl import sales.owl.ttl`: output has no `source:`,
  no field `expression:`, no relationship join columns, and prints the new
  logical note. The document loads under `bindingOptional` and the strict loader
  rejects it (proving it is logical).

## Open item

`schema-join` is a server-defined CLOSED metadataTemplate. This PR emits a
column-less edge as an **endpoint-only** join (omitting the empty `fields`). If
the live server *requires* `fields`, the fallback is to skip the schema-join
link for a column-less edge with a warning. This needs a live KC push of a
logical OWL model to confirm; it could not be exercised here (the `semantic-*`
entry-type gate blocks KC writes from a normal project). Flagged in a code
comment at the `schemaJoinAspectData` seam.
