### PR TITLE
docs(codelab): drop the owl import post-import note; keep §1 on the logical model

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -244,11 +244,6 @@ kcmd owl import /tmp/sales.ttl --out /tmp/sales_osi.yaml --compact
 ```
 converted 3 classes, 2 object properties, 7 datatype properties
 wrote /tmp/sales_osi.yaml
-note: this is a LOGICAL model (no physical binding).
-      `kcmd push` publishes it to Knowledge Catalog as-is.
-      A BigQuery or Spanner Graph deploy needs each relationship's join
-      columns added to the model, plus a binding profile (sources, field
-      columns) and a deployment target.
 ```
 
 Look at what it produced:
@@ -331,8 +326,7 @@ Preview the plan without writing anything:
 kcmd push --validate-only --print
 ```
 
-The model has no deployment target yet, so there is no graph to build — a bare
-`kcmd push` governs the logical model to Knowledge Catalog alone.
+A bare `kcmd push` governs the logical model in Knowledge Catalog.
 
 ```
 Validating semantic model for Knowledge Catalog...

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -1092,12 +1092,6 @@ export async function owl(
   }
 
   console.log(`wrote ${writtenPath}`);
-  console.log(
-      `note: this is a LOGICAL model (no physical binding).\n` +
-      `      \`kcmd push\` publishes it to Knowledge Catalog as-is.\n` +
-      `      A BigQuery or Spanner Graph deploy needs each relationship's join\n` +
-      `      columns added to the model, plus a binding profile (sources, field\n` +
-      `      columns) and a deployment target.`);
   return 0;
 }
 


### PR DESCRIPTION
`kcmd owl import` printed a multi-line `note:` (LOGICAL model, how to push, what a graph deploy needs). It forward-referenced the push/deploy commands introduced in later codelab steps and duplicated §1's own closing prose, which already explains the logical model, the missing join columns/metric, and that `kcmd push` publishes it to Knowledge Catalog as-is.

- Remove the note from the `owl` handler — it now prints only `converted…` / `wrote…`.
- Drop those lines from the codelab's shown output to match.
- Reword the plan-preview sentence to focus on the logical model — `A bare \`kcmd push\` governs the logical model in Knowledge Catalog.` — instead of leading with "no deployment target / no graph to build", which forward-referenced deploy machinery.

Follow-up to #376 (which merged before this fix landed on its branch), based on current `main`.

Verification: `tsc` clean; full suite 597 pass / 0 fail; no test pinned the note text.