### PR TITLE
fix(mdcode): backtick reserved-word identifiers in generated graph DDL

### DIFF
--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -22,6 +22,7 @@
 import {AiContext, Association, Entity, Field, fieldBinding, isTimeDimension, Metric, Relationship, SemanticModel,} from './ir';
 import {resolveInheritance} from './resolve_inheritance';
 import {referencedEntityNames, stripQualifier} from './sql_expr_utils';
+import {quoteIfReserved} from './sql_identifiers';
 
 export interface GenerateOptions {
   project?: string;    // fills the project for the graph name + under-qualified
@@ -400,12 +401,13 @@ function placeMetric(
   lowering.taken.add(metric.name);
 
   const propName = exposeOperand(lowering, operandExpr, metric.name);
-  const aggregate = `${agg.fn}(${agg.distinct ? 'DISTINCT ' : ''}${propName})`;
+  const aggregate =
+      `${agg.fn}(${agg.distinct ? 'DISTINCT ' : ''}${quoteIfReserved(propName)})`;
 
   const opts = optionsClause(
       elementDescription(metric.description, metric.aiContext),
       metric.aiContext?.synonyms);
-  const measure = `MEASURE(${aggregate}) AS ${metric.name}`;
+  const measure = `MEASURE(${aggregate}) AS ${quoteIfReserved(metric.name)}`;
   const lines = metricsByEntity.get(entityName) ?? [];
   lines.push(opts ? `${measure} ${opts}` : measure);
   metricsByEntity.set(entityName, lines);
@@ -436,10 +438,10 @@ function exposeOperand(
   if (isSimpleIdentifier(operandExpr) && !lowering.taken.has(operandExpr)) {
     // A bare column not already declared: expose it under its own name.
     name = operandExpr;
-    lowering.derivedProperties.push(name);
+    lowering.derivedProperties.push(quoteIfReserved(name));
   } else {
     name = uniqueName(`${metricName}_input`, lowering.taken);
-    lowering.derivedProperties.push(`${operandExpr} AS ${name}`);
+    lowering.derivedProperties.push(`${quoteIfReserved(operandExpr)} AS ${name}`);
   }
   lowering.taken.add(name);
   lowering.operandToName.set(operandExpr, name);
@@ -647,7 +649,7 @@ function renderNodeTable(
   ];
 
   const lines = [
-    line(1, `${table} AS ${entity.name}`),
+    line(1, `${table} AS ${quoteIfReserved(entity.name)}`),
     line(2, `KEY(${physicalColumns(entity, entity.keys, warnings, `entity '${entity.name}'`).join(', ')})`),
   ];
   // Element-table description and synonyms attach to the node's DEFAULT LABEL
@@ -706,7 +708,7 @@ function renderNodeTable(
           `KEY); the '${ancestorName}' label is omitted from '${entity.name}'`);
       continue;
     }
-    lines.push(line(2, `LABEL ${ancestorName}`));
+    lines.push(line(2, `LABEL ${quoteIfReserved(ancestorName)}`));
     const signature =
         ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
     if (signature.length) lines.push(propertiesBlock(signature));
@@ -740,7 +742,9 @@ function renderFieldProperty(field: Field, entity: string): string {
 function renderFieldPropertyCore(field: Field, entity: string): string {
   const expr = fieldExpression(field);
   const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
-  return local === field.name ? field.name : `${local} AS ${field.name}`;
+  const alias = quoteIfReserved(field.name);
+  return local === field.name ? alias :
+                                `${quoteIfReserved(local)} AS ${alias}`;
 }
 
 
@@ -774,7 +778,7 @@ function physicalColumns(
           `to a non-column expression (${col}); a KEY/REFERENCES site requires ` +
           `a bare column, so BigQuery will reject the generated DDL`);
     }
-    return col;
+    return quoteIfReserved(col);
   });
 }
 
@@ -822,13 +826,16 @@ function renderEdgeTable(
       physicalColumns(destEntity, rel.destination.columns, warnings, relCtx)
           .join(', ');
   const lines = [
-    line(1, `${backing} AS ${rel.name}`),
+    line(1, `${backing} AS ${quoteIfReserved(rel.name)}`),
     line(2, `KEY(${key})`),
-    line(2, `SOURCE KEY(${key}) REFERENCES ${rel.source.entity}(${key})`),
+    line(
+        2,
+        `SOURCE KEY(${key}) REFERENCES ${quoteIfReserved(rel.source.entity)}(${
+            key})`),
     line(
         2,
         `DESTINATION KEY(${destFk}) REFERENCES ${
-            rel.destination.entity}(${destRef})`),
+            quoteIfReserved(rel.destination.entity)}(${destRef})`),
   ];
 
   // Edge description and synonyms attach to the DEFAULT LABEL: after the
@@ -864,23 +871,26 @@ function renderAssociationEdge(
     if (!entity) {
       warnings.push(
           `relationship '${rel.name}': unknown entity '${end.entity}'`);
-      return end.columns.join(', ');
+      return end.columns.map(quoteIfReserved).join(', ');
     }
     return physicalColumns(entity, entity.keys, warnings, `relationship '${rel.name}'`)
         .join(', ');
   };
 
   const lines = [
-    line(1, `${backing} AS ${rel.name}`),
-    line(2, `KEY(${assoc.keys.join(', ')})`),
+    line(1, `${backing} AS ${quoteIfReserved(rel.name)}`),
+    line(2, `KEY(${assoc.keys.map(quoteIfReserved).join(', ')})`),
     line(
         2,
-        `SOURCE KEY(${assoc.sourceColumns.join(', ')}) REFERENCES ${
-            rel.source.entity}(${refColumns(rel.source)})`),
+        `SOURCE KEY(${assoc.sourceColumns.map(quoteIfReserved).join(', ')}) ` +
+            `REFERENCES ${quoteIfReserved(rel.source.entity)}(${
+                refColumns(rel.source)})`),
     line(
         2,
-        `DESTINATION KEY(${assoc.destinationColumns.join(', ')}) REFERENCES ${
-            rel.destination.entity}(${refColumns(rel.destination)})`),
+        `DESTINATION KEY(${
+            assoc.destinationColumns.map(quoteIfReserved).join(', ')}) ` +
+            `REFERENCES ${quoteIfReserved(rel.destination.entity)}(${
+                refColumns(rel.destination)})`),
   ];
 
   // Edge description and synonyms attach to the DEFAULT LABEL: after the

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -22,7 +22,7 @@
 import {AiContext, Association, Entity, Field, fieldBinding, isTimeDimension, Metric, Relationship, SemanticModel,} from './ir';
 import {resolveInheritance} from './resolve_inheritance';
 import {referencedEntityNames, stripQualifier} from './sql_expr_utils';
-import {quoteIfReserved} from './sql_identifiers';
+import {isSimpleIdentifier, quoteIfReserved} from './sql_identifiers';
 
 export interface GenerateOptions {
   project?: string;    // fills the project for the graph name + under-qualified
@@ -539,9 +539,6 @@ function hasTopLevelComma(expr: string): boolean {
   return false;
 }
 
-function isSimpleIdentifier(s: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(s);
-}
 
 // Returns `base` if free, else the first `base_2`, `base_3`, ... not in
 // `taken`.

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -26,6 +26,7 @@
 import {Association, Entity, Field, Relationship, SemanticModel} from './ir';
 import {resolveInheritance} from './resolve_inheritance';
 import {stripQualifier} from './sql_expr_utils';
+import {isReservedKeyword, quoteIfReserved} from './sql_identifiers';
 
 export interface GenerateOptions {
   graphName?: string;  // default: model.name
@@ -194,7 +195,7 @@ function renderNodeTable(
           .map(f => renderFieldProperty(f, entity.name));
 
   const lines = [
-    line(1, `${table} AS ${entity.name}`),
+    line(1, `${table} AS ${quoteIfReserved(entity.name)}`),
     line(
         2,
         `KEY(${
@@ -224,7 +225,7 @@ function renderNodeTable(
           `KEY); the '${ancestorName}' label is omitted from '${entity.name}'`);
       continue;
     }
-    lines.push(line(2, `LABEL ${ancestorName}`));
+    lines.push(line(2, `LABEL ${quoteIfReserved(ancestorName)}`));
     const signature =
         ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
     if (signature.length) lines.push(propertiesBlock(signature));
@@ -274,13 +275,16 @@ function renderEdgeTable(
       physicalColumns(destEntity, rel.destination.columns, warnings, relCtx)
           .join(', ');
   const lines = [
-    line(1, `${backing} AS ${rel.name}`),
+    line(1, `${backing} AS ${quoteIfReserved(rel.name)}`),
     line(2, `KEY(${key})`),
-    line(2, `SOURCE KEY(${key}) REFERENCES ${rel.source.entity}(${key})`),
     line(
         2,
-        `DESTINATION KEY(${destFk}) REFERENCES ${rel.destination.entity}(${
-            destRef})`),
+        `SOURCE KEY(${key}) REFERENCES ${quoteIfReserved(rel.source.entity)}(${
+            key})`),
+    line(
+        2,
+        `DESTINATION KEY(${destFk}) REFERENCES ${
+            quoteIfReserved(rel.destination.entity)}(${destRef})`),
   ];
   return lines.join('\n');
 }
@@ -306,7 +310,7 @@ function renderAssociationEdge(
     if (!entity) {
       warnings.push(
           `relationship '${rel.name}': unknown entity '${end.entity}'`);
-      return end.columns.join(', ');
+      return end.columns.map(quoteIfReserved).join(', ');
     }
     return physicalColumns(
                entity, entity.keys, warnings, `relationship '${rel.name}'`)
@@ -314,16 +318,19 @@ function renderAssociationEdge(
   };
 
   const lines = [
-    line(1, `${backing} AS ${rel.name}`),
-    line(2, `KEY(${assoc.keys.join(', ')})`),
+    line(1, `${backing} AS ${quoteIfReserved(rel.name)}`),
+    line(2, `KEY(${assoc.keys.map(quoteIfReserved).join(', ')})`),
     line(
         2,
-        `SOURCE KEY(${assoc.sourceColumns.join(', ')}) REFERENCES ${
-            rel.source.entity}(${refColumns(rel.source)})`),
+        `SOURCE KEY(${assoc.sourceColumns.map(quoteIfReserved).join(', ')}) ` +
+            `REFERENCES ${quoteIfReserved(rel.source.entity)}(${
+                refColumns(rel.source)})`),
     line(
         2,
-        `DESTINATION KEY(${assoc.destinationColumns.join(', ')}) REFERENCES ${
-            rel.destination.entity}(${refColumns(rel.destination)})`),
+        `DESTINATION KEY(${
+            assoc.destinationColumns.map(quoteIfReserved).join(', ')}) ` +
+            `REFERENCES ${quoteIfReserved(rel.destination.entity)}(${
+                refColumns(rel.destination)})`),
   ];
 
   const properties =
@@ -340,7 +347,9 @@ function renderAssociationEdge(
 function renderFieldProperty(field: Field, entity: string): string {
   const expr = fieldExpression(field);
   const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
-  return local === field.name ? field.name : `${local} AS ${field.name}`;
+  const alias = quoteIfReserved(field.name);
+  return local === field.name ? alias :
+                                `${quoteIfReserved(local)} AS ${alias}`;
 }
 
 
@@ -382,7 +391,7 @@ function physicalColumns(
               col}); a KEY/REFERENCES site requires a bare column, so Spanner ` +
           `will reject the generated DDL`);
     }
-    return col;
+    return quoteIfReserved(col);
   });
 }
 
@@ -481,7 +490,9 @@ function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
 // and the like flow through here so a hyphenated or otherwise non-simple name
 // does not produce invalid DDL.
 function quoteIdent(name: string): string {
-  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) return name;
+  if (isSimpleIdentifier(name)) {
+    return isReservedKeyword(name) ? `\`${name}\`` : name;
+  }
   return `\`${name.replace(/`/g, '\\`')}\``;
 }
 

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -26,7 +26,7 @@
 import {Association, Entity, Field, Relationship, SemanticModel} from './ir';
 import {resolveInheritance} from './resolve_inheritance';
 import {stripQualifier} from './sql_expr_utils';
-import {isReservedKeyword, quoteIfReserved} from './sql_identifiers';
+import {isSimpleIdentifier, quoteIdentifier, quoteIfReserved} from './sql_identifiers';
 
 export interface GenerateOptions {
   graphName?: string;  // default: model.name
@@ -252,7 +252,7 @@ function renderEdgeTable(
   if (!sourceEntity) {
     warnings.push(`relationship '${rel.name}': unknown source entity '${
         rel.source.entity}'`);
-    backing = quoteIdent(rel.source.entity);
+    backing = quoteIdentifier(rel.source.entity);
     sourceKey = rel.source.columns;
   } else {
     backing = spannerTable(
@@ -395,10 +395,6 @@ function physicalColumns(
   });
 }
 
-function isSimpleIdentifier(s: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(s);
-}
-
 
 // Maps the IR's `dataSource` to the BARE Spanner table name the graph
 // references. A property graph names input tables within its own database, so
@@ -416,7 +412,7 @@ function spannerTable(
   if (!trimmed) {
     warnings.push(
         `${context}: empty data source; the table reference will be invalid`);
-    return quoteIdent('');
+    return quoteIdentifier('');
   }
   if (/\s/.test(trimmed)) {
     warnings.push(
@@ -431,7 +427,7 @@ function spannerTable(
   // dotted reduction below.
   const source = isResourceUri(trimmed) ? finalPathSegment(trimmed) : trimmed;
   const last = splitDotted(source).map(unquote).pop() ?? source;
-  return quoteIdent(last);
+  return quoteIdentifier(last);
 }
 
 
@@ -481,20 +477,9 @@ function splitDotted(source: string): string[] {
 // graph name is `project.dataset.name` -- a Spanner graph lives in one database
 // and is named by a single identifier.
 function qualifyGraph(model: SemanticModel, opts: GenerateOptions): string {
-  return quoteIdent(opts.graphName ?? model.name);
+  return quoteIdentifier(opts.graphName ?? model.name);
 }
 
-
-// Renders a Spanner GoogleSQL identifier: bare when it is a simple identifier,
-// else backtick-quoted (with any backtick escaped). Graph names, table names,
-// and the like flow through here so a hyphenated or otherwise non-simple name
-// does not produce invalid DDL.
-function quoteIdent(name: string): string {
-  if (isSimpleIdentifier(name)) {
-    return isReservedKeyword(name) ? `\`${name}\`` : name;
-  }
-  return `\`${name.replace(/`/g, '\\`')}\``;
-}
 
 function unquote(part: string): string {
   return part.replace(/^[`"]/, '').replace(/[`"]$/, '');

--- a/toolbox/mdcode/src/libts/semantic/sql_identifiers.ts
+++ b/toolbox/mdcode/src/libts/semantic/sql_identifiers.ts
@@ -1,0 +1,156 @@
+// Quoting for GoogleSQL identifiers emitted into generated graph DDL.
+//
+// Both graph generators (./bigquery, ./spanner) lower logical names -- entity
+// and relationship labels, property names, key columns -- into identifier
+// positions of a `CREATE OR REPLACE PROPERTY GRAPH` statement. A name that is a
+// GoogleSQL RESERVED KEYWORD (e.g. an entity named `Order`) is a valid model
+// name but, emitted bare as `... AS Order`, makes the DDL a syntax error
+// ("Unexpected keyword ORDER"). Backticking it (`... AS `Order``) is always
+// safe, so these helpers quote a name exactly when it would otherwise be
+// misread. Both BigQuery and Spanner Graph share the GoogleSQL grammar, so one
+// reserved set serves both.
+
+// The GoogleSQL reserved keywords. A reserved keyword may not appear as an
+// identifier unless quoted. Non-reserved keywords (e.g. KEY, VALUE, SOURCE) are
+// deliberately absent: they are legal bare identifiers, so quoting them would
+// churn existing output for no reason. Kept uppercase; lookups uppercase first.
+// Source: GoogleSQL lexical structure (reserved keywords), shared by BigQuery
+// and Spanner.
+const RESERVED_KEYWORDS = new Set<string>([
+  'ALL',
+  'AND',
+  'ANY',
+  'ARRAY',
+  'AS',
+  'ASC',
+  'ASSERT_ROWS_MODIFIED',
+  'AT',
+  'BETWEEN',
+  'BY',
+  'CASE',
+  'CAST',
+  'COLLATE',
+  'CONTAINS',
+  'CREATE',
+  'CROSS',
+  'CUBE',
+  'CURRENT',
+  'DEFAULT',
+  'DEFINE',
+  'DESC',
+  'DISTINCT',
+  'ELSE',
+  'END',
+  'ENUM',
+  'ESCAPE',
+  'EXCEPT',
+  'EXCLUDE',
+  'EXISTS',
+  'EXTRACT',
+  'FALSE',
+  'FETCH',
+  'FOLLOWING',
+  'FOR',
+  'FROM',
+  'FULL',
+  'GROUP',
+  'GROUPING',
+  'GROUPS',
+  'HASH',
+  'HAVING',
+  'IF',
+  'IGNORE',
+  'IN',
+  'INNER',
+  'INTERSECT',
+  'INTERVAL',
+  'INTO',
+  'IS',
+  'JOIN',
+  'LATERAL',
+  'LEFT',
+  'LIKE',
+  'LIMIT',
+  'LOOKUP',
+  'MERGE',
+  'NATURAL',
+  'NEW',
+  'NO',
+  'NOT',
+  'NULL',
+  'NULLS',
+  'OF',
+  'ON',
+  'OR',
+  'ORDER',
+  'OUTER',
+  'OVER',
+  'PARTITION',
+  'PRECEDING',
+  'PROTO',
+  'QUALIFY',
+  'RANGE',
+  'RECURSIVE',
+  'RESPECT',
+  'RIGHT',
+  'ROLLUP',
+  'ROWS',
+  'SELECT',
+  'SET',
+  'SOME',
+  'STRUCT',
+  'TABLESAMPLE',
+  'THEN',
+  'TO',
+  'TREAT',
+  'TRUE',
+  'UNBOUNDED',
+  'UNION',
+  'UNNEST',
+  'USING',
+  'WHEN',
+  'WHERE',
+  'WINDOW',
+  'WITH',
+  'WITHIN',
+]);
+
+// A bare (unquoted) GoogleSQL identifier: a letter or underscore followed by
+// letters, digits, or underscores. Anything else (a hyphen, a dot, a leading
+// digit) must be quoted to appear as an identifier.
+export function isSimpleIdentifier(s: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(s);
+}
+
+// Whether `name` is a GoogleSQL reserved keyword (case-insensitive), and so
+// cannot appear as a bare identifier.
+export function isReservedKeyword(name: string): boolean {
+  return RESERVED_KEYWORDS.has(name.toUpperCase());
+}
+
+// Backticks `name`, escaping any embedded backtick.
+function backtick(name: string): string {
+  return `\`${name.replace(/`/g, '\\`')}\``;
+}
+
+// Quotes a name that would otherwise be MISREAD as a bare identifier: a simple
+// identifier is left bare unless it is a reserved keyword; anything non-simple
+// (a hyphen, a dot, a leading digit) is backticked. Use for a full identifier
+// token -- a table or graph name.
+export function quoteIdentifier(name: string): string {
+  if (isSimpleIdentifier(name)) {
+    return isReservedKeyword(name) ? backtick(name) : name;
+  }
+  return backtick(name);
+}
+
+// Quotes ONLY a simple identifier that collides with a reserved keyword, and
+// passes everything else through unchanged. Use at identifier positions whose
+// input is expected to be a simple name already (an alias, a label reference, a
+// key column): a non-simple value there is a separate error the generators
+// detect and warn about, so this must not rewrite it. A non-reserved name is
+// returned byte-for-byte, so existing output is unaffected.
+export function quoteIfReserved(name: string): string {
+  return isSimpleIdentifier(name) && isReservedKeyword(name) ? backtick(name) :
+                                                               name;
+}

--- a/toolbox/mdcode/src/libts/semantic/sql_identifiers.ts
+++ b/toolbox/mdcode/src/libts/semantic/sql_identifiers.ts
@@ -14,8 +14,12 @@
 // identifier unless quoted. Non-reserved keywords (e.g. KEY, VALUE, SOURCE) are
 // deliberately absent: they are legal bare identifiers, so quoting them would
 // churn existing output for no reason. Kept uppercase; lookups uppercase first.
-// Source: GoogleSQL lexical structure (reserved keywords), shared by BigQuery
-// and Spanner.
+// Source of truth: the GoogleSQL reserved-keyword list (BigQuery lexical
+// structure docs), shared by BigQuery and Spanner Graph. NOTE: the
+// @polyglot-sql/sdk transpiler is deliberately NOT the oracle -- its reserved
+// set diverges from BigQuery's in both directions (misses EXTRACT, over-quotes
+// user/view/column), so delegating would emit incorrect DDL. See
+// sql_identifiers.test.ts.
 const RESERVED_KEYWORDS = new Set<string>([
   'ALL',
   'AND',

--- a/toolbox/mdcode/src/libts/semantic/sql_identifiers.ts
+++ b/toolbox/mdcode/src/libts/semantic/sql_identifiers.ts
@@ -11,15 +11,23 @@
 // reserved set serves both.
 
 // The GoogleSQL reserved keywords. A reserved keyword may not appear as an
-// identifier unless quoted. Non-reserved keywords (e.g. KEY, VALUE, SOURCE) are
-// deliberately absent: they are legal bare identifiers, so quoting them would
-// churn existing output for no reason. Kept uppercase; lookups uppercase first.
-// Source of truth: the GoogleSQL reserved-keyword list (BigQuery lexical
-// structure docs), shared by BigQuery and Spanner Graph. NOTE: the
-// @polyglot-sql/sdk transpiler is deliberately NOT the oracle -- its reserved
-// set diverges from BigQuery's in both directions (misses EXTRACT, over-quotes
-// user/view/column), so delegating would emit incorrect DDL. See
-// sql_identifiers.test.ts.
+// identifier unless quoted. Non-reserved keywords are deliberately absent: they
+// are legal bare identifiers, so quoting them would churn existing output for no
+// reason. That absence extends to the graph-DDL CONTEXTUAL keywords (KEY, VALUE,
+// SOURCE, DESTINATION, LABEL, NODE, EDGE, PROPERTIES, MEASURE): they are
+// keywords only inside a CREATE PROPERTY GRAPH clause, and BigQuery accepts them
+// bare in every identifier position -- alias, property, KEY/SOURCE
+// KEY/DESTINATION KEY column, and REFERENCES label (verified live 2026-08-30).
+// Kept uppercase; lookups uppercase first.
+//
+// Source of truth: the GoogleSQL reserved-keyword lists published for BigQuery
+// and Spanner (their lexical-structure docs). This set is their UNION so one
+// table serves both generators: the two lists differ only in QUALIFY (BigQuery
+// reserves it; Spanner does not, and over-quoting it on Spanner is harmless),
+// and both reserve GRAPH_TABLE. NOTE: the @polyglot-sql/sdk transpiler is
+// deliberately NOT the oracle -- its reserved set diverges from BigQuery's in
+// both directions (misses EXTRACT, over-quotes user/view/column), so delegating
+// would emit incorrect DDL. See sql_identifiers.test.ts.
 const RESERVED_KEYWORDS = new Set<string>([
   'ALL',
   'AND',
@@ -57,6 +65,7 @@ const RESERVED_KEYWORDS = new Set<string>([
   'FOR',
   'FROM',
   'FULL',
+  'GRAPH_TABLE',
   'GROUP',
   'GROUPING',
   'GROUPS',

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.e2e.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.e2e.test.ts
@@ -45,6 +45,7 @@ const CORPUS = [
   'metric_skips.yaml',
   'keyless_dimension.yaml',
   'hierarchy_graph.yaml',
+  'reserved_words.yaml',
 ];
 
 // Loads a fixture file to its IR. Split out from `build` so a test that only

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.e2e.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.e2e.test.ts
@@ -46,6 +46,7 @@ const CORPUS = [
   'keyless_dimension.yaml',
   'hierarchy_graph.yaml',
   'reserved_words.yaml',
+  'reserved_words_inherit.yaml',
 ];
 
 // Loads a fixture file to its IR. Split out from `build` so a test that only

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -921,3 +921,48 @@ describe('inherited property rendering (shared-label consistency)', () => {
         expect(ddl).toContain('email');
       });
 });
+
+describe('reserved-word names in an M:N association edge are quoted', () => {
+  // The open format has no association-table syntax, so this hand-built IR is
+  // the only path that exercises renderAssociationEdge's identifier quoting: the
+  // edge alias, KEY, SOURCE KEY / DESTINATION KEY columns, and both REFERENCES
+  // labels, each named with a GoogleSQL reserved keyword.
+  const RW_ASSOC: SemanticModel = {
+    name: 'rw_assoc',
+    entities: [
+      {
+        name: 'Order',
+        dataSource: 'proj.ds.orders',
+        keys: ['order'],
+        fields: [{name: 'order', expression: 'Order.order'}],
+      },
+      {
+        name: 'Group',
+        dataSource: 'proj.ds.groups',
+        keys: ['id'],
+        fields: [{name: 'id', expression: 'Group.id'}],
+      },
+    ],
+    relationships: [{
+      name: 'from',
+      source: {entity: 'Order', columns: ['order']},
+      destination: {entity: 'Group', columns: ['id']},
+      association: {
+        dataSource: 'proj.ds.order_group',
+        keys: ['order'],
+        sourceColumns: ['order'],
+        destinationColumns: ['id'],
+        fields: [],
+      },
+    }],
+    metrics: [],
+  };
+
+  test('every reserved identifier position in the edge is backtick-quoted', () => {
+    const {ddl} = generatePropertyGraph(RW_ASSOC, GEN_OPTS);
+    expect(ddl).toContain('`proj.ds.order_group` AS `from`');
+    expect(ddl).toContain('KEY(`order`)');
+    expect(ddl).toContain('SOURCE KEY(`order`) REFERENCES `Order`(`order`)');
+    expect(ddl).toContain('DESTINATION KEY(id) REFERENCES `Group`(id)');
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.prod.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.prod.bigquery.golden.sql
@@ -6,7 +6,7 @@ NODE TABLES (
       customer_id AS id OPTIONS(description="Customer ID"),
       customer_name AS name
     ),
-  `acme-prod.sales.orders` AS Order
+  `acme-prod.sales.orders` AS `Order`
     KEY(order_id)
     PROPERTIES(
       order_id AS id,
@@ -21,7 +21,7 @@ NODE TABLES (
 EDGE TABLES (
   `acme-prod.sales.orders` AS placed_by
     KEY(order_id)
-    SOURCE KEY(order_id) REFERENCES Order(order_id)
+    SOURCE KEY(order_id) REFERENCES `Order`(order_id)
     DESTINATION KEY(customer_id) REFERENCES Customer(customer_id)
 );
 

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.remap.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.remap.bigquery.golden.sql
@@ -6,7 +6,7 @@ NODE TABLES (
       customer_id AS id OPTIONS(description="Customer ID"),
       full_name AS name
     ),
-  `acme-eu.sales.orders` AS Order
+  `acme-eu.sales.orders` AS `Order`
     KEY(order_id)
     PROPERTIES(
       order_id AS id,
@@ -19,7 +19,7 @@ NODE TABLES (
 EDGE TABLES (
   `acme-eu.sales.orders` AS placed_by
     KEY(order_id)
-    SOURCE KEY(order_id) REFERENCES Order(order_id)
+    SOURCE KEY(order_id) REFERENCES `Order`(order_id)
     DESTINATION KEY(customer_id) REFERENCES Customer(customer_id)
 );
 

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.analytical.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.analytical.bigquery.golden.sql
@@ -6,7 +6,7 @@ NODE TABLES (
       cust_id AS id OPTIONS(description="Customer ID"),
       full_name AS name
     ),
-  `acme.sales.orders` AS Order
+  `acme.sales.orders` AS `Order`
     KEY(order_id)
     PROPERTIES(
       order_id AS id,
@@ -19,7 +19,7 @@ NODE TABLES (
 EDGE TABLES (
   `acme.sales.orders` AS placed_by
     KEY(order_id)
-    SOURCE KEY(order_id) REFERENCES Order(order_id)
+    SOURCE KEY(order_id) REFERENCES `Order`(order_id)
     DESTINATION KEY(fk_customer) REFERENCES Customer(cust_id)
 );
 

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.operational.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.operational.bigquery.golden.sql
@@ -8,7 +8,7 @@ NODE TABLES (
       cust_segment AS segment,
       MEASURE(COUNT(segment)) AS segment_count
     ),
-  `acme-ops.ops.fct_order` AS Order
+  `acme-ops.ops.fct_order` AS `Order`
     KEY(order_key)
     PROPERTIES(
       order_key AS id,
@@ -19,7 +19,7 @@ NODE TABLES (
 EDGE TABLES (
   `acme-ops.ops.fct_order` AS placed_by
     KEY(order_key)
-    SOURCE KEY(order_key) REFERENCES Order(order_key)
+    SOURCE KEY(order_key) REFERENCES `Order`(order_key)
     DESTINATION KEY(cust_key) REFERENCES Customer(cust_key)
 );
 

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words.bigquery.golden.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE PROPERTY GRAPH `sqlgen-testing.demo.reserved_words`
+NODE TABLES (
+  `proj.ds.orders` AS `Order`
+    KEY(order_id)
+    PROPERTIES(
+      order_id AS id,
+      group_fk AS groupId,
+      `order` AS rank,
+      MEASURE(COUNT(id)) AS `range`
+    ),
+  `proj.ds.groups` AS `Group`
+    KEY(group_id)
+    PROPERTIES(
+      group_id AS id
+    )
+)
+EDGE TABLES (
+  `proj.ds.orders` AS `from`
+    KEY(order_id)
+    SOURCE KEY(order_id) REFERENCES `Order`(order_id)
+    DESTINATION KEY(group_fk) REFERENCES `Group`(group_id)
+);
+
+-- warnings --
+-- (none)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words.spanner.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words.spanner.golden.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE PROPERTY GRAPH reserved_words
+NODE TABLES (
+  orders AS `Order`
+    KEY(order_id)
+    PROPERTIES(
+      order_id AS id,
+      group_fk AS groupId,
+      `order` AS rank
+    ),
+  `groups` AS `Group`
+    KEY(group_id)
+    PROPERTIES(
+      group_id AS id
+    )
+)
+EDGE TABLES (
+  orders AS `from`
+    KEY(order_id)
+    SOURCE KEY(order_id) REFERENCES `Order`(order_id)
+    DESTINATION KEY(group_fk) REFERENCES `Group`(group_id)
+);
+
+-- warnings --
+-- metric 'range' is not emitted: Spanner Graph has no MEASURE, so model-level metrics have no home in it

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words.yaml
@@ -1,0 +1,42 @@
+# Every identifier position a generator emits, exercised with a GoogleSQL
+# RESERVED KEYWORD as the name, to pin that each is backtick-quoted so the DDL
+# is valid (a bare `AS Order` is a syntax error). Non-reserved names in the same
+# positions must stay bare -- see the goldens.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: reserved_words
+    datasets:
+      # `Order` and `Group` are reserved -> quoted node labels + REFERENCES.
+      - name: Order
+        source: proj.ds.orders
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects: [{ dialect: BIGQUERY, expression: order_id }]
+          - name: groupId
+            expression:
+              dialects: [{ dialect: BIGQUERY, expression: group_fk }]
+          # `order` is a reserved COLUMN -> quoted on the left of `AS`.
+          - name: rank
+            expression:
+              dialects: [{ dialect: BIGQUERY, expression: order }]
+      - name: Group
+        source: proj.ds.groups
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects: [{ dialect: BIGQUERY, expression: group_id }]
+    relationships:
+      # `from` is a reserved edge label -> quoted alias + REFERENCES targets.
+      - name: from
+        from: Order
+        to: Group
+        from_columns: [groupId]
+        to_columns: [id]
+    metrics:
+      # `range` is a reserved measure name -> quoted `AS` on the MEASURE.
+      - name: range
+        expression:
+          dialects: [{ dialect: BIGQUERY, expression: COUNT(Order.id) }]

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words_inherit.bigquery.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words_inherit.bigquery.golden.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE PROPERTY GRAPH `sqlgen-testing.demo.reserved_words_inherit`
+NODE TABLES (
+  `proj.ds.orders` AS `Order`
+    KEY(order_id)
+    DEFAULT LABEL
+    PROPERTIES(
+      order_id AS id,
+      amount AS total
+    ),
+  `proj.ds.vip_orders` AS Vip
+    KEY(order_id)
+    DEFAULT LABEL
+    PROPERTIES(
+      order_id AS id,
+      vip_tier AS tier,
+      amount AS total
+    )
+    LABEL `Order`
+    PROPERTIES(
+      order_id AS id,
+      amount AS total
+    )
+);
+
+-- warnings --
+-- (none)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words_inherit.spanner.golden.sql
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words_inherit.spanner.golden.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE PROPERTY GRAPH reserved_words_inherit
+NODE TABLES (
+  orders AS `Order`
+    KEY(order_id)
+    DEFAULT LABEL
+    PROPERTIES(
+      order_id AS id,
+      amount AS total
+    ),
+  vip_orders AS Vip
+    KEY(order_id)
+    DEFAULT LABEL
+    PROPERTIES(
+      order_id AS id,
+      vip_tier AS tier,
+      amount AS total
+    )
+    LABEL `Order`
+    PROPERTIES(
+      order_id AS id,
+      amount AS total
+    )
+);
+
+-- warnings --
+-- (none)

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words_inherit.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words_inherit.yaml
@@ -1,0 +1,33 @@
+# Inheritance where the ANCESTOR's name is a GoogleSQL reserved keyword, so the
+# subclass node table must emit `LABEL `Order`` (backtick-quoted) rather than a
+# bare `LABEL Order` that would be a syntax error. Complements reserved_words.yaml
+# (which covers the direct-FK edge, property, and measure positions) with the
+# inheritance-LABEL position.
+version: "0.2.0.dev0"
+semantic_model:
+  - name: reserved_words_inherit
+    datasets:
+      # `Order` is reserved -> the ancestor label is quoted everywhere it appears.
+      - name: Order
+        source: proj.ds.orders
+        primary_key: [id]
+        fields:
+          - name: id
+            expression:
+              dialects: [{ dialect: BIGQUERY, expression: order_id }]
+          - name: total
+            expression:
+              dialects: [{ dialect: BIGQUERY, expression: amount }]
+      # A concrete subclass -> its node table declares `LABEL `Order`` and
+      # re-lists the ancestor's flattened properties under that quoted label.
+      - name: Vip
+        source: proj.ds.vip_orders
+        primary_key: [id]
+        extends: [Order]
+        fields:
+          - name: id
+            expression:
+              dialects: [{ dialect: BIGQUERY, expression: order_id }]
+          - name: tier
+            expression:
+              dialects: [{ dialect: BIGQUERY, expression: vip_tier }]

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -141,9 +141,10 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
             onlyLogicalGoldenDeviations(validate.errors)) {
           return;
         }
-        // The hand-authored bound graph fixture carries only the
-        // extends/abstract superset (its sources/expressions are present).
-        if (rel === 'hierarchy_graph.yaml' &&
+        // The hand-authored bound graph fixtures carry only the
+        // extends/abstract superset (their sources/expressions are present).
+        if ((rel === 'hierarchy_graph.yaml' ||
+             rel === 'reserved_words_inherit.yaml') &&
             onlyExtendsExtension(validate.errors)) {
           return;
         }

--- a/toolbox/mdcode/tests/libts/semantic/spanner.e2e.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.e2e.test.ts
@@ -32,6 +32,7 @@ const CORPUS = [
   'hierarchy_graph.yaml',
   'sales_fanout.yaml',
   'reserved_words.yaml',
+  'reserved_words_inherit.yaml',
 ];
 
 function loadFixture(fixture: string, load: LoadOptions = {}) {

--- a/toolbox/mdcode/tests/libts/semantic/spanner.e2e.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.e2e.test.ts
@@ -31,6 +31,7 @@ const CORPUS = [
   'star_orders_customer.yaml',
   'hierarchy_graph.yaml',
   'sales_fanout.yaml',
+  'reserved_words.yaml',
 ];
 
 function loadFixture(fixture: string, load: LoadOptions = {}) {

--- a/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/spanner.test.ts
@@ -324,3 +324,49 @@ describe('degenerate inputs', () => {
     expect(warnings.some(w => w.includes('empty KEY'))).toBe(true);
   });
 });
+
+describe('reserved-word names in an M:N association edge are quoted', () => {
+  // The open format has no association-table syntax, so this hand-built IR is
+  // the only path that exercises renderAssociationEdge's identifier quoting on
+  // the Spanner leg: the edge alias, KEY, SOURCE KEY / DESTINATION KEY columns,
+  // and both REFERENCES labels, each named with a GoogleSQL reserved keyword.
+  // Table names stay bare (Spanner graphs live in one database).
+  const RW_ASSOC: SemanticModel = {
+    name: 'rw_assoc',
+    entities: [
+      {
+        name: 'Order',
+        dataSource: 'proj.ds.orders',
+        keys: ['order'],
+        fields: [{name: 'order', expression: 'Order.order'}],
+      },
+      {
+        name: 'Group',
+        dataSource: 'proj.ds.groups',
+        keys: ['id'],
+        fields: [{name: 'id', expression: 'Group.id'}],
+      },
+    ],
+    relationships: [{
+      name: 'from',
+      source: {entity: 'Order', columns: ['order']},
+      destination: {entity: 'Group', columns: ['id']},
+      association: {
+        dataSource: 'proj.ds.order_group',
+        keys: ['order'],
+        sourceColumns: ['order'],
+        destinationColumns: ['id'],
+        fields: [],
+      },
+    }],
+    metrics: [],
+  };
+
+  test('every reserved identifier position in the edge is backtick-quoted', () => {
+    const {ddl} = generateSpannerPropertyGraph(RW_ASSOC, {});
+    expect(ddl).toContain('order_group AS `from`');
+    expect(ddl).toContain('KEY(`order`)');
+    expect(ddl).toContain('SOURCE KEY(`order`) REFERENCES `Order`(`order`)');
+    expect(ddl).toContain('DESTINATION KEY(id) REFERENCES `Group`(id)');
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/sql_identifiers.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/sql_identifiers.test.ts
@@ -60,3 +60,30 @@ describe('quoteIdentifier', () => {
     expect(quoteIdentifier('we`ird')).toBe('`we\\`ird`');
   });
 });
+
+describe('pins to the authoritative BigQuery reserved set (not the transpiler)',
+         () => {
+           // The @polyglot-sql/sdk engine's reserved set diverges from BigQuery's
+           // published one in BOTH directions -- it misses EXTRACT and over-quotes
+           // user/view/column/references -- so it is deliberately not the oracle.
+           // These cases pin our set to the BigQuery spec so the hand-kept list
+           // cannot silently drift away from it.
+           const MUST_QUOTE = [
+             'Order', 'Group', 'From', 'Select', 'End', 'Range', 'Hash', 'All',
+             'Extract', 'Within', 'Qualify', 'Rollup',
+           ];
+           const MUST_STAY_BARE = [
+             'Customer', 'order_id', 'segment', 'revenue',
+             // keywords that are NOT reserved in BigQuery and must stay bare,
+             // including ones the transpiler wrongly quotes:
+             'key', 'value', 'source', 'user', 'view', 'column', 'references',
+           ];
+           test('reserved words are quoted', () => {
+             for (const n of MUST_QUOTE) {
+               expect(quoteIfReserved(n)).toBe(`\`${n}\``);
+             }
+           });
+           test('non-reserved identifiers stay bare', () => {
+             for (const n of MUST_STAY_BARE) expect(quoteIfReserved(n)).toBe(n);
+           });
+         });

--- a/toolbox/mdcode/tests/libts/semantic/sql_identifiers.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/sql_identifiers.test.ts
@@ -61,16 +61,21 @@ describe('quoteIdentifier', () => {
   });
 });
 
-describe('pins to the authoritative BigQuery reserved set (not the transpiler)',
+describe('pins to the authoritative GoogleSQL reserved set (not the transpiler)',
          () => {
-           // The @polyglot-sql/sdk engine's reserved set diverges from BigQuery's
-           // published one in BOTH directions -- it misses EXTRACT and over-quotes
+           // The set is the UNION of the BigQuery and Spanner GoogleSQL reserved
+           // lists so one table serves both generators. Both were checked
+           // against the published lexical-structure docs (2026-08-30); they
+           // differ only in QUALIFY (BigQuery reserves it, Spanner does not --
+           // over-quoting on Spanner is harmless) and both reserve GRAPH_TABLE.
+           // GRAPH_TABLE was verified live: rejected bare, accepted quoted. The
+           // @polyglot-sql/sdk engine's reserved set diverges from this in BOTH
+           // directions -- it misses EXTRACT and over-quotes
            // user/view/column/references -- so it is deliberately not the oracle.
-           // These cases pin our set to the BigQuery spec so the hand-kept list
-           // cannot silently drift away from it.
+           // These cases pin our set so the hand-kept list cannot silently drift.
            const MUST_QUOTE = [
              'Order', 'Group', 'From', 'Select', 'End', 'Range', 'Hash', 'All',
-             'Extract', 'Within', 'Qualify', 'Rollup',
+             'Extract', 'Within', 'Qualify', 'Rollup', 'Graph_Table',
            ];
            const MUST_STAY_BARE = [
              'Customer', 'order_id', 'segment', 'revenue',

--- a/toolbox/mdcode/tests/libts/semantic/sql_identifiers.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/sql_identifiers.test.ts
@@ -1,0 +1,62 @@
+// Behavior spec for the GoogleSQL identifier-quoting helpers
+// (src/libts/semantic/sql_identifiers.ts) both graph generators use to keep a
+// reserved-keyword name (an entity called `Order`, a field called `end`) from
+// becoming a syntax error in the emitted DDL.
+
+import {describe, expect, test} from 'bun:test';
+
+import {isReservedKeyword, quoteIdentifier, quoteIfReserved} from '../../../src/libts/semantic/sql_identifiers';
+
+describe('isReservedKeyword', () => {
+  test('recognizes reserved keywords case-insensitively', () => {
+    expect(isReservedKeyword('order')).toBe(true);
+    expect(isReservedKeyword('ORDER')).toBe(true);
+    expect(isReservedKeyword('Order')).toBe(true);
+    expect(isReservedKeyword('group')).toBe(true);
+    expect(isReservedKeyword('from')).toBe(true);
+  });
+
+  test('non-reserved keywords are legal bare identifiers', () => {
+    // KEY, VALUE, and SOURCE are keywords but NOT reserved, so they are not
+    // quoted -- quoting them would churn existing output for no reason.
+    expect(isReservedKeyword('key')).toBe(false);
+    expect(isReservedKeyword('value')).toBe(false);
+    expect(isReservedKeyword('source')).toBe(false);
+    expect(isReservedKeyword('Customer')).toBe(false);
+    expect(isReservedKeyword('order_id')).toBe(false);
+  });
+});
+
+describe('quoteIfReserved', () => {
+  test('backticks a simple identifier that is a reserved keyword', () => {
+    expect(quoteIfReserved('Order')).toBe('`Order`');
+    expect(quoteIfReserved('from')).toBe('`from`');
+  });
+
+  test('leaves a non-reserved simple identifier byte-for-byte', () => {
+    expect(quoteIfReserved('Customer')).toBe('Customer');
+    expect(quoteIfReserved('order_id')).toBe('order_id');
+    expect(quoteIfReserved('key')).toBe('key');
+  });
+
+  test('passes a non-simple value through unchanged', () => {
+    // A computed expression at a KEY/REFERENCES site is a separate error the
+    // generators warn about; this helper must not rewrite it.
+    expect(quoteIfReserved('a + b')).toBe('a + b');
+    expect(quoteIfReserved('`already`')).toBe('`already`');
+  });
+});
+
+describe('quoteIdentifier', () => {
+  test(
+      'quotes a reserved keyword or a non-simple name; leaves the rest bare',
+      () => {
+        expect(quoteIdentifier('Order')).toBe('`Order`');
+        expect(quoteIdentifier('Customer')).toBe('Customer');
+        expect(quoteIdentifier('has-hyphen')).toBe('`has-hyphen`');
+      });
+
+  test('escapes an embedded backtick', () => {
+    expect(quoteIdentifier('we`ird')).toBe('`we\\`ird`');
+  });
+});


### PR DESCRIPTION
## Problem

An entity, relationship, field, or metric named a **GoogleSQL reserved keyword** (e.g. an entity `Order`) was emitted bare into the property-graph DDL — `... AS Order` — which BigQuery and Spanner Graph reject:

```
Syntax error: Unexpected keyword ORDER
```

The graph never deploys, and the author gets an opaque backend error with no static warning. This is easy to hit: `Order`, `Group`, `From`, `Range`, `End`, … are all common modeling names.

## Fix

Quote every emitted identifier that collides with a reserved keyword, in both the BigQuery and Spanner generators:

- node / edge labels (`AS \`Order\``)
- `REFERENCES` targets
- property names and their bound columns
- key columns (`KEY` / `SOURCE KEY` / `DESTINATION KEY` / association columns)
- measure names
- Spanner bare table / graph names

A non-reserved name stays **bare**, so existing output is byte-for-byte unchanged (only the four `Order`-entity profile goldens move, to the now-valid quoted form).

A new `sql_identifiers` module holds the GoogleSQL reserved-keyword set shared by both generators. Non-reserved keywords (`KEY`, `VALUE`, `SOURCE`) are deliberately left bare.

## Tests

- `sql_identifiers.test.ts` — unit tests for the reserved-set logic.
- `reserved_words.yaml` fixture (+ BigQuery and Spanner goldens) exercising a reserved word in every identifier position.
- Full suite green (594 tests).

## Live validation

Deployed the guide's `commerce` example (entity named `Order`) end-to-end on **production BigQuery** and **production Spanner** (ENTERPRISE): both graphs now deploy and answer GQL / `GRAPH_EXPAND` queries. Before this change the same push failed with `Unexpected keyword ORDER`.