### PR TITLE
docs(mdcode): refresh OWL import guide for --compact and dropped note

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -132,16 +132,17 @@ literal types that become each field's `datatype`.
 $ kcmd owl import sales.owl.ttl
 converted 2 classes, 1 object property, 9 datatype properties
 wrote catalog/EntryGroups/<entryGroup>/sales.yaml
-note: this is a LOGICAL model (no physical binding).
-      `kcmd push` publishes it to Knowledge Catalog as-is.
-      A BigQuery or Spanner Graph deploy needs each relationship's join
-      columns added to the model, plus a binding profile (sources, field
-      columns) and a deployment target.
 ```
 
 The model name comes from the file (`sales.owl.ttl` → `sales`). By default the
 document is written into the semantic-model layout dir so the next `kcmd push`
-picks it up; pass `--out <path>` to write it elsewhere.
+picks it up; pass `--out <path>` to write it elsewhere. The output uses the
+block layout shown below; pass `--compact` for the compact flow layout
+(`primary_key: [id]`, inline `{ name, datatype }` field and relationship maps)
+instead. Either way it is a purely **logical** model — `kcmd push` publishes it
+to Knowledge Catalog as-is, while a BigQuery or Spanner Graph deploy needs each
+relationship's join columns added to the model plus a [binding
+profile](profiles.md) (see [§4](#4-going-from-ontology-to-a-running-graph-binding)).
 
 ## 3. The semantic model it produces — `sales.yaml`
 


### PR DESCRIPTION
The OWL import guide (`toolbox/mdcode/docs/semantic-model/owl-import.md`) drifted from the tool after two recent changes:

- **#379** removed the post-import `note: this is a LOGICAL model …` block from `kcmd owl import` output, but the guide's §2 console block still showed it.
- **#377** added the `--compact` flag, but the guide documented only `--out`.

This updates §2 to match: drops the stale `note:` lines from the shown output, documents `--compact` (compact flow layout) beside `--out`, and folds the logical-model framing the note carried into the surrounding prose (with a pointer to §4).

Verified the rest of the guide against the code: §3 YAML is byte-identical to `tests/.../fixtures/owl/sales.osi.golden.yaml`, and the datatype/keys/carriage tables still match the converter.