### PR TITLE
docs(codelab): lay the RDF ontology diagram top-down (taller, not wide)

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -141,7 +141,7 @@ labeled arcs. Each property is its own node, pointing to the class it describes
 each resource's `rdf:type`:
 
 ```mermaid
-graph LR
+graph TD
     classDef cls fill:#dae8fc,stroke:#6c8ebf,color:#000;
     classDef dp fill:#d5e8d4,stroke:#82b366,color:#000;
     classDef op fill:#ffe6cc,stroke:#d79b00,color:#000;


### PR DESCRIPTION
Layout-only change to the OWL ontology RDF diagram: switch `graph LR` → `graph TD` so it renders taller and narrower instead of short and wide. No nodes or arcs change — the diff is a single line.