### PR TITLE
docs(codelab): make <...> placeholders paste-safe and pre-set-aware

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -694,8 +694,8 @@ contract, see [binding profiles](profiles.md)). Write the operational binding
 into the same `sales.profiles/` directory:
 
 ```bash
-export SPANNER_INSTANCE="<your-spanner-instance>"   # a Spanner ENTERPRISE-edition instance
-export SPANNER_DB="<your-googlesql-database>"
+export SPANNER_INSTANCE="${SPANNER_INSTANCE:-<your-spanner-instance>}"   # a Spanner ENTERPRISE-edition instance
+export SPANNER_DB="${SPANNER_DB:-<your-googlesql-database>}"
 SPANNER_TARGET=//spanner.googleapis.com/projects/$PROJECT/instances/$SPANNER_INSTANCE/databases/$SPANNER_DB/propertyGraphs/$GRAPH
 
 mkdir -p catalog/EntryGroups/$DATASET/sales.profiles

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -20,8 +20,8 @@ configuration for credentials, project, and region:
 
 ```bash
 gcloud auth application-default login
-gcloud config set project <your-project>
-gcloud config set compute/region <your-region>
+gcloud config set project "<your-project>"
+gcloud config set compute/region "<your-region>"
 ```
 
 The commands below reuse a few names. Set them once for your own project:
@@ -694,8 +694,8 @@ contract, see [binding profiles](profiles.md)). Write the operational binding
 into the same `sales.profiles/` directory:
 
 ```bash
-export SPANNER_INSTANCE=<your-spanner-instance>   # a Spanner ENTERPRISE-edition instance
-export SPANNER_DB=<your-googlesql-database>
+export SPANNER_INSTANCE="<your-spanner-instance>"   # a Spanner ENTERPRISE-edition instance
+export SPANNER_DB="<your-googlesql-database>"
 SPANNER_TARGET=//spanner.googleapis.com/projects/$PROJECT/instances/$SPANNER_INSTANCE/databases/$SPANNER_DB/propertyGraphs/$GRAPH
 
 mkdir -p catalog/EntryGroups/$DATASET/sales.profiles


### PR DESCRIPTION
## What

Fix the codelab's `<...>` placeholders so the code blocks behave when pasted as-is.

- **Setup** — quote the two `gcloud config set` placeholders:
  - `gcloud config set project "<your-project>"`
  - `gcloud config set compute/region "<your-region>"`
- **Step 4 (Spanner)** — make the exports honor a pre-set value:
  - `export SPANNER_INSTANCE="${SPANNER_INSTANCE:-<your-spanner-instance>}"`
  - `export SPANNER_DB="${SPANNER_DB:-<your-googlesql-database>}"`

## Why

Written bare, bash reads `<` / `>` as redirection operators, so pasting any of these lines verbatim fails with `syntax error near unexpected token 'newline'` — before the reader even learns a value needs substituting.

Plain quoting fixes the syntax error, but for the Spanner exports it introduces a subtler problem: it *silently overwrites* a value the reader may have pre-exported (e.g. when the codelab is driven from an outer setup script), so `SPANNER_TARGET` ends up pointing at the literal `<your-spanner-instance>` and the deploy fails later with no obvious cause. The `${VAR:-<placeholder>}` form is paste-safe **and** lets a pre-set value survive:

- pre-set `SPANNER_INSTANCE` → kept, block runs as-is;
- unset → resolves to `<your-spanner-instance>`, the same placeholder to substitute as before.

The `gcloud config set` lines are a one-time literal substitution (not env-driven), so quoting is sufficient there.

## Test

`bash -n` / execution: the old bare form reproduces the syntax error; the quoted `gcloud` lines parse clean; the Spanner `${VAR:-...}` form resolves to the pre-set value when set and to the placeholder when unset. Docs-only change.