### PR TITLE
fix(kc): tolerate a non-addressable entry-link aspect update on re-push

### DIFF
--- a/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
@@ -657,7 +657,16 @@ async function writeEntryLink(
     const upd = await cat.updateEntryLink(
         {name: link.name, aspects: link.aspects} as EntryLink,
         Object.keys(link.aspects ?? {}));
-    if (!isOk(upd)) return {error: `entry link '${linkId}': ${errText(upd)}`};
+    // A 409 already proved the link is present, and its entry references and type
+    // are immutable, so this follow-up only refreshes the aspect. Some catalog
+    // surfaces expose only create + lookup for an entry link and cannot address
+    // it by name for an update -- there the link is still fully written and only
+    // the aspect refresh is unavailable, so treat a not-addressable response as a
+    // no-op success rather than failing an otherwise-complete push. (This mirrors
+    // deleteOwnedLinks tolerating a 404 on delete.)
+    if (!isOk(upd) && !isLinkNotAddressable(upd)) {
+      return {error: `entry link '${linkId}': ${errText(upd)}`};
+    }
     return {};
   }
   if (!isOk(res)) return {error: `entry link '${linkId}': ${errText(res)}`};
@@ -770,6 +779,15 @@ function isOk(res: {status: number}): boolean {
 // need to match the error text.
 function isExists(res: {status: number}): boolean {
   return res.status === 409;
+}
+
+// An entry link that a create reported as already existing (409) but that the
+// by-name UpdateEntryLink then could not address: NOT_FOUND (404) or a masked
+// PERMISSION_DENIED (403). Some catalog surfaces expose only create + lookup for
+// entry links, so the aspect-refresh update is unavailable there even though the
+// link itself is present -- writeEntryLink treats this as a no-op success.
+function isLinkNotAddressable(res: {status: number}): boolean {
+  return res.status === 404 || res.status === 403;
 }
 
 // A transient "not visible yet" error worth retrying, matching the propagation

--- a/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
@@ -229,6 +229,38 @@ describe('deployKnowledgeCatalog: relationship entry links', () => {
     expect(aspectKeys.some((k: string) => k.endsWith('schema-join'))).toBe(true);
   });
 
+  test('an existing link whose update is not addressable still succeeds',
+       async () => {
+         // The link exists (409), but this catalog surface exposes only create
+         // + lookup for entry links, so the by-name aspect-refresh update comes
+         // back NOT_FOUND. The link is fully present; only the aspect refresh is
+         // unavailable, so the push must not fail on it.
+         const {createLink, updateLink} = stubClient({
+           createLink: () => err(409, 'entry link already exists'),
+           updateLink: err(404, 'entry link not found'),
+         });
+
+         const result = await deployKnowledgeCatalog(models(STAR_DOCS), CTX, OPTS);
+
+         expect(result.success).toBe(true);
+         expect(result.linked).toBe(1);
+         expect(createLink).toHaveBeenCalledTimes(1);
+         expect(updateLink).toHaveBeenCalledTimes(1);
+       });
+
+  test('a masked PERMISSION_DENIED on the link update also succeeds', async () => {
+    const {updateLink} = stubClient({
+      createLink: () => err(409, 'entry link already exists'),
+      updateLink: err(403, 'permission denied'),
+    });
+
+    const result = await deployKnowledgeCatalog(models(STAR_DOCS), CTX, OPTS);
+
+    expect(result.success).toBe(true);
+    expect(result.linked).toBe(1);
+    expect(updateLink).toHaveBeenCalledTimes(1);
+  });
+
   test('a failed link write fails the push, naming the link', async () => {
     stubClient({
       createLink: () => err(500, 'boom'),


### PR DESCRIPTION
## What

`writeEntryLink` creates a schema-join entry link and, on `409 ALREADY_EXISTS`, falls back to an in-place aspect refresh through the by-name `UpdateEntryLink`. On some catalog surfaces entry links are reachable only via create + lookup, so that follow-up update returns `NOT_FOUND` (404) or a masked `PERMISSION_DENIED` (403) even though the link is present — its entry references and type are immutable, and only the aspect refresh is unavailable.

This change treats a not-addressable update response as a no-op success (new `isLinkNotAddressable` predicate), mirroring how `deleteOwnedLinks` already tolerates a 404 on delete.

## Why

Without it, a **re-push** over a relationship whose link already exists fails the entire push at the link step — even though the link (the essential state) is already there. A second `kcmd push` of the same model, or two runners sharing an entry group, should be idempotent. This makes it so.

## Tests

Adds two cases to `deploy_knowledge_catalog.test.ts`: an existing link whose update returns 404, and one returning 403 — both now succeed with `linked == 1`. Full semantic suite passes (`npm run test:semantic`), `npm run compile` clean.