### PR TITLE
docs(codelab): rename step 1 + fix step 5 cleanup

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -918,17 +918,24 @@ Drop the Spanner database from step 4 (its tables and the graph go with it):
 gcloud spanner databases delete $SPANNER_DB --instance=$SPANNER_INSTANCE --quiet
 ```
 
-Remove the Knowledge Catalog entries and entry group via REST:
+Remove the Knowledge Catalog entries and entry group via REST. Delete the
+schema-join links first, while their endpoint entries still exist: a link whose
+entries are already gone is orphaned and can no longer be addressed by name.
 
 ```bash
 TOKEN=$(gcloud auth application-default print-access-token)
+DATAPLEX=${DATAPLEX_ENDPOINT:-https://dataplex.googleapis.com}
 EG=projects/$PROJECT/locations/$LOCATION/entryGroups/$DATASET
 
+for L in sales-placed-by sales-part-of; do
+  curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+    "$DATAPLEX/v1/$EG/entryLinks/$L" >/dev/null
+done
 for E in sales sales.entities.orders sales.entities.customer sales.entities.lineitem sales.metrics.revenue; do
   curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
-    "https://dataplex.googleapis.com/v1/$EG/entries/$E" >/dev/null
+    "$DATAPLEX/v1/$EG/entries/$E" >/dev/null
 done
-curl -s -X DELETE -H "Authorization: Bearer $TOKEN" "https://dataplex.googleapis.com/v1/$EG"
+curl -s -X DELETE -H "Authorization: Bearer $TOKEN" "$DATAPLEX/v1/$EG"
 ```
 
 Remove the local workspace that step 1 created:

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -35,7 +35,7 @@ export GRAPH=sales                                  # property-graph name
 
 ---
 
-## 1. Author the logical model
+## 1. Author the semantic model
 
 `init` provisions the Knowledge Catalog entry group and a local workspace:
 


### PR DESCRIPTION
Two fixes to the semantic-model codelab, both in `docs/semantic-model/codelab.md`, validated end-to-end against live autopush Dataplex + BigQuery + Spanner (ENTERPRISE).

**1. Rename step 1 heading** — "Author the logical model" → "Author the semantic model". Also fixes a broken link: the internal demo runner links to the anchor `#1-author-the-semantic-model`, which did not exist while the heading read "logical model".

**2. Fix step 5 cleanup** — two problems:
- It deleted entries and the entry group but never the schema-join **entry links**. Entry-group deletion does not cascade links, and once the endpoint entries are gone a link is orphaned and can no longer be deleted by name — so every run left links behind, and a second run on the same dataset collided (409 → update fallback 404). Fixed by deleting the links **first**, while their entries still exist.
- The cleanup curls hardcoded `https://dataplex.googleapis.com`, so a run pointed at another Dataplex instance (e.g. the demo runners `$DATAPLEX_ENDPOINT`) would not actually delete the KC resources. Now routed through `${DATAPLEX_ENDPOINT:-https://dataplex.googleapis.com}`.