### PR TITLE
docs(semantic-model): retitle codelab to 'one semantic ontology, one data journey'

### DIFF
--- a/toolbox/mdcode/docs/semantic-model.md
+++ b/toolbox/mdcode/docs/semantic-model.md
@@ -5,8 +5,8 @@ now split by what you came to do:
 
 - **[Deploy guide](semantic-model/README.md)** — author a model, push it, update
   it, pull it back.
-- **[End-to-end codelab](semantic-model/codelab.md)** — author, govern, hydrate,
-  and query one model, start to finish.
+- **[Codelab: one semantic ontology, one data journey](semantic-model/codelab.md)** —
+  author, govern, hydrate, and query one model, start to finish.
 - **[Reference](semantic-model/reference.md)** — every flag, what push creates in
   BigQuery Graph, Spanner Graph, and Knowledge Catalog (including class
   hierarchies), validation, and permissions.

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -25,7 +25,7 @@ back. For the Ossie document format itself, see
 | Page | Open it to… |
 |---|---|
 | **This page** | author a model and deploy it |
-| [End-to-end codelab](codelab.md) | see the whole lifecycle: author, govern, hydrate, query |
+| [Codelab: one semantic ontology, one data journey](codelab.md) | see the whole lifecycle: author, govern, hydrate, query |
 | [Reference](reference.md) | look up a flag, what push creates, validation, or permissions |
 | [What push and pull preserve](fidelity.md) | understand why something changed or wasn't recovered |
 | [Importing an OWL ontology](owl-import.md) | start from an OWL ontology instead of hand-authoring |

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -1,4 +1,4 @@
-# End-to-end codelab: one semantic model, from authoring to query
+# Codelab: one semantic ontology, one data journey
 
 A self-contained walkthrough. You author a semantic model, govern it in Knowledge
 Catalog, and bind it to physical stores — BigQuery and Spanner — to query it in


### PR DESCRIPTION
Renames the semantic-model codelab title to **Codelab: one semantic ontology, one data journey** and updates the two doc links that referenced it (`semantic-model.md`, `semantic-model/README.md`) so their labels match.

Docs-only change.