### PR TITLE
docs: add a class-hierarchies modeling guide

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -44,6 +44,7 @@ example that carries one model through the whole lifecycle, see the
 |---|---|
 | **This page** | look up each deploy operation and its rules |
 | [Binding profiles](profiles.md) | bind one logical model to several stores |
+| [Modeling class hierarchies](inheritance.md) | model subtypes with `extends` so a supertype query gathers them |
 | [Codelab: one semantic ontology, one data journey](codelab.md) | see the whole lifecycle: author, govern, hydrate, query |
 | [Reference](reference.md) | look up a flag, what push creates, validation, or permissions |
 | [What push and pull preserve](fidelity.md) | understand why something changed or wasn't recovered |
@@ -112,9 +113,11 @@ metric's `expression` may be a bare formula over the logical fields or the fulle
 per-dialect form. `entities` may also be written `datasets`.
 
 Entities can **extend** other entities (`extends: [Parent]`); push flattens the
-supertype's fields down and expresses the hierarchy as BigQuery labels. See
-[Class hierarchies](reference.md#class-hierarchies-extends--labels) for the
-rules.
+supertype's fields down and expresses the hierarchy as graph labels, so a query
+against the supertype gathers every subtype. See
+[Modeling class hierarchies](inheritance.md) to model one step by step, and
+[Class hierarchies](reference.md#class-hierarchies-extends--labels) for the rules
+push enforces.
 
 This model names no table and no store, so it is complete enough to govern in
 Knowledge Catalog as-is (step 2). Where each entity reads from — the store and the

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -904,9 +904,232 @@ every field mean the same thing in both; only the bindings differ.
 
 ---
 
-## 5. Clean up
+## 5. Model a class hierarchy with `extends`
 
-Drop the BigQuery dataset (tables + property graph):
+A customer and a supplier are both parties you deal with. When several entities
+are kinds of one thing, declare the general kind once and say each specific kind
+`extends` it. A query written against the general kind then reaches every
+specific kind. This step adds a `supplier` entity beside `customer` and lifts the
+shared idea into an abstract `party` supertype, then deploys the result to
+BigQuery. For the modeling guide, see [class hierarchies](inheritance.md); for
+the generation rules, see
+[Reference → Class hierarchies](reference.md#class-hierarchies-extends--labels).
+
+### Add the supertype and a second subtype
+
+Rewrite the logical model to add three things: an abstract `party` that declares
+the shared `name` field, an `extends: [party]` on `customer`, and a new
+`supplier` entity that also extends `party`. `party` is `abstract`, so it has no
+`source` and no key and produces no node table; it survives in the graph only as
+a label on its subtypes. Each subtype keeps its own `name` field, and the two
+line up under the shared label by that name:
+
+```bash
+cat > catalog/EntryGroups/$DATASET/sales.yaml <<'YAML'
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    description: Orders, line items, and customers for the codelab
+    entities:
+      - name: orders
+        primary_key: [order_id]
+        fields:
+          - { name: order_id,    datatype: Integer }
+          - { name: customer_id, datatype: Integer }
+          - { name: net_amount,  datatype: Decimal }
+      - name: party
+        abstract: true               # no source, no key, no node table; a shared label
+        fields:
+          - { name: name, datatype: String }
+      - name: customer
+        extends: [party]
+        primary_key: [customer_id]
+        fields:
+          - { name: customer_id, datatype: Integer }
+          - { name: name,        datatype: String }
+      - name: supplier
+        extends: [party]
+        primary_key: [supplier_id]
+        fields:
+          - { name: supplier_id, datatype: Integer }
+          - { name: name,        datatype: String }
+      - name: lineitem
+        primary_key: [line_id]
+        fields:
+          - { name: line_id,  datatype: Integer }
+          - { name: order_id, datatype: Integer }
+    relationships:
+      - name: placed_by
+        from: orders
+        to: customer
+        from_columns: [customer_id]
+        to_columns: [customer_id]
+      - name: part_of
+        from: lineitem
+        to: orders
+        from_columns: [order_id]
+        to_columns: [order_id]
+    metrics:
+      - name: revenue
+        datatype: Decimal
+        expression:
+          dialects: [{ dialect: BIGQUERY, expression: SUM(orders.net_amount) }]
+YAML
+```
+
+```mermaid
+classDiagram
+    class party {
+        <<abstract>>
+        name : string
+    }
+    class customer {
+        customer_id : integer
+    }
+    class supplier {
+        supplier_id : integer
+    }
+    party <|-- customer
+    party <|-- supplier
+```
+
+Add the `supplier` binding to the `analytical` profile. `party` binds nothing —
+it has no table — so each subtype's own binding supplies the `name` column that
+its `party` label reads. Rewrite the profile to include `supplier`:
+
+```bash
+cat > catalog/EntryGroups/$DATASET/sales.profiles/analytical.yaml <<YAML
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    deployment_target: $TARGET
+    entities:
+      - name: orders
+        source: $PROJECT.$DATASET.orders
+        fields:
+          - { name: order_id,    expression: o_orderkey }
+          - { name: customer_id, expression: o_custkey }
+          - { name: net_amount,  expression: net_amount }
+      - name: customer
+        source: $PROJECT.$DATASET.customer
+        fields:
+          - { name: customer_id, expression: c_custkey }
+          - { name: name,        expression: c_name }
+      - name: supplier
+        source: $PROJECT.$DATASET.supplier
+        fields:
+          - { name: supplier_id, expression: s_suppkey }
+          - { name: name,        expression: s_name }
+      - name: lineitem
+        source: $PROJECT.$DATASET.lineitem
+        fields:
+          - { name: line_id,  expression: l_linekey }
+          - { name: order_id, expression: l_orderkey }
+YAML
+```
+
+### Create the supplier table
+
+Create the `supplier` table beside the others and load two rows:
+
+```bash
+bq query --use_legacy_sql=false '
+CREATE OR REPLACE TABLE `'"$PROJECT.$DATASET"'.supplier` AS
+SELECT * FROM UNNEST([STRUCT(1 AS s_suppkey, "Northwind" AS s_name),
+                      STRUCT(2, "Initech")]);'
+```
+
+### Deploy and read the labels
+
+Deploy the model again. The `orders`, `lineitem`, and edge tables are unchanged
+from step 3; the two node tables that matter now each carry the `party` label
+alongside their own default label. Each renders `name` from its own column:
+`c_name` on the customer table, `s_name` on the supplier table. The shared label
+reconciles by property name, so the two tables never have to agree on a physical
+column:
+
+```bash
+kcmd push --no-kc --print
+```
+
+```sql
+Pushing semantic model (BigQuery Graph)...
+-- BigQuery Graph --
+-- //bigquery.googleapis.com/projects/$PROJECT/datasets/$DATASET/propertyGraphs/$GRAPH
+CREATE OR REPLACE PROPERTY GRAPH `$PROJECT.$DATASET.$GRAPH`
+NODE TABLES (
+  ...
+  `$PROJECT.$DATASET.customer` AS customer
+    KEY(c_custkey)
+    DEFAULT LABEL
+    PROPERTIES(
+      c_custkey AS customer_id,
+      c_name AS name
+    )
+    LABEL party
+    PROPERTIES(
+      c_name AS name
+    ),
+  `$PROJECT.$DATASET.supplier` AS supplier
+    KEY(s_suppkey)
+    DEFAULT LABEL
+    PROPERTIES(
+      s_suppkey AS supplier_id,
+      s_name AS name
+    )
+    LABEL party
+    PROPERTIES(
+      s_name AS name
+    ),
+  ...
+);
+
+Deployed 1 BigQuery Graph(s).
+```
+
+### Query the supertype
+
+A query against `party` reaches both subtypes. Match every party and return its
+name:
+
+```bash
+bq query --use_legacy_sql=false --nouse_cache '
+GRAPH `'"$PROJECT.$DATASET.$GRAPH"'`
+MATCH (p:party)
+RETURN p.name AS name ORDER BY name'
+```
+
+Every customer and every supplier comes back, each once, because each real party
+lives in exactly one table:
+
+```
++-----------+
+|   name    |
++-----------+
+| Acme      |
+| Globex    |
+| Initech   |
+| Northwind |
++-----------+
+```
+
+`MATCH (:customer)` still returns Acme and Globex alone, and `MATCH (:supplier)`
+Northwind and Initech alone: each subtype keeps its own label as well as the
+shared one.
+
+> **Spanner works the same way.** Inheritance deploys identically to Spanner
+> Graph — the extra labels and the flattened fields are the same on both
+> backends. To include suppliers on the operational Spanner graph from step 4,
+> add a `supplier` binding and a `Supplier` table to the `operational` profile
+> the same way you did here. Spanner carries no measures, as it does for any
+> model.
+
+---
+
+## 6. Clean up
+
+Drop the BigQuery dataset (tables, including `supplier`, plus the property
+graph):
 
 ```bash
 bq rm -r -f -d $PROJECT:$DATASET

--- a/toolbox/mdcode/docs/semantic-model/inheritance.md
+++ b/toolbox/mdcode/docs/semantic-model/inheritance.md
@@ -127,35 +127,163 @@ RETURN p.name
 Every customer and every supplier comes back, each once, because each real party
 lives in exactly one table.
 
-## Extending more than one supertype
+## More hierarchy shapes
 
-`extends` takes a list. A subtype may extend several supertypes and then carries
-every one's label:
+`extends` composes. A subtype can extend several supertypes, and a supertype can
+extend another supertype above it. Two facts hold for every shape: the supertype
+fields flatten down, and each concrete table binds every inherited field to its
+own column. So the shapes below all deploy the same way, and each was verified to
+deploy on BigQuery Graph.
+
+### Extending more than one supertype, and diamonds
+
+`extends` takes a list. Here an `Employee` is both a `Person` and a `Taxpayer`,
+and each of those is a `Party`:
 
 ```yaml
+      - name: Party
+        abstract: true
+        primary_key: [id]
+        fields:
+          - { name: id,   datatype: Integer }
+          - { name: name, datatype: String }
+      - name: Person
+        abstract: true
+        extends: [Party]
+        fields:
+          - { name: birth_year, datatype: Integer }
+      - name: Taxpayer
+        abstract: true
+        extends: [Party]
+        fields:
+          - { name: tax_id, datatype: String }
       - name: Employee
         extends: [Person, Taxpayer]
         primary_key: [id]
+        source: my-project.hr.employee
         fields:
-          - { name: department, datatype: String }
+          - { name: id,         datatype: Integer, expression: e_id }
+          - { name: name,       datatype: String,  expression: e_name }
+          - { name: birth_year, datatype: Integer, expression: e_birth }
+          - { name: tax_id,     datatype: String,  expression: e_tax }
+          - { name: department, datatype: String,  expression: e_dept }
 ```
 
 ```mermaid
 classDiagram
-    class Person
-    class Taxpayer
+    class Party {
+        <<abstract>>
+        id : integer
+        name : string
+    }
+    class Person {
+        <<abstract>>
+        birth_year : integer
+    }
+    class Taxpayer {
+        <<abstract>>
+        tax_id : string
+    }
     class Employee {
         department : string
     }
+    Party <|-- Person
+    Party <|-- Taxpayer
     Person <|-- Employee
     Taxpayer <|-- Employee
 ```
 
-`MATCH (:Person)` and `MATCH (:Taxpayer)` each return the employee once. A diamond
-— two supertypes that share a grandparent — resolves cleanly too: the shared
-ancestor's label appears once on the leaf and matches once. Double-counting comes
-only from the same thing sitting in two sibling tables, never from how many
-supertypes an entity has or how deep the chain runs.
+`Party` sits at the top and is reached through two paths, so this is a diamond.
+`Employee` carries the `Person`, `Taxpayer`, and `Party` labels, and `Party`
+appears once. `MATCH (:Person)`, `MATCH (:Taxpayer)`, and `MATCH (:Party)` each
+return every employee a single time. The number of supertypes a subtype has, and
+the number of paths that reach a shared ancestor, do not change the count.
+
+### Deeper hierarchies
+
+A hierarchy can run several levels deep with a concrete table at each leaf. Here
+`Party` divides into `Person` and `Organization`, and each has its own concrete
+kind: a `Customer` is a person, a `Vendor` is an organization:
+
+```yaml
+      - name: Party
+        abstract: true
+        primary_key: [id]
+        fields:
+          - { name: id,   datatype: Integer }
+          - { name: name, datatype: String }
+      - name: Person
+        abstract: true
+        extends: [Party]
+        fields:
+          - { name: birth_year, datatype: Integer }
+      - name: Organization
+        abstract: true
+        extends: [Party]
+        fields:
+          - { name: founded_year, datatype: Integer }
+      - name: Customer
+        extends: [Person]
+        primary_key: [id]
+        source: my-project.sales.customer
+        fields:
+          - { name: id,         datatype: Integer, expression: c_id }
+          - { name: name,       datatype: String,  expression: c_name }
+          - { name: birth_year, datatype: Integer, expression: c_birth }
+          - { name: tier,       datatype: String,  expression: c_tier }
+      - name: Vendor
+        extends: [Organization]
+        primary_key: [id]
+        source: my-project.sales.vendor
+        fields:
+          - { name: id,           datatype: Integer, expression: v_id }
+          - { name: name,         datatype: String,  expression: v_name }
+          - { name: founded_year, datatype: Integer, expression: v_founded }
+          - { name: rating,       datatype: Integer, expression: v_rating }
+```
+
+```mermaid
+classDiagram
+    class Party {
+        <<abstract>>
+        id : integer
+        name : string
+    }
+    class Person {
+        <<abstract>>
+        birth_year : integer
+    }
+    class Organization {
+        <<abstract>>
+        founded_year : integer
+    }
+    class Customer {
+        tier : string
+    }
+    class Vendor {
+        rating : integer
+    }
+    Party <|-- Person
+    Party <|-- Organization
+    Person <|-- Customer
+    Organization <|-- Vendor
+```
+
+`Customer` and `Vendor` are the only tables. `MATCH (:Party)` returns every
+customer and every vendor; `MATCH (:Person)` returns customers alone, and
+`MATCH (:Organization)` vendors alone. Each real party lives in one table, so
+every count is exact.
+
+### What keeps every shape correct
+
+These shapes deploy because their supertypes are abstract. Each concrete table
+binds every inherited field to its own column, and BigQuery matches a shared
+label by property name, so the subtype tables never have to agree on a physical
+column. A supertype with its own table works too. Then every subtype table must
+carry that supertype's columns under the same names, and a thing present in both
+the supertype table and a subtype table is counted twice under the supertype
+label. Keeping supertypes abstract keeps the one rule — one real thing, one node
+— automatic.
 
 ## Match the shape to how your data is stored
 

--- a/toolbox/mdcode/docs/semantic-model/inheritance.md
+++ b/toolbox/mdcode/docs/semantic-model/inheritance.md
@@ -70,6 +70,26 @@ The supertype's `id` and `name` flatten down onto both subtypes, so `Customer`
 and `Supplier` each expose them, and each subtype node carries both its own label
 and the `Party` label.
 
+```mermaid
+classDiagram
+    class Party {
+        <<abstract>>
+        id : integer
+        name : string
+    }
+    class Customer {
+        loyalty_tier : string
+    }
+    class Supplier {
+        rating : integer
+    }
+    Party <|-- Customer
+    Party <|-- Supplier
+```
+
+`Party` is abstract, so it has no table of its own; the arrows are `extends`. A
+query against `Party` reaches every subtype below it.
+
 ## 2. Bind each subtype's table
 
 Inheritance meets binding at one requirement: **each subtype's table must expose
@@ -118,6 +138,17 @@ every one's label:
         primary_key: [id]
         fields:
           - { name: department, datatype: String }
+```
+
+```mermaid
+classDiagram
+    class Person
+    class Taxpayer
+    class Employee {
+        department : string
+    }
+    Person <|-- Employee
+    Taxpayer <|-- Employee
 ```
 
 `MATCH (:Person)` and `MATCH (:Taxpayer)` each return the employee once. A diamond

--- a/toolbox/mdcode/docs/semantic-model/inheritance.md
+++ b/toolbox/mdcode/docs/semantic-model/inheritance.md
@@ -1,0 +1,172 @@
+# Modeling class hierarchies
+
+When several entities are kinds of one thing — a customer and a supplier are both
+parties you deal with — you can declare the general kind once and say that each
+specific kind `extends` it. A query written against the general kind then reaches
+every specific kind. `extends` is the semantic model's *is-a*: a customer is a
+party.
+
+`kcmd push` expresses the hierarchy on the graph as **labels**. A subtype's node
+table carries its own label plus one label per supertype, so `MATCH (:Party)`
+matches every customer and every supplier. The exact generation rules — how
+fields flatten down, what a label signature must contain — are in
+[Reference → Class hierarchies](reference.md#class-hierarchies-extends--labels);
+this page is the modeling guide.
+
+## When to use it
+
+Use `extends` when the shared fields reflect a real *is a kind of* relationship
+and you want a supertype query to gather every subtype.
+
+Do not use it when the shared fields are a coincidence of naming, or when you
+have one entity whose columns happen to be split across two tables — that is a
+[binding](profiles.md), and modeling it as inheritance produces the double-count
+described below.
+
+## The one rule
+
+A supertype query gathers every subtype. Because it gathers subtypes, **each real
+thing must live in exactly one place**, or it is gathered more than once and your
+counts double. State it once and rely on it:
+
+> **One real thing, one row, one node.**
+
+Everything below is a way to honor this rule.
+
+## 1. Declare the hierarchy
+
+`Party` is the general kind. In this model no row is *just* a party — every party
+is a customer or a supplier — so `Party` has no table of its own. Mark it
+`abstract: true`: it has no `source` and no key, produces no node table, and
+survives in the graph only as a label on its subtypes.
+
+Each concrete kind declares its own fields and the one `extends` keyword. The
+supertype's fields are inherited, so you do not repeat them:
+
+```yaml
+version: "0.2.0.dev0"
+semantic_model:
+  - name: parties
+    entities:
+      - name: Party
+        abstract: true
+        primary_key: [id]
+        fields:
+          - { name: id,   datatype: Integer }
+          - { name: name, datatype: String }
+      - name: Customer
+        extends: [Party]
+        primary_key: [id]          # each subtype keeps its OWN key; keys are not inherited
+        fields:
+          - { name: loyalty_tier, datatype: String }
+      - name: Supplier
+        extends: [Party]
+        primary_key: [id]
+        fields:
+          - { name: rating, datatype: Integer }
+```
+
+The supertype's `id` and `name` flatten down onto both subtypes, so `Customer`
+and `Supplier` each expose them, and each subtype node carries both its own label
+and the `Party` label.
+
+## 2. Bind each subtype's table
+
+Inheritance meets binding at one requirement: **each subtype's table must expose
+the inherited columns**, because those fields are read from the subtype's own
+table. `Party.name`, flattened onto `Customer`, is read from the customer table,
+so that table must have a name column.
+
+A binding gives each entity its `source` and each field its column. With one
+store you can bind inline on the model as the `default` profile:
+
+```yaml
+      - name: Customer
+        extends: [Party]
+        primary_key: [id]
+        source: my-project.sales.customer
+        fields:
+          - { name: id,           datatype: Integer, expression: c_custkey }
+          - { name: name,         datatype: String,  expression: c_name }   # the inherited field, bound here
+          - { name: loyalty_tier, datatype: String,  expression: c_tier }
+```
+
+To bind the same hierarchy to more than one store, put each binding in its own
+[profile](profiles.md). A profile answers the supertype query only for the
+subtypes it binds: bind `Customer` but leave `Supplier` unbound and
+`MATCH (:Party)` returns customers alone.
+
+## 3. Query the supertype
+
+```
+GRAPH my-project.sales.parties
+MATCH (p:Party)
+RETURN p.name
+```
+
+Every customer and every supplier comes back, each once, because each real party
+lives in exactly one table.
+
+## Extending more than one supertype
+
+`extends` takes a list. A subtype may extend several supertypes and then carries
+every one's label:
+
+```yaml
+      - name: Employee
+        extends: [Person, Taxpayer]
+        primary_key: [id]
+        fields:
+          - { name: department, datatype: String }
+```
+
+`MATCH (:Person)` and `MATCH (:Taxpayer)` each return the employee once. A diamond
+— two supertypes that share a grandparent — resolves cleanly too: the shared
+ancestor's label appears once on the leaf and matches once. Double-counting comes
+only from the same thing sitting in two sibling tables, never from how many
+supertypes an entity has or how deep the chain runs.
+
+## Match the shape to how your data is stored
+
+How your subtypes are already stored decides how you model them. `extends` builds
+one shape directly, and the other two common layouts are modeled without it:
+
+- **One table per kind, the parent has none.** Each concrete kind has its own
+  complete table; the supertype has no table and survives as a label; a supertype
+  query is the union of the kind tables. This is the shape `extends` builds — the
+  hierarchy above. It is correct as long as the kind tables hold disjoint things,
+  which is why the parent is `abstract`.
+- **One table for the whole family, with a kind column.** All parties in one
+  table, a `type` column saying which kind each row is. Model this as one entity
+  with a dimension field; it holds one row per thing, so it cannot double-count.
+- **A base table plus an extension table.** A thing's general fields in one table
+  and its specific fields in another, tied by a shared key. Model this as one
+  entity whose binding joins the two tables, so the thing keeps one identity.
+
+## When a supertype total looks too high
+
+If a supertype count or sum comes back larger than the data warrants, the same
+real thing lives in more than one table under the hierarchy. Every table carrying
+the label contributes that thing as its own node. Take three people split across
+a `person` table and a `customer` table that both carry the `Person` label, with
+two of the three present in both. `MATCH (:Person)` returns **five** nodes,
+because no identity link across the two tables tells the graph that the shared
+rows are the same person.
+
+The fix is the one rule. Make the parent `abstract` so no real thing lives in more
+than one table under the hierarchy. When the two tables are instead the general
+and specific halves of one thing, model them as one entity whose binding joins
+them by key.
+
+## The rules push enforces
+
+Fields flow down to subtypes; relationships and keys do not. A subtype's table
+must expose every inherited column, or the deploy fails. A metric cannot sit on a
+shared supertype; attach it to a concrete subtype. An inherited field cannot be
+redefined with a different meaning, and every table under a shared supertype must
+expose the identical field set. Each rule and the error it raises is in
+[Reference → Class hierarchies](reference.md#class-hierarchies-extends--labels).
+
+Inheritance deploys the same way to BigQuery Graph and Spanner Graph — the extra
+labels and the flattened fields are identical on both backends. On Spanner the
+model carries no measures, as it does for any model.

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -89,6 +89,10 @@ labels, …) lands in the graph and which is dropped, see
 
 ### Class hierarchies (`extends` → labels)
 
+This section is the rules lookup. To model a hierarchy step by step — declaring
+it, binding each subtype's table, and keeping supertype counts correct — see
+[Modeling class hierarchies](inheritance.md).
+
 An entity that declares `extends: [Parent]` is a **subclass**. BigQuery Graph has
 no inheritance keyword, so the push expresses the hierarchy with **labels**: a
 subclass node table declares its own default label **plus one `LABEL <Ancestor>`

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -97,63 +97,83 @@ An entity that declares `extends: [Parent]` is a **subclass**. BigQuery Graph ha
 no inheritance keyword, so the push expresses the hierarchy with **labels**: a
 subclass node table declares its own default label **plus one `LABEL <Ancestor>`
 per supertype**, walking the full transitive chain. A node then matches its
-supertype in a query — `MATCH (:Person)` returns `Person`, `Customer`,
-`Employee`, and `Manager` nodes alike.
+supertype in a query — `MATCH (:Party)` returns every `Customer` and every
+`Supplier` node.
 
-You author only each entity's **own** fields plus the one `extends` keyword; the
-push does the rest:
+You author each entity's **own** fields plus the one `extends` keyword, and the
+push flattens the supertype's fields down onto each subclass. The usual
+supertype has no table of its own, so mark it `abstract: true`: it has no
+`source` and no key, produces no node table, and survives only as a label on its
+subtypes.
 
 ```yaml
-datasets:
-  - name: Person
-    source: proj.ds.person
+entities:
+  - name: Party
+    abstract: true             # no table; becomes a label on every subtype
     primary_key: [id]
     fields:
-      - {name: id,        expression: {dialects: [{dialect: BIGQUERY, expression: id}]}}
-      - {name: full_name, expression: {dialects: [{dialect: BIGQUERY, expression: full_name}]}}
-      - {name: email,     expression: {dialects: [{dialect: BIGQUERY, expression: email}]}}
+      - { name: id,   datatype: Integer }
+      - { name: name, datatype: String }
   - name: Customer
-    source: proj.ds.customer
+    extends: [Party]           # the one keyword you add
     primary_key: [id]          # each subclass keeps its OWN key; keys do not inherit
-    extends: [Person]          # the one keyword you add
+    source: proj.ds.customer
     fields:
-      - {name: loyalty_tier, expression: {dialects: [{dialect: BIGQUERY, expression: loyalty_tier}]}}
+      - { name: id,   datatype: Integer, expression: c_custkey }
+      - { name: name, datatype: String,  expression: c_name }   # the inherited field, bound to this table's column
+      - { name: tier, datatype: String,  expression: c_tier }
+  - name: Supplier
+    extends: [Party]
+    primary_key: [id]
+    source: proj.ds.supplier
+    fields:
+      - { name: id,     datatype: Integer, expression: s_suppkey }
+      - { name: name,   datatype: String,  expression: s_name }
+      - { name: rating, datatype: Integer, expression: s_rating }
 ```
 
-For those shared labels to work, **the supertype's fields flatten down** onto the
-subclass. BigQuery requires every table exposing a label to expose the **same
-property signature**, so a subclass's `LABEL Person` block must list exactly what
-`Person`'s own table lists. The push copies each ancestor's fields onto the
-subclass (a nearer definition wins on a name clash) so those signatures line up,
-and the subclass's default label carries the inherited fields too:
+**The supertype's fields flatten down** onto each subclass. A supertype
+contributes its field names to every subclass, ordered own fields first then
+inherited, and a nearer definition wins on a name clash. An abstract supertype
+binds no columns of its own, so each subtype supplies the column for every
+inherited name on its own table — `id` and `name` above are bound on both the
+customer and the supplier. A concrete supertype's bound fields flatten straight
+down, and a subtype need not repeat them.
+
+**A shared label is reconciled by property name rather than by backing column**
+(verified live). Every table that carries `LABEL Party` must expose the same property
+names — here `id` and `name` — and each backs them with its own column. So the
+push renders each inherited property from the subtype's own binding: `c_name AS
+name` on the customer table, `s_name AS name` on the supplier table. A bare-alias
+reference such as `PROPERTIES(name)` does not deploy; BigQuery rejects it with
+`Unrecognized name: name`.
 
 ```sql
 `proj.ds.customer` AS Customer
-  KEY(id)
+  KEY(c_custkey)
   DEFAULT LABEL
-  PROPERTIES( loyalty_tier, id, full_name, email )   -- own field first, then inherited (flattened)
-  LABEL Person
-  PROPERTIES( id, full_name, email )                 -- matches Person's own signature
+  PROPERTIES( c_custkey AS id, c_name AS name, c_tier AS tier )   -- id and name inherited from Party; tier is Customer's own
+  LABEL Party
+  PROPERTIES( c_custkey AS id, c_name AS name )                   -- Party's signature, backed by this table's columns
 ```
 
 ```
-GRAPH proj.ds.people
-MATCH (p:Person) RETURN p.full_name   -- resolves on Customer/Employee/Manager too
+GRAPH proj.ds.parties
+MATCH (p:Party) RETURN p.name   -- resolves on Customer and Supplier alike
 ```
 
-Four boundaries:
+The boundaries:
 
 - **Fields flow down; edges and keys do not.** A subclass gains its supertypes'
   fields but **not** their relationships or their key: an edge stays bound to the
   exact node table it was declared on, and each subclass keeps its own `KEY` (a
   node table is identified by its own grain, never its supertype's). If
   `Person —livesIn→ City`, a `Customer` node does not get a `livesIn` edge.
-- **The subclass's `source` must physically expose the inherited columns.** The
-  flattened `full_name`/`email` above are read from `proj.ds.customer`, so that
-  table (or a view over it) must include those columns. Parent and child are
-  separate physical tables, so the same real-world entity present in both
-  `person` and `customer` appears as two nodes under `MATCH (:Person)` — a
-  modeling choice for the binding step, not something the DDL enforces.
+- **The subclass's `source` must physically expose every inherited column.** The
+  flattened `name` above is read from `proj.ds.customer`, so that table (or a view
+  over it) must include the column that `Customer`'s `name` field binds. A
+  subclass whose table lacks a column that one of its inherited properties needs
+  fails the push when the graph deploys.
 - **A shared supertype label carries no OPTIONS and no measures.** A supertype's
   label is bound by every subclass table, and BigQuery forbids a label carried by
   more than one element table from carrying an `OPTIONS` clause or a `MEASURE`. So
@@ -161,23 +181,45 @@ Four boundaries:
   warning), and a metric that targets a supertype is skipped (with a warning) —
   attach metrics to a leaf class instead. Subclass and leaf labels are
   unaffected.
-- **An inherited field cannot be redefined.** A shared label requires one
-  identical definition per property across every table that binds it, so if a
-  subclass declares a field of the same name as an inherited one but with a
-  different expression, the supertype's definition wins and the subclass's is
-  dropped (with a warning). Redeclaring it identically is a harmless no-op.
+- **Each inherited property has one definition under the shared label.** For an
+  abstract supertype, the subtype supplies that definition — it binds the
+  inherited field to its own column, as `name` is bound above, and that binding is
+  used. A concrete supertype already defines the property on its own table, so a
+  subtype that declares the same-named field with a different column or expression
+  cannot override it: the supertype's definition wins and the subtype's is dropped
+  (with a warning). Redeclaring it identically is a harmless no-op.
 
-An entity may also be marked **`abstract: true`** — a conceptual class with no
-physical table (so it has no `source` and no key). It produces **no node table**;
-it survives only as a `LABEL` on its concrete descendants (its fields still
-flatten down so the label's signature is present). An abstract entity that no
-concrete entity extends has nothing to attach to and is dropped with a warning.
-`abstract` is an explicit marker: an entity left with an unbound `source`
-placeholder is treated as a binding error and fails the push, never silently
-dropped as if it were table-less. The Knowledge Catalog leg does not
+An entity marked **`abstract: true`** is a conceptual class with no physical
+table: it has no `source` and no key, produces **no node table**, and survives
+only as a `LABEL` on its concrete descendants. Its field names still flatten
+down, and each concrete subtype supplies the column for each of those names, so
+the shared label's signature is present on every subtype table. An abstract
+entity that no concrete entity extends has nothing to attach to and is dropped
+with a warning. `abstract` is an explicit marker: an entity left with an unbound
+`source` placeholder is treated as a binding error and fails the push, never
+silently dropped as if it were table-less. The Knowledge Catalog leg does not
 model inheritance today, so an abstract entity has no physical resource to
 catalog and is skipped there (with a warning); its concrete subtypes are
 published normally.
+
+A supertype **may** instead be concrete — carry its own `source` and key. It then
+becomes both its own node table and a label on its subtypes. Every subtype table
+must still expose columns that render to the supertype's property signature, so
+each subtype table has to carry the supertype's columns under the same names. The
+supertype's own rows and its subtypes' rows are distinct nodes: a real thing
+present in both the supertype table and a subtype table is matched twice under the
+supertype label. Prefer an abstract supertype unless each real thing lives in
+exactly one table under the hierarchy.
+
+**Multiple supertypes and diamonds.** `extends` takes a list, so a subclass may
+extend several supertypes and carry every one's label. The push expands `extends`
+to the full transitive ancestor set, de-duplicated. A diamond — two supertypes
+that share a grandparent — lists that grandparent's label once, so
+`MATCH (:Grandparent)` matches the leaf a single time. Depth and breadth do not
+change the rules: each concrete table binds every inherited property to its own
+column, and these shapes deploy on both BigQuery Graph and Spanner Graph
+(verified live for a diamond and for a three-level hierarchy with several
+concrete leaves).
 
 ## What gets created in Spanner
 

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -222,7 +222,7 @@ export function generatePropertyGraph(
 interface MeasureLowering {
   derivedProperties: string[];  // extra property lines to emit on the node
   taken: Set<string>;           // property names already in use on the node
-  fieldNames: Set<string>;      // declared field names (each an exposed property)
+  fieldNames: Set<string>;  // declared field names (each an exposed property)
   byLocalExpr: Map<string, string>;  // existing field local-expression -> its
                                      // property name
   operandToName:
@@ -401,8 +401,8 @@ function placeMetric(
   lowering.taken.add(metric.name);
 
   const propName = exposeOperand(lowering, operandExpr, metric.name);
-  const aggregate =
-      `${agg.fn}(${agg.distinct ? 'DISTINCT ' : ''}${quoteIfReserved(propName)})`;
+  const aggregate = `${agg.fn}(${agg.distinct ? 'DISTINCT ' : ''}${
+      quoteIfReserved(propName)})`;
 
   const opts = optionsClause(
       elementDescription(metric.description, metric.aiContext),
@@ -429,9 +429,9 @@ function exposeOperand(
   // field to a differently named physical column (the property is
   // `<column> AS <field>`, and a MEASURE may reference a sibling alias).
   // Synthesizing an input property here would emit `<field> AS ..._input`, and
-  // an alias is illegal inside a property expression -- BigQuery rejects it with
-  // "Unrecognized name". (A raw column that is not a field still falls through
-  // to be exposed under its own name, which BigQuery requires.)
+  // an alias is illegal inside a property expression -- BigQuery rejects it
+  // with "Unrecognized name". (A raw column that is not a field still falls
+  // through to be exposed under its own name, which BigQuery requires.)
   if (lowering.fieldNames.has(operandExpr)) return operandExpr;
 
   let name: string;
@@ -441,7 +441,8 @@ function exposeOperand(
     lowering.derivedProperties.push(quoteIfReserved(name));
   } else {
     name = uniqueName(`${metricName}_input`, lowering.taken);
-    lowering.derivedProperties.push(`${quoteIfReserved(operandExpr)} AS ${name}`);
+    lowering.derivedProperties.push(
+        `${quoteIfReserved(operandExpr)} AS ${name}`);
   }
   lowering.taken.add(name);
   lowering.operandToName.set(operandExpr, name);
@@ -567,20 +568,28 @@ function renderNodeTable(
   const table = qualifyTable(
       entity.dataSource, opts, warnings, `entity '${entity.name}'`);
 
-  // Canonical rendering of every inherited property: its supertype's OWN
-  // definition, keyed by property name (nearest ancestor wins, matching field
-  // flattening). A property that appears under a label shared across element
-  // tables must have one identical definition everywhere it appears, so the
-  // supertype is authoritative -- both this node's DEFAULT LABEL and its
-  // `LABEL <ancestor>` blocks render an inherited property exactly as the
-  // supertype's node table does. resolveInheritance localizes the inherited
-  // copies on this entity, so in a well-formed hierarchy `renderOwn` below is a
-  // no-op; the map's real job is to catch and neutralize a genuine override.
+  // Canonical rendering of every property inherited from a CONCRETE supertype:
+  // that supertype's OWN definition, keyed by property name (nearest ancestor
+  // wins, matching field flattening). A property under a label shared across
+  // element tables must have the same name in each, and a concrete supertype
+  // has its own node table binding that property, so it is authoritative --
+  // both this node's DEFAULT LABEL and its `LABEL <ancestor>` blocks render
+  // such a property exactly as the supertype's node table does.
+  // resolveInheritance localizes the inherited copies on this entity, so in a
+  // well-formed hierarchy `renderOwn` below is a no-op; the map's real job is
+  // to catch and neutralize a genuine override. An ABSTRACT supertype is
+  // excluded (it has no binding); its inherited names are rendered from this
+  // subtype's own binding instead.
   const inheritedRender = new Map<string, string>();
   const inheritedCore = new Map<string, string>();
   for (const ancestorName of entity.extends ?? []) {
     const ancestor = labelByName.get(ancestorName);
-    if (!ancestor) continue;
+    // Skip an ABSTRACT ancestor: it has no table and no binding of its own, so
+    // it cannot be authoritative for an inherited property's rendering. This
+    // subtype's own binding is the canonical one (e.g. `c_name AS name`), so we
+    // leave the inherited names out of this map and let `renderOwn` render them
+    // straight from this table. A concrete ancestor keeps its authority.
+    if (!ancestor || ancestor.abstract) continue;
     for (const f of ancestor.fields) {
       if (!inheritedRender.has(f.name)) {
         inheritedRender.set(f.name, renderFieldProperty(f, ancestor.name));
@@ -647,7 +656,12 @@ function renderNodeTable(
 
   const lines = [
     line(1, `${table} AS ${quoteIfReserved(entity.name)}`),
-    line(2, `KEY(${physicalColumns(entity, entity.keys, warnings, `entity '${entity.name}'`).join(', ')})`),
+    line(
+        2,
+        `KEY(${
+            physicalColumns(
+                entity, entity.keys, warnings, `entity '${entity.name}'`)
+                .join(', ')})`),
   ];
   // Element-table description and synonyms attach to the node's DEFAULT LABEL
   // -- UNLESS this entity is a supertype whose label is shared by subclass
@@ -684,13 +698,20 @@ function renderNodeTable(
   // Inheritance: declare one LABEL per transitive ancestor (resolveInheritance
   // expanded `extends` to the full ancestor set), each re-listing that
   // ancestor's properties so `MATCH (:Ancestor)` also matches this subclass
-  // node. The block is rendered straight from the ANCESTOR's own fields with
-  // the ancestor as qualifier, so it is byte-for-byte identical to the
-  // ancestor's own DEFAULT LABEL -- the exact match BigQuery requires for a
-  // property shared across the element tables that bind a label ("same set of
-  // property declarations under the same label"). This node's DEFAULT LABEL
-  // renders the same inherited names via `renderOwn`, which also defers to the
-  // ancestor, so the label is consistent within this table too.
+  // node. BigQuery reconciles a label shared across element tables by property
+  // NAME, not by backing column (verified live), so every table under a label
+  // must declare the same property names -- each backed by its own column.
+  //   - A CONCRETE ancestor has its own node table. Render its block straight
+  //     from the ancestor's own fields (ancestor qualifier), byte-for-byte
+  //     identical to the ancestor's own DEFAULT LABEL.
+  //   - An ABSTRACT ancestor has no table and no binding of its own, so its
+  //     names must be rendered from THIS subtype's binding of each inherited
+  //     field (e.g. `c_name AS name` on the customer table, `s_name AS name` on
+  //     the supplier table). A bare-alias reference (`PROPERTIES(name)`) does
+  //     NOT deploy -- "Unrecognized name: name" (verified live).
+  // Either way this node's DEFAULT LABEL renders the same inherited names (via
+  // `renderOwn`, which defers to a concrete ancestor and renders an abstract
+  // one's names from this table), so the label is consistent within this table.
   for (const ancestorName of entity.extends ?? []) {
     const ancestor = labelByName.get(ancestorName);
     if (!ancestor) {
@@ -706,8 +727,22 @@ function renderNodeTable(
       continue;
     }
     lines.push(line(2, `LABEL ${quoteIfReserved(ancestorName)}`));
-    const signature =
-        ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
+    let signature: string[];
+    if (ancestor.abstract) {
+      // Render each inherited field from THIS subtype's own binding, keyed by
+      // the abstract ancestor's field names. Skip any the subtype leaves
+      // unbound so the block matches the DEFAULT LABEL (which lists only bound
+      // fields); a profile that binds the subtype but not an inherited field
+      // simply does not expose that property under the shared label.
+      signature = [];
+      for (const af of ancestor.fields) {
+        const child = boundFields.find(cf => cf.name === af.name);
+        if (child) signature.push(renderFieldProperty(child, entity.name));
+      }
+    } else {
+      signature =
+          ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
+    }
     if (signature.length) lines.push(propertiesBlock(signature));
   }
   return lines.join('\n');
@@ -740,8 +775,7 @@ function renderFieldPropertyCore(field: Field, entity: string): string {
   const expr = fieldExpression(field);
   const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
   const alias = quoteIfReserved(field.name);
-  return local === field.name ? alias :
-                                `${quoteIfReserved(local)} AS ${alias}`;
+  return local === field.name ? alias : `${quoteIfReserved(local)} AS ${alias}`;
 }
 
 
@@ -751,8 +785,8 @@ function renderFieldPropertyCore(field: Field, entity: string): string {
 // never the property alias exposed under the field's name: BigQuery rejects an
 // alias there ("Column '<alias>' not found"). A profile that binds a field to a
 // differently named column makes name != column common. Falls back to the name
-// itself when it is not a declared field (already a raw column) or the entity is
-// unknown.
+// itself when it is not a declared field (already a raw column) or the entity
+// is unknown.
 function physicalColumn(entity: Entity|undefined, fieldName: string): string {
   const field = entity?.fields.find(f => f.name === fieldName);
   if (entity === undefined || field === undefined) return fieldName;
@@ -771,8 +805,10 @@ function physicalColumns(
     // problem is named statically rather than surfacing as opaque DDL.
     if (warnings && !isSimpleIdentifier(col)) {
       warnings.push(
-          `${ctx ?? `entity '${entity?.name ?? '?'}'`}: field '${n}' is bound ` +
-          `to a non-column expression (${col}); a KEY/REFERENCES site requires ` +
+          `${ctx ?? `entity '${entity?.name ?? '?'}'`}: field '${
+              n}' is bound ` +
+          `to a non-column expression (${
+              col}); a KEY/REFERENCES site requires ` +
           `a bare column, so BigQuery will reject the generated DDL`);
     }
     return quoteIfReserved(col);
@@ -810,12 +846,13 @@ function renderEdgeTable(
     sourceKey = sourceEntity.keys;
   }
 
-  // Every key clause names physical columns: the edge is the source entity's own
-  // table, so its KEY / SOURCE KEY / the FK in DESTINATION KEY all resolve
-  // against the source entity, while the destination REFERENCES resolves against
-  // the destination entity's key.
+  // Every key clause names physical columns: the edge is the source entity's
+  // own table, so its KEY / SOURCE KEY / the FK in DESTINATION KEY all resolve
+  // against the source entity, while the destination REFERENCES resolves
+  // against the destination entity's key.
   const relCtx = `relationship '${rel.name}'`;
-  const key = physicalColumns(sourceEntity, sourceKey, warnings, relCtx).join(', ');
+  const key =
+      physicalColumns(sourceEntity, sourceKey, warnings, relCtx).join(', ');
   const destFk =
       physicalColumns(sourceEntity, rel.source.columns, warnings, relCtx)
           .join(', ');
@@ -870,7 +907,8 @@ function renderAssociationEdge(
           `relationship '${rel.name}': unknown entity '${end.entity}'`);
       return end.columns.map(quoteIfReserved).join(', ');
     }
-    return physicalColumns(entity, entity.keys, warnings, `relationship '${rel.name}'`)
+    return physicalColumns(
+               entity, entity.keys, warnings, `relationship '${rel.name}'`)
         .join(', ');
   };
 

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -222,7 +222,7 @@ export function generatePropertyGraph(
 interface MeasureLowering {
   derivedProperties: string[];  // extra property lines to emit on the node
   taken: Set<string>;           // property names already in use on the node
-  fieldNames: Set<string>;  // declared field names (each an exposed property)
+  fieldNames: Set<string>;      // declared field names (each an exposed property)
   byLocalExpr: Map<string, string>;  // existing field local-expression -> its
                                      // property name
   operandToName:
@@ -401,8 +401,8 @@ function placeMetric(
   lowering.taken.add(metric.name);
 
   const propName = exposeOperand(lowering, operandExpr, metric.name);
-  const aggregate = `${agg.fn}(${agg.distinct ? 'DISTINCT ' : ''}${
-      quoteIfReserved(propName)})`;
+  const aggregate =
+      `${agg.fn}(${agg.distinct ? 'DISTINCT ' : ''}${quoteIfReserved(propName)})`;
 
   const opts = optionsClause(
       elementDescription(metric.description, metric.aiContext),
@@ -429,9 +429,9 @@ function exposeOperand(
   // field to a differently named physical column (the property is
   // `<column> AS <field>`, and a MEASURE may reference a sibling alias).
   // Synthesizing an input property here would emit `<field> AS ..._input`, and
-  // an alias is illegal inside a property expression -- BigQuery rejects it
-  // with "Unrecognized name". (A raw column that is not a field still falls
-  // through to be exposed under its own name, which BigQuery requires.)
+  // an alias is illegal inside a property expression -- BigQuery rejects it with
+  // "Unrecognized name". (A raw column that is not a field still falls through
+  // to be exposed under its own name, which BigQuery requires.)
   if (lowering.fieldNames.has(operandExpr)) return operandExpr;
 
   let name: string;
@@ -441,8 +441,7 @@ function exposeOperand(
     lowering.derivedProperties.push(quoteIfReserved(name));
   } else {
     name = uniqueName(`${metricName}_input`, lowering.taken);
-    lowering.derivedProperties.push(
-        `${quoteIfReserved(operandExpr)} AS ${name}`);
+    lowering.derivedProperties.push(`${quoteIfReserved(operandExpr)} AS ${name}`);
   }
   lowering.taken.add(name);
   lowering.operandToName.set(operandExpr, name);
@@ -568,18 +567,15 @@ function renderNodeTable(
   const table = qualifyTable(
       entity.dataSource, opts, warnings, `entity '${entity.name}'`);
 
-  // Canonical rendering of every property inherited from a CONCRETE supertype:
-  // that supertype's OWN definition, keyed by property name (nearest ancestor
-  // wins, matching field flattening). A property under a label shared across
-  // element tables must have the same name in each, and a concrete supertype
-  // has its own node table binding that property, so it is authoritative --
-  // both this node's DEFAULT LABEL and its `LABEL <ancestor>` blocks render
-  // such a property exactly as the supertype's node table does.
-  // resolveInheritance localizes the inherited copies on this entity, so in a
-  // well-formed hierarchy `renderOwn` below is a no-op; the map's real job is
-  // to catch and neutralize a genuine override. An ABSTRACT supertype is
-  // excluded (it has no binding); its inherited names are rendered from this
-  // subtype's own binding instead.
+  // Canonical rendering of every inherited property: its supertype's OWN
+  // definition, keyed by property name (nearest ancestor wins, matching field
+  // flattening). A property that appears under a label shared across element
+  // tables must have one identical definition everywhere it appears, so the
+  // supertype is authoritative -- both this node's DEFAULT LABEL and its
+  // `LABEL <ancestor>` blocks render an inherited property exactly as the
+  // supertype's node table does. resolveInheritance localizes the inherited
+  // copies on this entity, so in a well-formed hierarchy `renderOwn` below is a
+  // no-op; the map's real job is to catch and neutralize a genuine override.
   const inheritedRender = new Map<string, string>();
   const inheritedCore = new Map<string, string>();
   for (const ancestorName of entity.extends ?? []) {
@@ -656,12 +652,7 @@ function renderNodeTable(
 
   const lines = [
     line(1, `${table} AS ${quoteIfReserved(entity.name)}`),
-    line(
-        2,
-        `KEY(${
-            physicalColumns(
-                entity, entity.keys, warnings, `entity '${entity.name}'`)
-                .join(', ')})`),
+    line(2, `KEY(${physicalColumns(entity, entity.keys, warnings, `entity '${entity.name}'`).join(', ')})`),
   ];
   // Element-table description and synonyms attach to the node's DEFAULT LABEL
   // -- UNLESS this entity is a supertype whose label is shared by subclass
@@ -698,20 +689,13 @@ function renderNodeTable(
   // Inheritance: declare one LABEL per transitive ancestor (resolveInheritance
   // expanded `extends` to the full ancestor set), each re-listing that
   // ancestor's properties so `MATCH (:Ancestor)` also matches this subclass
-  // node. BigQuery reconciles a label shared across element tables by property
-  // NAME, not by backing column (verified live), so every table under a label
-  // must declare the same property names -- each backed by its own column.
-  //   - A CONCRETE ancestor has its own node table. Render its block straight
-  //     from the ancestor's own fields (ancestor qualifier), byte-for-byte
-  //     identical to the ancestor's own DEFAULT LABEL.
-  //   - An ABSTRACT ancestor has no table and no binding of its own, so its
-  //     names must be rendered from THIS subtype's binding of each inherited
-  //     field (e.g. `c_name AS name` on the customer table, `s_name AS name` on
-  //     the supplier table). A bare-alias reference (`PROPERTIES(name)`) does
-  //     NOT deploy -- "Unrecognized name: name" (verified live).
-  // Either way this node's DEFAULT LABEL renders the same inherited names (via
-  // `renderOwn`, which defers to a concrete ancestor and renders an abstract
-  // one's names from this table), so the label is consistent within this table.
+  // node. The block is rendered straight from the ANCESTOR's own fields with
+  // the ancestor as qualifier, so it is byte-for-byte identical to the
+  // ancestor's own DEFAULT LABEL -- the exact match BigQuery requires for a
+  // property shared across the element tables that bind a label ("same set of
+  // property declarations under the same label"). This node's DEFAULT LABEL
+  // renders the same inherited names via `renderOwn`, which also defers to the
+  // ancestor, so the label is consistent within this table too.
   for (const ancestorName of entity.extends ?? []) {
     const ancestor = labelByName.get(ancestorName);
     if (!ancestor) {
@@ -775,7 +759,8 @@ function renderFieldPropertyCore(field: Field, entity: string): string {
   const expr = fieldExpression(field);
   const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
   const alias = quoteIfReserved(field.name);
-  return local === field.name ? alias : `${quoteIfReserved(local)} AS ${alias}`;
+  return local === field.name ? alias :
+                                `${quoteIfReserved(local)} AS ${alias}`;
 }
 
 
@@ -785,8 +770,8 @@ function renderFieldPropertyCore(field: Field, entity: string): string {
 // never the property alias exposed under the field's name: BigQuery rejects an
 // alias there ("Column '<alias>' not found"). A profile that binds a field to a
 // differently named column makes name != column common. Falls back to the name
-// itself when it is not a declared field (already a raw column) or the entity
-// is unknown.
+// itself when it is not a declared field (already a raw column) or the entity is
+// unknown.
 function physicalColumn(entity: Entity|undefined, fieldName: string): string {
   const field = entity?.fields.find(f => f.name === fieldName);
   if (entity === undefined || field === undefined) return fieldName;
@@ -805,10 +790,8 @@ function physicalColumns(
     // problem is named statically rather than surfacing as opaque DDL.
     if (warnings && !isSimpleIdentifier(col)) {
       warnings.push(
-          `${ctx ?? `entity '${entity?.name ?? '?'}'`}: field '${
-              n}' is bound ` +
-          `to a non-column expression (${
-              col}); a KEY/REFERENCES site requires ` +
+          `${ctx ?? `entity '${entity?.name ?? '?'}'`}: field '${n}' is bound ` +
+          `to a non-column expression (${col}); a KEY/REFERENCES site requires ` +
           `a bare column, so BigQuery will reject the generated DDL`);
     }
     return quoteIfReserved(col);
@@ -846,13 +829,12 @@ function renderEdgeTable(
     sourceKey = sourceEntity.keys;
   }
 
-  // Every key clause names physical columns: the edge is the source entity's
-  // own table, so its KEY / SOURCE KEY / the FK in DESTINATION KEY all resolve
-  // against the source entity, while the destination REFERENCES resolves
-  // against the destination entity's key.
+  // Every key clause names physical columns: the edge is the source entity's own
+  // table, so its KEY / SOURCE KEY / the FK in DESTINATION KEY all resolve
+  // against the source entity, while the destination REFERENCES resolves against
+  // the destination entity's key.
   const relCtx = `relationship '${rel.name}'`;
-  const key =
-      physicalColumns(sourceEntity, sourceKey, warnings, relCtx).join(', ');
+  const key = physicalColumns(sourceEntity, sourceKey, warnings, relCtx).join(', ');
   const destFk =
       physicalColumns(sourceEntity, rel.source.columns, warnings, relCtx)
           .join(', ');
@@ -907,8 +889,7 @@ function renderAssociationEdge(
           `relationship '${rel.name}': unknown entity '${end.entity}'`);
       return end.columns.map(quoteIfReserved).join(', ');
     }
-    return physicalColumns(
-               entity, entity.keys, warnings, `relationship '${rel.name}'`)
+    return physicalColumns(entity, entity.keys, warnings, `relationship '${rel.name}'`)
         .join(', ');
   };
 

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -4,23 +4,23 @@
 // The format describes a semantic model as datasets (entities), foreign-key
 // relationships, and model-level metrics, with entity-qualified SQL expressions
 // (`Entity.column`) supplied per SQL dialect. This module reads the subset of
-// that logical layer needed to normalize a model into the IR, so the rest of
-// the toolbox (e.g. the BigQuery property-graph generator) can consume models
+// that logical layer needed to normalize a model into the IR, so the rest of the
+// toolbox (e.g. the BigQuery property-graph generator) can consume models
 // authored in it. Fields outside the supported subset are accepted and ignored.
 //
 
 import * as yaml from 'yaml';
 import * as z from 'zod';
-
-import {AiContext, CustomExtension, DATA_TYPES, Entity, Field, Metric, Relationship, SemanticModel,} from './ir';
-import {referencedEntityNames} from './sql_expr_utils';
+import {
+  SemanticModel, Entity, Field, Relationship, Metric, AiContext, CustomExtension,
+  DATA_TYPES,
+} from './ir';
+import { referencedEntityNames } from './sql_expr_utils';
 
 export interface LoadOptions {
-  dialect?: string;  // preferred expression dialect; default 'BIGQUERY'
-  defaultProject?:
-      string;  // fallback when a dataset `source` omits the project
-  defaultDataset?:
-      string;  // fallback when a dataset `source` omits the dataset
+  dialect?: string;         // preferred expression dialect; default 'BIGQUERY'
+  defaultProject?: string;  // fallback when a dataset `source` omits the project
+  defaultDataset?: string;  // fallback when a dataset `source` omits the dataset
   // Accept a purely logical model: do not require a `source` on each concrete
   // dataset or an `expression` on each field. Set for a Knowledge-Catalog-only
   // push, which governs the logical model (meaning) and needs no physical
@@ -52,14 +52,14 @@ const SUPPORTED_VERSION = '0.2.0.dev0';
 // only ever sees the per-dialect object.
 const expressionObjectSchema = z.object({
   dialects: z.array(z.object({
-               dialect: z.string(),
-               expression: z.string(),
-             })).min(1),
+    dialect: z.string(),
+    expression: z.string(),
+  })).min(1),
 });
 const expressionSchema = z.union([
   z.string().transform((s): z.infer<typeof expressionObjectSchema> => ({
-                         dialects: [{dialect: DEFAULT_DIALECT, expression: s}],
-                       })),
+    dialects: [{ dialect: DEFAULT_DIALECT, expression: s }],
+  })),
   expressionObjectSchema,
 ]);
 
@@ -79,9 +79,8 @@ const aiContextSchema = z.union([
 // A vendor-scoped extension block: opaque `data` (a JSON string) tagged by
 // `vendor_name`. The spec allows these at every level (model, dataset, field,
 // relationship, metric). All are preserved verbatim on the IR (see
-// toCustomExtensions) for lossless round-trip; no vendor block is interpreted
-// at load time -- typed views (e.g. off the GOOGLE block) are a consumer
-// concern.
+// toCustomExtensions) for lossless round-trip; no vendor block is interpreted at
+// load time -- typed views (e.g. off the GOOGLE block) are a consumer concern.
 const customExtensionSchema = z.object({
   vendor_name: z.string(),
   data: z.string(),
@@ -105,8 +104,7 @@ const fieldBase = z.object({
   // logical field carries neither.
   expression: expressionSchema.optional(),
   unbound: z.boolean().optional(),
-  datatype: z.enum(DATA_TYPES).optional(),  // closed, case-sensitive
-                                            // vocabulary; see DATA_TYPES
+  datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
   description: z.string().optional(),
   label: z.string().optional(),
   dimension: dimensionSchema.optional(),
@@ -140,32 +138,27 @@ const datasetBase = z.object({
 });
 
 const relationshipSchema = z.object({
-                              name: z.string(),
-                              from: z.string(),
-                              to: z.string(),
-                              // Join columns are the physical binding of the
-                              // edge and are OPTIONAL, so a purely logical
-                              // relationship (an ontology edge, direction only)
-                              // loads. When present they must be non-empty;
-                              // either both endpoints are bound or neither is
-                              // (a half-bound edge is a malformed join, caught
-                              // below). A graph push still requires both (see
-                              // validatePushRequirements).
-                              from_columns:
-                                  z.array(z.string()).min(1).optional(),
-                              to_columns: z.array(z.string()).min(1).optional(),
-                              description: z.string().optional(),
-                              ai_context: aiContextSchema.optional(),
-                              custom_extensions:
-                                  z.array(customExtensionSchema).optional(),
-                            }).superRefine((r, ctx) => {
+  name: z.string(),
+  from: z.string(),
+  to: z.string(),
+  // Join columns are the physical binding of the edge and are OPTIONAL, so a
+  // purely logical relationship (an ontology edge, direction only) loads. When
+  // present they must be non-empty; either both endpoints are bound or neither
+  // is (a half-bound edge is a malformed join, caught below). A graph push still
+  // requires both (see validatePushRequirements).
+  from_columns: z.array(z.string()).min(1).optional(),
+  to_columns: z.array(z.string()).min(1).optional(),
+  description: z.string().optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+}).superRefine((r, ctx) => {
   if ((r.from_columns === undefined) !== (r.to_columns === undefined)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `relationship '${
-                   r.name}': from_columns and to_columns must be given ` +
-          `together (both bind the edge) or both omitted (a logical edge); one ` +
-          `without the other is a half-bound join.`,
+      message:
+        `relationship '${r.name}': from_columns and to_columns must be given ` +
+        `together (both bind the edge) or both omitted (a logical edge); one ` +
+        `without the other is a half-bound join.`,
     });
   }
 });
@@ -173,8 +166,7 @@ const relationshipSchema = z.object({
 const metricSchema = z.object({
   name: z.string(),
   expression: expressionSchema,
-  datatype: z.enum(DATA_TYPES).optional(),  // closed, case-sensitive
-                                            // vocabulary; see DATA_TYPES
+  datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
@@ -207,58 +199,54 @@ function buildDocumentSchema(bindingOptional: boolean) {
             `'expression', or drop 'unbound: true' to bind it to that column`,
       });
     }
-    // The "requires an expression" check lives at the dataset level below, not
-    // here: a field on an ABSTRACT dataset legitimately has no column (the
-    // supertype has no table -- it survives only as a label on its subtypes),
-    // and only the dataset's superRefine can see `abstract`.
+    // The expression-required check is applied at the dataset level (below),
+    // not here, so it can skip a dataset marked `abstract`: an abstract
+    // supertype has no table and its fields carry no expression, surviving only
+    // as labels on its concrete descendants.
   });
-  const dataset =
-      datasetBase.extend({fields: z.array(field).optional()})
-          .superRefine((ds, ctx) => {
-            // A concrete (non-abstract) dataset must name its backing table;
-            // only an abstract one may omit `source`. Relaxed under
-            // bindingOptional, where a logical dataset has no source.
-            if (!bindingOptional && !ds.abstract && ds.source === undefined) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['source'],
-                message:
-                    `dataset '${ds.name}': a non-abstract dataset requires a ` +
-                    `source; set 'source', or mark it 'abstract: true' if it has no table`,
-              });
-            }
-            // The converse is always contradictory: an abstract dataset has no
-            // physical table, so a `source` on it would be silently ignored by
-            // the BigQuery leg. Reject it regardless of bindingOptional.
-            if (ds.abstract && ds.source !== undefined) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['source'],
-                message:
-                    `dataset '${ds.name}': an abstract dataset has no table; ` +
-                    `remove 'source', or drop 'abstract: true' to bind it to that table`,
-              });
-            }
-            // Under a graph leg, every field of a CONCRETE dataset must be
-            // bound or explicitly unbound. An abstract dataset is exempt: it
-            // has no table, so its fields carry no column -- they define the
-            // label signature its subtypes bind. Enforced here (not on the
-            // field) so `abstract` is visible.
-            if (!bindingOptional && !ds.abstract) {
-              (ds.fields ?? []).forEach((f, i) => {
-                if (!f.unbound && f.expression === undefined) {
-                  ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: ['fields', i, 'expression'],
-                    message: `field '${f.name}': requires an expression; set ` +
-                        `'expression', or mark it 'unbound: true' if this ` +
-                        `binding has no column for it`,
-                  });
-                }
-              });
-            }
-          });
-  const model = modelBase.extend({datasets: z.array(dataset).min(1)});
+  const dataset = datasetBase.extend({ fields: z.array(field).optional() })
+    .superRefine((ds, ctx) => {
+      // A concrete (non-abstract) dataset must name its backing table; only an
+      // abstract one may omit `source`. Relaxed under bindingOptional, where a
+      // logical dataset has no source.
+      if (!bindingOptional && !ds.abstract && ds.source === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['source'],
+          message: `dataset '${ds.name}': a non-abstract dataset requires a ` +
+              `source; set 'source', or mark it 'abstract: true' if it has no table`,
+        });
+      }
+      // The converse is always contradictory: an abstract dataset has no
+      // physical table, so a `source` on it would be silently ignored by the
+      // BigQuery leg. Reject it regardless of bindingOptional.
+      if (ds.abstract && ds.source !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['source'],
+          message: `dataset '${ds.name}': an abstract dataset has no table; ` +
+              `remove 'source', or drop 'abstract: true' to bind it to that table`,
+        });
+      }
+      // Each concrete dataset's fields must be bound (or explicitly `unbound`)
+      // under a graph leg. An abstract dataset is skipped: it has no table, so
+      // its fields carry no column. Checked here rather than per-field because
+      // abstractness is a dataset-level fact.
+      if (!bindingOptional && !ds.abstract) {
+        (ds.fields ?? []).forEach((f, i) => {
+          if (!f.unbound && f.expression === undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['fields', i, 'expression'],
+              message: `field '${f.name}': requires an expression; set ` +
+                  `'expression', or mark it 'unbound: true' if this ` +
+                  `binding has no column for it`,
+            });
+          }
+        });
+      }
+    });
+  const model = modelBase.extend({ datasets: z.array(dataset).min(1) });
   return z.object({
     version: z.string().optional(),
     semantic_model: z.array(model).min(1),
@@ -267,8 +255,8 @@ function buildDocumentSchema(bindingOptional: boolean) {
 
 // Only two schema shapes exist (strict vs binding-optional) and each is
 // immutable, so build both once at module load and select between them rather
-// than reconstructing the whole field/dataset/model/document graph -- with
-// fresh superRefine closures -- on every fromDocument call.
+// than reconstructing the whole field/dataset/model/document graph -- with fresh
+// superRefine closures -- on every fromDocument call.
 const strictDocumentSchema = buildDocumentSchema(false);
 const logicalDocumentSchema = buildDocumentSchema(true);
 function makeDocumentSchema(bindingOptional: boolean) {
@@ -287,16 +275,14 @@ type AiContextDoc = z.infer<typeof aiContextSchema>;
 // The AI-first `ai_context` normalized to the IR's common shape: a bare string
 // is read as `instructions`; a structured object keeps its parts. `examples` is
 // filtered to strings (producers vary; non-string examples are dropped).
-function normalizeAiContext(ai: AiContextDoc|undefined): AiContext {
+function normalizeAiContext(ai: AiContextDoc | undefined): AiContext {
   if (ai === undefined) return {};
-  if (typeof ai === 'string') return {instructions: ai};
+  if (typeof ai === 'string') return { instructions: ai };
   const out: AiContext = {};
   if (ai.instructions) out.instructions = ai.instructions;
-  if (ai.synonyms && ai.synonyms.length)
-    out.synonyms = [...new Set(ai.synonyms)];
+  if (ai.synonyms && ai.synonyms.length) out.synonyms = [...new Set(ai.synonyms)];
   if (ai.examples && ai.examples.length) {
-    const strings =
-        ai.examples.filter((e): e is string => typeof e === 'string');
+    const strings = ai.examples.filter((e): e is string => typeof e === 'string');
     if (strings.length) out.examples = strings;
   }
   return out;
@@ -304,7 +290,7 @@ function normalizeAiContext(ai: AiContextDoc|undefined): AiContext {
 
 // Normalizes `ai_context` and returns it only when it carries something, so the
 // IR omits empty aiContext objects.
-function aiContextOrUndefined(ai: AiContextDoc|undefined): AiContext|undefined {
+function aiContextOrUndefined(ai: AiContextDoc | undefined): AiContext | undefined {
   const ctx = normalizeAiContext(ai);
   return (ctx.instructions || ctx.synonyms || ctx.examples) ? ctx : undefined;
 }
@@ -313,21 +299,22 @@ function aiContextOrUndefined(ai: AiContextDoc|undefined): AiContext|undefined {
 // `vendorName`; `data` kept as the opaque, vendor-serialized string) so nothing
 // is lost and a 1P round-trip stays lossless. Typed views over specific vendors
 // are derived by the consumers that need them, not here.
-function toCustomExtensions(exts: CustomExtensionDoc[]|undefined):
-    CustomExtension[]|undefined {
+function toCustomExtensions(
+    exts: CustomExtensionDoc[] | undefined): CustomExtension[] | undefined {
   if (!exts || !exts.length) return undefined;
-  return exts.map(e => ({vendorName: e.vendor_name, data: e.data}));
+  return exts.map(e => ({ vendorName: e.vendor_name, data: e.data }));
 }
 
 // Composes a single description string from ordered parts, dropping empties.
 // Parts are separated by blank lines so a base description and derived markers
 // read as distinct paragraphs in the emitted metadata. AI-first annotations
-// (instructions / synonyms / examples) are NOT folded in here — they are
-// carried structurally on the IR (aiContext) so an emitter can route them to
-// their own aspects.
-function composeDescription(...parts: (string|undefined)[]): string|undefined {
-  const kept = parts.map(p => (p === undefined ? undefined : p.trim()))
-                   .filter((p): p is string => !!p);
+// (instructions / synonyms / examples) are NOT folded in here — they are carried
+// structurally on the IR (aiContext) so an emitter can route them to their own
+// aspects.
+function composeDescription(...parts: (string | undefined)[]): string | undefined {
+  const kept = parts
+    .map(p => (p === undefined ? undefined : p.trim()))
+    .filter((p): p is string => !!p);
   return kept.length ? kept.join('\n\n') : undefined;
 }
 
@@ -359,8 +346,7 @@ function normalizeModelSugars(m: any): void {
 
   if (m.entities !== undefined) {
     if (m.datasets !== undefined) {
-      throw new Error(
-          `Semantic model load error: ${label}: set either ` +
+      throw new Error(`Semantic model load error: ${label}: set either ` +
           `'entities' or 'datasets', not both (they are the same key).`);
     }
     m.datasets = m.entities;
@@ -370,8 +356,7 @@ function normalizeModelSugars(m: any): void {
   if (m.deployment_target !== undefined) {
     const target = m.deployment_target;
     if (typeof target !== 'string') {
-      throw new Error(
-          `Semantic model load error: ${label}: ` +
+      throw new Error(`Semantic model load error: ${label}: ` +
           `'deployment_target' must be a URI string.`);
     }
     foldDeploymentTarget(m, target, label);
@@ -399,8 +384,7 @@ function foldDeploymentTarget(m: any, target: string, label: string): void {
     const list = data?.deploymentTargets;
     if (Array.isArray(list) && list.length) {
       if (!list.includes(target)) {
-        throw new Error(
-            `Semantic model load error: ${label}: ` +
+        throw new Error(`Semantic model load error: ${label}: ` +
             `'deployment_target' disagrees with the GOOGLE custom_extension ` +
             `already on this model; set one, or make them match.`);
       }
@@ -409,22 +393,21 @@ function foldDeploymentTarget(m: any, target: string, label: string): void {
   }
   exts.push({
     vendor_name: GOOGLE_VENDOR,
-    data: JSON.stringify({deploymentTargets: [target]}),
+    data: JSON.stringify({ deploymentTargets: [target] }),
   });
   m.custom_extensions = exts;
 }
 
 /**
- * Loads YAML or JSON text (a document in the AI-first semantics format) into
- * the Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
+ * Loads YAML or JSON text (a document in the AI-first semantics format) into the
+ * Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
  */
 export function loadModels(text: string, opts: LoadOptions = {}): LoadResult {
   let doc: unknown;
   try {
     doc = yaml.parse(text);
   } catch (err: any) {
-    throw new Error(`Semantic model load error: could not parse input: ${
-        err?.message ?? err}`);
+    throw new Error(`Semantic model load error: could not parse input: ${err?.message ?? err}`);
   }
   return fromDocument(doc, opts);
 }
@@ -447,14 +430,12 @@ export function fromDocument(doc: unknown, opts: LoadOptions = {}): LoadResult {
 
   if (parsed.version && parsed.version !== SUPPORTED_VERSION) {
     warnings.push(
-        `document version '${parsed.version}' differs from the supported '${
-            SUPPORTED_VERSION}'; ` +
-        `loading anyway`);
+      `document version '${parsed.version}' differs from the supported '${SUPPORTED_VERSION}'; ` +
+      `loading anyway`);
   }
 
-  const models =
-      parsed.semantic_model.map(m => convertModel(m, opts, warnings));
-  return {models, warnings: [...new Set(warnings)]};
+  const models = parsed.semantic_model.map(m => convertModel(m, opts, warnings));
+  return { models, warnings: [...new Set(warnings)] };
 }
 
 
@@ -469,40 +450,34 @@ function warnDuplicateNames(
   for (const n of names) {
     if (seen.has(n)) {
       warnings.push(
-          `${scope}: duplicate ${kind} '${n}'; names must be unique ` +
-          `(the generated graph will be invalid)`);
+        `${scope}: duplicate ${kind} '${n}'; names must be unique ` +
+        `(the generated graph will be invalid)`);
     }
     seen.add(n);
   }
 }
 
-function convertModel(
-    m: ModelDoc, opts: LoadOptions, warnings: string[]): SemanticModel {
+function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): SemanticModel {
   const dialect = opts.dialect ?? DEFAULT_DIALECT;
 
-  const entities =
-      m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
-  warnDuplicateNames(
-      entities.map(e => e.name), 'dataset name', `model '${m.name}'`, warnings);
+  const entities = m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
+  warnDuplicateNames(entities.map(e => e.name), 'dataset name', `model '${m.name}'`, warnings);
 
   const entityNames = entities.map(e => e.name);
   const entityNameSet = new Set(entityNames);
 
-  const relationships =
-      (m.relationships ?? []).map(r => convertRelationship(r, entityNameSet));
+  const relationships = (m.relationships ?? []).map(
+    r => convertRelationship(r, entityNameSet));
   warnDuplicateNames(
-      relationships.map(r => r.name), 'relationship name', `model '${m.name}'`,
-      warnings);
+    relationships.map(r => r.name), 'relationship name', `model '${m.name}'`, warnings);
 
-  const metrics =
-      (m.metrics ??
-       []).map(mt => convertMetric(mt, entityNames, warnings, dialect));
-  warnDuplicateNames(
-      metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`, warnings);
+  const metrics = (m.metrics ?? []).map(
+    mt => convertMetric(mt, entityNames, warnings, dialect));
+  warnDuplicateNames(metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`, warnings);
 
   const description = composeDescription(m.description);
 
-  const model: SemanticModel = {name: m.name, entities, relationships, metrics};
+  const model: SemanticModel = { name: m.name, entities, relationships, metrics };
   if (description) model.description = description;
   const ai = aiContextOrUndefined(m.ai_context);
   if (ai) model.aiContext = ai;
@@ -511,9 +486,8 @@ function convertModel(
   return model;
 }
 
-function convertDataset(
-    ds: DatasetDoc, opts: LoadOptions, warnings: string[],
-    dialect: string): Entity {
+function convertDataset(ds: DatasetDoc, opts: LoadOptions,
+                        warnings: string[], dialect: string): Entity {
   const ctxLabel = `dataset '${ds.name}'`;
   // An abstract entity has no physical table, so it carries no source (empty
   // dataSource) and no key -- both are meaningless for a class never
@@ -523,17 +497,13 @@ function convertDataset(
       '';
   const keys = ds.primary_key ?? [];
   if (!keys.length && !ds.abstract) {
-    warnings.push(`${
-        ctxLabel}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
+    warnings.push(`${ctxLabel}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
   }
-  const fields =
-      (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
-  warnDuplicateNames(
-      fields.map(f => f.name), 'field name', `dataset '${ds.name}'`, warnings);
+  const fields = (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
+  warnDuplicateNames(fields.map(f => f.name), 'field name', `dataset '${ds.name}'`, warnings);
 
-  const entity: Entity = {name: ds.name, dataSource, keys, fields};
-  if (ds.unique_keys && ds.unique_keys.length)
-    entity.uniqueKeys = ds.unique_keys;
+  const entity: Entity = { name: ds.name, dataSource, keys, fields };
+  if (ds.unique_keys && ds.unique_keys.length) entity.uniqueKeys = ds.unique_keys;
   if (ds.extends && ds.extends.length) entity.extends = ds.extends;
   if (ds.abstract) entity.abstract = true;
   const description = composeDescription(ds.description);
@@ -545,22 +515,20 @@ function convertDataset(
   return entity;
 }
 
-function convertField(
-    f: FieldDoc, entityName: string, warnings: string[],
-    dialect: string): Field {
+function convertField(f: FieldDoc, entityName: string, warnings: string[], dialect: string): Field {
   // `label`, `dimension`, and AI-first annotations are carried structurally on
   // the IR (not folded into `description`) so an emitter can route each to its
   // own destination and a 1P round-trip stays lossless.
   const description = composeDescription(f.description);
 
-  const field: Field = {name: f.name};
+  const field: Field = { name: f.name };
   if (f.unbound) {
     // Declared but not bound under this binding: no column, no expression (the
     // schema guarantees `expression` is absent here). See Field.unbound.
     field.unbound = true;
   } else if (f.expression !== undefined) {
     const picked = pickDialect(
-        f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
+      f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
     if (picked.expression !== undefined) field.expression = picked.expression;
     if (picked.importedExpression !== undefined) {
       field.importedExpression = picked.importedExpression;
@@ -574,8 +542,7 @@ function convertField(
   if (f.label) field.label = f.label;
   if (f.dimension) {
     field.dimension = {};
-    if (f.dimension.is_time !== undefined)
-      field.dimension.isTime = f.dimension.is_time;
+    if (f.dimension.is_time !== undefined) field.dimension.isTime = f.dimension.is_time;
   }
   if (description) field.description = description;
   const ai = aiContextOrUndefined(f.ai_context);
@@ -585,41 +552,35 @@ function convertField(
   return field;
 }
 
-// Maps an OSI foreign-key relationship onto the IR edge. `source.columns` are
-// the FK columns on the `from` table (`from_columns`); `destination.columns`
-// are the referenced key columns on the `to` table (`to_columns`), paired
-// positionally. A logical relationship carries no columns (both endpoints
-// empty); a graph push requires them and rejects a column-less edge (see
-// validatePushRequirements). The source entity's own primary key is not
-// duplicated here -- downstream consumers look it up from the entity. A
-// malformed relationship (an endpoint not declared in the model, or mismatched
-// column arity) is a hard error, not a warning: the resulting edge would be
-// structurally invalid.
-function convertRelationship(
-    r: RelationshipDoc, entityNames: Set<string>): Relationship {
+// Maps an OSI foreign-key relationship onto the IR edge. `source.columns` are the
+// FK columns on the `from` table (`from_columns`); `destination.columns` are the
+// referenced key columns on the `to` table (`to_columns`), paired positionally.
+// A logical relationship carries no columns (both endpoints empty); a graph
+// push requires them and rejects a column-less edge (see validatePushRequirements).
+// The source entity's own primary key is not duplicated here -- downstream
+// consumers look it up from the entity. A malformed relationship (an endpoint not
+// declared in the model, or mismatched column arity) is a hard error, not a
+// warning: the resulting edge would be structurally invalid.
+function convertRelationship(r: RelationshipDoc, entityNames: Set<string>): Relationship {
   const ctx = `relationship '${r.name}'`;
   if (!entityNames.has(r.from)) {
-    throw new Error(
-        `${ctx}: 'from' dataset '${r.from}' is not defined in the model`);
+    throw new Error(`${ctx}: 'from' dataset '${r.from}' is not defined in the model`);
   }
   if (!entityNames.has(r.to)) {
-    throw new Error(
-        `${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
+    throw new Error(`${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
   }
   const fromColumns = r.from_columns ?? [];
   const toColumns = r.to_columns ?? [];
   if (fromColumns.length !== toColumns.length) {
     throw new Error(
-        `${ctx}: from_columns (${fromColumns.length}) and to_columns ` +
-        `(${
-            toColumns
-                .length}) have different lengths; the join keys are mismatched`);
+      `${ctx}: from_columns (${fromColumns.length}) and to_columns ` +
+      `(${toColumns.length}) have different lengths; the join keys are mismatched`);
   }
 
   const relationship: Relationship = {
     name: r.name,
-    source: {entity: r.from, columns: fromColumns},
-    destination: {entity: r.to, columns: toColumns},
+    source: { entity: r.from, columns: fromColumns },
+    destination: { entity: r.to, columns: toColumns },
   };
   const description = composeDescription(r.description);
   if (description) relationship.description = description;
@@ -630,9 +591,8 @@ function convertRelationship(
   return relationship;
 }
 
-function convertMetric(
-    mt: MetricDoc, entityNames: string[], warnings: string[],
-    dialect: string): Metric {
+function convertMetric(mt: MetricDoc, entityNames: string[],
+                       warnings: string[], dialect: string): Metric {
   const ctx = `metric '${mt.name}'`;
   const picked = pickDialect(mt.expression, dialect, ctx, warnings);
   // Infer referenced entities from whichever expression form we have; the
@@ -640,13 +600,11 @@ function convertMetric(
   const exprForRefs = picked.expression ?? picked.importedExpression ?? '';
   const referenced = referencedEntityNames(exprForRefs, entityNames);
   if (!referenced.length) {
-    warnings.push(`${
-        ctx}: expression references no known entity; it may not be placeable downstream`);
+    warnings.push(`${ctx}: expression references no known entity; it may not be placeable downstream`);
   }
-  const metric: Metric = {name: mt.name};
-  // Attach only when the reference is unambiguous; a cross-entity metric is
-  // left unattached (its qualifiers stay inline in the expression for
-  // consumers).
+  const metric: Metric = { name: mt.name };
+  // Attach only when the reference is unambiguous; a cross-entity metric is left
+  // unattached (its qualifiers stay inline in the expression for consumers).
   if (referenced.length === 1) metric.entity = referenced[0];
   if (picked.expression !== undefined) metric.expression = picked.expression;
   if (picked.importedExpression !== undefined) {
@@ -664,15 +622,13 @@ function convertMetric(
 }
 
 // Collapses an expression's per-dialect variants into at most two forms:
-//   - `expression`: a target/canonical form valid against the target.
-//   Preference
+//   - `expression`: a target/canonical form valid against the target. Preference
 //     is the requested dialect, else the portable canonical dialect (ANSI_SQL).
 //   - `importedExpression` (+ `importedDialect`): the original vendor SQL, kept
 //     verbatim so nothing is lost and a later transpile pass (see ./transpile)
 //     can fill `expression` from it.
 // Dialect names are compared case-insensitively. No transpilation is performed
-// here; chosen expressions are passed through verbatim. At least one form is
-// set.
+// here; chosen expressions are passed through verbatim. At least one form is set.
 //
 // The fallbacks differ in risk, so they are surfaced differently:
 //   - ANSI_SQL is the AI-first format's default expression language (ANSI
@@ -689,18 +645,16 @@ interface PickedExpression {
   importedDialect?: string;
 }
 
-function pickDialect(
-    expr: ExpressionDoc, preferred: string, ctx: string,
-    warnings: string[]): PickedExpression {
+function pickDialect(expr: ExpressionDoc, preferred: string,
+                     ctx: string, warnings: string[]): PickedExpression {
   const upper = (s: string) => s.toUpperCase();
   const byName = (name: string) =>
-      expr.dialects.find(d => upper(d.dialect) === upper(name));
+    expr.dialects.find(d => upper(d.dialect) === upper(name));
 
   // The original vendor variant, if any: the first dialect that is neither the
   // target nor the portable canonical. Kept as `importedExpression`.
   const vendor = expr.dialects.find(
-      d => upper(d.dialect) !== upper(preferred) &&
-          upper(d.dialect) !== FALLBACK_DIALECT);
+    d => upper(d.dialect) !== upper(preferred) && upper(d.dialect) !== FALLBACK_DIALECT);
 
   const out: PickedExpression = {};
   if (vendor) {
@@ -718,21 +672,17 @@ function pickDialect(
   if (canonical) {
     out.expression = canonical.expression;
     warnings.push(
-        `note: no '${
-            preferred}' dialect for one or more expressions; using the portable ` +
-        `'${FALLBACK_DIALECT}' dialect verbatim ('${
-            preferred}' accepts the ANSI core subset — ` +
-        `supply '${preferred}' variants only for ${preferred}-specific SQL)`);
+      `note: no '${preferred}' dialect for one or more expressions; using the portable ` +
+      `'${FALLBACK_DIALECT}' dialect verbatim ('${preferred}' accepts the ANSI core subset — ` +
+      `supply '${preferred}' variants only for ${preferred}-specific SQL)`);
     return out;
   }
 
   // Neither target nor canonical: keep only the imported vendor form; the
   // target `expression` awaits a transpile pass.
   warnings.push(
-      `${ctx}: no '${preferred}' or '${
-          FALLBACK_DIALECT}' dialect; keeping the ` +
-      `'${out.importedDialect}' expression as imported_expression (needs transpilation to '${
-          preferred}')`);
+    `${ctx}: no '${preferred}' or '${FALLBACK_DIALECT}' dialect; keeping the ` +
+    `'${out.importedDialect}' expression as imported_expression (needs transpilation to '${preferred}')`);
   return out;
 }
 
@@ -740,18 +690,16 @@ function pickDialect(
 // reference. Each identifier segment is unquoted, and a short reference has its
 // leading qualifiers prepended from options (a bare `table` gets both defaults;
 // a `dataset.table` gets the project). References that already carry three or
-// more segments are passed through untouched, so an already-qualified name
-// keeps whatever shape the source system gave it rather than being forced into
-// fixed slots. A source that looks like a query (contains whitespace) cannot be
+// more segments are passed through untouched, so an already-qualified name keeps
+// whatever shape the source system gave it rather than being forced into fixed
+// slots. A source that looks like a query (contains whitespace) cannot be
 // qualified, so it is kept verbatim.
-function parseSource(
-    source: string, opts: LoadOptions, warnings: string[],
-    ctx: string): string {
+function parseSource(source: string, opts: LoadOptions,
+                     warnings: string[], ctx: string): string {
   const trimmed = source.trim();
 
   if (/\s/.test(trimmed)) {
-    warnings.push(`${
-        ctx}: source looks like a query, not a table reference; keeping it verbatim`);
+    warnings.push(`${ctx}: source looks like a query, not a table reference; keeping it verbatim`);
     return trimmed;
   }
 
@@ -771,10 +719,8 @@ function parseSource(
   }
 
   const parts = trimmed.split('.').map(unquote);
-  if (parts.length === 1 && opts.defaultDataset)
-    parts.unshift(opts.defaultDataset);
-  if (parts.length < 3 && opts.defaultProject)
-    parts.unshift(opts.defaultProject);
+  if (parts.length === 1 && opts.defaultDataset) parts.unshift(opts.defaultDataset);
+  if (parts.length < 3 && opts.defaultProject) parts.unshift(opts.defaultProject);
   return parts.join('.');
 }
 

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -4,23 +4,23 @@
 // The format describes a semantic model as datasets (entities), foreign-key
 // relationships, and model-level metrics, with entity-qualified SQL expressions
 // (`Entity.column`) supplied per SQL dialect. This module reads the subset of
-// that logical layer needed to normalize a model into the IR, so the rest of the
-// toolbox (e.g. the BigQuery property-graph generator) can consume models
+// that logical layer needed to normalize a model into the IR, so the rest of
+// the toolbox (e.g. the BigQuery property-graph generator) can consume models
 // authored in it. Fields outside the supported subset are accepted and ignored.
 //
 
 import * as yaml from 'yaml';
 import * as z from 'zod';
-import {
-  SemanticModel, Entity, Field, Relationship, Metric, AiContext, CustomExtension,
-  DATA_TYPES,
-} from './ir';
-import { referencedEntityNames } from './sql_expr_utils';
+
+import {AiContext, CustomExtension, DATA_TYPES, Entity, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {referencedEntityNames} from './sql_expr_utils';
 
 export interface LoadOptions {
-  dialect?: string;         // preferred expression dialect; default 'BIGQUERY'
-  defaultProject?: string;  // fallback when a dataset `source` omits the project
-  defaultDataset?: string;  // fallback when a dataset `source` omits the dataset
+  dialect?: string;  // preferred expression dialect; default 'BIGQUERY'
+  defaultProject?:
+      string;  // fallback when a dataset `source` omits the project
+  defaultDataset?:
+      string;  // fallback when a dataset `source` omits the dataset
   // Accept a purely logical model: do not require a `source` on each concrete
   // dataset or an `expression` on each field. Set for a Knowledge-Catalog-only
   // push, which governs the logical model (meaning) and needs no physical
@@ -52,14 +52,14 @@ const SUPPORTED_VERSION = '0.2.0.dev0';
 // only ever sees the per-dialect object.
 const expressionObjectSchema = z.object({
   dialects: z.array(z.object({
-    dialect: z.string(),
-    expression: z.string(),
-  })).min(1),
+               dialect: z.string(),
+               expression: z.string(),
+             })).min(1),
 });
 const expressionSchema = z.union([
   z.string().transform((s): z.infer<typeof expressionObjectSchema> => ({
-    dialects: [{ dialect: DEFAULT_DIALECT, expression: s }],
-  })),
+                         dialects: [{dialect: DEFAULT_DIALECT, expression: s}],
+                       })),
   expressionObjectSchema,
 ]);
 
@@ -79,8 +79,9 @@ const aiContextSchema = z.union([
 // A vendor-scoped extension block: opaque `data` (a JSON string) tagged by
 // `vendor_name`. The spec allows these at every level (model, dataset, field,
 // relationship, metric). All are preserved verbatim on the IR (see
-// toCustomExtensions) for lossless round-trip; no vendor block is interpreted at
-// load time -- typed views (e.g. off the GOOGLE block) are a consumer concern.
+// toCustomExtensions) for lossless round-trip; no vendor block is interpreted
+// at load time -- typed views (e.g. off the GOOGLE block) are a consumer
+// concern.
 const customExtensionSchema = z.object({
   vendor_name: z.string(),
   data: z.string(),
@@ -104,7 +105,8 @@ const fieldBase = z.object({
   // logical field carries neither.
   expression: expressionSchema.optional(),
   unbound: z.boolean().optional(),
-  datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
+  datatype: z.enum(DATA_TYPES).optional(),  // closed, case-sensitive
+                                            // vocabulary; see DATA_TYPES
   description: z.string().optional(),
   label: z.string().optional(),
   dimension: dimensionSchema.optional(),
@@ -138,27 +140,32 @@ const datasetBase = z.object({
 });
 
 const relationshipSchema = z.object({
-  name: z.string(),
-  from: z.string(),
-  to: z.string(),
-  // Join columns are the physical binding of the edge and are OPTIONAL, so a
-  // purely logical relationship (an ontology edge, direction only) loads. When
-  // present they must be non-empty; either both endpoints are bound or neither
-  // is (a half-bound edge is a malformed join, caught below). A graph push still
-  // requires both (see validatePushRequirements).
-  from_columns: z.array(z.string()).min(1).optional(),
-  to_columns: z.array(z.string()).min(1).optional(),
-  description: z.string().optional(),
-  ai_context: aiContextSchema.optional(),
-  custom_extensions: z.array(customExtensionSchema).optional(),
-}).superRefine((r, ctx) => {
+                              name: z.string(),
+                              from: z.string(),
+                              to: z.string(),
+                              // Join columns are the physical binding of the
+                              // edge and are OPTIONAL, so a purely logical
+                              // relationship (an ontology edge, direction only)
+                              // loads. When present they must be non-empty;
+                              // either both endpoints are bound or neither is
+                              // (a half-bound edge is a malformed join, caught
+                              // below). A graph push still requires both (see
+                              // validatePushRequirements).
+                              from_columns:
+                                  z.array(z.string()).min(1).optional(),
+                              to_columns: z.array(z.string()).min(1).optional(),
+                              description: z.string().optional(),
+                              ai_context: aiContextSchema.optional(),
+                              custom_extensions:
+                                  z.array(customExtensionSchema).optional(),
+                            }).superRefine((r, ctx) => {
   if ((r.from_columns === undefined) !== (r.to_columns === undefined)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message:
-        `relationship '${r.name}': from_columns and to_columns must be given ` +
-        `together (both bind the edge) or both omitted (a logical edge); one ` +
-        `without the other is a half-bound join.`,
+      message: `relationship '${
+                   r.name}': from_columns and to_columns must be given ` +
+          `together (both bind the edge) or both omitted (a logical edge); one ` +
+          `without the other is a half-bound join.`,
     });
   }
 });
@@ -166,7 +173,8 @@ const relationshipSchema = z.object({
 const metricSchema = z.object({
   name: z.string(),
   expression: expressionSchema,
-  datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
+  datatype: z.enum(DATA_TYPES).optional(),  // closed, case-sensitive
+                                            // vocabulary; see DATA_TYPES
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
@@ -199,41 +207,58 @@ function buildDocumentSchema(bindingOptional: boolean) {
             `'expression', or drop 'unbound: true' to bind it to that column`,
       });
     }
-    if (!bindingOptional && !f.unbound && f.expression === undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['expression'],
-        message: `field '${f.name}': requires an expression; set 'expression', ` +
-            `or mark it 'unbound: true' if this binding has no column for it`,
-      });
-    }
+    // The "requires an expression" check lives at the dataset level below, not
+    // here: a field on an ABSTRACT dataset legitimately has no column (the
+    // supertype has no table -- it survives only as a label on its subtypes),
+    // and only the dataset's superRefine can see `abstract`.
   });
-  const dataset = datasetBase.extend({ fields: z.array(field).optional() })
-    .superRefine((ds, ctx) => {
-      // A concrete (non-abstract) dataset must name its backing table; only an
-      // abstract one may omit `source`. Relaxed under bindingOptional, where a
-      // logical dataset has no source.
-      if (!bindingOptional && !ds.abstract && ds.source === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['source'],
-          message: `dataset '${ds.name}': a non-abstract dataset requires a ` +
-              `source; set 'source', or mark it 'abstract: true' if it has no table`,
-        });
-      }
-      // The converse is always contradictory: an abstract dataset has no
-      // physical table, so a `source` on it would be silently ignored by the
-      // BigQuery leg. Reject it regardless of bindingOptional.
-      if (ds.abstract && ds.source !== undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['source'],
-          message: `dataset '${ds.name}': an abstract dataset has no table; ` +
-              `remove 'source', or drop 'abstract: true' to bind it to that table`,
-        });
-      }
-    });
-  const model = modelBase.extend({ datasets: z.array(dataset).min(1) });
+  const dataset =
+      datasetBase.extend({fields: z.array(field).optional()})
+          .superRefine((ds, ctx) => {
+            // A concrete (non-abstract) dataset must name its backing table;
+            // only an abstract one may omit `source`. Relaxed under
+            // bindingOptional, where a logical dataset has no source.
+            if (!bindingOptional && !ds.abstract && ds.source === undefined) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['source'],
+                message:
+                    `dataset '${ds.name}': a non-abstract dataset requires a ` +
+                    `source; set 'source', or mark it 'abstract: true' if it has no table`,
+              });
+            }
+            // The converse is always contradictory: an abstract dataset has no
+            // physical table, so a `source` on it would be silently ignored by
+            // the BigQuery leg. Reject it regardless of bindingOptional.
+            if (ds.abstract && ds.source !== undefined) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['source'],
+                message:
+                    `dataset '${ds.name}': an abstract dataset has no table; ` +
+                    `remove 'source', or drop 'abstract: true' to bind it to that table`,
+              });
+            }
+            // Under a graph leg, every field of a CONCRETE dataset must be
+            // bound or explicitly unbound. An abstract dataset is exempt: it
+            // has no table, so its fields carry no column -- they define the
+            // label signature its subtypes bind. Enforced here (not on the
+            // field) so `abstract` is visible.
+            if (!bindingOptional && !ds.abstract) {
+              (ds.fields ?? []).forEach((f, i) => {
+                if (!f.unbound && f.expression === undefined) {
+                  ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['fields', i, 'expression'],
+                    message: `field '${f.name}': requires an expression; set ` +
+                        `'expression', or mark it 'unbound: true' if this ` +
+                        `binding has no column for it`,
+                  });
+                }
+              });
+            }
+          });
+  const model = modelBase.extend({datasets: z.array(dataset).min(1)});
   return z.object({
     version: z.string().optional(),
     semantic_model: z.array(model).min(1),
@@ -242,8 +267,8 @@ function buildDocumentSchema(bindingOptional: boolean) {
 
 // Only two schema shapes exist (strict vs binding-optional) and each is
 // immutable, so build both once at module load and select between them rather
-// than reconstructing the whole field/dataset/model/document graph -- with fresh
-// superRefine closures -- on every fromDocument call.
+// than reconstructing the whole field/dataset/model/document graph -- with
+// fresh superRefine closures -- on every fromDocument call.
 const strictDocumentSchema = buildDocumentSchema(false);
 const logicalDocumentSchema = buildDocumentSchema(true);
 function makeDocumentSchema(bindingOptional: boolean) {
@@ -262,14 +287,16 @@ type AiContextDoc = z.infer<typeof aiContextSchema>;
 // The AI-first `ai_context` normalized to the IR's common shape: a bare string
 // is read as `instructions`; a structured object keeps its parts. `examples` is
 // filtered to strings (producers vary; non-string examples are dropped).
-function normalizeAiContext(ai: AiContextDoc | undefined): AiContext {
+function normalizeAiContext(ai: AiContextDoc|undefined): AiContext {
   if (ai === undefined) return {};
-  if (typeof ai === 'string') return { instructions: ai };
+  if (typeof ai === 'string') return {instructions: ai};
   const out: AiContext = {};
   if (ai.instructions) out.instructions = ai.instructions;
-  if (ai.synonyms && ai.synonyms.length) out.synonyms = [...new Set(ai.synonyms)];
+  if (ai.synonyms && ai.synonyms.length)
+    out.synonyms = [...new Set(ai.synonyms)];
   if (ai.examples && ai.examples.length) {
-    const strings = ai.examples.filter((e): e is string => typeof e === 'string');
+    const strings =
+        ai.examples.filter((e): e is string => typeof e === 'string');
     if (strings.length) out.examples = strings;
   }
   return out;
@@ -277,7 +304,7 @@ function normalizeAiContext(ai: AiContextDoc | undefined): AiContext {
 
 // Normalizes `ai_context` and returns it only when it carries something, so the
 // IR omits empty aiContext objects.
-function aiContextOrUndefined(ai: AiContextDoc | undefined): AiContext | undefined {
+function aiContextOrUndefined(ai: AiContextDoc|undefined): AiContext|undefined {
   const ctx = normalizeAiContext(ai);
   return (ctx.instructions || ctx.synonyms || ctx.examples) ? ctx : undefined;
 }
@@ -286,22 +313,21 @@ function aiContextOrUndefined(ai: AiContextDoc | undefined): AiContext | undefin
 // `vendorName`; `data` kept as the opaque, vendor-serialized string) so nothing
 // is lost and a 1P round-trip stays lossless. Typed views over specific vendors
 // are derived by the consumers that need them, not here.
-function toCustomExtensions(
-    exts: CustomExtensionDoc[] | undefined): CustomExtension[] | undefined {
+function toCustomExtensions(exts: CustomExtensionDoc[]|undefined):
+    CustomExtension[]|undefined {
   if (!exts || !exts.length) return undefined;
-  return exts.map(e => ({ vendorName: e.vendor_name, data: e.data }));
+  return exts.map(e => ({vendorName: e.vendor_name, data: e.data}));
 }
 
 // Composes a single description string from ordered parts, dropping empties.
 // Parts are separated by blank lines so a base description and derived markers
 // read as distinct paragraphs in the emitted metadata. AI-first annotations
-// (instructions / synonyms / examples) are NOT folded in here — they are carried
-// structurally on the IR (aiContext) so an emitter can route them to their own
-// aspects.
-function composeDescription(...parts: (string | undefined)[]): string | undefined {
-  const kept = parts
-    .map(p => (p === undefined ? undefined : p.trim()))
-    .filter((p): p is string => !!p);
+// (instructions / synonyms / examples) are NOT folded in here — they are
+// carried structurally on the IR (aiContext) so an emitter can route them to
+// their own aspects.
+function composeDescription(...parts: (string|undefined)[]): string|undefined {
+  const kept = parts.map(p => (p === undefined ? undefined : p.trim()))
+                   .filter((p): p is string => !!p);
   return kept.length ? kept.join('\n\n') : undefined;
 }
 
@@ -333,7 +359,8 @@ function normalizeModelSugars(m: any): void {
 
   if (m.entities !== undefined) {
     if (m.datasets !== undefined) {
-      throw new Error(`Semantic model load error: ${label}: set either ` +
+      throw new Error(
+          `Semantic model load error: ${label}: set either ` +
           `'entities' or 'datasets', not both (they are the same key).`);
     }
     m.datasets = m.entities;
@@ -343,7 +370,8 @@ function normalizeModelSugars(m: any): void {
   if (m.deployment_target !== undefined) {
     const target = m.deployment_target;
     if (typeof target !== 'string') {
-      throw new Error(`Semantic model load error: ${label}: ` +
+      throw new Error(
+          `Semantic model load error: ${label}: ` +
           `'deployment_target' must be a URI string.`);
     }
     foldDeploymentTarget(m, target, label);
@@ -371,7 +399,8 @@ function foldDeploymentTarget(m: any, target: string, label: string): void {
     const list = data?.deploymentTargets;
     if (Array.isArray(list) && list.length) {
       if (!list.includes(target)) {
-        throw new Error(`Semantic model load error: ${label}: ` +
+        throw new Error(
+            `Semantic model load error: ${label}: ` +
             `'deployment_target' disagrees with the GOOGLE custom_extension ` +
             `already on this model; set one, or make them match.`);
       }
@@ -380,21 +409,22 @@ function foldDeploymentTarget(m: any, target: string, label: string): void {
   }
   exts.push({
     vendor_name: GOOGLE_VENDOR,
-    data: JSON.stringify({ deploymentTargets: [target] }),
+    data: JSON.stringify({deploymentTargets: [target]}),
   });
   m.custom_extensions = exts;
 }
 
 /**
- * Loads YAML or JSON text (a document in the AI-first semantics format) into the
- * Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
+ * Loads YAML or JSON text (a document in the AI-first semantics format) into
+ * the Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
  */
 export function loadModels(text: string, opts: LoadOptions = {}): LoadResult {
   let doc: unknown;
   try {
     doc = yaml.parse(text);
   } catch (err: any) {
-    throw new Error(`Semantic model load error: could not parse input: ${err?.message ?? err}`);
+    throw new Error(`Semantic model load error: could not parse input: ${
+        err?.message ?? err}`);
   }
   return fromDocument(doc, opts);
 }
@@ -417,12 +447,14 @@ export function fromDocument(doc: unknown, opts: LoadOptions = {}): LoadResult {
 
   if (parsed.version && parsed.version !== SUPPORTED_VERSION) {
     warnings.push(
-      `document version '${parsed.version}' differs from the supported '${SUPPORTED_VERSION}'; ` +
-      `loading anyway`);
+        `document version '${parsed.version}' differs from the supported '${
+            SUPPORTED_VERSION}'; ` +
+        `loading anyway`);
   }
 
-  const models = parsed.semantic_model.map(m => convertModel(m, opts, warnings));
-  return { models, warnings: [...new Set(warnings)] };
+  const models =
+      parsed.semantic_model.map(m => convertModel(m, opts, warnings));
+  return {models, warnings: [...new Set(warnings)]};
 }
 
 
@@ -437,34 +469,40 @@ function warnDuplicateNames(
   for (const n of names) {
     if (seen.has(n)) {
       warnings.push(
-        `${scope}: duplicate ${kind} '${n}'; names must be unique ` +
-        `(the generated graph will be invalid)`);
+          `${scope}: duplicate ${kind} '${n}'; names must be unique ` +
+          `(the generated graph will be invalid)`);
     }
     seen.add(n);
   }
 }
 
-function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): SemanticModel {
+function convertModel(
+    m: ModelDoc, opts: LoadOptions, warnings: string[]): SemanticModel {
   const dialect = opts.dialect ?? DEFAULT_DIALECT;
 
-  const entities = m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
-  warnDuplicateNames(entities.map(e => e.name), 'dataset name', `model '${m.name}'`, warnings);
+  const entities =
+      m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
+  warnDuplicateNames(
+      entities.map(e => e.name), 'dataset name', `model '${m.name}'`, warnings);
 
   const entityNames = entities.map(e => e.name);
   const entityNameSet = new Set(entityNames);
 
-  const relationships = (m.relationships ?? []).map(
-    r => convertRelationship(r, entityNameSet));
+  const relationships =
+      (m.relationships ?? []).map(r => convertRelationship(r, entityNameSet));
   warnDuplicateNames(
-    relationships.map(r => r.name), 'relationship name', `model '${m.name}'`, warnings);
+      relationships.map(r => r.name), 'relationship name', `model '${m.name}'`,
+      warnings);
 
-  const metrics = (m.metrics ?? []).map(
-    mt => convertMetric(mt, entityNames, warnings, dialect));
-  warnDuplicateNames(metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`, warnings);
+  const metrics =
+      (m.metrics ??
+       []).map(mt => convertMetric(mt, entityNames, warnings, dialect));
+  warnDuplicateNames(
+      metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`, warnings);
 
   const description = composeDescription(m.description);
 
-  const model: SemanticModel = { name: m.name, entities, relationships, metrics };
+  const model: SemanticModel = {name: m.name, entities, relationships, metrics};
   if (description) model.description = description;
   const ai = aiContextOrUndefined(m.ai_context);
   if (ai) model.aiContext = ai;
@@ -473,8 +511,9 @@ function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): Seman
   return model;
 }
 
-function convertDataset(ds: DatasetDoc, opts: LoadOptions,
-                        warnings: string[], dialect: string): Entity {
+function convertDataset(
+    ds: DatasetDoc, opts: LoadOptions, warnings: string[],
+    dialect: string): Entity {
   const ctxLabel = `dataset '${ds.name}'`;
   // An abstract entity has no physical table, so it carries no source (empty
   // dataSource) and no key -- both are meaningless for a class never
@@ -484,13 +523,17 @@ function convertDataset(ds: DatasetDoc, opts: LoadOptions,
       '';
   const keys = ds.primary_key ?? [];
   if (!keys.length && !ds.abstract) {
-    warnings.push(`${ctxLabel}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
+    warnings.push(`${
+        ctxLabel}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
   }
-  const fields = (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
-  warnDuplicateNames(fields.map(f => f.name), 'field name', `dataset '${ds.name}'`, warnings);
+  const fields =
+      (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
+  warnDuplicateNames(
+      fields.map(f => f.name), 'field name', `dataset '${ds.name}'`, warnings);
 
-  const entity: Entity = { name: ds.name, dataSource, keys, fields };
-  if (ds.unique_keys && ds.unique_keys.length) entity.uniqueKeys = ds.unique_keys;
+  const entity: Entity = {name: ds.name, dataSource, keys, fields};
+  if (ds.unique_keys && ds.unique_keys.length)
+    entity.uniqueKeys = ds.unique_keys;
   if (ds.extends && ds.extends.length) entity.extends = ds.extends;
   if (ds.abstract) entity.abstract = true;
   const description = composeDescription(ds.description);
@@ -502,20 +545,22 @@ function convertDataset(ds: DatasetDoc, opts: LoadOptions,
   return entity;
 }
 
-function convertField(f: FieldDoc, entityName: string, warnings: string[], dialect: string): Field {
+function convertField(
+    f: FieldDoc, entityName: string, warnings: string[],
+    dialect: string): Field {
   // `label`, `dimension`, and AI-first annotations are carried structurally on
   // the IR (not folded into `description`) so an emitter can route each to its
   // own destination and a 1P round-trip stays lossless.
   const description = composeDescription(f.description);
 
-  const field: Field = { name: f.name };
+  const field: Field = {name: f.name};
   if (f.unbound) {
     // Declared but not bound under this binding: no column, no expression (the
     // schema guarantees `expression` is absent here). See Field.unbound.
     field.unbound = true;
   } else if (f.expression !== undefined) {
     const picked = pickDialect(
-      f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
+        f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
     if (picked.expression !== undefined) field.expression = picked.expression;
     if (picked.importedExpression !== undefined) {
       field.importedExpression = picked.importedExpression;
@@ -529,7 +574,8 @@ function convertField(f: FieldDoc, entityName: string, warnings: string[], diale
   if (f.label) field.label = f.label;
   if (f.dimension) {
     field.dimension = {};
-    if (f.dimension.is_time !== undefined) field.dimension.isTime = f.dimension.is_time;
+    if (f.dimension.is_time !== undefined)
+      field.dimension.isTime = f.dimension.is_time;
   }
   if (description) field.description = description;
   const ai = aiContextOrUndefined(f.ai_context);
@@ -539,35 +585,41 @@ function convertField(f: FieldDoc, entityName: string, warnings: string[], diale
   return field;
 }
 
-// Maps an OSI foreign-key relationship onto the IR edge. `source.columns` are the
-// FK columns on the `from` table (`from_columns`); `destination.columns` are the
-// referenced key columns on the `to` table (`to_columns`), paired positionally.
-// A logical relationship carries no columns (both endpoints empty); a graph
-// push requires them and rejects a column-less edge (see validatePushRequirements).
-// The source entity's own primary key is not duplicated here -- downstream
-// consumers look it up from the entity. A malformed relationship (an endpoint not
-// declared in the model, or mismatched column arity) is a hard error, not a
-// warning: the resulting edge would be structurally invalid.
-function convertRelationship(r: RelationshipDoc, entityNames: Set<string>): Relationship {
+// Maps an OSI foreign-key relationship onto the IR edge. `source.columns` are
+// the FK columns on the `from` table (`from_columns`); `destination.columns`
+// are the referenced key columns on the `to` table (`to_columns`), paired
+// positionally. A logical relationship carries no columns (both endpoints
+// empty); a graph push requires them and rejects a column-less edge (see
+// validatePushRequirements). The source entity's own primary key is not
+// duplicated here -- downstream consumers look it up from the entity. A
+// malformed relationship (an endpoint not declared in the model, or mismatched
+// column arity) is a hard error, not a warning: the resulting edge would be
+// structurally invalid.
+function convertRelationship(
+    r: RelationshipDoc, entityNames: Set<string>): Relationship {
   const ctx = `relationship '${r.name}'`;
   if (!entityNames.has(r.from)) {
-    throw new Error(`${ctx}: 'from' dataset '${r.from}' is not defined in the model`);
+    throw new Error(
+        `${ctx}: 'from' dataset '${r.from}' is not defined in the model`);
   }
   if (!entityNames.has(r.to)) {
-    throw new Error(`${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
+    throw new Error(
+        `${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
   }
   const fromColumns = r.from_columns ?? [];
   const toColumns = r.to_columns ?? [];
   if (fromColumns.length !== toColumns.length) {
     throw new Error(
-      `${ctx}: from_columns (${fromColumns.length}) and to_columns ` +
-      `(${toColumns.length}) have different lengths; the join keys are mismatched`);
+        `${ctx}: from_columns (${fromColumns.length}) and to_columns ` +
+        `(${
+            toColumns
+                .length}) have different lengths; the join keys are mismatched`);
   }
 
   const relationship: Relationship = {
     name: r.name,
-    source: { entity: r.from, columns: fromColumns },
-    destination: { entity: r.to, columns: toColumns },
+    source: {entity: r.from, columns: fromColumns},
+    destination: {entity: r.to, columns: toColumns},
   };
   const description = composeDescription(r.description);
   if (description) relationship.description = description;
@@ -578,8 +630,9 @@ function convertRelationship(r: RelationshipDoc, entityNames: Set<string>): Rela
   return relationship;
 }
 
-function convertMetric(mt: MetricDoc, entityNames: string[],
-                       warnings: string[], dialect: string): Metric {
+function convertMetric(
+    mt: MetricDoc, entityNames: string[], warnings: string[],
+    dialect: string): Metric {
   const ctx = `metric '${mt.name}'`;
   const picked = pickDialect(mt.expression, dialect, ctx, warnings);
   // Infer referenced entities from whichever expression form we have; the
@@ -587,11 +640,13 @@ function convertMetric(mt: MetricDoc, entityNames: string[],
   const exprForRefs = picked.expression ?? picked.importedExpression ?? '';
   const referenced = referencedEntityNames(exprForRefs, entityNames);
   if (!referenced.length) {
-    warnings.push(`${ctx}: expression references no known entity; it may not be placeable downstream`);
+    warnings.push(`${
+        ctx}: expression references no known entity; it may not be placeable downstream`);
   }
-  const metric: Metric = { name: mt.name };
-  // Attach only when the reference is unambiguous; a cross-entity metric is left
-  // unattached (its qualifiers stay inline in the expression for consumers).
+  const metric: Metric = {name: mt.name};
+  // Attach only when the reference is unambiguous; a cross-entity metric is
+  // left unattached (its qualifiers stay inline in the expression for
+  // consumers).
   if (referenced.length === 1) metric.entity = referenced[0];
   if (picked.expression !== undefined) metric.expression = picked.expression;
   if (picked.importedExpression !== undefined) {
@@ -609,13 +664,15 @@ function convertMetric(mt: MetricDoc, entityNames: string[],
 }
 
 // Collapses an expression's per-dialect variants into at most two forms:
-//   - `expression`: a target/canonical form valid against the target. Preference
+//   - `expression`: a target/canonical form valid against the target.
+//   Preference
 //     is the requested dialect, else the portable canonical dialect (ANSI_SQL).
 //   - `importedExpression` (+ `importedDialect`): the original vendor SQL, kept
 //     verbatim so nothing is lost and a later transpile pass (see ./transpile)
 //     can fill `expression` from it.
 // Dialect names are compared case-insensitively. No transpilation is performed
-// here; chosen expressions are passed through verbatim. At least one form is set.
+// here; chosen expressions are passed through verbatim. At least one form is
+// set.
 //
 // The fallbacks differ in risk, so they are surfaced differently:
 //   - ANSI_SQL is the AI-first format's default expression language (ANSI
@@ -632,16 +689,18 @@ interface PickedExpression {
   importedDialect?: string;
 }
 
-function pickDialect(expr: ExpressionDoc, preferred: string,
-                     ctx: string, warnings: string[]): PickedExpression {
+function pickDialect(
+    expr: ExpressionDoc, preferred: string, ctx: string,
+    warnings: string[]): PickedExpression {
   const upper = (s: string) => s.toUpperCase();
   const byName = (name: string) =>
-    expr.dialects.find(d => upper(d.dialect) === upper(name));
+      expr.dialects.find(d => upper(d.dialect) === upper(name));
 
   // The original vendor variant, if any: the first dialect that is neither the
   // target nor the portable canonical. Kept as `importedExpression`.
   const vendor = expr.dialects.find(
-    d => upper(d.dialect) !== upper(preferred) && upper(d.dialect) !== FALLBACK_DIALECT);
+      d => upper(d.dialect) !== upper(preferred) &&
+          upper(d.dialect) !== FALLBACK_DIALECT);
 
   const out: PickedExpression = {};
   if (vendor) {
@@ -659,17 +718,21 @@ function pickDialect(expr: ExpressionDoc, preferred: string,
   if (canonical) {
     out.expression = canonical.expression;
     warnings.push(
-      `note: no '${preferred}' dialect for one or more expressions; using the portable ` +
-      `'${FALLBACK_DIALECT}' dialect verbatim ('${preferred}' accepts the ANSI core subset — ` +
-      `supply '${preferred}' variants only for ${preferred}-specific SQL)`);
+        `note: no '${
+            preferred}' dialect for one or more expressions; using the portable ` +
+        `'${FALLBACK_DIALECT}' dialect verbatim ('${
+            preferred}' accepts the ANSI core subset — ` +
+        `supply '${preferred}' variants only for ${preferred}-specific SQL)`);
     return out;
   }
 
   // Neither target nor canonical: keep only the imported vendor form; the
   // target `expression` awaits a transpile pass.
   warnings.push(
-    `${ctx}: no '${preferred}' or '${FALLBACK_DIALECT}' dialect; keeping the ` +
-    `'${out.importedDialect}' expression as imported_expression (needs transpilation to '${preferred}')`);
+      `${ctx}: no '${preferred}' or '${
+          FALLBACK_DIALECT}' dialect; keeping the ` +
+      `'${out.importedDialect}' expression as imported_expression (needs transpilation to '${
+          preferred}')`);
   return out;
 }
 
@@ -677,16 +740,18 @@ function pickDialect(expr: ExpressionDoc, preferred: string,
 // reference. Each identifier segment is unquoted, and a short reference has its
 // leading qualifiers prepended from options (a bare `table` gets both defaults;
 // a `dataset.table` gets the project). References that already carry three or
-// more segments are passed through untouched, so an already-qualified name keeps
-// whatever shape the source system gave it rather than being forced into fixed
-// slots. A source that looks like a query (contains whitespace) cannot be
+// more segments are passed through untouched, so an already-qualified name
+// keeps whatever shape the source system gave it rather than being forced into
+// fixed slots. A source that looks like a query (contains whitespace) cannot be
 // qualified, so it is kept verbatim.
-function parseSource(source: string, opts: LoadOptions,
-                     warnings: string[], ctx: string): string {
+function parseSource(
+    source: string, opts: LoadOptions, warnings: string[],
+    ctx: string): string {
   const trimmed = source.trim();
 
   if (/\s/.test(trimmed)) {
-    warnings.push(`${ctx}: source looks like a query, not a table reference; keeping it verbatim`);
+    warnings.push(`${
+        ctx}: source looks like a query, not a table reference; keeping it verbatim`);
     return trimmed;
   }
 
@@ -706,8 +771,10 @@ function parseSource(source: string, opts: LoadOptions,
   }
 
   const parts = trimmed.split('.').map(unquote);
-  if (parts.length === 1 && opts.defaultDataset) parts.unshift(opts.defaultDataset);
-  if (parts.length < 3 && opts.defaultProject) parts.unshift(opts.defaultProject);
+  if (parts.length === 1 && opts.defaultDataset)
+    parts.unshift(opts.defaultDataset);
+  if (parts.length < 3 && opts.defaultProject)
+    parts.unshift(opts.defaultProject);
   return parts.join('.');
 }
 

--- a/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
@@ -1,33 +1,31 @@
-// Merges a logical semantic model with a chosen binding profile, and prunes what
-// the resulting binding cannot answer.
+// Merges a logical semantic model with a chosen binding profile, and prunes
+// what the resulting binding cannot answer.
 //
 // A model is authored as ONE logical declaration (entities, fields,
 // relationships, metrics, the grain, and the graph shape) plus zero or more
-// BINDING PROFILES that supply the physical facets it leaves open: each entity's
-// `source`, each field's column (`expression`), and the deployment target.
-// `kcmd push --profile <name>` merges the selected profile onto the logical
-// model BY NAME and deploys the result. See docs/semantic-model/profiles.md.
+// BINDING PROFILES that supply the physical facets it leaves open: each
+// entity's `source`, each field's column (`expression`), and the deployment
+// target. `kcmd push --profile <name>` merges the selected profile onto the
+// logical model BY NAME and deploys the result. See
+// docs/semantic-model/profiles.md.
 //
 // Two passes live here:
 //   - mergeProfile overlays one profile document onto the logical document,
-//     enforcing the binding-only contract: a profile may set physical facets and
-//     may leave a field unbound, but it may not add or remove elements or change
-//     what anything means. It runs on the parsed authoring documents (the
-//     readable, sugared form) before schema validation, so a profile is written
-//     in the same syntax as the model.
-//   - pruneUnavailable runs over the loaded IR and drops each field left unbound
-//     plus everything that depends on it -- a metric whose expression reads it, a
-//     relationship whose join column is unbound, a cross-entity metric over a
+//     enforcing the binding-only contract: a profile may set physical facets
+//     and may leave a field unbound, but it may not add or remove elements or
+//     change what anything means. It runs on the parsed authoring documents
+//     (the readable, sugared form) before schema validation, so a profile is
+//     written in the same syntax as the model.
+//   - pruneUnavailable runs over the loaded IR and drops each field left
+//   unbound
+//     plus everything that depends on it -- a metric whose expression reads it,
+//     a relationship whose join column is unbound, a cross-entity metric over a
 //     dropped relationship -- returning the pruned model and a per-profile
 //     availability report. Availability propagates UP the dependency graph from
 //     the fields a profile binds.
 
 import {fieldBinding, Metric, Relationship, SemanticModel} from './ir';
-import {
-  blankStringLiterals,
-  escapeRegExp,
-  referencedEntityNames,
-} from './sql_expr_utils';
+import {blankStringLiterals, escapeRegExp, referencedEntityNames,} from './sql_expr_utils';
 
 // The implicit profile: the inline bindings already in the model document (the
 // combined single-file form). It is never merged -- it IS the document as
@@ -48,7 +46,11 @@ export interface MergeResult {
 // declaration the model owns; setting it in a profile is rejected so swapping a
 // profile can move data but never change what the model means.
 const PROFILE_MODEL_KEYS = new Set([
-  'name', 'version', 'deployment_target', 'entities', 'datasets',
+  'name',
+  'version',
+  'deployment_target',
+  'entities',
+  'datasets',
 ]);
 const PROFILE_ENTITY_KEYS = new Set(['name', 'source', 'fields']);
 const PROFILE_FIELD_KEYS = new Set(['name', 'expression', 'unbound']);
@@ -56,9 +58,9 @@ const PROFILE_FIELD_KEYS = new Set(['name', 'expression', 'unbound']);
 /**
  * Overlays `profileDoc` onto `logicalDoc`, matching models, entities, fields by
  * `name`, and returns the merged document. The inputs are never mutated. A
- * profile supplies physical bindings only; a violation of that contract (setting
- * a declaration, or naming an element the logical model does not declare) is
- * returned as `error`, naming the path.
+ * profile supplies physical bindings only; a violation of that contract
+ * (setting a declaration, or naming an element the logical model does not
+ * declare) is returned as `error`, naming the path.
  */
 export function mergeProfile(
     logicalDoc: unknown, profileDoc: unknown,
@@ -70,14 +72,16 @@ export function mergeProfile(
   if (!merged || typeof merged !== 'object' ||
       !Array.isArray(merged.semantic_model)) {
     return {
-      doc: merged, warnings,
+      doc: merged,
+      warnings,
       error: 'the logical model is not a semantic_model document',
     };
   }
   if (!profile || typeof profile !== 'object' ||
       !Array.isArray(profile.semantic_model)) {
     return {
-      doc: merged, warnings,
+      doc: merged,
+      warnings,
       error: `profile '${profileName}' is not a semantic_model document`,
     };
   }
@@ -94,7 +98,8 @@ export function mergeProfile(
     const lm = logicalByName.get(pm.name);
     if (!lm) {
       return {
-        doc: merged, warnings,
+        doc: merged,
+        warnings,
         error: `profile '${profileName}': model '${
             pm.name}' is not in the logical model`,
       };
@@ -103,9 +108,10 @@ export function mergeProfile(
     if (err) return {doc: merged, warnings, error: err};
   }
 
-  // A field the profile neither bound nor marked unbound is carried through from
-  // the logical model with no column -- unbound under this profile. Mark it so
-  // the merged document is self-describing and the availability pass sees it.
+  // A field the profile neither bound nor marked unbound is carried through
+  // from the logical model with no column -- unbound under this profile. Mark
+  // it so the merged document is self-describing and the availability pass sees
+  // it.
   markOmittedFieldsUnbound(merged);
   return {doc: merged, warnings};
 }
@@ -149,7 +155,8 @@ function mergeEntity(le: any, pe: any, profileName: string): string|undefined {
 
   if (pe.fields === undefined) return undefined;
   if (!Array.isArray(pe.fields)) {
-    return `profile '${profileName}': entity '${pe.name}' 'fields' must be a list`;
+    return `profile '${profileName}': entity '${
+        pe.name}' 'fields' must be a list`;
   }
   const lByName = indexByName(le.fields ?? []);
   for (const pf of pe.fields) {
@@ -165,9 +172,8 @@ function mergeEntity(le: any, pe: any, profileName: string): string|undefined {
   return undefined;
 }
 
-function mergeField(
-    lf: any, pf: any, entityName: string,
-    profileName: string): string|undefined {
+function mergeField(lf: any, pf: any, entityName: string, profileName: string):
+    string|undefined {
   for (const k of Object.keys(pf)) {
     if (!PROFILE_FIELD_KEYS.has(k)) {
       return declError(profileName, `field '${entityName}.${pf.name}'`, k);
@@ -181,7 +187,7 @@ function mergeField(
   if (pf.expression !== undefined) {
     if (!isBareColumnRef(pf.expression)) {
       return `profile '${profileName}': field '${entityName}.${
-          pf.name}' expression must be a bare column reference, not arbitrary ` +
+                 pf.name}' expression must be a bare column reference, not arbitrary ` +
           `SQL; the computation is the logical model's to define`;
     }
     lf.expression = pf.expression;
@@ -198,14 +204,16 @@ function declError(profileName: string, where: string, key: string): string {
 
 // A profile's field expression must be a BARE column reference (e.g. `c_name`),
 // never arbitrary SQL: the computation belongs to the logical model, and only
-// the column it reads may vary per profile. Accepts the bare-string form and the
-// per-dialect object; rejects any variant that contains whitespace or a call.
+// the column it reads may vary per profile. Accepts the bare-string form and
+// the per-dialect object; rejects any variant that contains whitespace or a
+// call.
 function isBareColumnRef(expr: unknown): boolean {
   const parts: string[] = [];
   if (typeof expr === 'string') {
     parts.push(expr);
-  } else if (expr && typeof expr === 'object' &&
-             Array.isArray((expr as any).dialects)) {
+  } else if (
+      expr && typeof expr === 'object' &&
+      Array.isArray((expr as any).dialects)) {
     for (const d of (expr as any).dialects) {
       if (d && typeof d.expression === 'string') parts.push(d.expression);
     }
@@ -250,8 +258,8 @@ function markOmittedFieldsUnbound(doc: any): void {
 export interface AvailabilityReport {
   profile: string;
   unboundFields: string[];  // "Entity.field"
-  // An entity dropped whole because its key names an unbound field: a graph node
-  // must be keyed, so an unbound key makes the entire entity unavailable.
+  // An entity dropped whole because its key names an unbound field: a graph
+  // node must be keyed, so an unbound key makes the entire entity unavailable.
   droppedEntities: {name: string; reason: string}[];
   droppedMetrics: {name: string; reason: string}[];
   droppedRelationships: {name: string; reason: string}[];
@@ -276,11 +284,18 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
   };
 
   // A field is bound when fieldBinding resolves it to a column; otherwise it is
-  // unbound (structurally absent under this profile). fieldBinding is the shared
-  // predicate the generator also uses, so a field awaiting transpilation (its
-  // column carried on the imported expression) counts as bound, not dropped.
+  // unbound (structurally absent under this profile). fieldBinding is the
+  // shared predicate the generator also uses, so a field awaiting transpilation
+  // (its column carried on the imported expression) counts as bound, not
+  // dropped.
   const unbound = new Set<string>();
   for (const e of clone.entities ?? []) {
+    // An abstract entity has no table and no bindings by design: it survives
+    // only as a label on its subtypes (which bind its inherited fields on their
+    // own tables). Its fields are legitimately column-less, so they are not
+    // "unbound" in the pruning sense -- skip them so the entity is not dropped
+    // and its field names remain to define the shared label's signature.
+    if (e.abstract) continue;
     for (const f of e.fields ?? []) {
       if (fieldBinding(f) === undefined) unbound.add(`${e.name}.${f.name}`);
     }
@@ -288,17 +303,17 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
   report.unboundFields = [...unbound];
 
   // An entity whose key names an unbound field cannot be a node -- a graph node
-  // must be keyed -- so the WHOLE entity is unavailable and everything on it (its
-  // relationships and the metrics over it) falls with it. This is availability
-  // propagating up from the unbound key. Record the entity, and add every one of
-  // its fields to the unbound set so the relationship and metric passes below
-  // cascade over it. Entity names are captured before any drop so a metric or
-  // relationship that references a dropped entity is still detected.
+  // must be keyed -- so the WHOLE entity is unavailable and everything on it
+  // (its relationships and the metrics over it) falls with it. This is
+  // availability propagating up from the unbound key. Record the entity, and
+  // add every one of its fields to the unbound set so the relationship and
+  // metric passes below cascade over it. Entity names are captured before any
+  // drop so a metric or relationship that references a dropped entity is still
+  // detected.
   const allEntityNames = (clone.entities ?? []).map(e => e.name);
   const unavailableEntities = new Set<string>();
   for (const e of clone.entities ?? []) {
-    const missingKey =
-        (e.keys ?? []).find(k => unbound.has(`${e.name}.${k}`));
+    const missingKey = (e.keys ?? []).find(k => unbound.has(`${e.name}.${k}`));
     if (missingKey !== undefined) {
       unavailableEntities.add(e.name);
       report.droppedEntities.push(
@@ -313,6 +328,9 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
   clone.entities =
       (clone.entities ?? []).filter(e => !unavailableEntities.has(e.name));
   for (const e of clone.entities) {
+    // Keep an abstract entity's fields intact: they are column-less by design
+    // and name the shared label's property set for the emitter (see above).
+    if (e.abstract) continue;
     e.fields = (e.fields ?? []).filter(f => fieldBinding(f) !== undefined);
   }
 
@@ -339,8 +357,8 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
   clone.relationships = keptRels;
 
   // A metric is available only when no entity it spans is unavailable, every
-  // field it references is bound, and -- when it spans entities -- a relationship
-  // connecting them survives.
+  // field it references is bound, and -- when it spans entities -- a
+  // relationship connecting them survives.
   const keptMetrics: Metric[] = [];
   for (const mt of clone.metrics ?? []) {
     const expr = mt.expression ?? '';
@@ -373,16 +391,15 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
 
 // The first unbound "Entity.field" a metric expression references (qualified),
 // or null. Text inside string literals is ignored.
-function firstUnboundReferenced(
-    expr: string, unbound: Set<string>): string|null {
+function firstUnboundReferenced(expr: string, unbound: Set<string>): string|
+    null {
   const scannable = blankStringLiterals(expr);
   for (const key of unbound) {
     const dot = key.indexOf('.');
     const entity = key.slice(0, dot);
     const field = key.slice(dot + 1);
-    const re = new RegExp(
-        `(?<![\\w\`])\`?${escapeRegExp(entity)}\`?\\.\`?${
-            escapeRegExp(field)}\`?(?![\\w])`);
+    const re = new RegExp(`(?<![\\w\`])\`?${escapeRegExp(entity)}\`?\\.\`?${
+        escapeRegExp(field)}\`?(?![\\w])`);
     if (re.test(scannable)) return key;
   }
   return null;
@@ -403,8 +420,8 @@ function unboundJoinField(r: Relationship, unbound: Set<string>): string|null {
 }
 
 // Whether any surviving relationship directly connects two of the referenced
-// entities -- the minimal check that a cross-entity metric still has a join path
-// after unavailable relationships were dropped.
+// entities -- the minimal check that a cross-entity metric still has a join
+// path after unavailable relationships were dropped.
 function connectingRelationshipKept(
     refEntities: string[], kept: Relationship[]): boolean {
   const set = new Set(refEntities);

--- a/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
@@ -1,31 +1,33 @@
-// Merges a logical semantic model with a chosen binding profile, and prunes
-// what the resulting binding cannot answer.
+// Merges a logical semantic model with a chosen binding profile, and prunes what
+// the resulting binding cannot answer.
 //
 // A model is authored as ONE logical declaration (entities, fields,
 // relationships, metrics, the grain, and the graph shape) plus zero or more
-// BINDING PROFILES that supply the physical facets it leaves open: each
-// entity's `source`, each field's column (`expression`), and the deployment
-// target. `kcmd push --profile <name>` merges the selected profile onto the
-// logical model BY NAME and deploys the result. See
-// docs/semantic-model/profiles.md.
+// BINDING PROFILES that supply the physical facets it leaves open: each entity's
+// `source`, each field's column (`expression`), and the deployment target.
+// `kcmd push --profile <name>` merges the selected profile onto the logical
+// model BY NAME and deploys the result. See docs/semantic-model/profiles.md.
 //
 // Two passes live here:
 //   - mergeProfile overlays one profile document onto the logical document,
-//     enforcing the binding-only contract: a profile may set physical facets
-//     and may leave a field unbound, but it may not add or remove elements or
-//     change what anything means. It runs on the parsed authoring documents
-//     (the readable, sugared form) before schema validation, so a profile is
-//     written in the same syntax as the model.
-//   - pruneUnavailable runs over the loaded IR and drops each field left
-//   unbound
-//     plus everything that depends on it -- a metric whose expression reads it,
-//     a relationship whose join column is unbound, a cross-entity metric over a
+//     enforcing the binding-only contract: a profile may set physical facets and
+//     may leave a field unbound, but it may not add or remove elements or change
+//     what anything means. It runs on the parsed authoring documents (the
+//     readable, sugared form) before schema validation, so a profile is written
+//     in the same syntax as the model.
+//   - pruneUnavailable runs over the loaded IR and drops each field left unbound
+//     plus everything that depends on it -- a metric whose expression reads it, a
+//     relationship whose join column is unbound, a cross-entity metric over a
 //     dropped relationship -- returning the pruned model and a per-profile
 //     availability report. Availability propagates UP the dependency graph from
 //     the fields a profile binds.
 
 import {fieldBinding, Metric, Relationship, SemanticModel} from './ir';
-import {blankStringLiterals, escapeRegExp, referencedEntityNames,} from './sql_expr_utils';
+import {
+  blankStringLiterals,
+  escapeRegExp,
+  referencedEntityNames,
+} from './sql_expr_utils';
 
 // The implicit profile: the inline bindings already in the model document (the
 // combined single-file form). It is never merged -- it IS the document as
@@ -46,11 +48,7 @@ export interface MergeResult {
 // declaration the model owns; setting it in a profile is rejected so swapping a
 // profile can move data but never change what the model means.
 const PROFILE_MODEL_KEYS = new Set([
-  'name',
-  'version',
-  'deployment_target',
-  'entities',
-  'datasets',
+  'name', 'version', 'deployment_target', 'entities', 'datasets',
 ]);
 const PROFILE_ENTITY_KEYS = new Set(['name', 'source', 'fields']);
 const PROFILE_FIELD_KEYS = new Set(['name', 'expression', 'unbound']);
@@ -58,9 +56,9 @@ const PROFILE_FIELD_KEYS = new Set(['name', 'expression', 'unbound']);
 /**
  * Overlays `profileDoc` onto `logicalDoc`, matching models, entities, fields by
  * `name`, and returns the merged document. The inputs are never mutated. A
- * profile supplies physical bindings only; a violation of that contract
- * (setting a declaration, or naming an element the logical model does not
- * declare) is returned as `error`, naming the path.
+ * profile supplies physical bindings only; a violation of that contract (setting
+ * a declaration, or naming an element the logical model does not declare) is
+ * returned as `error`, naming the path.
  */
 export function mergeProfile(
     logicalDoc: unknown, profileDoc: unknown,
@@ -72,16 +70,14 @@ export function mergeProfile(
   if (!merged || typeof merged !== 'object' ||
       !Array.isArray(merged.semantic_model)) {
     return {
-      doc: merged,
-      warnings,
+      doc: merged, warnings,
       error: 'the logical model is not a semantic_model document',
     };
   }
   if (!profile || typeof profile !== 'object' ||
       !Array.isArray(profile.semantic_model)) {
     return {
-      doc: merged,
-      warnings,
+      doc: merged, warnings,
       error: `profile '${profileName}' is not a semantic_model document`,
     };
   }
@@ -98,8 +94,7 @@ export function mergeProfile(
     const lm = logicalByName.get(pm.name);
     if (!lm) {
       return {
-        doc: merged,
-        warnings,
+        doc: merged, warnings,
         error: `profile '${profileName}': model '${
             pm.name}' is not in the logical model`,
       };
@@ -108,10 +103,9 @@ export function mergeProfile(
     if (err) return {doc: merged, warnings, error: err};
   }
 
-  // A field the profile neither bound nor marked unbound is carried through
-  // from the logical model with no column -- unbound under this profile. Mark
-  // it so the merged document is self-describing and the availability pass sees
-  // it.
+  // A field the profile neither bound nor marked unbound is carried through from
+  // the logical model with no column -- unbound under this profile. Mark it so
+  // the merged document is self-describing and the availability pass sees it.
   markOmittedFieldsUnbound(merged);
   return {doc: merged, warnings};
 }
@@ -155,8 +149,7 @@ function mergeEntity(le: any, pe: any, profileName: string): string|undefined {
 
   if (pe.fields === undefined) return undefined;
   if (!Array.isArray(pe.fields)) {
-    return `profile '${profileName}': entity '${
-        pe.name}' 'fields' must be a list`;
+    return `profile '${profileName}': entity '${pe.name}' 'fields' must be a list`;
   }
   const lByName = indexByName(le.fields ?? []);
   for (const pf of pe.fields) {
@@ -172,8 +165,9 @@ function mergeEntity(le: any, pe: any, profileName: string): string|undefined {
   return undefined;
 }
 
-function mergeField(lf: any, pf: any, entityName: string, profileName: string):
-    string|undefined {
+function mergeField(
+    lf: any, pf: any, entityName: string,
+    profileName: string): string|undefined {
   for (const k of Object.keys(pf)) {
     if (!PROFILE_FIELD_KEYS.has(k)) {
       return declError(profileName, `field '${entityName}.${pf.name}'`, k);
@@ -187,7 +181,7 @@ function mergeField(lf: any, pf: any, entityName: string, profileName: string):
   if (pf.expression !== undefined) {
     if (!isBareColumnRef(pf.expression)) {
       return `profile '${profileName}': field '${entityName}.${
-                 pf.name}' expression must be a bare column reference, not arbitrary ` +
+          pf.name}' expression must be a bare column reference, not arbitrary ` +
           `SQL; the computation is the logical model's to define`;
     }
     lf.expression = pf.expression;
@@ -204,16 +198,14 @@ function declError(profileName: string, where: string, key: string): string {
 
 // A profile's field expression must be a BARE column reference (e.g. `c_name`),
 // never arbitrary SQL: the computation belongs to the logical model, and only
-// the column it reads may vary per profile. Accepts the bare-string form and
-// the per-dialect object; rejects any variant that contains whitespace or a
-// call.
+// the column it reads may vary per profile. Accepts the bare-string form and the
+// per-dialect object; rejects any variant that contains whitespace or a call.
 function isBareColumnRef(expr: unknown): boolean {
   const parts: string[] = [];
   if (typeof expr === 'string') {
     parts.push(expr);
-  } else if (
-      expr && typeof expr === 'object' &&
-      Array.isArray((expr as any).dialects)) {
+  } else if (expr && typeof expr === 'object' &&
+             Array.isArray((expr as any).dialects)) {
     for (const d of (expr as any).dialects) {
       if (d && typeof d.expression === 'string') parts.push(d.expression);
     }
@@ -258,8 +250,8 @@ function markOmittedFieldsUnbound(doc: any): void {
 export interface AvailabilityReport {
   profile: string;
   unboundFields: string[];  // "Entity.field"
-  // An entity dropped whole because its key names an unbound field: a graph
-  // node must be keyed, so an unbound key makes the entire entity unavailable.
+  // An entity dropped whole because its key names an unbound field: a graph node
+  // must be keyed, so an unbound key makes the entire entity unavailable.
   droppedEntities: {name: string; reason: string}[];
   droppedMetrics: {name: string; reason: string}[];
   droppedRelationships: {name: string; reason: string}[];
@@ -284,10 +276,9 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
   };
 
   // A field is bound when fieldBinding resolves it to a column; otherwise it is
-  // unbound (structurally absent under this profile). fieldBinding is the
-  // shared predicate the generator also uses, so a field awaiting transpilation
-  // (its column carried on the imported expression) counts as bound, not
-  // dropped.
+  // unbound (structurally absent under this profile). fieldBinding is the shared
+  // predicate the generator also uses, so a field awaiting transpilation (its
+  // column carried on the imported expression) counts as bound, not dropped.
   const unbound = new Set<string>();
   for (const e of clone.entities ?? []) {
     // An abstract entity has no table and no bindings by design: it survives
@@ -303,17 +294,17 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
   report.unboundFields = [...unbound];
 
   // An entity whose key names an unbound field cannot be a node -- a graph node
-  // must be keyed -- so the WHOLE entity is unavailable and everything on it
-  // (its relationships and the metrics over it) falls with it. This is
-  // availability propagating up from the unbound key. Record the entity, and
-  // add every one of its fields to the unbound set so the relationship and
-  // metric passes below cascade over it. Entity names are captured before any
-  // drop so a metric or relationship that references a dropped entity is still
-  // detected.
+  // must be keyed -- so the WHOLE entity is unavailable and everything on it (its
+  // relationships and the metrics over it) falls with it. This is availability
+  // propagating up from the unbound key. Record the entity, and add every one of
+  // its fields to the unbound set so the relationship and metric passes below
+  // cascade over it. Entity names are captured before any drop so a metric or
+  // relationship that references a dropped entity is still detected.
   const allEntityNames = (clone.entities ?? []).map(e => e.name);
   const unavailableEntities = new Set<string>();
   for (const e of clone.entities ?? []) {
-    const missingKey = (e.keys ?? []).find(k => unbound.has(`${e.name}.${k}`));
+    const missingKey =
+        (e.keys ?? []).find(k => unbound.has(`${e.name}.${k}`));
     if (missingKey !== undefined) {
       unavailableEntities.add(e.name);
       report.droppedEntities.push(
@@ -357,8 +348,8 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
   clone.relationships = keptRels;
 
   // A metric is available only when no entity it spans is unavailable, every
-  // field it references is bound, and -- when it spans entities -- a
-  // relationship connecting them survives.
+  // field it references is bound, and -- when it spans entities -- a relationship
+  // connecting them survives.
   const keptMetrics: Metric[] = [];
   for (const mt of clone.metrics ?? []) {
     const expr = mt.expression ?? '';
@@ -391,15 +382,16 @@ export function pruneUnavailable(model: SemanticModel, profileName: string):
 
 // The first unbound "Entity.field" a metric expression references (qualified),
 // or null. Text inside string literals is ignored.
-function firstUnboundReferenced(expr: string, unbound: Set<string>): string|
-    null {
+function firstUnboundReferenced(
+    expr: string, unbound: Set<string>): string|null {
   const scannable = blankStringLiterals(expr);
   for (const key of unbound) {
     const dot = key.indexOf('.');
     const entity = key.slice(0, dot);
     const field = key.slice(dot + 1);
-    const re = new RegExp(`(?<![\\w\`])\`?${escapeRegExp(entity)}\`?\\.\`?${
-        escapeRegExp(field)}\`?(?![\\w])`);
+    const re = new RegExp(
+        `(?<![\\w\`])\`?${escapeRegExp(entity)}\`?\\.\`?${
+            escapeRegExp(field)}\`?(?![\\w])`);
     if (re.test(scannable)) return key;
   }
   return null;
@@ -420,8 +412,8 @@ function unboundJoinField(r: Relationship, unbound: Set<string>): string|null {
 }
 
 // Whether any surviving relationship directly connects two of the referenced
-// entities -- the minimal check that a cross-entity metric still has a join
-// path after unavailable relationships were dropped.
+// entities -- the minimal check that a cross-entity metric still has a join path
+// after unavailable relationships were dropped.
 function connectingRelationshipKept(
     refEntities: string[], kept: Relationship[]): boolean {
   const set = new Set(refEntities);

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -180,19 +180,18 @@ function renderNodeTable(
   // Defense in depth: availability pruning normally strips every unbound field
   // (it has no column) before generation. A caller that generates DDL straight
   // from a bindingOptional load without pruning could still reach here with an
-  // unbound (e.g. purely logical) field; skip it with a warning rather than emit
+  // unbound (e.g. purely logical) field; skip it with a warning rather than
+  // emit
   // `<name>` as a phantom bare column the source table does not have.
-  const properties =
-      entity.fields
-          .filter(f => {
-            if (fieldExpression(f) !== undefined) return true;
-            warnings.push(
-                `entity '${entity.name}': field '${f.name}' has no column ` +
-                `under this binding; omitted from the node table (bind it, or ` +
-                `govern the logical model in Knowledge Catalog instead)`);
-            return false;
-          })
-          .map(f => renderFieldProperty(f, entity.name));
+  const boundFields = entity.fields.filter(f => {
+    if (fieldExpression(f) !== undefined) return true;
+    warnings.push(
+        `entity '${entity.name}': field '${f.name}' has no column ` +
+        `under this binding; omitted from the node table (bind it, or ` +
+        `govern the logical model in Knowledge Catalog instead)`);
+    return false;
+  });
+  const properties = boundFields.map(f => renderFieldProperty(f, entity.name));
 
   const lines = [
     line(1, `${table} AS ${quoteIfReserved(entity.name)}`),
@@ -214,8 +213,10 @@ function renderNodeTable(
 
   // Inheritance: declare one LABEL per transitive ancestor (resolveInheritance
   // expanded `extends` to the full ancestor set), each re-listing that
-  // ancestor's own properties so `MATCH (:Ancestor)` also matches this
-  // subclass.
+  // ancestor's properties so `MATCH (:Ancestor)` also matches this subclass. A
+  // CONCRETE ancestor's block is rendered from its own fields; an ABSTRACT
+  // ancestor has no table of its own, so its names are rendered from THIS
+  // subtype's binding of each inherited field (mirrors the BigQuery leg).
   for (const ancestorName of entity.extends ?? []) {
     const ancestor = labelByName.get(ancestorName);
     if (!ancestor) {
@@ -226,8 +227,17 @@ function renderNodeTable(
       continue;
     }
     lines.push(line(2, `LABEL ${quoteIfReserved(ancestorName)}`));
-    const signature =
-        ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
+    let signature: string[];
+    if (ancestor.abstract) {
+      signature = [];
+      for (const af of ancestor.fields) {
+        const child = boundFields.find(cf => cf.name === af.name);
+        if (child) signature.push(renderFieldProperty(child, entity.name));
+      }
+    } else {
+      signature =
+          ancestor.fields.map(f => renderFieldProperty(f, ancestor.name));
+    }
     if (signature.length) lines.push(propertiesBlock(signature));
   }
   return lines.join('\n');
@@ -348,8 +358,7 @@ function renderFieldProperty(field: Field, entity: string): string {
   const expr = fieldExpression(field);
   const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
   const alias = quoteIfReserved(field.name);
-  return local === field.name ? alias :
-                                `${quoteIfReserved(local)} AS ${alias}`;
+  return local === field.name ? alias : `${quoteIfReserved(local)} AS ${alias}`;
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -180,8 +180,7 @@ function renderNodeTable(
   // Defense in depth: availability pruning normally strips every unbound field
   // (it has no column) before generation. A caller that generates DDL straight
   // from a bindingOptional load without pruning could still reach here with an
-  // unbound (e.g. purely logical) field; skip it with a warning rather than
-  // emit
+  // unbound (e.g. purely logical) field; skip it with a warning rather than emit
   // `<name>` as a phantom bare column the source table does not have.
   const boundFields = entity.fields.filter(f => {
     if (fieldExpression(f) !== undefined) return true;
@@ -358,7 +357,8 @@ function renderFieldProperty(field: Field, entity: string): string {
   const expr = fieldExpression(field);
   const local = expr !== undefined ? stripQualifier(expr, entity) : field.name;
   const alias = quoteIfReserved(field.name);
-  return local === field.name ? alias : `${quoteIfReserved(local)} AS ${alias}`;
+  return local === field.name ? alias :
+                                `${quoteIfReserved(local)} AS ${alias}`;
 }
 
 

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -146,21 +146,18 @@ describe('IR-contract metric cases the loader cannot produce', () => {
         expect(ddl).toContain('MEASURE(COUNT(o_orderkey)) AS order_count');
       });
 
-  test(
-      'a key field bound to a computed expression warns at the structural site',
-      () => {
-        // A KEY / SOURCE KEY / REFERENCES site must name a bare column. A key
-        // bound to a computed expression resolves to SQL, not a column, which
-        // BigQuery rejects; the generator must warn statically rather than emit
-        // broken DDL.
-        const model = orders();
-        model.entities[0].fields[0].expression = 'CONCAT(orders.a, orders.b)';
-        const {warnings} = generatePropertyGraph(model, GEN_OPTS);
-        expect(warnings.some(
-                   w => w.includes('o_orderkey') &&
-                       w.includes('non-column expression')))
-            .toBe(true);
-      });
+  test('a key field bound to a computed expression warns at the structural site', () => {
+    // A KEY / SOURCE KEY / REFERENCES site must name a bare column. A key bound
+    // to a computed expression resolves to SQL, not a column, which BigQuery
+    // rejects; the generator must warn statically rather than emit broken DDL.
+    const model = orders();
+    model.entities[0].fields[0].expression = 'CONCAT(orders.a, orders.b)';
+    const {warnings} = generatePropertyGraph(model, GEN_OPTS);
+    expect(warnings.some(
+               w => w.includes('o_orderkey') &&
+                   w.includes('non-column expression')))
+        .toBe(true);
+  });
 
   test(
       'an unbound field (no column) is omitted from the node table with a warning',
@@ -169,12 +166,11 @@ describe('IR-contract metric cases the loader cannot produce', () => {
         // without pruning (e.g. straight from a bindingOptional load) must not
         // emit the field as a phantom bare column.
         const model = orders();
-        model.entities[0].fields.push(
-            {name: 'notes'});  // no expression/binding
+        model.entities[0].fields.push({name: 'notes'});  // no expression/binding
         const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
         expect(ddl).not.toContain('notes');
-        expect(
-            warnings.some(w => w.includes('notes') && w.includes('no column')))
+        expect(warnings.some(
+                   w => w.includes('notes') && w.includes('no column')))
             .toBe(true);
       });
 
@@ -700,9 +696,8 @@ describe('abstract (table-less) superclasses are eliminated to labels', () => {
         }
         // The label signature must REDEFINE each inherited property with the
         // subtype's own column (`<col> AS <name>`), never a bare-alias
-        // reference
-        // -- the shape BigQuery accepts across element tables with differing
-        // columns (verified live).
+        // reference -- the shape BigQuery accepts across element tables with
+        // differing columns (verified live).
         const props = partyBlocks.map(m => m[1]);
         expect(props.some(p => /p_name\s+AS\s+name/.test(p))).toBe(true);
         expect(props.some(p => /o_name\s+AS\s+name/.test(p))).toBe(true);
@@ -950,9 +945,9 @@ describe('inherited property rendering (shared-label consistency)', () => {
 
 describe('reserved-word names in an M:N association edge are quoted', () => {
   // The open format has no association-table syntax, so this hand-built IR is
-  // the only path that exercises renderAssociationEdge's identifier quoting:
-  // the edge alias, KEY, SOURCE KEY / DESTINATION KEY columns, and both
-  // REFERENCES labels, each named with a GoogleSQL reserved keyword.
+  // the only path that exercises renderAssociationEdge's identifier quoting: the
+  // edge alias, KEY, SOURCE KEY / DESTINATION KEY columns, and both REFERENCES
+  // labels, each named with a GoogleSQL reserved keyword.
   const RW_ASSOC: SemanticModel = {
     name: 'rw_assoc',
     entities: [
@@ -984,14 +979,11 @@ describe('reserved-word names in an M:N association edge are quoted', () => {
     metrics: [],
   };
 
-  test(
-      'every reserved identifier position in the edge is backtick-quoted',
-      () => {
-        const {ddl} = generatePropertyGraph(RW_ASSOC, GEN_OPTS);
-        expect(ddl).toContain('`proj.ds.order_group` AS `from`');
-        expect(ddl).toContain('KEY(`order`)');
-        expect(ddl).toContain(
-            'SOURCE KEY(`order`) REFERENCES `Order`(`order`)');
-        expect(ddl).toContain('DESTINATION KEY(id) REFERENCES `Group`(id)');
-      });
+  test('every reserved identifier position in the edge is backtick-quoted', () => {
+    const {ddl} = generatePropertyGraph(RW_ASSOC, GEN_OPTS);
+    expect(ddl).toContain('`proj.ds.order_group` AS `from`');
+    expect(ddl).toContain('KEY(`order`)');
+    expect(ddl).toContain('SOURCE KEY(`order`) REFERENCES `Order`(`order`)');
+    expect(ddl).toContain('DESTINATION KEY(id) REFERENCES `Group`(id)');
+  });
 });

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -146,18 +146,21 @@ describe('IR-contract metric cases the loader cannot produce', () => {
         expect(ddl).toContain('MEASURE(COUNT(o_orderkey)) AS order_count');
       });
 
-  test('a key field bound to a computed expression warns at the structural site', () => {
-    // A KEY / SOURCE KEY / REFERENCES site must name a bare column. A key bound
-    // to a computed expression resolves to SQL, not a column, which BigQuery
-    // rejects; the generator must warn statically rather than emit broken DDL.
-    const model = orders();
-    model.entities[0].fields[0].expression = 'CONCAT(orders.a, orders.b)';
-    const {warnings} = generatePropertyGraph(model, GEN_OPTS);
-    expect(warnings.some(
-               w => w.includes('o_orderkey') &&
-                   w.includes('non-column expression')))
-        .toBe(true);
-  });
+  test(
+      'a key field bound to a computed expression warns at the structural site',
+      () => {
+        // A KEY / SOURCE KEY / REFERENCES site must name a bare column. A key
+        // bound to a computed expression resolves to SQL, not a column, which
+        // BigQuery rejects; the generator must warn statically rather than emit
+        // broken DDL.
+        const model = orders();
+        model.entities[0].fields[0].expression = 'CONCAT(orders.a, orders.b)';
+        const {warnings} = generatePropertyGraph(model, GEN_OPTS);
+        expect(warnings.some(
+                   w => w.includes('o_orderkey') &&
+                       w.includes('non-column expression')))
+            .toBe(true);
+      });
 
   test(
       'an unbound field (no column) is omitted from the node table with a warning',
@@ -166,11 +169,12 @@ describe('IR-contract metric cases the loader cannot produce', () => {
         // without pruning (e.g. straight from a bindingOptional load) must not
         // emit the field as a phantom bare column.
         const model = orders();
-        model.entities[0].fields.push({name: 'notes'});  // no expression/binding
+        model.entities[0].fields.push(
+            {name: 'notes'});  // no expression/binding
         const {ddl, warnings} = generatePropertyGraph(model, GEN_OPTS);
         expect(ddl).not.toContain('notes');
-        expect(warnings.some(
-                   w => w.includes('notes') && w.includes('no column')))
+        expect(
+            warnings.some(w => w.includes('notes') && w.includes('no column')))
             .toBe(true);
       });
 
@@ -620,10 +624,16 @@ describe(
 
 describe('abstract (table-less) superclasses are eliminated to labels', () => {
   // An abstract `Party` has no physical table; two concrete subtypes, `Person`
-  // and `Organization`, bind it. resolveInheritance flattens Party's `name`
-  // onto each subtype and expands their `extends` to [Party], so each concrete
-  // node table declares `LABEL Party` with Party's own signature. Party itself
-  // must produce NO node table -- it survives only as that shared label.
+  // and `Organization`, bind it. Party's inherited `id`/`name` are bound on
+  // each subtype's OWN table under DIFFERENT columns (person.p_name vs
+  // org.o_name). resolveInheritance flattens Party's fields onto each subtype
+  // and expands their `extends` to [Party], so each concrete node table
+  // declares `LABEL Party` with that subtype's OWN binding of the inherited
+  // names (`p_name AS name` / `o_name AS name`). BigQuery reconciles a shared
+  // label by property name, not backing column, so the differing columns are
+  // valid; a bare-alias reference (`PROPERTIES(name)`) would not deploy
+  // (verified live). Party itself must produce NO node table -- it survives
+  // only as that shared label.
   function partyModel(): SemanticModel {
     return {
       name: 'party_graph',
@@ -640,14 +650,22 @@ describe('abstract (table-less) superclasses are eliminated to labels', () => {
           dataSource: 'sqlgen-testing.demo.person',
           keys: ['id'],
           extends: ['Party'],
-          fields: [{name: 'id'}, {name: 'ssn'}],
+          fields: [
+            {name: 'id', expression: 'p_id'},
+            {name: 'name', expression: 'p_name'},
+            {name: 'ssn', expression: 'p_ssn'},
+          ],
         },
         {
           name: 'Organization',
           dataSource: 'sqlgen-testing.demo.organization',
           keys: ['id'],
           extends: ['Party'],
-          fields: [{name: 'id'}, {name: 'taxId'}],
+          fields: [
+            {name: 'id', expression: 'o_id'},
+            {name: 'name', expression: 'o_name'},
+            {name: 'taxId', expression: 'o_tax'},
+          ],
         },
       ],
       relationships: [],
@@ -670,9 +688,9 @@ describe('abstract (table-less) superclasses are eliminated to labels', () => {
       () => {
         const {ddl} = generatePropertyGraph(partyModel(), GEN_OPTS);
         // Both Person and Organization declare the shared Party label, each
-        // with a PROPERTIES block that lists Party's flattened `name` (assert
-        // inside the block, so an unrelated `name` substring elsewhere can't
-        // satisfy this).
+        // with a PROPERTIES block listing Party's flattened `id`/`name`
+        // rendered from that subtype's OWN binding (assert inside the block, so
+        // an unrelated substring elsewhere can't satisfy this).
         const partyBlocks =
             [...ddl.matchAll(/LABEL Party\s*\n\s*PROPERTIES\(([\s\S]*?)\)/g)];
         expect(partyBlocks.length).toBe(2);
@@ -680,6 +698,14 @@ describe('abstract (table-less) superclasses are eliminated to labels', () => {
           expect(props).toContain('name');
           expect(props).toContain('id');
         }
+        // The label signature must REDEFINE each inherited property with the
+        // subtype's own column (`<col> AS <name>`), never a bare-alias
+        // reference
+        // -- the shape BigQuery accepts across element tables with differing
+        // columns (verified live).
+        const props = partyBlocks.map(m => m[1]);
+        expect(props.some(p => /p_name\s+AS\s+name/.test(p))).toBe(true);
+        expect(props.some(p => /o_name\s+AS\s+name/.test(p))).toBe(true);
       });
 
   test('both concrete node tables are still emitted', () => {
@@ -924,9 +950,9 @@ describe('inherited property rendering (shared-label consistency)', () => {
 
 describe('reserved-word names in an M:N association edge are quoted', () => {
   // The open format has no association-table syntax, so this hand-built IR is
-  // the only path that exercises renderAssociationEdge's identifier quoting: the
-  // edge alias, KEY, SOURCE KEY / DESTINATION KEY columns, and both REFERENCES
-  // labels, each named with a GoogleSQL reserved keyword.
+  // the only path that exercises renderAssociationEdge's identifier quoting:
+  // the edge alias, KEY, SOURCE KEY / DESTINATION KEY columns, and both
+  // REFERENCES labels, each named with a GoogleSQL reserved keyword.
   const RW_ASSOC: SemanticModel = {
     name: 'rw_assoc',
     entities: [
@@ -958,11 +984,14 @@ describe('reserved-word names in an M:N association edge are quoted', () => {
     metrics: [],
   };
 
-  test('every reserved identifier position in the edge is backtick-quoted', () => {
-    const {ddl} = generatePropertyGraph(RW_ASSOC, GEN_OPTS);
-    expect(ddl).toContain('`proj.ds.order_group` AS `from`');
-    expect(ddl).toContain('KEY(`order`)');
-    expect(ddl).toContain('SOURCE KEY(`order`) REFERENCES `Order`(`order`)');
-    expect(ddl).toContain('DESTINATION KEY(id) REFERENCES `Group`(id)');
-  });
+  test(
+      'every reserved identifier position in the edge is backtick-quoted',
+      () => {
+        const {ddl} = generatePropertyGraph(RW_ASSOC, GEN_OPTS);
+        expect(ddl).toContain('`proj.ds.order_group` AS `from`');
+        expect(ddl).toContain('KEY(`order`)');
+        expect(ddl).toContain(
+            'SOURCE KEY(`order`) REFERENCES `Order`(`order`)');
+        expect(ddl).toContain('DESTINATION KEY(id) REFERENCES `Group`(id)');
+      });
 });

--- a/toolbox/mdcode/tests/libts/semantic/loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/loader.test.ts
@@ -2,39 +2,35 @@
 // (src/libts/semantic/loader.ts).
 //
 // The loader reads the subset of an open, AI-first semantics format needed to
-// normalize a model into the IR. Each test names one behavior. Focused tests
-// use `fromDocument` with object literals; document-level tests parse raw
-// YAML/JSON text via `loadModels`. This file asserts only the IR — the BigQuery
-// generator is covered by `bigquery.test.ts` (unit) and `bigquery.e2e.test.ts`
-// (file -> DDL).
+// normalize a model into the IR. Each test names one behavior. Focused tests use
+// `fromDocument` with object literals; document-level tests parse raw YAML/JSON
+// text via `loadModels`. This file asserts only the IR — the BigQuery generator
+// is covered by `bigquery.test.ts` (unit) and `bigquery.e2e.test.ts` (file -> DDL).
 //
 
-import {describe, expect, test} from 'bun:test';
-import {readFileSync} from 'fs';
-import {join} from 'path';
-
-import {DATA_TYPES, isTimeDimension} from '../../../src/libts/semantic/ir';
-import {fromDocument, loadModels} from '../../../src/libts/semantic/loader';
+import { describe, test, expect } from 'bun:test';
+import { loadModels, fromDocument } from '../../../src/libts/semantic/loader';
+import { isTimeDimension, DATA_TYPES } from '../../../src/libts/semantic/ir';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 // Shorthand for the format's per-dialect expression object.
 function expr(expression: string, dialect = 'BIGQUERY') {
-  return {dialects: [{dialect, expression}]};
+  return { dialects: [{ dialect, expression }] };
 }
 
 
 describe('dataset source strings normalize to fully-qualified references', () => {
-  const {models} = fromDocument(
-      {
-        semantic_model: [{
-          name: 'm',
-          datasets: [
-            {name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: []},
-            {name: 'b', source: 'ds.tbl', primary_key: ['id'], fields: []},
-            {name: 'c', source: 'tbl', primary_key: ['id'], fields: []},
-          ],
-        }],
-      },
-      {defaultProject: 'P', defaultDataset: 'D'});
+  const { models } = fromDocument({
+    semantic_model: [{
+      name: 'm',
+      datasets: [
+        { name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] },
+        { name: 'b', source: 'ds.tbl', primary_key: ['id'], fields: [] },
+        { name: 'c', source: 'tbl', primary_key: ['id'], fields: [] },
+      ],
+    }],
+  }, { defaultProject: 'P', defaultDataset: 'D' });
   const [a, b, c] = models[0].entities;
 
   test('a three-part source becomes project.dataset.table', () => {
@@ -50,286 +46,177 @@ describe('dataset source strings normalize to fully-qualified references', () =>
   });
 
   test('a query-like source is kept verbatim with a warning', () => {
-    const {models, warnings} = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{
-          name: 'a',
-          source: 'SELECT 1 FROM t',
-          primary_key: ['id'],
-          fields: []
-        }]
-      }],
+    const { models, warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'SELECT 1 FROM t', primary_key: ['id'], fields: [] }] }],
     });
     expect(models[0].entities[0].dataSource).toBe('SELECT 1 FROM t');
     expect(warnings.some(w => w.includes('looks like a query'))).toBe(true);
   });
 
   test('a dataset without a primary key warns (its KEY would be empty)', () => {
-    const {warnings} = fromDocument({
-      semantic_model:
-          [{name: 'm', datasets: [{name: 'a', source: 'a', fields: []}]}],
+    const { warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'a', fields: [] }] }],
     });
     expect(warnings.some(w => w.includes('no primary_key'))).toBe(true);
   });
 
   test('backtick- or double-quoted identifiers are unquoted', () => {
-    const {models} = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{
-          name: 'a',
-          source: '`proj`.`ds`.`tbl`',
-          primary_key: ['id'],
-          fields: []
-        }]
-      }],
+    const { models } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: '`proj`.`ds`.`tbl`', primary_key: ['id'], fields: [] }] }],
     });
     expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
   });
 
   test('a four-part Lakehouse catalog name passes through untouched', () => {
-    const {models, warnings} = fromDocument(
-        {
-          semantic_model: [{
-            name: 'm',
-            datasets: [{
-              name: 'a',
-              source: 'proj.cat.ns.tbl',
-              primary_key: ['id'],
-              fields: []
-            }]
-          }],
-        },
-        {defaultProject: 'P', defaultDataset: 'D'});
+    const { models, warnings } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'proj.cat.ns.tbl', primary_key: ['id'], fields: [] }] }],
+    }, { defaultProject: 'P', defaultDataset: 'D' });
     expect(models[0].entities[0].dataSource).toBe('proj.cat.ns.tbl');
     expect(warnings).toEqual([]);
   });
 
-  test(
-      'an explicit project/dataset in the source is not overridden by defaults',
-      () => {
-        const {models} = fromDocument(
-            {
-              semantic_model: [{
-                name: 'm',
-                datasets: [{
-                  name: 'a',
-                  source: 'realproj.realds.tbl',
-                  primary_key: ['id'],
-                  fields: []
-                }]
-              }],
-            },
-            {defaultProject: 'P', defaultDataset: 'D'});
-        expect(models[0].entities[0].dataSource).toBe('realproj.realds.tbl');
-      });
+  test('an explicit project/dataset in the source is not overridden by defaults', () => {
+    const { models } = fromDocument({
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'realproj.realds.tbl', primary_key: ['id'], fields: [] }] }],
+    }, { defaultProject: 'P', defaultDataset: 'D' });
+    expect(models[0].entities[0].dataSource).toBe('realproj.realds.tbl');
+  });
 });
 
 
 describe('per-dialect expressions collapse to a single string', () => {
-  function metricDoc(
-      dialectList: Array<{dialect: string; expression: string}>) {
+  function metricDoc(dialectList: Array<{ dialect: string; expression: string }>) {
     return {
       semantic_model: [{
         name: 'm',
-        datasets: [
-          {name: 'orders', source: 'orders', primary_key: ['id'], fields: []}
-        ],
-        metrics: [{name: 'mx', expression: {dialects: dialectList}}],
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'mx', expression: { dialects: dialectList } }],
       }],
     };
   }
 
-  test(
-      'the preferred dialect (BIGQUERY) is chosen with no warning or provenance',
-      () => {
-        const {models, warnings} = fromDocument(metricDoc([
-          {dialect: 'ANSI_SQL', expression: 'SUM(orders.a)'},
-          {dialect: 'BIGQUERY', expression: 'SUM(orders.b)'},
-        ]));
-        expect(models[0].metrics[0].expression).toBe('SUM(orders.b)');
-        expect(warnings.some(w => w.includes('dialect'))).toBe(false);
-        // Target dialect is already valid; no imported (vendor) form to
-        // preserve.
-        expect(models[0].metrics[0].importedExpression).toBeUndefined();
-      });
+  test('the preferred dialect (BIGQUERY) is chosen with no warning or provenance', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'ANSI_SQL', expression: 'SUM(orders.a)' },
+      { dialect: 'BIGQUERY', expression: 'SUM(orders.b)' },
+    ]));
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.b)');
+    expect(warnings.some(w => w.includes('dialect'))).toBe(false);
+    // Target dialect is already valid; no imported (vendor) form to preserve.
+    expect(models[0].metrics[0].importedExpression).toBeUndefined();
+  });
 
-  test(
-      'ANSI_SQL is the fallback when the preferred dialect is absent, with an informational note',
-      () => {
-        const {models, warnings} = fromDocument(metricDoc([
-          {dialect: 'ANSI_SQL', expression: 'SUM(orders.a)'},
-        ]));
-        expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
-        expect(warnings.some(
-                   w => w.startsWith('note:') &&
-                       w.includes('using the portable \'ANSI_SQL\'')))
-            .toBe(true);
-        // The portable canonical dialect targets BigQuery by design; no
-        // imported form.
-        expect(models[0].metrics[0].importedExpression).toBeUndefined();
-      });
+  test('ANSI_SQL is the fallback when the preferred dialect is absent, with an informational note', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'ANSI_SQL', expression: 'SUM(orders.a)' },
+    ]));
+    expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
+    expect(warnings.some(w => w.startsWith('note:') && w.includes("using the portable 'ANSI_SQL'"))).toBe(true);
+    // The portable canonical dialect targets BigQuery by design; no imported form.
+    expect(models[0].metrics[0].importedExpression).toBeUndefined();
+  });
 
-  test(
-      'a vendor-only expression is kept as imported_expression, with no target expression',
-      () => {
-        const {models, warnings} = fromDocument(metricDoc([
-          {dialect: 'SNOWFLAKE', expression: 'SUM(orders.a)'},
-        ]));
-        // No target/canonical form, so the target `expression` is left unset
-        // and the original vendor SQL is preserved for a later transpile pass.
-        expect(models[0].metrics[0].expression).toBeUndefined();
-        expect(models[0].metrics[0].importedExpression).toBe('SUM(orders.a)');
-        expect(models[0].metrics[0].importedDialect).toBe('SNOWFLAKE');
-        expect(warnings.some(
-                   w => w.includes('\'SNOWFLAKE\'') &&
-                       w.includes('imported_expression')))
-            .toBe(true);
-      });
+  test('a vendor-only expression is kept as imported_expression, with no target expression', () => {
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'SNOWFLAKE', expression: 'SUM(orders.a)' },
+    ]));
+    // No target/canonical form, so the target `expression` is left unset and the
+    // original vendor SQL is preserved for a later transpile pass.
+    expect(models[0].metrics[0].expression).toBeUndefined();
+    expect(models[0].metrics[0].importedExpression).toBe('SUM(orders.a)');
+    expect(models[0].metrics[0].importedDialect).toBe('SNOWFLAKE');
+    expect(warnings.some(w => w.includes("'SNOWFLAKE'") && w.includes('imported_expression'))).toBe(true);
+  });
 
   test('an explicit dialect option overrides the default preference', () => {
-    const {models} = fromDocument(
-        metricDoc([
-          {dialect: 'SNOWFLAKE', expression: 'SF'},
-          {dialect: 'BIGQUERY', expression: 'BQ'},
-        ]),
-        {dialect: 'SNOWFLAKE'});
+    const { models } = fromDocument(metricDoc([
+      { dialect: 'SNOWFLAKE', expression: 'SF' },
+      { dialect: 'BIGQUERY', expression: 'BQ' },
+    ]), { dialect: 'SNOWFLAKE' });
     expect(models[0].metrics[0].expression).toBe('SF');
   });
 
   test('dialect names are matched case-insensitively', () => {
-    const {models, warnings} = fromDocument(
-        metricDoc([
-          {dialect: 'BigQuery', expression: 'SUM(orders.a)'},
-        ]),
-        {dialect: 'bigquery'});
+    const { models, warnings } = fromDocument(metricDoc([
+      { dialect: 'BigQuery', expression: 'SUM(orders.a)' },
+    ]), { dialect: 'bigquery' });
     expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
     expect(warnings.some(w => w.includes('dialect'))).toBe(false);
   });
 
-  test(
-      'field expressions select their dialect independently of metrics', () => {
-        const {models, warnings} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            datasets: [{
-              name: 'orders',
-              source: 'orders',
-              primary_key: ['id'],
-              fields: [
-                {name: 'id', expression: expr('orders.id')},
-                {
-                  name: 'net',
-                  expression: {
-                    dialects: [{
-                      dialect: 'ANSI_SQL',
-                      expression: 'orders.gross - orders.tax'
-                    }]
-                  }
-                },
-                {
-                  name: 'label',
-                  expression: {
-                    dialects: [{
-                      dialect: 'SNOWFLAKE',
-                      expression: 'IFF(orders.ok, \'y\', \'n\')'
-                    }]
-                  }
-                },
-              ],
-            }],
-          }],
-        });
-        const fields = models[0].entities[0].fields;
-        expect(fields[0].expression)
-            .toBe('orders.id');  // BIGQUERY, no fallback
-        expect(fields[1].expression)
-            .toBe('orders.gross - orders.tax');  // ANSI_SQL fallback
-        expect(fields[2].expression)
-            .toBeUndefined();  // no target/canonical form
-        expect(fields[2].importedExpression)
-            .toBe(
-                'IFF(orders.ok, \'y\', \'n\')');  // SNOWFLAKE, kept as imported
-        // The canonical-fallback note is field-agnostic (so it dedupes); the
-        // point here is that the two fields still pick their expressions
-        // independently.
-        expect(
-            warnings.some(w => w.includes('using the portable \'ANSI_SQL\'')))
-            .toBe(true);
-        // The imported (vendor) dialect is recorded only for the vendor field,
-        // so the transpile pass rewrites just that one.
-        expect(fields[0].importedDialect).toBeUndefined();
-        expect(fields[1].importedDialect).toBeUndefined();
-        expect(fields[2].importedDialect).toBe('SNOWFLAKE');
-      });
+  test('field expressions select their dialect independently of metrics', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [
+            { name: 'id', expression: expr('orders.id') },
+            { name: 'net', expression: {
+              dialects: [{ dialect: 'ANSI_SQL', expression: 'orders.gross - orders.tax' }] } },
+            { name: 'label', expression: {
+              dialects: [{ dialect: 'SNOWFLAKE', expression: "IFF(orders.ok, 'y', 'n')" }] } },
+          ],
+        }],
+      }],
+    });
+    const fields = models[0].entities[0].fields;
+    expect(fields[0].expression).toBe('orders.id');                  // BIGQUERY, no fallback
+    expect(fields[1].expression).toBe('orders.gross - orders.tax');  // ANSI_SQL fallback
+    expect(fields[2].expression).toBeUndefined();                    // no target/canonical form
+    expect(fields[2].importedExpression).toBe("IFF(orders.ok, 'y', 'n')");  // SNOWFLAKE, kept as imported
+    // The canonical-fallback note is field-agnostic (so it dedupes); the point
+    // here is that the two fields still pick their expressions independently.
+    expect(warnings.some(w => w.includes("using the portable 'ANSI_SQL'"))).toBe(true);
+    // The imported (vendor) dialect is recorded only for the vendor field, so the
+    // transpile pass rewrites just that one.
+    expect(fields[0].importedDialect).toBeUndefined();
+    expect(fields[1].importedDialect).toBeUndefined();
+    expect(fields[2].importedDialect).toBe('SNOWFLAKE');
+  });
 });
 
 
 describe('relationships map onto the direct-FK IR convention', () => {
-  const {models} = fromDocument({
+  const { models } = fromDocument({
     semantic_model: [{
       name: 'm',
       datasets: [
-        {
-          name: 'orders',
-          source: 'orders',
-          primary_key: ['order_id'],
-          fields: []
-        },
-        {
-          name: 'customers',
-          source: 'customers',
-          primary_key: ['customer_id'],
-          fields: []
-        },
+        { name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] },
+        { name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] },
       ],
       relationships: [{
-        name: 'orders_customers',
-        from: 'orders',
-        to: 'customers',
-        from_columns: ['customer_id'],
-        to_columns: ['customer_id'],
+        name: 'orders_customers', from: 'orders', to: 'customers',
+        from_columns: ['customer_id'], to_columns: ['customer_id'],
       }],
     }],
   });
   const rel = models[0].relationships[0];
 
   test('the source end carries the from_columns (the FK columns)', () => {
-    expect(rel.source).toEqual({entity: 'orders', columns: ['customer_id']});
+    expect(rel.source).toEqual({ entity: 'orders', columns: ['customer_id'] });
   });
 
-  test(
-      'the destination end carries the to_columns (the referenced key columns)',
-      () => {
-        expect(rel.destination)
-            .toEqual({entity: 'customers', columns: ['customer_id']});
-      });
+  test('the destination end carries the to_columns (the referenced key columns)', () => {
+    expect(rel.destination).toEqual({ entity: 'customers', columns: ['customer_id'] });
+  });
 
   test('a composite foreign key maps column-for-column', () => {
-    const {models} = fromDocument({
+    const { models } = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [
-          {
-            name: 'sales',
-            source: 'sales',
-            primary_key: ['sale_id'],
-            fields: []
-          },
-          {
-            name: 'stores',
-            source: 'stores',
-            primary_key: ['region', 'store_no'],
-            fields: []
-          },
+          { name: 'sales', source: 'sales', primary_key: ['sale_id'], fields: [] },
+          { name: 'stores', source: 'stores', primary_key: ['region', 'store_no'], fields: [] },
         ],
         relationships: [{
-          name: 'sales_stores',
-          from: 'sales',
-          to: 'stores',
-          from_columns: ['region', 'store_no'],
-          to_columns: ['region', 'store_no'],
+          name: 'sales_stores', from: 'sales', to: 'stores',
+          from_columns: ['region', 'store_no'], to_columns: ['region', 'store_no'],
         }],
       }],
     });
@@ -338,164 +225,110 @@ describe('relationships map onto the direct-FK IR convention', () => {
     expect(rel.destination.columns).toEqual(['region', 'store_no']);
   });
 
-  test(
-      'the source columns come from from_columns, not the from dataset PK',
-      () => {
-        // The FK columns are taken straight from from_columns; the source
-        // entity's own primary key is looked up from the entity by downstream
-        // consumers, never duplicated onto the relationship (so a missing
-        // from-PK is irrelevant here).
-        const {models} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            datasets: [
-              {name: 'orders', source: 'orders', fields: []},  // no primary_key
-              {
-                name: 'customers',
-                source: 'customers',
-                primary_key: ['customer_id'],
-                fields: []
-              },
-            ],
-            relationships: [{
-              name: 'r',
-              from: 'orders',
-              to: 'customers',
-              from_columns: ['customer_id'],
-              to_columns: ['customer_id'],
-            }],
-          }],
-        });
-        expect(models[0].relationships[0].source)
-            .toEqual({entity: 'orders', columns: ['customer_id']});
-      });
+  test('the source columns come from from_columns, not the from dataset PK', () => {
+    // The FK columns are taken straight from from_columns; the source entity's own
+    // primary key is looked up from the entity by downstream consumers, never
+    // duplicated onto the relationship (so a missing from-PK is irrelevant here).
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', fields: [] },  // no primary_key
+          { name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] },
+        ],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'customers',
+          from_columns: ['customer_id'], to_columns: ['customer_id'],
+        }],
+      }],
+    });
+    expect(models[0].relationships[0].source).toEqual({
+      entity: 'orders', columns: ['customer_id'] });
+  });
 
   test('an unresolved to dataset is a hard error', () => {
     expect(() => fromDocument({
-             semantic_model: [{
-               name: 'm',
-               datasets: [{
-                 name: 'orders',
-                 source: 'orders',
-                 primary_key: ['order_id'],
-                 fields: []
-               }],
-               relationships: [{
-                 name: 'r',
-                 from: 'orders',
-                 to: 'ghost',
-                 from_columns: ['g_id'],
-                 to_columns: ['id'],
-               }],
-             }],
-           }))
-        .toThrow(/'to' dataset 'ghost' is not defined/);
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] }],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'ghost',
+          from_columns: ['g_id'], to_columns: ['id'],
+        }],
+      }],
+    })).toThrow(/'to' dataset 'ghost' is not defined/);
   });
 
   test('an unresolved from dataset is a hard error', () => {
     expect(() => fromDocument({
-             semantic_model: [{
-               name: 'm',
-               datasets: [{
-                 name: 'customers',
-                 source: 'customers',
-                 primary_key: ['customer_id'],
-                 fields: []
-               }],
-               relationships: [{
-                 name: 'r',
-                 from: 'ghost',
-                 to: 'customers',
-                 from_columns: ['c_id'],
-                 to_columns: ['customer_id'],
-               }],
-             }],
-           }))
-        .toThrow(/'from' dataset 'ghost' is not defined/);
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] }],
+        relationships: [{
+          name: 'r', from: 'ghost', to: 'customers',
+          from_columns: ['c_id'], to_columns: ['customer_id'],
+        }],
+      }],
+    })).toThrow(/'from' dataset 'ghost' is not defined/);
   });
 
   test('mismatched from_columns/to_columns arity is a hard error', () => {
     expect(() => fromDocument({
-             semantic_model: [{
-               name: 'm',
-               datasets: [
-                 {
-                   name: 'orders',
-                   source: 'orders',
-                   primary_key: ['order_id'],
-                   fields: []
-                 },
-                 {
-                   name: 'customers',
-                   source: 'customers',
-                   primary_key: ['a', 'b'],
-                   fields: []
-                 },
-               ],
-               relationships: [{
-                 name: 'r',
-                 from: 'orders',
-                 to: 'customers',
-                 from_columns: ['x', 'y'],
-                 to_columns: ['a'],
-               }],
-             }],
-           }))
-        .toThrow(/different lengths/);
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['a', 'b'], fields: [] },
+        ],
+        relationships: [{
+          name: 'r', from: 'orders', to: 'customers',
+          from_columns: ['x', 'y'], to_columns: ['a'],
+        }],
+      }],
+    })).toThrow(/different lengths/);
   });
 });
 
 describe('abstract datasets and their source constraint', () => {
   test('a non-abstract dataset with no source is a hard error', () => {
     expect(() => fromDocument({
-             semantic_model: [{
-               name: 'm',
-               datasets: [{name: 'orders', primary_key: ['id'], fields: []}],
-             }],
-           }))
-        .toThrow(/non-abstract dataset requires a source/);
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', primary_key: ['id'], fields: [] }],
+      }],
+    })).toThrow(/non-abstract dataset requires a source/);
   });
 
-  test(
-      'an abstract dataset that also declares a source is a hard error', () => {
-        // abstract == no physical table; a source would be silently ignored by
-        // the BigQuery leg, dropping a table the author intended, so reject the
-        // combo.
-        expect(() => fromDocument({
-                 semantic_model: [{
-                   name: 'm',
-                   datasets: [{
-                     name: 'Party',
-                     source: 'proj.ds.party',
-                     abstract: true,
-                     primary_key: ['id'],
-                     fields: [],
-                   }],
-                 }],
-               }))
-            .toThrow(/an abstract dataset has no table/);
-      });
+  test('an abstract dataset that also declares a source is a hard error', () => {
+    // abstract == no physical table; a source would be silently ignored by the
+    // BigQuery leg, dropping a table the author intended, so reject the combo.
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'Party', source: 'proj.ds.party', abstract: true,
+          primary_key: ['id'], fields: [],
+        }],
+      }],
+    })).toThrow(/an abstract dataset has no table/);
+  });
 
-  test(
-      'an abstract dataset with no source loads and is marked abstract', () => {
-        const {models} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            datasets: [{name: 'Party', abstract: true, fields: []}],
-          }],
-        });
-        expect(models[0].entities[0].abstract).toBe(true);
-        expect(models[0].entities[0].dataSource).toBe('');
-      });
+  test('an abstract dataset with no source loads and is marked abstract', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'Party', abstract: true, fields: [] }],
+      }],
+    });
+    expect(models[0].entities[0].abstract).toBe(true);
+    expect(models[0].entities[0].dataSource).toBe('');
+  });
 
-  test(
-      'an abstract dataset\'s fields need no expression under a graph leg',
-      () => {
-        // The supertype has no table, so its fields carry no column -- they
-        // name the label its subtypes bind. The strict (graph-leg) schema must
-        // accept them even though a concrete dataset's field would require an
-        // expression.
-        const { models } = fromDocument({
+  test('an abstract dataset\'s fields need no expression under a graph leg', () => {
+    // The supertype has no table, so its fields carry no column -- they name
+    // the label its subtypes bind. The strict (graph-leg) schema must accept
+    // them even though a concrete dataset's field would require an expression.
+    const { models } = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -514,243 +347,167 @@ describe('abstract datasets and their source constraint', () => {
         ],
       }],
     });
-        const party = models[0].entities.find(e => e.name === 'Party')!;
-        expect(party.abstract).toBe(true);
-        expect(party.fields.map(f => f.name)).toEqual(['id', 'name']);
-        expect(party.fields.every(f => f.expression === undefined)).toBe(true);
-      });
+    const party = models[0].entities.find(e => e.name === 'Party')!;
+    expect(party.abstract).toBe(true);
+    expect(party.fields.map(f => f.name)).toEqual(['id', 'name']);
+    expect(party.fields.every(f => f.expression === undefined)).toBe(true);
+  });
 
-  test(
-      'a CONCRETE dataset\'s expression-less field still fails under a graph leg',
-      () => {
-        // The abstract exemption must not leak to concrete datasets: a real
-        // table's field still needs a column (or an explicit `unbound`).
-        expect(
-            () => fromDocument({
-              semantic_model: [{
-                name: 'm',
-                datasets: [{
-                  name: 'orders',
-                  primary_key: ['id'],
-                  source: 'proj.ds.orders',
-                  fields: [{name: 'id', expression: 'o_id'}, {name: 'total'}],
-                }],
-              }],
-            }))
-            .toThrow(/field 'total': requires an expression/);
-      });
+  test('a concrete dataset\'s expression-less field still fails under a graph leg', () => {
+    // The abstract exemption must not leak to concrete datasets: a real
+    // table's field still needs a column (or an explicit `unbound`).
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders',
+          primary_key: ['id'],
+          source: 'proj.ds.orders',
+          fields: [{ name: 'id', expression: 'o_id' }, { name: 'total' }],
+        }],
+      }],
+    })).toThrow(/field 'total': requires an expression/);
+  });
 });
 
 
 describe('metrics infer their referenced entities from the expression', () => {
   test('a single referenced entity becomes the metric attach entity', () => {
-    const {models} = fromDocument({
+    const { models } = fromDocument({
       semantic_model: [{
         name: 'm',
-        datasets: [{
-          name: 'order_items',
-          source: 'order_items',
-          primary_key: ['id'],
-          fields: []
-        }],
-        metrics: [
-          {name: 'total_revenue', expression: expr('SUM(order_items.amount)')}
-        ],
+        datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'total_revenue', expression: expr('SUM(order_items.amount)') }],
       }],
     });
     expect(models[0].metrics[0].entity).toBe('order_items');
   });
 
-  test(
-      'a metric spanning multiple entities has no single attach entity', () => {
-        // A cross-entity metric references known entities but cannot hang off
-        // one node, so `entity` is left undefined -- not a missing-entity
-        // warning.
-        const {models, warnings} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            datasets: [
-              {
-                name: 'orders',
-                source: 'orders',
-                primary_key: ['id'],
-                fields: []
-              },
-              {
-                name: 'customers',
-                source: 'customers',
-                primary_key: ['id'],
-                fields: []
-              },
-            ],
-            metrics: [{
-              name: 'ratio',
-              expression: expr('SUM(orders.amount) / COUNT(customers.id)'),
-            }],
-          }],
-        });
-        expect(models[0].metrics[0].entity).toBeUndefined();
-        expect(warnings.some(w => w.includes('references no known entity')))
-            .toBe(false);
-      });
-
-  test('a metric referencing no known entity warns', () => {
-    const {warnings} = fromDocument({
+  test('a metric spanning multiple entities has no single attach entity', () => {
+    // A cross-entity metric references known entities but cannot hang off one
+    // node, so `entity` is left undefined -- not a missing-entity warning.
+    const { models, warnings } = fromDocument({
       semantic_model: [{
         name: 'm',
-        datasets: [{
-          name: 'order_items',
-          source: 'order_items',
-          primary_key: ['id'],
-          fields: []
+        datasets: [
+          { name: 'orders', source: 'orders', primary_key: ['id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['id'], fields: [] },
+        ],
+        metrics: [{
+          name: 'ratio',
+          expression: expr('SUM(orders.amount) / COUNT(customers.id)'),
         }],
-        metrics: [{name: 'weird', expression: expr('SUM(unknown.x)')}],
       }],
     });
-    expect(warnings.some(w => w.includes('references no known entity')))
-        .toBe(true);
+    expect(models[0].metrics[0].entity).toBeUndefined();
+    expect(warnings.some(w => w.includes('references no known entity'))).toBe(false);
   });
 
-  test(
-      'a qualifier inside a string literal is not counted as a reference',
-      () => {
-        // 'customers.region' is data, not a column reference, so the metric
-        // must be attributed only to order_items.
-        const {models} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            datasets: [
-              {
-                name: 'order_items',
-                source: 'order_items',
-                primary_key: ['id'],
-                fields: []
-              },
-              {
-                name: 'customers',
-                source: 'customers',
-                primary_key: ['id'],
-                fields: []
-              },
-            ],
-            metrics: [{
-              name: 'tagged',
-              expression:
-                  expr('CONCAT(SUM(order_items.amount), \'customers.region\')'),
-            }],
-          }],
-        });
-        expect(models[0].metrics[0].entity).toBe('order_items');
-      });
+  test('a metric referencing no known entity warns', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'weird', expression: expr('SUM(unknown.x)') }],
+      }],
+    });
+    expect(warnings.some(w => w.includes('references no known entity'))).toBe(true);
+  });
 
-  test(
-      'a backtick-quoted entity qualifier is recognized (BigQuery quoting)',
-      () => {
-        // BigQuery quotes identifiers with backticks; `orders`.amount must
-        // still be attributed to the orders entity, not dropped as unqualified.
-        const {models, warnings} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            datasets: [{
-              name: 'orders',
-              source: 'orders',
-              primary_key: ['id'],
-              fields: []
-            }],
-            metrics: [{name: 'rev', expression: expr('SUM(`orders`.amount)')}],
-          }],
-        });
-        expect(models[0].metrics[0].entity).toBe('orders');
-        expect(warnings.some(w => w.includes('references no known entity')))
-            .toBe(false);
-      });
+  test('a qualifier inside a string literal is not counted as a reference', () => {
+    // 'customers.region' is data, not a column reference, so the metric must be
+    // attributed only to order_items.
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] },
+          { name: 'customers', source: 'customers', primary_key: ['id'], fields: [] },
+        ],
+        metrics: [{
+          name: 'tagged',
+          expression: expr("CONCAT(SUM(order_items.amount), 'customers.region')"),
+        }],
+      }],
+    });
+    expect(models[0].metrics[0].entity).toBe('order_items');
+  });
+
+  test('a backtick-quoted entity qualifier is recognized (BigQuery quoting)', () => {
+    // BigQuery quotes identifiers with backticks; `orders`.amount must still be
+    // attributed to the orders entity, not dropped as unqualified.
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'rev', expression: expr('SUM(`orders`.amount)') }],
+      }],
+    });
+    expect(models[0].metrics[0].entity).toBe('orders');
+    expect(warnings.some(w => w.includes('references no known entity'))).toBe(false);
+  });
 });
 
 
 describe('document-level handling', () => {
   test('a mismatched version warns but still loads', () => {
-    const {models, warnings} = fromDocument({
+    const { models, warnings } = fromDocument({
       version: '9.9.9',
-      semantic_model: [{
-        name: 'm',
-        datasets: [{name: 'a', source: 'a', primary_key: ['id'], fields: []}]
-      }],
+      semantic_model: [{ name: 'm', datasets: [
+        { name: 'a', source: 'a', primary_key: ['id'], fields: [] }] }],
     });
     expect(models).toHaveLength(1);
-    expect(warnings.some(w => w.includes('differs from the supported')))
-        .toBe(true);
+    expect(warnings.some(w => w.includes('differs from the supported'))).toBe(true);
   });
 
-  test(
-      'unknown/extra fields outside the subset are ignored, not errors', () => {
-        const {models} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            ai_context: {instructions: 'ignored'},
-            custom_extensions: [{vendor_name: 'X', data: '{}'}],
-            datasets: [{
-              name: 'a',
-              source: 'a',
-              primary_key: ['id'],
-              unique_keys: [['id']],
-              fields: [{
-                name: 'id',
-                label: 'ignored',
-                dimension: {is_time: false},
-                expression: expr('a.id'),
-              }],
-            }],
+  test('unknown/extra fields outside the subset are ignored, not errors', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        ai_context: { instructions: 'ignored' },
+        custom_extensions: [{ vendor_name: 'X', data: '{}' }],
+        datasets: [{
+          name: 'a', source: 'a', primary_key: ['id'],
+          unique_keys: [['id']],
+          fields: [{
+            name: 'id', label: 'ignored', dimension: { is_time: false },
+            expression: expr('a.id'),
           }],
-        });
-        expect(models[0].entities[0].fields[0].name).toBe('id');
-      });
+        }],
+      }],
+    });
+    expect(models[0].entities[0].fields[0].name).toBe('id');
+  });
 
-  test(
-      'duplicate dataset names warn (only one node table can carry the label)',
-      () => {
-        const {warnings} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            datasets: [
-              {name: 'orders', source: 'a', primary_key: ['id'], fields: []},
-              {name: 'orders', source: 'b', primary_key: ['id'], fields: []},
-            ],
-          }],
-        });
-        expect(
-            warnings.some(w => w.includes('duplicate dataset name \'orders\'')))
-            .toBe(true);
-      });
+  test('duplicate dataset names warn (only one node table can carry the label)', () => {
+    const { warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [
+          { name: 'orders', source: 'a', primary_key: ['id'], fields: [] },
+          { name: 'orders', source: 'b', primary_key: ['id'], fields: [] },
+        ],
+      }],
+    });
+    expect(warnings.some(w => w.includes("duplicate dataset name 'orders'"))).toBe(true);
+  });
 
   test('each semantic_model entry becomes its own IR model', () => {
-    const {models} = fromDocument({
+    const { models } = fromDocument({
       semantic_model: [
-        {
-          name: 'first',
-          datasets: [{name: 'a', source: 'a', primary_key: ['id'], fields: []}]
-        },
-        {
-          name: 'second',
-          datasets: [{name: 'b', source: 'b', primary_key: ['id'], fields: []}]
-        },
+        { name: 'first', datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }] },
+        { name: 'second', datasets: [{ name: 'b', source: 'b', primary_key: ['id'], fields: [] }] },
       ],
     });
     expect(models.map(m => m.name)).toEqual(['first', 'second']);
   });
 
   test('model and metric descriptions carry through to the IR', () => {
-    const {models} = fromDocument({
+    const { models } = fromDocument({
       semantic_model: [{
-        name: 'm',
-        description: 'a sales model',
-        datasets: [
-          {name: 'orders', source: 'orders', primary_key: ['id'], fields: []}
-        ],
-        metrics: [{
-          name: 'c',
-          description: 'row count',
-          expression: expr('COUNT(orders.id)')
-        }],
+        name: 'm', description: 'a sales model',
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
+        metrics: [{ name: 'c', description: 'row count', expression: expr('COUNT(orders.id)') }],
       }],
     });
     expect(models[0].description).toBe('a sales model');
@@ -761,23 +518,19 @@ describe('document-level handling', () => {
     const json = JSON.stringify({
       semantic_model: [{
         name: 'm',
-        datasets: [
-          {name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: []}
-        ],
+        datasets: [{ name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] }],
       }],
     });
-    const {models} = loadModels(json);
+    const { models } = loadModels(json);
     expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
   });
 
   test('a document without semantic_model throws', () => {
-    expect(() => fromDocument({foo: 'bar'}))
-        .toThrow(/Semantic model load error/);
+    expect(() => fromDocument({ foo: 'bar' })).toThrow(/Semantic model load error/);
   });
 
   test('an empty semantic_model array throws (min one model required)', () => {
-    expect(() => fromDocument({semantic_model: []}))
-        .toThrow(/Semantic model load error/);
+    expect(() => fromDocument({ semantic_model: [] })).toThrow(/Semantic model load error/);
   });
 
   test('unparseable input throws', () => {
@@ -788,167 +541,115 @@ describe('document-level handling', () => {
 
 describe('richer IR fields carry through from the format', () => {
   test('field and metric datatype populate the IR type', () => {
-    const {models} = fromDocument({
+    const { models } = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'orders',
-          source: 'orders',
-          primary_key: ['id'],
-          fields: [{
-            name: 'amount',
-            datatype: 'Decimal',
-            expression: expr('orders.amount')
-          }],
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [{ name: 'amount', datatype: 'Decimal', expression: expr('orders.amount') }],
         }],
-        metrics: [{
-          name: 'total',
-          datatype: 'Decimal',
-          expression: expr('SUM(orders.amount)')
-        }],
+        metrics: [{ name: 'total', datatype: 'Decimal', expression: expr('SUM(orders.amount)') }],
       }],
     });
     expect(models[0].entities[0].fields[0].type).toBe('Decimal');
     expect(models[0].metrics[0].type).toBe('Decimal');
   });
 
-  test(
-      'an off-vocabulary datatype is rejected (closed, case-sensitive enum)',
-      () => {
-        // Lowercase 'date' is not in the vocabulary (only 'Date' is); the
-        // closed enum makes this a hard parse error rather than a silently
-        // mis-typed field.
-        expect(() => fromDocument({
-                 semantic_model: [{
-                   name: 'm',
-                   datasets: [{
-                     name: 'orders',
-                     source: 'orders',
-                     primary_key: ['id'],
-                     fields: [{
-                       name: 'created',
-                       datatype: 'date',
-                       expression: expr('orders.created')
-                     }],
-                   }],
-                 }],
-               }))
-            .toThrow(/Semantic model load error/);
-      });
-
-  test('a dataset unique_keys becomes Entity.uniqueKeys', () => {
-    const {models} = fromDocument({
+  test('an off-vocabulary datatype is rejected (closed, case-sensitive enum)', () => {
+    // Lowercase 'date' is not in the vocabulary (only 'Date' is); the closed
+    // enum makes this a hard parse error rather than a silently mis-typed field.
+    expect(() => fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'orders',
-          source: 'orders',
-          primary_key: ['id'],
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [{ name: 'created', datatype: 'date', expression: expr('orders.created') }],
+        }],
+      }],
+    })).toThrow(/Semantic model load error/);
+  });
+
+  test('a dataset unique_keys becomes Entity.uniqueKeys', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
           unique_keys: [['sku', 'region'], ['external_id']],
           fields: [],
         }],
       }],
     });
-    expect(models[0].entities[0].uniqueKeys).toEqual([
-      ['sku', 'region'], ['external_id']
+    expect(models[0].entities[0].uniqueKeys).toEqual([['sku', 'region'], ['external_id']]);
+  });
+
+  test('the GOOGLE block is carried verbatim, not interpreted at load time', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        custom_extensions: [
+          { vendor_name: 'OTHER', data: '{"ignored": true}' },
+          { vendor_name: 'GOOGLE', data: JSON.stringify({
+            deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
+        ],
+        datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }],
+      }],
+    });
+    // GOOGLE gets no special treatment -- it rides along in customExtensions like
+    // any other vendor block; a typed deployment view is a consumer concern.
+    expect(models[0].customExtensions).toEqual([
+      { vendorName: 'OTHER', data: '{"ignored": true}' },
+      { vendorName: 'GOOGLE', data: JSON.stringify({
+        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
     ]);
   });
 
-  test(
-      'the GOOGLE block is carried verbatim, not interpreted at load time',
-      () => {
-        const {models} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            custom_extensions: [
-              {vendor_name: 'OTHER', data: '{"ignored": true}'},
-              {
-                vendor_name: 'GOOGLE',
-                data: JSON.stringify(
-                    {deploymentTargets: ['projects/p/locations/us/graphs/g']})
-              },
-            ],
-            datasets:
-                [{name: 'a', source: 'a', primary_key: ['id'], fields: []}],
+  test('a malformed GOOGLE block is kept verbatim without warning (not parsed)', () => {
+    const { models, warnings } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        custom_extensions: [{ vendor_name: 'GOOGLE', data: '{not json' }],
+        datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }],
+      }],
+    });
+    // The loader never parses the block, so malformed JSON is not its concern.
+    expect(models[0].customExtensions).toEqual([{ vendorName: 'GOOGLE', data: '{not json' }]);
+    expect(warnings).toEqual([]);
+  });
+
+  test('ai_context instructions and synonyms are structural, not folded into description', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm', description: 'a sales model',
+        ai_context: { instructions: 'Prefer net revenue.', synonyms: ['sales', 'commerce'] },
+        datasets: [{
+          name: 'orders', source: 'orders', primary_key: ['id'],
+          ai_context: { instructions: 'One row per order.', synonyms: ['purchases'] },
+          fields: [{
+            name: 'amount', expression: expr('orders.amount'),
+            ai_context: { instructions: 'Gross, before tax.' },
           }],
-        });
-        // GOOGLE gets no special treatment -- it rides along in
-        // customExtensions like any other vendor block; a typed deployment view
-        // is a consumer concern.
-        expect(models[0].customExtensions).toEqual([
-          {vendorName: 'OTHER', data: '{"ignored": true}'},
-          {
-            vendorName: 'GOOGLE',
-            data: JSON.stringify(
-                {deploymentTargets: ['projects/p/locations/us/graphs/g']})
-          },
-        ]);
-      });
+        }],
+      }],
+    });
+    const model = models[0];
+    // Description stays the base text; instructions/synonyms live on aiContext.
+    expect(model.description).toBe('a sales model');
+    expect(model.aiContext?.instructions).toBe('Prefer net revenue.');
+    expect(model.aiContext?.synonyms).toEqual(['sales', 'commerce']);
 
-  test(
-      'a malformed GOOGLE block is kept verbatim without warning (not parsed)',
-      () => {
-        const {models, warnings} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            custom_extensions: [{vendor_name: 'GOOGLE', data: '{not json'}],
-            datasets:
-                [{name: 'a', source: 'a', primary_key: ['id'], fields: []}],
-          }],
-        });
-        // The loader never parses the block, so malformed JSON is not its
-        // concern.
-        expect(models[0].customExtensions).toEqual([
-          {vendorName: 'GOOGLE', data: '{not json'}
-        ]);
-        expect(warnings).toEqual([]);
-      });
+    // Dataset-level: no base description supplied, so it stays unset; instructions
+    // and synonyms are structural.
+    const entity = model.entities[0];
+    expect(entity.description).toBeUndefined();
+    expect(entity.aiContext?.instructions).toBe('One row per order.');
+    expect(entity.aiContext?.synonyms).toEqual(['purchases']);
 
-  test(
-      'ai_context instructions and synonyms are structural, not folded into description',
-      () => {
-        const {models} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            description: 'a sales model',
-            ai_context: {
-              instructions: 'Prefer net revenue.',
-              synonyms: ['sales', 'commerce']
-            },
-            datasets: [{
-              name: 'orders',
-              source: 'orders',
-              primary_key: ['id'],
-              ai_context:
-                  {instructions: 'One row per order.', synonyms: ['purchases']},
-              fields: [{
-                name: 'amount',
-                expression: expr('orders.amount'),
-                ai_context: {instructions: 'Gross, before tax.'},
-              }],
-            }],
-          }],
-        });
-        const model = models[0];
-        // Description stays the base text; instructions/synonyms live on
-        // aiContext.
-        expect(model.description).toBe('a sales model');
-        expect(model.aiContext?.instructions).toBe('Prefer net revenue.');
-        expect(model.aiContext?.synonyms).toEqual(['sales', 'commerce']);
-
-        // Dataset-level: no base description supplied, so it stays unset;
-        // instructions and synonyms are structural.
-        const entity = model.entities[0];
-        expect(entity.description).toBeUndefined();
-        expect(entity.aiContext?.instructions).toBe('One row per order.');
-        expect(entity.aiContext?.synonyms).toEqual(['purchases']);
-
-        // Field-level: instructions structural; no description text was
-        // supplied.
-        const field = entity.fields[0];
-        expect(field.description).toBeUndefined();
-        expect(field.aiContext?.instructions).toBe('Gross, before tax.');
-      });
+    // Field-level: instructions structural; no description text was supplied.
+    const field = entity.fields[0];
+    expect(field.description).toBeUndefined();
+    expect(field.aiContext?.instructions).toBe('Gross, before tax.');
+  });
 });
 
 
@@ -962,16 +663,9 @@ describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
     semantic_model: [{
       name: 'sales',
       description: 'Sales semantic model',
-      ai_context: {
-        instructions: 'Prefer net.',
-        synonyms: ['commerce'],
-        examples: ['revenue by month']
-      },
-      custom_extensions: [{
-        vendor_name: 'GOOGLE',
-        data: JSON.stringify(
-            {deploymentTargets: ['projects/p/locations/us/graphs/g']})
-      }],
+      ai_context: { instructions: 'Prefer net.', synonyms: ['commerce'], examples: ['revenue by month'] },
+      custom_extensions: [{ vendor_name: 'GOOGLE', data: JSON.stringify({
+        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) }],
       datasets: [
         {
           name: 'orders',
@@ -979,46 +673,35 @@ describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
           primary_key: ['order_id'],
           unique_keys: [['external_id']],
           description: 'One row per order',
-          ai_context: {instructions: 'Grain: order.', synonyms: ['purchases']},
-          custom_extensions: [{vendor_name: 'DBT', data: '{"model":"orders"}'}],
+          ai_context: { instructions: 'Grain: order.', synonyms: ['purchases'] },
+          custom_extensions: [{ vendor_name: 'DBT', data: '{"model":"orders"}' }],
           fields: [{
             name: 'amount',
-            expression: {
-              dialects: [{dialect: 'BIGQUERY', expression: 'orders.amount'}]
-            },
-            dimension: {is_time: false},
+            expression: { dialects: [{ dialect: 'BIGQUERY', expression: 'orders.amount' }] },
+            dimension: { is_time: false },
             label: 'Order amount',
             description: 'Gross amount',
             datatype: 'Decimal',
-            ai_context: {instructions: 'Before tax.', synonyms: ['gross']},
-            custom_extensions: [{vendor_name: 'SNOWFLAKE', data: '{}'}],
+            ai_context: { instructions: 'Before tax.', synonyms: ['gross'] },
+            custom_extensions: [{ vendor_name: 'SNOWFLAKE', data: '{}' }],
           }],
         },
-        {
-          name: 'customers',
-          source: 'proj.ds.customers',
-          primary_key: ['customer_id'],
-          fields: []
-        },
+        { name: 'customers', source: 'proj.ds.customers', primary_key: ['customer_id'], fields: [] },
       ],
       relationships: [{
         name: 'orders_customers',
-        from: 'orders',
-        to: 'customers',
-        from_columns: ['customer_id'],
-        to_columns: ['customer_id'],
-        ai_context: {instructions: 'Each order has one customer.'},
-        custom_extensions: [{vendor_name: 'COMMON', data: '{}'}],
+        from: 'orders', to: 'customers',
+        from_columns: ['customer_id'], to_columns: ['customer_id'],
+        ai_context: { instructions: 'Each order has one customer.' },
+        custom_extensions: [{ vendor_name: 'COMMON', data: '{}' }],
       }],
       metrics: [{
         name: 'total_amount',
-        expression: {
-          dialects: [{dialect: 'BIGQUERY', expression: 'SUM(orders.amount)'}]
-        },
+        expression: { dialects: [{ dialect: 'BIGQUERY', expression: 'SUM(orders.amount)' }] },
         description: 'Total sales',
         datatype: 'Decimal',
-        ai_context: {instructions: 'Sum of amounts.', synonyms: ['revenue']},
-        custom_extensions: [{vendor_name: 'GOODDATA', data: '{}'}],
+        ai_context: { instructions: 'Sum of amounts.', synonyms: ['revenue'] },
+        custom_extensions: [{ vendor_name: 'GOODDATA', data: '{}' }],
       }],
     }],
   };
@@ -1027,44 +710,30 @@ describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
     expect(() => fromDocument(doc)).not.toThrow();
   });
 
-  test(
-      'nested custom_extensions do not produce warnings (accepted, validated)',
-      () => {
-        const {warnings} = fromDocument(doc);
-        // No vendor extension is acted upon at load time; all are accepted
-        // silently. No dialect fallbacks here either, so no notes.
-        expect(warnings).toEqual([]);
-      });
+  test('nested custom_extensions do not produce warnings (accepted, validated)', () => {
+    const { warnings } = fromDocument(doc);
+    // No vendor extension is acted upon at load time; all are accepted silently.
+    // No dialect fallbacks here either, so no notes.
+    expect(warnings).toEqual([]);
+  });
 
   test('nested custom_extensions are preserved verbatim at every level', () => {
-    const {models} = fromDocument(doc);
+    const { models } = fromDocument(doc);
     const m = models[0];
     // Model level: the raw GOOGLE block is kept verbatim, uninterpreted.
     expect(m.customExtensions).toEqual([
-      {
-        vendorName: 'GOOGLE',
-        data: JSON.stringify(
-            {deploymentTargets: ['projects/p/locations/us/graphs/g']})
-      },
+      { vendorName: 'GOOGLE', data: JSON.stringify({
+        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
     ]);
-    // Dataset / field / relationship / metric levels: kept verbatim, data
-    // opaque.
-    expect(m.entities[0].customExtensions).toEqual([
-      {vendorName: 'DBT', data: '{"model":"orders"}'}
-    ]);
-    expect(m.entities[0].fields[0].customExtensions).toEqual([
-      {vendorName: 'SNOWFLAKE', data: '{}'}
-    ]);
-    expect(m.relationships[0].customExtensions).toEqual([
-      {vendorName: 'COMMON', data: '{}'}
-    ]);
-    expect(m.metrics[0].customExtensions).toEqual([
-      {vendorName: 'GOODDATA', data: '{}'}
-    ]);
+    // Dataset / field / relationship / metric levels: kept verbatim, data opaque.
+    expect(m.entities[0].customExtensions).toEqual([{ vendorName: 'DBT', data: '{"model":"orders"}' }]);
+    expect(m.entities[0].fields[0].customExtensions).toEqual([{ vendorName: 'SNOWFLAKE', data: '{}' }]);
+    expect(m.relationships[0].customExtensions).toEqual([{ vendorName: 'COMMON', data: '{}' }]);
+    expect(m.metrics[0].customExtensions).toEqual([{ vendorName: 'GOODDATA', data: '{}' }]);
   });
 
   test('every supported field maps into the IR', () => {
-    const {models} = fromDocument(doc);
+    const { models } = fromDocument(doc);
     const m = models[0];
     expect(m.name).toBe('sales');
     expect(m.description).toBe('Sales semantic model');
@@ -1103,30 +772,18 @@ describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
   });
 
   test('all seven spec dialects and ten datatypes are accepted', () => {
-    const dialects = [
-      'ANSI_SQL', 'SNOWFLAKE', 'MDX', 'TABLEAU', 'DATABRICKS', 'MAQL',
-      'BIGQUERY'
-    ];
-    const datatypes =
-        [...DATA_TYPES];  // the loader accepts exactly the IR vocabulary
-    const {models} = fromDocument({
+    const dialects = ['ANSI_SQL', 'SNOWFLAKE', 'MDX', 'TABLEAU', 'DATABRICKS', 'MAQL', 'BIGQUERY'];
+    const datatypes = [...DATA_TYPES];  // the loader accepts exactly the IR vocabulary
+    const { models } = fromDocument({
       version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'd',
-          source: 'd',
-          primary_key: ['id'],
+          name: 'd', source: 'd', primary_key: ['id'],
           fields: datatypes.map((dt, i) => ({
-                                  name: `f${i}`,
-                                  datatype: dt,
-                                  expression: {
-                                    dialects: [{
-                                      dialect: dialects[i % dialects.length],
-                                      expression: `d.c${i}`
-                                    }]
-                                  },
-                                })),
+            name: `f${i}`, datatype: dt,
+            expression: { dialects: [{ dialect: dialects[i % dialects.length], expression: `d.c${i}` }] },
+          })),
         }],
       }],
     });
@@ -1143,237 +800,168 @@ function fixture(name: string): string {
 }
 
 describe('gold fixtures parse from disk (real YAML files)', () => {
-  test(
-      'star_orders_customer.yaml: happy path (ai_context, time dimension, metrics)',
-      () => {
-        const {models} = loadModels(fixture('star_orders_customer.yaml'));
-        expect(models).toHaveLength(1);
-        const m = models[0];
-        expect(m.name).toBe('sales');
-        expect(m.aiContext?.instructions)
-            .toBe('Use this model for order analysis.');
-        expect(m.entities.map(e => e.name)).toEqual(['orders', 'customer']);
-        expect(m.entities[0].keys).toEqual(['o_orderkey']);
-        expect(m.relationships.map(r => r.name)).toEqual([
-          'orders_to_customer'
-        ]);
+  test('star_orders_customer.yaml: happy path (ai_context, time dimension, metrics)', () => {
+    const { models } = loadModels(fixture('star_orders_customer.yaml'));
+    expect(models).toHaveLength(1);
+    const m = models[0];
+    expect(m.name).toBe('sales');
+    expect(m.aiContext?.instructions).toBe('Use this model for order analysis.');
+    expect(m.entities.map(e => e.name)).toEqual(['orders', 'customer']);
+    expect(m.entities[0].keys).toEqual(['o_orderkey']);
+    expect(m.relationships.map(r => r.name)).toEqual(['orders_to_customer']);
 
-        const orderdate =
-            m.entities[0].fields.find(f => f.name === 'o_orderdate')!;
-        expect(orderdate.aiContext?.synonyms).toEqual(['order date', 'date']);
-        // label and time-dimension role are structural now, not folded into
-        // text.
-        expect(orderdate.label).toBe('Order Date');
-        expect(orderdate.dimension?.isTime).toBe(true);
-        expect(isTimeDimension(orderdate)).toBe(true);
-        expect(orderdate.description).toBeUndefined();
+    const orderdate = m.entities[0].fields.find(f => f.name === 'o_orderdate')!;
+    expect(orderdate.aiContext?.synonyms).toEqual(['order date', 'date']);
+    // label and time-dimension role are structural now, not folded into text.
+    expect(orderdate.label).toBe('Order Date');
+    expect(orderdate.dimension?.isTime).toBe(true);
+    expect(isTimeDimension(orderdate)).toBe(true);
+    expect(orderdate.description).toBeUndefined();
 
-        const revenue = m.metrics.find(mt => mt.name === 'total_revenue')!;
-        expect(revenue.expression).toBe('SUM(orders.o_totalprice)');
-        expect(revenue.entity).toBe('orders');
-        expect(revenue.aiContext?.synonyms).toEqual(['revenue', 'sales']);
-        // order_count is entity-scoped (COUNT(orders.o_orderkey)) -> attach
-        // entity inferred from the qualifier, so it is a valid single-entity
-        // measure.
-        const count = m.metrics.find(mt => mt.name === 'order_count')!;
-        expect(count.entity).toBe('orders');
-        expect(count.expression).toBe('COUNT(orders.o_orderkey)');
-      });
+    const revenue = m.metrics.find(mt => mt.name === 'total_revenue')!;
+    expect(revenue.expression).toBe('SUM(orders.o_totalprice)');
+    expect(revenue.entity).toBe('orders');
+    expect(revenue.aiContext?.synonyms).toEqual(['revenue', 'sales']);
+    // order_count is entity-scoped (COUNT(orders.o_orderkey)) -> attach entity
+    // inferred from the qualifier, so it is a valid single-entity measure.
+    const count = m.metrics.find(mt => mt.name === 'order_count')!;
+    expect(count.entity).toBe('orders');
+    expect(count.expression).toBe('COUNT(orders.o_orderkey)');
+  });
 
-  test(
-      'vendor_dialects.yaml: non-target dialects kept as imported_expression',
-      () => {
-        const {models, warnings} = loadModels(fixture('vendor_dialects.yaml'));
-        const m = models[0];
-        expect(m.name).toBe('vendor_sales');
+  test('vendor_dialects.yaml: non-target dialects kept as imported_expression', () => {
+    const { models, warnings } = loadModels(fixture('vendor_dialects.yaml'));
+    const m = models[0];
+    expect(m.name).toBe('vendor_sales');
 
-        const label =
-            m.entities[0].fields.find(f => f.name === 'order_status_label')!;
-        expect(label.expression).toBeUndefined();
-        expect(label.importedDialect).toBe('SNOWFLAKE');
-        expect(label.importedExpression).toContain('IFF(');
+    const label = m.entities[0].fields.find(f => f.name === 'order_status_label')!;
+    expect(label.expression).toBeUndefined();
+    expect(label.importedDialect).toBe('SNOWFLAKE');
+    expect(label.importedExpression).toContain('IFF(');
 
-        const fulfilled =
-            m.metrics.find(mt => mt.name === 'fulfilled_revenue')!;
-        expect(fulfilled.expression).toBeUndefined();
-        expect(fulfilled.importedDialect).toBe('SNOWFLAKE');
-        expect(fulfilled.entity).toBe('orders');
+    const fulfilled = m.metrics.find(mt => mt.name === 'fulfilled_revenue')!;
+    expect(fulfilled.expression).toBeUndefined();
+    expect(fulfilled.importedDialect).toBe('SNOWFLAKE');
+    expect(fulfilled.entity).toBe('orders');
 
-        // Portable control metric still resolves to a target expression.
-        const control = m.metrics.find(mt => mt.name === 'total_revenue')!;
-        expect(control.expression).toBe('SUM(orders.o_totalprice)');
+    // Portable control metric still resolves to a target expression.
+    const control = m.metrics.find(mt => mt.name === 'total_revenue')!;
+    expect(control.expression).toBe('SUM(orders.o_totalprice)');
 
-        expect(warnings.some(
-                   w => w.includes('field \'orders.order_status_label\'') &&
-                       w.includes('imported_expression')))
-            .toBe(true);
-      });
+    expect(warnings.some(w =>
+      w.includes("field 'orders.order_status_label'") && w.includes('imported_expression'))).toBe(true);
+  });
 
-  test(
-      'lineitem_databricks_ext.yaml: unique_keys + no-primary-key warning',
-      () => {
-        const {models, warnings} =
-            loadModels(fixture('lineitem_databricks_ext.yaml'));
-        const m = models[0];
-        const orders = m.entities.find(e => e.name === 'orders')!;
-        expect(orders.keys).toEqual([]);
-        expect(orders.uniqueKeys).toEqual([['o_orderkey']]);
-        expect(warnings.some(
-                   w => w.includes('dataset \'lineitem\'') &&
-                       w.includes('no primary_key')))
-            .toBe(true);
+  test('lineitem_databricks_ext.yaml: unique_keys + no-primary-key warning', () => {
+    const { models, warnings } = loadModels(fixture('lineitem_databricks_ext.yaml'));
+    const m = models[0];
+    const orders = m.entities.find(e => e.name === 'orders')!;
+    expect(orders.keys).toEqual([]);
+    expect(orders.uniqueKeys).toEqual([['o_orderkey']]);
+    expect(warnings.some(w => w.includes("dataset 'lineitem'") && w.includes('no primary_key'))).toBe(true);
 
-        // custom_extensions are preserved verbatim at model / field /
-        // relationship / metric levels.
-        expect(m.customExtensions?.[0].vendorName).toBe('DATABRICKS');
-        const lineitem = m.entities.find(e => e.name === 'lineitem')!;
-        expect(lineitem.fields[0].customExtensions?.[0].vendorName)
-            .toBe('DATABRICKS');
-        expect(m.relationships[0].customExtensions?.[0].vendorName)
-            .toBe('DATABRICKS');
-        expect(
-            m.metrics.find(mt => mt.name === 'revenue')!.customExtensions?.[0]
-                .data)
-            .toContain('currency');
-      });
+    // custom_extensions are preserved verbatim at model / field / relationship / metric levels.
+    expect(m.customExtensions?.[0].vendorName).toBe('DATABRICKS');
+    const lineitem = m.entities.find(e => e.name === 'lineitem')!;
+    expect(lineitem.fields[0].customExtensions?.[0].vendorName).toBe('DATABRICKS');
+    expect(m.relationships[0].customExtensions?.[0].vendorName).toBe('DATABRICKS');
+    expect(m.metrics.find(mt => mt.name === 'revenue')!.customExtensions?.[0].data).toContain('currency');
+  });
 
-  test(
-      'sales_google_ext.yaml: GOOGLE block verbatim + datatypes + unique_keys',
-      () => {
-        const {models} = loadModels(fixture('sales_google_ext.yaml'));
-        const m = models[0];
-        expect(m.customExtensions).toEqual([{
-          vendorName: 'GOOGLE',
-          data:
-              '{"deploymentTargets": ["projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph"]}',
-        }]);
-        const orders = m.entities[0];
-        expect(orders.uniqueKeys).toEqual([['o_orderkey'], ['o_ordernumber']]);
-        expect(orders.fields.map(f => f.type)).toEqual([
-          'Integer', 'String', 'Date', 'Decimal'
-        ]);
-        expect(m.metrics[0].type).toBe('Decimal');
-        // Expressions are supplied in the BIGQUERY dialect (the default
-        // target), so they resolve directly as `expression` -- exercising
-        // pickDialect's target-dialect-present path, not the ANSI_SQL fallback.
-        // Nothing is left as an imported (needs-transpile) form.
-        expect(m.metrics[0].expression).toBe('SUM(orders.o_totalprice)');
-        expect(m.metrics[0].importedExpression).toBeUndefined();
-        expect(orders.fields.every(f => f.expression && !f.importedExpression))
-            .toBe(true);
-      });
+  test('sales_google_ext.yaml: GOOGLE block verbatim + datatypes + unique_keys', () => {
+    const { models } = loadModels(fixture('sales_google_ext.yaml'));
+    const m = models[0];
+    expect(m.customExtensions).toEqual([{
+      vendorName: 'GOOGLE',
+      data: '{"deploymentTargets": ["projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph"]}',
+    }]);
+    const orders = m.entities[0];
+    expect(orders.uniqueKeys).toEqual([['o_orderkey'], ['o_ordernumber']]);
+    expect(orders.fields.map(f => f.type)).toEqual(['Integer', 'String', 'Date', 'Decimal']);
+    expect(m.metrics[0].type).toBe('Decimal');
+    // Expressions are supplied in the BIGQUERY dialect (the default target), so
+    // they resolve directly as `expression` -- exercising pickDialect's
+    // target-dialect-present path, not the ANSI_SQL fallback. Nothing is left as
+    // an imported (needs-transpile) form.
+    expect(m.metrics[0].expression).toBe('SUM(orders.o_totalprice)');
+    expect(m.metrics[0].importedExpression).toBeUndefined();
+    expect(orders.fields.every(f => f.expression && !f.importedExpression)).toBe(true);
+  });
 
-  test(
-      'ossie/tpcds_semantic_model.yaml: the Apache reference example loads',
-      () => {
-        // The unmodified spec-owner-authored example (interop proof).
-        const {models, warnings} =
-            loadModels(fixture('ossie/tpcds_semantic_model.yaml'));
-        expect(models).toHaveLength(1);
-        const m = models[0];
-        expect(m.name).toBe('tpcds_retail_model');
-        expect(m.entities).toHaveLength(5);
-        expect(m.relationships).toHaveLength(4);
-        expect(m.metrics).toHaveLength(5);
+  test('ossie/tpcds_semantic_model.yaml: the Apache reference example loads', () => {
+    // The unmodified spec-owner-authored example (interop proof).
+    const { models, warnings } = loadModels(fixture('ossie/tpcds_semantic_model.yaml'));
+    expect(models).toHaveLength(1);
+    const m = models[0];
+    expect(m.name).toBe('tpcds_retail_model');
+    expect(m.entities).toHaveLength(5);
+    expect(m.relationships).toHaveLength(4);
+    expect(m.metrics).toHaveLength(5);
 
-        // A cross-entity metric references more than one entity, so it has no
-        // single attach entity.
-        const clv =
-            m.metrics.find(mt => mt.name === 'customer_lifetime_value')!;
-        expect(clv.entity).toBeUndefined();
+    // A cross-entity metric references more than one entity, so it has no
+    // single attach entity.
+    const clv = m.metrics.find(mt => mt.name === 'customer_lifetime_value')!;
+    expect(clv.entity).toBeUndefined();
 
-        // Every field and metric expression is ANSI_SQL -> resolves to a target
-        // expression, so nothing is left needing transpilation.
-        const needsTranspile =
-            warnings.filter(w => w.includes('imported_expression'));
-        expect(needsTranspile).toEqual([]);
-      });
+    // Every field and metric expression is ANSI_SQL -> resolves to a target
+    // expression, so nothing is left needing transpilation.
+    const needsTranspile = warnings.filter(w => w.includes('imported_expression'));
+    expect(needsTranspile).toEqual([]);
+  });
 });
 
 describe('duplicate names within a model warn (uniqueness checks)', () => {
   test('duplicate field names within a dataset warn', () => {
-    const {warnings} = fromDocument({
+    const { warnings } = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'orders',
-          source: 'orders',
-          primary_key: ['id'],
+          name: 'orders', source: 'orders', primary_key: ['id'],
           fields: [
-            {name: 'amount', expression: expr('orders.amount')},
-            {name: 'amount', expression: expr('orders.amount2')},
+            { name: 'amount', expression: expr('orders.amount') },
+            { name: 'amount', expression: expr('orders.amount2') },
           ],
         }],
       }],
     });
-    expect(warnings.some(
-               w => w.includes('dataset \'orders\'') &&
-                   w.includes('duplicate field name \'amount\'')))
-        .toBe(true);
+    expect(warnings.some(w =>
+      w.includes("dataset 'orders'") && w.includes("duplicate field name 'amount'"))).toBe(true);
   });
 
   test('duplicate metric names within a model warn', () => {
-    const {warnings} = fromDocument({
+    const { warnings } = fromDocument({
       semantic_model: [{
         name: 'm',
-        datasets: [{
-          name: 'orders',
-          source: 'orders',
-          primary_key: ['id'],
-          fields: [{name: 'amount', expression: expr('orders.amount')}]
-        }],
+        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'],
+          fields: [{ name: 'amount', expression: expr('orders.amount') }] }],
         metrics: [
-          {name: 'total', expression: expr('SUM(orders.amount)')},
-          {name: 'total', expression: expr('AVG(orders.amount)')},
+          { name: 'total', expression: expr('SUM(orders.amount)') },
+          { name: 'total', expression: expr('AVG(orders.amount)') },
         ],
       }],
     });
-    expect(warnings.some(
-               w => w.includes('model \'m\'') &&
-                   w.includes('duplicate metric name \'total\'')))
-        .toBe(true);
+    expect(warnings.some(w =>
+      w.includes("model 'm'") && w.includes("duplicate metric name 'total'"))).toBe(true);
   });
 
   test('duplicate relationship names within a model warn', () => {
-    const {warnings} = fromDocument({
+    const { warnings } = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [
-          {
-            name: 'orders',
-            source: 'orders',
-            primary_key: ['o_id'],
-            fields: [{name: 'c_id', expression: expr('orders.c_id')}]
-          },
-          {
-            name: 'customer',
-            source: 'customer',
-            primary_key: ['c_id'],
-            fields: [{name: 'c_id', expression: expr('customer.c_id')}]
-          },
+          { name: 'orders', source: 'orders', primary_key: ['o_id'],
+            fields: [{ name: 'c_id', expression: expr('orders.c_id') }] },
+          { name: 'customer', source: 'customer', primary_key: ['c_id'],
+            fields: [{ name: 'c_id', expression: expr('customer.c_id') }] },
         ],
         relationships: [
-          {
-            name: 'o2c',
-            from: 'orders',
-            to: 'customer',
-            from_columns: ['c_id'],
-            to_columns: ['c_id']
-          },
-          {
-            name: 'o2c',
-            from: 'orders',
-            to: 'customer',
-            from_columns: ['c_id'],
-            to_columns: ['c_id']
-          },
+          { name: 'o2c', from: 'orders', to: 'customer', from_columns: ['c_id'], to_columns: ['c_id'] },
+          { name: 'o2c', from: 'orders', to: 'customer', from_columns: ['c_id'], to_columns: ['c_id'] },
         ],
       }],
     });
-    expect(warnings.some(
-               w => w.includes('model \'m\'') &&
-                   w.includes('duplicate relationship name \'o2c\'')))
-        .toBe(true);
+    expect(warnings.some(w =>
+      w.includes("model 'm'") && w.includes("duplicate relationship name 'o2c'"))).toBe(true);
   });
 });
 
@@ -1381,14 +969,12 @@ describe('duplicate names within a model warn (uniqueness checks)', () => {
 describe('field label and time-dimension role align with the format models', () => {
   // Builds one field with the given extra props and returns its IR form.
   function field(props: Record<string, unknown>) {
-    const {models} = fromDocument({
+    const { models } = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'd',
-          source: 'd',
-          primary_key: ['id'],
-          fields: [{name: 'f', expression: expr('d.f'), ...props}],
+          name: 'd', source: 'd', primary_key: ['id'],
+          fields: [{ name: 'f', expression: expr('d.f'), ...props }],
         }],
       }],
     });
@@ -1396,202 +982,152 @@ describe('field label and time-dimension role align with the format models', () 
   }
 
   test('label is preserved structurally, separate from description', () => {
-    const f = field({label: 'Order Date', description: 'The order date'});
+    const f = field({ label: 'Order Date', description: 'The order date' });
     expect(f.label).toBe('Order Date');
     expect(f.description).toBe('The order date');
   });
 
   test('a label alone is not mis-mapped into description', () => {
-    const f = field({label: 'Order Date'});
+    const f = field({ label: 'Order Date' });
     expect(f.label).toBe('Order Date');
     expect(f.description).toBeUndefined();
   });
 
   test('an explicit is_time:true makes it a time dimension', () => {
-    const f = field({dimension: {is_time: true}});
+    const f = field({ dimension: { is_time: true } });
     expect(f.dimension?.isTime).toBe(true);
     expect(isTimeDimension(f)).toBe(true);
   });
 
   test('an explicit is_time:false overrides a temporal datatype', () => {
-    const f = field({dimension: {is_time: false}, datatype: 'Date'});
+    const f = field({ dimension: { is_time: false }, datatype: 'Date' });
     expect(f.dimension?.isTime).toBe(false);
     expect(isTimeDimension(f)).toBe(false);
   });
 
-  test(
-      'a temporal datatype infers a time dimension when is_time is unset',
-      () => {
-        const f = field({dimension: {}, datatype: 'Date'});
-        expect(f.dimension?.isTime).toBeUndefined();
-        expect(isTimeDimension(f)).toBe(true);
-      });
+  test('a temporal datatype infers a time dimension when is_time is unset', () => {
+    const f = field({ dimension: {}, datatype: 'Date' });
+    expect(f.dimension?.isTime).toBeUndefined();
+    expect(isTimeDimension(f)).toBe(true);
+  });
 
   test('a temporal datatype with no dimension block is not a dimension', () => {
-    const f = field({datatype: 'Date'});
+    const f = field({ datatype: 'Date' });
     expect(f.dimension).toBeUndefined();
     expect(isTimeDimension(f)).toBe(false);
   });
 
-  test(
-      'a non-temporal datatype with an empty dimension is not a time dimension',
-      () => {
-        const f = field({dimension: {}, datatype: 'String'});
-        expect(isTimeDimension(f)).toBe(false);
-      });
+  test('a non-temporal datatype with an empty dimension is not a time dimension', () => {
+    const f = field({ dimension: {}, datatype: 'String' });
+    expect(isTimeDimension(f)).toBe(false);
+  });
 });
 
 
-describe(
-    'authoring sugars: entities alias, bare-string expression, deployment_target',
-    () => {
-      const URI =
-          '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
+describe('authoring sugars: entities alias, bare-string expression, deployment_target', () => {
+  const URI =
+    '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
 
-      test('\'entities:\' is an alias for \'datasets:\'', () => {
-        const {models} = fromDocument({
-          semantic_model: [{
-            name: 'm',
-            entities: [
-              {
-                name: 'a',
-                source: 'proj.ds.tbl',
-                primary_key: ['id'],
-                fields: [{name: 'id', expression: expr('id')}]
-              },
-            ],
-          }],
-        });
-        expect(models[0].entities.map(e => e.name)).toEqual(['a']);
-        expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
-      });
-
-      test('declaring both \'entities\' and \'datasets\' is an error', () => {
-        expect(() => fromDocument({
-                 semantic_model: [{
-                   name: 'm',
-                   entities: [{name: 'a', source: 's', fields: []}],
-                   datasets: [{name: 'b', source: 's', fields: []}],
-                 }],
-               }))
-            .toThrow(/set either 'entities' or 'datasets', not both/);
-      });
-
-      test(
-          'a bare-string expression expands to the target-dialect object',
-          () => {
-            const {models} = fromDocument({
-              semantic_model: [{
-                name: 'm',
-                datasets: [{
-                  name: 'a',
-                  source: 'proj.ds.tbl',
-                  primary_key: ['id'],
-                  fields: [{name: 'id', expression: 'id_col'}],
-                }],
-              }],
-            });
-            expect(models[0].entities[0].fields[0].expression).toBe('id_col');
-          });
-
-      test(
-          'a top-level \'deployment_target\' folds into the GOOGLE block form',
-          () => {
-            const sugar = fromDocument({
-              semantic_model: [{
-                name: 'm',
-                deployment_target: URI,
-                datasets: [{
-                  name: 'a',
-                  source: 's',
-                  primary_key: ['id'],
-                  fields: [{name: 'id', expression: 'id'}]
-                }],
-              }],
-            });
-            const explicit = fromDocument({
-              semantic_model: [{
-                name: 'm',
-                custom_extensions: [{
-                  vendor_name: 'GOOGLE',
-                  data: JSON.stringify({deploymentTargets: [URI]})
-                }],
-                datasets: [{
-                  name: 'a',
-                  source: 's',
-                  primary_key: ['id'],
-                  fields: [{name: 'id', expression: 'id'}]
-                }],
-              }],
-            });
-            expect(sugar.models[0].customExtensions)
-                .toEqual(explicit.models[0].customExtensions);
-            expect(sugar.models[0].customExtensions).toEqual([
-              {
-                vendorName: 'GOOGLE',
-                data: JSON.stringify({deploymentTargets: [URI]})
-              },
-            ]);
-          });
-
-      test(
-          '\'deployment_target\' agreeing with a GOOGLE block adds no duplicate',
-          () => {
-            const {models} = fromDocument({
-              semantic_model: [{
-                name: 'm',
-                deployment_target: URI,
-                custom_extensions: [{
-                  vendor_name: 'GOOGLE',
-                  data: JSON.stringify({deploymentTargets: [URI]})
-                }],
-                datasets: [{
-                  name: 'a',
-                  source: 's',
-                  primary_key: ['id'],
-                  fields: [{name: 'id', expression: 'id'}]
-                }],
-              }],
-            });
-            expect(models[0].customExtensions).toEqual([
-              {
-                vendorName: 'GOOGLE',
-                data: JSON.stringify({deploymentTargets: [URI]})
-              },
-            ]);
-          });
-
-      test(
-          '\'deployment_target\' disagreeing with a GOOGLE block is an error',
-          () => {
-            expect(() => fromDocument({
-                     semantic_model: [{
-                       name: 'm',
-                       deployment_target: URI,
-                       custom_extensions: [{
-                         vendor_name: 'GOOGLE',
-                         data: JSON.stringify(
-                             {deploymentTargets: ['//other/target']})
-                       }],
-                       datasets: [{name: 'a', source: 's', fields: []}],
-                     }],
-                   }))
-                .toThrow(/disagrees with the GOOGLE custom_extension/);
-          });
+  test("'entities:' is an alias for 'datasets:'", () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        entities: [
+          { name: 'a', source: 'proj.ds.tbl', primary_key: ['id'],
+            fields: [{ name: 'id', expression: expr('id') }] },
+        ],
+      }],
     });
+    expect(models[0].entities.map(e => e.name)).toEqual(['a']);
+    expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
+  });
 
-describe('fields may be declared unbound (no physical column)', () => {
-  test('an unbound field loads with no expression', () => {
-    const {models} = fromDocument({
+  test("declaring both 'entities' and 'datasets' is an error", () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        entities: [{ name: 'a', source: 's', fields: [] }],
+        datasets: [{ name: 'b', source: 's', fields: [] }],
+      }],
+    })).toThrow(/set either 'entities' or 'datasets', not both/);
+  });
+
+  test('a bare-string expression expands to the target-dialect object', () => {
+    const { models } = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'a',
-          source: 's',
-          primary_key: ['id'],
+          name: 'a', source: 'proj.ds.tbl', primary_key: ['id'],
+          fields: [{ name: 'id', expression: 'id_col' }],
+        }],
+      }],
+    });
+    expect(models[0].entities[0].fields[0].expression).toBe('id_col');
+  });
+
+  test("a top-level 'deployment_target' folds into the GOOGLE block form", () => {
+    const sugar = fromDocument({
+      semantic_model: [{
+        name: 'm', deployment_target: URI,
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'id', expression: 'id' }] }],
+      }],
+    });
+    const explicit = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        custom_extensions: [{ vendor_name: 'GOOGLE',
+          data: JSON.stringify({ deploymentTargets: [URI] }) }],
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'id', expression: 'id' }] }],
+      }],
+    });
+    expect(sugar.models[0].customExtensions)
+      .toEqual(explicit.models[0].customExtensions);
+    expect(sugar.models[0].customExtensions).toEqual([
+      { vendorName: 'GOOGLE',
+        data: JSON.stringify({ deploymentTargets: [URI] }) },
+    ]);
+  });
+
+  test("'deployment_target' agreeing with a GOOGLE block adds no duplicate", () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm', deployment_target: URI,
+        custom_extensions: [{ vendor_name: 'GOOGLE',
+          data: JSON.stringify({ deploymentTargets: [URI] }) }],
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'id', expression: 'id' }] }],
+      }],
+    });
+    expect(models[0].customExtensions).toEqual([
+      { vendorName: 'GOOGLE',
+        data: JSON.stringify({ deploymentTargets: [URI] }) },
+    ]);
+  });
+
+  test("'deployment_target' disagreeing with a GOOGLE block is an error", () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm', deployment_target: URI,
+        custom_extensions: [{ vendor_name: 'GOOGLE',
+          data: JSON.stringify({ deploymentTargets: ['//other/target'] }) }],
+        datasets: [{ name: 'a', source: 's', fields: [] }],
+      }],
+    })).toThrow(/disagrees with the GOOGLE custom_extension/);
+  });
+});
+
+describe('fields may be declared unbound (no physical column)', () => {
+  test('an unbound field loads with no expression', () => {
+    const { models } = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'a', source: 's', primary_key: ['id'],
           fields: [
-            {name: 'id', expression: 'id'},
-            {name: 'credit', unbound: true},
+            { name: 'id', expression: 'id' },
+            { name: 'credit', unbound: true },
           ],
         }],
       }],
@@ -1604,35 +1140,23 @@ describe('fields may be declared unbound (no physical column)', () => {
 
   test('a field that is both bound and unbound is an error', () => {
     expect(() => fromDocument({
-             semantic_model: [{
-               name: 'm',
-               datasets: [{
-                 name: 'a',
-                 source: 's',
-                 primary_key: ['id'],
-                 fields: [{name: 'credit', unbound: true, expression: 'c'}]
-               }],
-             }],
-           }))
-        .toThrow(/an unbound field has no column/);
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'credit', unbound: true, expression: 'c' }] }],
+      }],
+    })).toThrow(/an unbound field has no column/);
   });
 
-  test(
-      'a field that is neither bound nor unbound is an error naming the field',
-      () => {
-        expect(() => fromDocument({
-                 semantic_model: [{
-                   name: 'm',
-                   datasets: [{
-                     name: 'a',
-                     source: 's',
-                     primary_key: ['id'],
-                     fields: [{name: 'credit'}]
-                   }],
-                 }],
-               }))
-            .toThrow(/field 'credit': requires an expression/);
-      });
+  test('a field that is neither bound nor unbound is an error naming the field', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
+          fields: [{ name: 'credit' }] }],
+      }],
+    })).toThrow(/field 'credit': requires an expression/);
+  });
 });
 
 
@@ -1645,78 +1169,52 @@ describe('a purely logical model loads only under bindingOptional', () => {
     semantic_model: [{
       name: 'm',
       datasets: [{
-        name: 'orders',
-        primary_key: ['id'],
-        fields: [{name: 'amount'}, {name: 'status'}],
+        name: 'orders', primary_key: ['id'],
+        fields: [{ name: 'amount' }, { name: 'status' }],
       }],
     }],
   };
 
-  test(
-      'under bindingOptional it loads with an empty source and unbound fields',
-      () => {
-        const {models} = fromDocument(logicalOnly, {bindingOptional: true});
-        const orders = models[0].entities[0];
-        // No source -> empty dataSource (the emitter tolerates this); the
-        // fields carry no expression because there is no binding.
-        expect(orders.dataSource).toBe('');
-        expect(orders.keys).toEqual(['id']);
-        expect(orders.fields.map(f => f.name)).toEqual(['amount', 'status']);
-        expect(orders.fields.every(f => f.expression === undefined)).toBe(true);
-      });
+  test('under bindingOptional it loads with an empty source and unbound fields', () => {
+    const { models } = fromDocument(logicalOnly, { bindingOptional: true });
+    const orders = models[0].entities[0];
+    // No source -> empty dataSource (the emitter tolerates this); the fields
+    // carry no expression because there is no binding.
+    expect(orders.dataSource).toBe('');
+    expect(orders.keys).toEqual(['id']);
+    expect(orders.fields.map(f => f.name)).toEqual(['amount', 'status']);
+    expect(orders.fields.every(f => f.expression === undefined)).toBe(true);
+  });
 
-  test(
-      'without bindingOptional the same model fails for the missing source and expression',
-      () => {
-        let message = '';
-        try {
-          fromDocument(logicalOnly);
-        } catch (e: any) {
-          message = String(e.message ?? e);
-        }
-        // Both binding-completeness checks fire in the default (strict) mode.
-        expect(message).toContain(
-            'dataset \'orders\': a non-abstract dataset requires a source');
-        expect(message).toContain('field \'amount\': requires an expression');
-      });
+  test('without bindingOptional the same model fails for the missing source and expression', () => {
+    let message = '';
+    try {
+      fromDocument(logicalOnly);
+    } catch (e: any) {
+      message = String(e.message ?? e);
+    }
+    // Both binding-completeness checks fire in the default (strict) mode.
+    expect(message).toContain("dataset 'orders': a non-abstract dataset requires a source");
+    expect(message).toContain("field 'amount': requires an expression");
+  });
 
-  test(
-      'bindingOptional still rejects an unbound field that also has an expression',
-      () => {
-        // The contradiction check is independent of binding-completeness, so it
-        // fires even when a source/expression is otherwise optional.
-        expect(
-            () => fromDocument(
-                {
-                  semantic_model: [{
-                    name: 'm',
-                    datasets: [{
-                      name: 'a',
-                      fields: [{name: 'c', unbound: true, expression: 'c'}]
-                    }],
-                  }],
-                },
-                {bindingOptional: true}))
-            .toThrow(/an unbound field has no column/);
-      });
+  test('bindingOptional still rejects an unbound field that also has an expression', () => {
+    // The contradiction check is independent of binding-completeness, so it
+    // fires even when a source/expression is otherwise optional.
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'a', fields: [{ name: 'c', unbound: true, expression: 'c' }] }],
+      }],
+    }, { bindingOptional: true })).toThrow(/an unbound field has no column/);
+  });
 
-  test(
-      'bindingOptional still rejects an abstract dataset that also names a source',
-      () => {
-        expect(
-            () => fromDocument(
-                {
-                  semantic_model: [{
-                    name: 'm',
-                    datasets: [{
-                      name: 'Party',
-                      abstract: true,
-                      source: 'p.d.party',
-                      fields: []
-                    }],
-                  }],
-                },
-                {bindingOptional: true}))
-            .toThrow(/an abstract dataset has no table/);
-      });
+  test('bindingOptional still rejects an abstract dataset that also names a source', () => {
+    expect(() => fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{ name: 'Party', abstract: true, source: 'p.d.party', fields: [] }],
+      }],
+    }, { bindingOptional: true })).toThrow(/an abstract dataset has no table/);
+  });
 });

--- a/toolbox/mdcode/tests/libts/semantic/loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/loader.test.ts
@@ -2,35 +2,39 @@
 // (src/libts/semantic/loader.ts).
 //
 // The loader reads the subset of an open, AI-first semantics format needed to
-// normalize a model into the IR. Each test names one behavior. Focused tests use
-// `fromDocument` with object literals; document-level tests parse raw YAML/JSON
-// text via `loadModels`. This file asserts only the IR — the BigQuery generator
-// is covered by `bigquery.test.ts` (unit) and `bigquery.e2e.test.ts` (file -> DDL).
+// normalize a model into the IR. Each test names one behavior. Focused tests
+// use `fromDocument` with object literals; document-level tests parse raw
+// YAML/JSON text via `loadModels`. This file asserts only the IR — the BigQuery
+// generator is covered by `bigquery.test.ts` (unit) and `bigquery.e2e.test.ts`
+// (file -> DDL).
 //
 
-import { describe, test, expect } from 'bun:test';
-import { loadModels, fromDocument } from '../../../src/libts/semantic/loader';
-import { isTimeDimension, DATA_TYPES } from '../../../src/libts/semantic/ir';
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import {describe, expect, test} from 'bun:test';
+import {readFileSync} from 'fs';
+import {join} from 'path';
+
+import {DATA_TYPES, isTimeDimension} from '../../../src/libts/semantic/ir';
+import {fromDocument, loadModels} from '../../../src/libts/semantic/loader';
 
 // Shorthand for the format's per-dialect expression object.
 function expr(expression: string, dialect = 'BIGQUERY') {
-  return { dialects: [{ dialect, expression }] };
+  return {dialects: [{dialect, expression}]};
 }
 
 
 describe('dataset source strings normalize to fully-qualified references', () => {
-  const { models } = fromDocument({
-    semantic_model: [{
-      name: 'm',
-      datasets: [
-        { name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] },
-        { name: 'b', source: 'ds.tbl', primary_key: ['id'], fields: [] },
-        { name: 'c', source: 'tbl', primary_key: ['id'], fields: [] },
-      ],
-    }],
-  }, { defaultProject: 'P', defaultDataset: 'D' });
+  const {models} = fromDocument(
+      {
+        semantic_model: [{
+          name: 'm',
+          datasets: [
+            {name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: []},
+            {name: 'b', source: 'ds.tbl', primary_key: ['id'], fields: []},
+            {name: 'c', source: 'tbl', primary_key: ['id'], fields: []},
+          ],
+        }],
+      },
+      {defaultProject: 'P', defaultDataset: 'D'});
   const [a, b, c] = models[0].entities;
 
   test('a three-part source becomes project.dataset.table', () => {
@@ -46,177 +50,286 @@ describe('dataset source strings normalize to fully-qualified references', () =>
   });
 
   test('a query-like source is kept verbatim with a warning', () => {
-    const { models, warnings } = fromDocument({
-      semantic_model: [{ name: 'm', datasets: [
-        { name: 'a', source: 'SELECT 1 FROM t', primary_key: ['id'], fields: [] }] }],
+    const {models, warnings} = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'a',
+          source: 'SELECT 1 FROM t',
+          primary_key: ['id'],
+          fields: []
+        }]
+      }],
     });
     expect(models[0].entities[0].dataSource).toBe('SELECT 1 FROM t');
     expect(warnings.some(w => w.includes('looks like a query'))).toBe(true);
   });
 
   test('a dataset without a primary key warns (its KEY would be empty)', () => {
-    const { warnings } = fromDocument({
-      semantic_model: [{ name: 'm', datasets: [
-        { name: 'a', source: 'a', fields: [] }] }],
+    const {warnings} = fromDocument({
+      semantic_model:
+          [{name: 'm', datasets: [{name: 'a', source: 'a', fields: []}]}],
     });
     expect(warnings.some(w => w.includes('no primary_key'))).toBe(true);
   });
 
   test('backtick- or double-quoted identifiers are unquoted', () => {
-    const { models } = fromDocument({
-      semantic_model: [{ name: 'm', datasets: [
-        { name: 'a', source: '`proj`.`ds`.`tbl`', primary_key: ['id'], fields: [] }] }],
+    const {models} = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets: [{
+          name: 'a',
+          source: '`proj`.`ds`.`tbl`',
+          primary_key: ['id'],
+          fields: []
+        }]
+      }],
     });
     expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
   });
 
   test('a four-part Lakehouse catalog name passes through untouched', () => {
-    const { models, warnings } = fromDocument({
-      semantic_model: [{ name: 'm', datasets: [
-        { name: 'a', source: 'proj.cat.ns.tbl', primary_key: ['id'], fields: [] }] }],
-    }, { defaultProject: 'P', defaultDataset: 'D' });
+    const {models, warnings} = fromDocument(
+        {
+          semantic_model: [{
+            name: 'm',
+            datasets: [{
+              name: 'a',
+              source: 'proj.cat.ns.tbl',
+              primary_key: ['id'],
+              fields: []
+            }]
+          }],
+        },
+        {defaultProject: 'P', defaultDataset: 'D'});
     expect(models[0].entities[0].dataSource).toBe('proj.cat.ns.tbl');
     expect(warnings).toEqual([]);
   });
 
-  test('an explicit project/dataset in the source is not overridden by defaults', () => {
-    const { models } = fromDocument({
-      semantic_model: [{ name: 'm', datasets: [
-        { name: 'a', source: 'realproj.realds.tbl', primary_key: ['id'], fields: [] }] }],
-    }, { defaultProject: 'P', defaultDataset: 'D' });
-    expect(models[0].entities[0].dataSource).toBe('realproj.realds.tbl');
-  });
+  test(
+      'an explicit project/dataset in the source is not overridden by defaults',
+      () => {
+        const {models} = fromDocument(
+            {
+              semantic_model: [{
+                name: 'm',
+                datasets: [{
+                  name: 'a',
+                  source: 'realproj.realds.tbl',
+                  primary_key: ['id'],
+                  fields: []
+                }]
+              }],
+            },
+            {defaultProject: 'P', defaultDataset: 'D'});
+        expect(models[0].entities[0].dataSource).toBe('realproj.realds.tbl');
+      });
 });
 
 
 describe('per-dialect expressions collapse to a single string', () => {
-  function metricDoc(dialectList: Array<{ dialect: string; expression: string }>) {
+  function metricDoc(
+      dialectList: Array<{dialect: string; expression: string}>) {
     return {
       semantic_model: [{
         name: 'm',
-        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
-        metrics: [{ name: 'mx', expression: { dialects: dialectList } }],
+        datasets: [
+          {name: 'orders', source: 'orders', primary_key: ['id'], fields: []}
+        ],
+        metrics: [{name: 'mx', expression: {dialects: dialectList}}],
       }],
     };
   }
 
-  test('the preferred dialect (BIGQUERY) is chosen with no warning or provenance', () => {
-    const { models, warnings } = fromDocument(metricDoc([
-      { dialect: 'ANSI_SQL', expression: 'SUM(orders.a)' },
-      { dialect: 'BIGQUERY', expression: 'SUM(orders.b)' },
-    ]));
-    expect(models[0].metrics[0].expression).toBe('SUM(orders.b)');
-    expect(warnings.some(w => w.includes('dialect'))).toBe(false);
-    // Target dialect is already valid; no imported (vendor) form to preserve.
-    expect(models[0].metrics[0].importedExpression).toBeUndefined();
-  });
+  test(
+      'the preferred dialect (BIGQUERY) is chosen with no warning or provenance',
+      () => {
+        const {models, warnings} = fromDocument(metricDoc([
+          {dialect: 'ANSI_SQL', expression: 'SUM(orders.a)'},
+          {dialect: 'BIGQUERY', expression: 'SUM(orders.b)'},
+        ]));
+        expect(models[0].metrics[0].expression).toBe('SUM(orders.b)');
+        expect(warnings.some(w => w.includes('dialect'))).toBe(false);
+        // Target dialect is already valid; no imported (vendor) form to
+        // preserve.
+        expect(models[0].metrics[0].importedExpression).toBeUndefined();
+      });
 
-  test('ANSI_SQL is the fallback when the preferred dialect is absent, with an informational note', () => {
-    const { models, warnings } = fromDocument(metricDoc([
-      { dialect: 'ANSI_SQL', expression: 'SUM(orders.a)' },
-    ]));
-    expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
-    expect(warnings.some(w => w.startsWith('note:') && w.includes("using the portable 'ANSI_SQL'"))).toBe(true);
-    // The portable canonical dialect targets BigQuery by design; no imported form.
-    expect(models[0].metrics[0].importedExpression).toBeUndefined();
-  });
+  test(
+      'ANSI_SQL is the fallback when the preferred dialect is absent, with an informational note',
+      () => {
+        const {models, warnings} = fromDocument(metricDoc([
+          {dialect: 'ANSI_SQL', expression: 'SUM(orders.a)'},
+        ]));
+        expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
+        expect(warnings.some(
+                   w => w.startsWith('note:') &&
+                       w.includes('using the portable \'ANSI_SQL\'')))
+            .toBe(true);
+        // The portable canonical dialect targets BigQuery by design; no
+        // imported form.
+        expect(models[0].metrics[0].importedExpression).toBeUndefined();
+      });
 
-  test('a vendor-only expression is kept as imported_expression, with no target expression', () => {
-    const { models, warnings } = fromDocument(metricDoc([
-      { dialect: 'SNOWFLAKE', expression: 'SUM(orders.a)' },
-    ]));
-    // No target/canonical form, so the target `expression` is left unset and the
-    // original vendor SQL is preserved for a later transpile pass.
-    expect(models[0].metrics[0].expression).toBeUndefined();
-    expect(models[0].metrics[0].importedExpression).toBe('SUM(orders.a)');
-    expect(models[0].metrics[0].importedDialect).toBe('SNOWFLAKE');
-    expect(warnings.some(w => w.includes("'SNOWFLAKE'") && w.includes('imported_expression'))).toBe(true);
-  });
+  test(
+      'a vendor-only expression is kept as imported_expression, with no target expression',
+      () => {
+        const {models, warnings} = fromDocument(metricDoc([
+          {dialect: 'SNOWFLAKE', expression: 'SUM(orders.a)'},
+        ]));
+        // No target/canonical form, so the target `expression` is left unset
+        // and the original vendor SQL is preserved for a later transpile pass.
+        expect(models[0].metrics[0].expression).toBeUndefined();
+        expect(models[0].metrics[0].importedExpression).toBe('SUM(orders.a)');
+        expect(models[0].metrics[0].importedDialect).toBe('SNOWFLAKE');
+        expect(warnings.some(
+                   w => w.includes('\'SNOWFLAKE\'') &&
+                       w.includes('imported_expression')))
+            .toBe(true);
+      });
 
   test('an explicit dialect option overrides the default preference', () => {
-    const { models } = fromDocument(metricDoc([
-      { dialect: 'SNOWFLAKE', expression: 'SF' },
-      { dialect: 'BIGQUERY', expression: 'BQ' },
-    ]), { dialect: 'SNOWFLAKE' });
+    const {models} = fromDocument(
+        metricDoc([
+          {dialect: 'SNOWFLAKE', expression: 'SF'},
+          {dialect: 'BIGQUERY', expression: 'BQ'},
+        ]),
+        {dialect: 'SNOWFLAKE'});
     expect(models[0].metrics[0].expression).toBe('SF');
   });
 
   test('dialect names are matched case-insensitively', () => {
-    const { models, warnings } = fromDocument(metricDoc([
-      { dialect: 'BigQuery', expression: 'SUM(orders.a)' },
-    ]), { dialect: 'bigquery' });
+    const {models, warnings} = fromDocument(
+        metricDoc([
+          {dialect: 'BigQuery', expression: 'SUM(orders.a)'},
+        ]),
+        {dialect: 'bigquery'});
     expect(models[0].metrics[0].expression).toBe('SUM(orders.a)');
     expect(warnings.some(w => w.includes('dialect'))).toBe(false);
   });
 
-  test('field expressions select their dialect independently of metrics', () => {
-    const { models, warnings } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{
-          name: 'orders', source: 'orders', primary_key: ['id'],
-          fields: [
-            { name: 'id', expression: expr('orders.id') },
-            { name: 'net', expression: {
-              dialects: [{ dialect: 'ANSI_SQL', expression: 'orders.gross - orders.tax' }] } },
-            { name: 'label', expression: {
-              dialects: [{ dialect: 'SNOWFLAKE', expression: "IFF(orders.ok, 'y', 'n')" }] } },
-          ],
-        }],
-      }],
-    });
-    const fields = models[0].entities[0].fields;
-    expect(fields[0].expression).toBe('orders.id');                  // BIGQUERY, no fallback
-    expect(fields[1].expression).toBe('orders.gross - orders.tax');  // ANSI_SQL fallback
-    expect(fields[2].expression).toBeUndefined();                    // no target/canonical form
-    expect(fields[2].importedExpression).toBe("IFF(orders.ok, 'y', 'n')");  // SNOWFLAKE, kept as imported
-    // The canonical-fallback note is field-agnostic (so it dedupes); the point
-    // here is that the two fields still pick their expressions independently.
-    expect(warnings.some(w => w.includes("using the portable 'ANSI_SQL'"))).toBe(true);
-    // The imported (vendor) dialect is recorded only for the vendor field, so the
-    // transpile pass rewrites just that one.
-    expect(fields[0].importedDialect).toBeUndefined();
-    expect(fields[1].importedDialect).toBeUndefined();
-    expect(fields[2].importedDialect).toBe('SNOWFLAKE');
-  });
+  test(
+      'field expressions select their dialect independently of metrics', () => {
+        const {models, warnings} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            datasets: [{
+              name: 'orders',
+              source: 'orders',
+              primary_key: ['id'],
+              fields: [
+                {name: 'id', expression: expr('orders.id')},
+                {
+                  name: 'net',
+                  expression: {
+                    dialects: [{
+                      dialect: 'ANSI_SQL',
+                      expression: 'orders.gross - orders.tax'
+                    }]
+                  }
+                },
+                {
+                  name: 'label',
+                  expression: {
+                    dialects: [{
+                      dialect: 'SNOWFLAKE',
+                      expression: 'IFF(orders.ok, \'y\', \'n\')'
+                    }]
+                  }
+                },
+              ],
+            }],
+          }],
+        });
+        const fields = models[0].entities[0].fields;
+        expect(fields[0].expression)
+            .toBe('orders.id');  // BIGQUERY, no fallback
+        expect(fields[1].expression)
+            .toBe('orders.gross - orders.tax');  // ANSI_SQL fallback
+        expect(fields[2].expression)
+            .toBeUndefined();  // no target/canonical form
+        expect(fields[2].importedExpression)
+            .toBe(
+                'IFF(orders.ok, \'y\', \'n\')');  // SNOWFLAKE, kept as imported
+        // The canonical-fallback note is field-agnostic (so it dedupes); the
+        // point here is that the two fields still pick their expressions
+        // independently.
+        expect(
+            warnings.some(w => w.includes('using the portable \'ANSI_SQL\'')))
+            .toBe(true);
+        // The imported (vendor) dialect is recorded only for the vendor field,
+        // so the transpile pass rewrites just that one.
+        expect(fields[0].importedDialect).toBeUndefined();
+        expect(fields[1].importedDialect).toBeUndefined();
+        expect(fields[2].importedDialect).toBe('SNOWFLAKE');
+      });
 });
 
 
 describe('relationships map onto the direct-FK IR convention', () => {
-  const { models } = fromDocument({
+  const {models} = fromDocument({
     semantic_model: [{
       name: 'm',
       datasets: [
-        { name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] },
-        { name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] },
+        {
+          name: 'orders',
+          source: 'orders',
+          primary_key: ['order_id'],
+          fields: []
+        },
+        {
+          name: 'customers',
+          source: 'customers',
+          primary_key: ['customer_id'],
+          fields: []
+        },
       ],
       relationships: [{
-        name: 'orders_customers', from: 'orders', to: 'customers',
-        from_columns: ['customer_id'], to_columns: ['customer_id'],
+        name: 'orders_customers',
+        from: 'orders',
+        to: 'customers',
+        from_columns: ['customer_id'],
+        to_columns: ['customer_id'],
       }],
     }],
   });
   const rel = models[0].relationships[0];
 
   test('the source end carries the from_columns (the FK columns)', () => {
-    expect(rel.source).toEqual({ entity: 'orders', columns: ['customer_id'] });
+    expect(rel.source).toEqual({entity: 'orders', columns: ['customer_id']});
   });
 
-  test('the destination end carries the to_columns (the referenced key columns)', () => {
-    expect(rel.destination).toEqual({ entity: 'customers', columns: ['customer_id'] });
-  });
+  test(
+      'the destination end carries the to_columns (the referenced key columns)',
+      () => {
+        expect(rel.destination)
+            .toEqual({entity: 'customers', columns: ['customer_id']});
+      });
 
   test('a composite foreign key maps column-for-column', () => {
-    const { models } = fromDocument({
+    const {models} = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [
-          { name: 'sales', source: 'sales', primary_key: ['sale_id'], fields: [] },
-          { name: 'stores', source: 'stores', primary_key: ['region', 'store_no'], fields: [] },
+          {
+            name: 'sales',
+            source: 'sales',
+            primary_key: ['sale_id'],
+            fields: []
+          },
+          {
+            name: 'stores',
+            source: 'stores',
+            primary_key: ['region', 'store_no'],
+            fields: []
+          },
         ],
         relationships: [{
-          name: 'sales_stores', from: 'sales', to: 'stores',
-          from_columns: ['region', 'store_no'], to_columns: ['region', 'store_no'],
+          name: 'sales_stores',
+          from: 'sales',
+          to: 'stores',
+          from_columns: ['region', 'store_no'],
+          to_columns: ['region', 'store_no'],
         }],
       }],
     });
@@ -225,244 +338,419 @@ describe('relationships map onto the direct-FK IR convention', () => {
     expect(rel.destination.columns).toEqual(['region', 'store_no']);
   });
 
-  test('the source columns come from from_columns, not the from dataset PK', () => {
-    // The FK columns are taken straight from from_columns; the source entity's own
-    // primary key is looked up from the entity by downstream consumers, never
-    // duplicated onto the relationship (so a missing from-PK is irrelevant here).
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [
-          { name: 'orders', source: 'orders', fields: [] },  // no primary_key
-          { name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] },
-        ],
-        relationships: [{
-          name: 'r', from: 'orders', to: 'customers',
-          from_columns: ['customer_id'], to_columns: ['customer_id'],
-        }],
-      }],
-    });
-    expect(models[0].relationships[0].source).toEqual({
-      entity: 'orders', columns: ['customer_id'] });
-  });
+  test(
+      'the source columns come from from_columns, not the from dataset PK',
+      () => {
+        // The FK columns are taken straight from from_columns; the source
+        // entity's own primary key is looked up from the entity by downstream
+        // consumers, never duplicated onto the relationship (so a missing
+        // from-PK is irrelevant here).
+        const {models} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            datasets: [
+              {name: 'orders', source: 'orders', fields: []},  // no primary_key
+              {
+                name: 'customers',
+                source: 'customers',
+                primary_key: ['customer_id'],
+                fields: []
+              },
+            ],
+            relationships: [{
+              name: 'r',
+              from: 'orders',
+              to: 'customers',
+              from_columns: ['customer_id'],
+              to_columns: ['customer_id'],
+            }],
+          }],
+        });
+        expect(models[0].relationships[0].source)
+            .toEqual({entity: 'orders', columns: ['customer_id']});
+      });
 
   test('an unresolved to dataset is a hard error', () => {
     expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] }],
-        relationships: [{
-          name: 'r', from: 'orders', to: 'ghost',
-          from_columns: ['g_id'], to_columns: ['id'],
-        }],
-      }],
-    })).toThrow(/'to' dataset 'ghost' is not defined/);
+             semantic_model: [{
+               name: 'm',
+               datasets: [{
+                 name: 'orders',
+                 source: 'orders',
+                 primary_key: ['order_id'],
+                 fields: []
+               }],
+               relationships: [{
+                 name: 'r',
+                 from: 'orders',
+                 to: 'ghost',
+                 from_columns: ['g_id'],
+                 to_columns: ['id'],
+               }],
+             }],
+           }))
+        .toThrow(/'to' dataset 'ghost' is not defined/);
   });
 
   test('an unresolved from dataset is a hard error', () => {
     expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] }],
-        relationships: [{
-          name: 'r', from: 'ghost', to: 'customers',
-          from_columns: ['c_id'], to_columns: ['customer_id'],
-        }],
-      }],
-    })).toThrow(/'from' dataset 'ghost' is not defined/);
+             semantic_model: [{
+               name: 'm',
+               datasets: [{
+                 name: 'customers',
+                 source: 'customers',
+                 primary_key: ['customer_id'],
+                 fields: []
+               }],
+               relationships: [{
+                 name: 'r',
+                 from: 'ghost',
+                 to: 'customers',
+                 from_columns: ['c_id'],
+                 to_columns: ['customer_id'],
+               }],
+             }],
+           }))
+        .toThrow(/'from' dataset 'ghost' is not defined/);
   });
 
   test('mismatched from_columns/to_columns arity is a hard error', () => {
     expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [
-          { name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] },
-          { name: 'customers', source: 'customers', primary_key: ['a', 'b'], fields: [] },
-        ],
-        relationships: [{
-          name: 'r', from: 'orders', to: 'customers',
-          from_columns: ['x', 'y'], to_columns: ['a'],
-        }],
-      }],
-    })).toThrow(/different lengths/);
+             semantic_model: [{
+               name: 'm',
+               datasets: [
+                 {
+                   name: 'orders',
+                   source: 'orders',
+                   primary_key: ['order_id'],
+                   fields: []
+                 },
+                 {
+                   name: 'customers',
+                   source: 'customers',
+                   primary_key: ['a', 'b'],
+                   fields: []
+                 },
+               ],
+               relationships: [{
+                 name: 'r',
+                 from: 'orders',
+                 to: 'customers',
+                 from_columns: ['x', 'y'],
+                 to_columns: ['a'],
+               }],
+             }],
+           }))
+        .toThrow(/different lengths/);
   });
 });
 
 describe('abstract datasets and their source constraint', () => {
   test('a non-abstract dataset with no source is a hard error', () => {
     expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'orders', primary_key: ['id'], fields: [] }],
-      }],
-    })).toThrow(/non-abstract dataset requires a source/);
+             semantic_model: [{
+               name: 'm',
+               datasets: [{name: 'orders', primary_key: ['id'], fields: []}],
+             }],
+           }))
+        .toThrow(/non-abstract dataset requires a source/);
   });
 
-  test('an abstract dataset that also declares a source is a hard error', () => {
-    // abstract == no physical table; a source would be silently ignored by the
-    // BigQuery leg, dropping a table the author intended, so reject the combo.
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{
-          name: 'Party', source: 'proj.ds.party', abstract: true,
-          primary_key: ['id'], fields: [],
-        }],
-      }],
-    })).toThrow(/an abstract dataset has no table/);
-  });
+  test(
+      'an abstract dataset that also declares a source is a hard error', () => {
+        // abstract == no physical table; a source would be silently ignored by
+        // the BigQuery leg, dropping a table the author intended, so reject the
+        // combo.
+        expect(() => fromDocument({
+                 semantic_model: [{
+                   name: 'm',
+                   datasets: [{
+                     name: 'Party',
+                     source: 'proj.ds.party',
+                     abstract: true,
+                     primary_key: ['id'],
+                     fields: [],
+                   }],
+                 }],
+               }))
+            .toThrow(/an abstract dataset has no table/);
+      });
 
-  test('an abstract dataset with no source loads and is marked abstract', () => {
-    const { models } = fromDocument({
+  test(
+      'an abstract dataset with no source loads and is marked abstract', () => {
+        const {models} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            datasets: [{name: 'Party', abstract: true, fields: []}],
+          }],
+        });
+        expect(models[0].entities[0].abstract).toBe(true);
+        expect(models[0].entities[0].dataSource).toBe('');
+      });
+
+  test(
+      'an abstract dataset\'s fields need no expression under a graph leg',
+      () => {
+        // The supertype has no table, so its fields carry no column -- they
+        // name the label its subtypes bind. The strict (graph-leg) schema must
+        // accept them even though a concrete dataset's field would require an
+        // expression.
+        const { models } = fromDocument({
       semantic_model: [{
         name: 'm',
-        datasets: [{ name: 'Party', abstract: true, fields: [] }],
+        datasets: [
+          {
+            name: 'Party', abstract: true, primary_key: ['id'],
+            fields: [{ name: 'id' }, { name: 'name' }],
+          },
+          {
+            name: 'Customer', extends: ['Party'], primary_key: ['id'],
+            source: 'proj.ds.customer',
+            fields: [
+              { name: 'id', expression: 'c_custkey' },
+              { name: 'name', expression: 'c_name' },
+            ],
+          },
+        ],
       }],
     });
-    expect(models[0].entities[0].abstract).toBe(true);
-    expect(models[0].entities[0].dataSource).toBe('');
-  });
+        const party = models[0].entities.find(e => e.name === 'Party')!;
+        expect(party.abstract).toBe(true);
+        expect(party.fields.map(f => f.name)).toEqual(['id', 'name']);
+        expect(party.fields.every(f => f.expression === undefined)).toBe(true);
+      });
+
+  test(
+      'a CONCRETE dataset\'s expression-less field still fails under a graph leg',
+      () => {
+        // The abstract exemption must not leak to concrete datasets: a real
+        // table's field still needs a column (or an explicit `unbound`).
+        expect(
+            () => fromDocument({
+              semantic_model: [{
+                name: 'm',
+                datasets: [{
+                  name: 'orders',
+                  primary_key: ['id'],
+                  source: 'proj.ds.orders',
+                  fields: [{name: 'id', expression: 'o_id'}, {name: 'total'}],
+                }],
+              }],
+            }))
+            .toThrow(/field 'total': requires an expression/);
+      });
 });
 
 
 describe('metrics infer their referenced entities from the expression', () => {
   test('a single referenced entity becomes the metric attach entity', () => {
-    const { models } = fromDocument({
+    const {models} = fromDocument({
       semantic_model: [{
         name: 'm',
-        datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
-        metrics: [{ name: 'total_revenue', expression: expr('SUM(order_items.amount)') }],
+        datasets: [{
+          name: 'order_items',
+          source: 'order_items',
+          primary_key: ['id'],
+          fields: []
+        }],
+        metrics: [
+          {name: 'total_revenue', expression: expr('SUM(order_items.amount)')}
+        ],
       }],
     });
     expect(models[0].metrics[0].entity).toBe('order_items');
   });
 
-  test('a metric spanning multiple entities has no single attach entity', () => {
-    // A cross-entity metric references known entities but cannot hang off one
-    // node, so `entity` is left undefined -- not a missing-entity warning.
-    const { models, warnings } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [
-          { name: 'orders', source: 'orders', primary_key: ['id'], fields: [] },
-          { name: 'customers', source: 'customers', primary_key: ['id'], fields: [] },
-        ],
-        metrics: [{
-          name: 'ratio',
-          expression: expr('SUM(orders.amount) / COUNT(customers.id)'),
-        }],
-      }],
-    });
-    expect(models[0].metrics[0].entity).toBeUndefined();
-    expect(warnings.some(w => w.includes('references no known entity'))).toBe(false);
-  });
+  test(
+      'a metric spanning multiple entities has no single attach entity', () => {
+        // A cross-entity metric references known entities but cannot hang off
+        // one node, so `entity` is left undefined -- not a missing-entity
+        // warning.
+        const {models, warnings} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            datasets: [
+              {
+                name: 'orders',
+                source: 'orders',
+                primary_key: ['id'],
+                fields: []
+              },
+              {
+                name: 'customers',
+                source: 'customers',
+                primary_key: ['id'],
+                fields: []
+              },
+            ],
+            metrics: [{
+              name: 'ratio',
+              expression: expr('SUM(orders.amount) / COUNT(customers.id)'),
+            }],
+          }],
+        });
+        expect(models[0].metrics[0].entity).toBeUndefined();
+        expect(warnings.some(w => w.includes('references no known entity')))
+            .toBe(false);
+      });
 
   test('a metric referencing no known entity warns', () => {
-    const { warnings } = fromDocument({
+    const {warnings} = fromDocument({
       semantic_model: [{
         name: 'm',
-        datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
-        metrics: [{ name: 'weird', expression: expr('SUM(unknown.x)') }],
-      }],
-    });
-    expect(warnings.some(w => w.includes('references no known entity'))).toBe(true);
-  });
-
-  test('a qualifier inside a string literal is not counted as a reference', () => {
-    // 'customers.region' is data, not a column reference, so the metric must be
-    // attributed only to order_items.
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [
-          { name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] },
-          { name: 'customers', source: 'customers', primary_key: ['id'], fields: [] },
-        ],
-        metrics: [{
-          name: 'tagged',
-          expression: expr("CONCAT(SUM(order_items.amount), 'customers.region')"),
+        datasets: [{
+          name: 'order_items',
+          source: 'order_items',
+          primary_key: ['id'],
+          fields: []
         }],
+        metrics: [{name: 'weird', expression: expr('SUM(unknown.x)')}],
       }],
     });
-    expect(models[0].metrics[0].entity).toBe('order_items');
+    expect(warnings.some(w => w.includes('references no known entity')))
+        .toBe(true);
   });
 
-  test('a backtick-quoted entity qualifier is recognized (BigQuery quoting)', () => {
-    // BigQuery quotes identifiers with backticks; `orders`.amount must still be
-    // attributed to the orders entity, not dropped as unqualified.
-    const { models, warnings } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
-        metrics: [{ name: 'rev', expression: expr('SUM(`orders`.amount)') }],
-      }],
-    });
-    expect(models[0].metrics[0].entity).toBe('orders');
-    expect(warnings.some(w => w.includes('references no known entity'))).toBe(false);
-  });
+  test(
+      'a qualifier inside a string literal is not counted as a reference',
+      () => {
+        // 'customers.region' is data, not a column reference, so the metric
+        // must be attributed only to order_items.
+        const {models} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            datasets: [
+              {
+                name: 'order_items',
+                source: 'order_items',
+                primary_key: ['id'],
+                fields: []
+              },
+              {
+                name: 'customers',
+                source: 'customers',
+                primary_key: ['id'],
+                fields: []
+              },
+            ],
+            metrics: [{
+              name: 'tagged',
+              expression:
+                  expr('CONCAT(SUM(order_items.amount), \'customers.region\')'),
+            }],
+          }],
+        });
+        expect(models[0].metrics[0].entity).toBe('order_items');
+      });
+
+  test(
+      'a backtick-quoted entity qualifier is recognized (BigQuery quoting)',
+      () => {
+        // BigQuery quotes identifiers with backticks; `orders`.amount must
+        // still be attributed to the orders entity, not dropped as unqualified.
+        const {models, warnings} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            datasets: [{
+              name: 'orders',
+              source: 'orders',
+              primary_key: ['id'],
+              fields: []
+            }],
+            metrics: [{name: 'rev', expression: expr('SUM(`orders`.amount)')}],
+          }],
+        });
+        expect(models[0].metrics[0].entity).toBe('orders');
+        expect(warnings.some(w => w.includes('references no known entity')))
+            .toBe(false);
+      });
 });
 
 
 describe('document-level handling', () => {
   test('a mismatched version warns but still loads', () => {
-    const { models, warnings } = fromDocument({
+    const {models, warnings} = fromDocument({
       version: '9.9.9',
-      semantic_model: [{ name: 'm', datasets: [
-        { name: 'a', source: 'a', primary_key: ['id'], fields: [] }] }],
+      semantic_model: [{
+        name: 'm',
+        datasets: [{name: 'a', source: 'a', primary_key: ['id'], fields: []}]
+      }],
     });
     expect(models).toHaveLength(1);
-    expect(warnings.some(w => w.includes('differs from the supported'))).toBe(true);
+    expect(warnings.some(w => w.includes('differs from the supported')))
+        .toBe(true);
   });
 
-  test('unknown/extra fields outside the subset are ignored, not errors', () => {
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        ai_context: { instructions: 'ignored' },
-        custom_extensions: [{ vendor_name: 'X', data: '{}' }],
-        datasets: [{
-          name: 'a', source: 'a', primary_key: ['id'],
-          unique_keys: [['id']],
-          fields: [{
-            name: 'id', label: 'ignored', dimension: { is_time: false },
-            expression: expr('a.id'),
+  test(
+      'unknown/extra fields outside the subset are ignored, not errors', () => {
+        const {models} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            ai_context: {instructions: 'ignored'},
+            custom_extensions: [{vendor_name: 'X', data: '{}'}],
+            datasets: [{
+              name: 'a',
+              source: 'a',
+              primary_key: ['id'],
+              unique_keys: [['id']],
+              fields: [{
+                name: 'id',
+                label: 'ignored',
+                dimension: {is_time: false},
+                expression: expr('a.id'),
+              }],
+            }],
           }],
-        }],
-      }],
-    });
-    expect(models[0].entities[0].fields[0].name).toBe('id');
-  });
+        });
+        expect(models[0].entities[0].fields[0].name).toBe('id');
+      });
 
-  test('duplicate dataset names warn (only one node table can carry the label)', () => {
-    const { warnings } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [
-          { name: 'orders', source: 'a', primary_key: ['id'], fields: [] },
-          { name: 'orders', source: 'b', primary_key: ['id'], fields: [] },
-        ],
-      }],
-    });
-    expect(warnings.some(w => w.includes("duplicate dataset name 'orders'"))).toBe(true);
-  });
+  test(
+      'duplicate dataset names warn (only one node table can carry the label)',
+      () => {
+        const {warnings} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            datasets: [
+              {name: 'orders', source: 'a', primary_key: ['id'], fields: []},
+              {name: 'orders', source: 'b', primary_key: ['id'], fields: []},
+            ],
+          }],
+        });
+        expect(
+            warnings.some(w => w.includes('duplicate dataset name \'orders\'')))
+            .toBe(true);
+      });
 
   test('each semantic_model entry becomes its own IR model', () => {
-    const { models } = fromDocument({
+    const {models} = fromDocument({
       semantic_model: [
-        { name: 'first', datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }] },
-        { name: 'second', datasets: [{ name: 'b', source: 'b', primary_key: ['id'], fields: [] }] },
+        {
+          name: 'first',
+          datasets: [{name: 'a', source: 'a', primary_key: ['id'], fields: []}]
+        },
+        {
+          name: 'second',
+          datasets: [{name: 'b', source: 'b', primary_key: ['id'], fields: []}]
+        },
       ],
     });
     expect(models.map(m => m.name)).toEqual(['first', 'second']);
   });
 
   test('model and metric descriptions carry through to the IR', () => {
-    const { models } = fromDocument({
+    const {models} = fromDocument({
       semantic_model: [{
-        name: 'm', description: 'a sales model',
-        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
-        metrics: [{ name: 'c', description: 'row count', expression: expr('COUNT(orders.id)') }],
+        name: 'm',
+        description: 'a sales model',
+        datasets: [
+          {name: 'orders', source: 'orders', primary_key: ['id'], fields: []}
+        ],
+        metrics: [{
+          name: 'c',
+          description: 'row count',
+          expression: expr('COUNT(orders.id)')
+        }],
       }],
     });
     expect(models[0].description).toBe('a sales model');
@@ -473,19 +761,23 @@ describe('document-level handling', () => {
     const json = JSON.stringify({
       semantic_model: [{
         name: 'm',
-        datasets: [{ name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] }],
+        datasets: [
+          {name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: []}
+        ],
       }],
     });
-    const { models } = loadModels(json);
+    const {models} = loadModels(json);
     expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
   });
 
   test('a document without semantic_model throws', () => {
-    expect(() => fromDocument({ foo: 'bar' })).toThrow(/Semantic model load error/);
+    expect(() => fromDocument({foo: 'bar'}))
+        .toThrow(/Semantic model load error/);
   });
 
   test('an empty semantic_model array throws (min one model required)', () => {
-    expect(() => fromDocument({ semantic_model: [] })).toThrow(/Semantic model load error/);
+    expect(() => fromDocument({semantic_model: []}))
+        .toThrow(/Semantic model load error/);
   });
 
   test('unparseable input throws', () => {
@@ -496,115 +788,167 @@ describe('document-level handling', () => {
 
 describe('richer IR fields carry through from the format', () => {
   test('field and metric datatype populate the IR type', () => {
-    const { models } = fromDocument({
+    const {models} = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'orders', source: 'orders', primary_key: ['id'],
-          fields: [{ name: 'amount', datatype: 'Decimal', expression: expr('orders.amount') }],
+          name: 'orders',
+          source: 'orders',
+          primary_key: ['id'],
+          fields: [{
+            name: 'amount',
+            datatype: 'Decimal',
+            expression: expr('orders.amount')
+          }],
         }],
-        metrics: [{ name: 'total', datatype: 'Decimal', expression: expr('SUM(orders.amount)') }],
+        metrics: [{
+          name: 'total',
+          datatype: 'Decimal',
+          expression: expr('SUM(orders.amount)')
+        }],
       }],
     });
     expect(models[0].entities[0].fields[0].type).toBe('Decimal');
     expect(models[0].metrics[0].type).toBe('Decimal');
   });
 
-  test('an off-vocabulary datatype is rejected (closed, case-sensitive enum)', () => {
-    // Lowercase 'date' is not in the vocabulary (only 'Date' is); the closed
-    // enum makes this a hard parse error rather than a silently mis-typed field.
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{
-          name: 'orders', source: 'orders', primary_key: ['id'],
-          fields: [{ name: 'created', datatype: 'date', expression: expr('orders.created') }],
-        }],
-      }],
-    })).toThrow(/Semantic model load error/);
-  });
+  test(
+      'an off-vocabulary datatype is rejected (closed, case-sensitive enum)',
+      () => {
+        // Lowercase 'date' is not in the vocabulary (only 'Date' is); the
+        // closed enum makes this a hard parse error rather than a silently
+        // mis-typed field.
+        expect(() => fromDocument({
+                 semantic_model: [{
+                   name: 'm',
+                   datasets: [{
+                     name: 'orders',
+                     source: 'orders',
+                     primary_key: ['id'],
+                     fields: [{
+                       name: 'created',
+                       datatype: 'date',
+                       expression: expr('orders.created')
+                     }],
+                   }],
+                 }],
+               }))
+            .toThrow(/Semantic model load error/);
+      });
 
   test('a dataset unique_keys becomes Entity.uniqueKeys', () => {
-    const { models } = fromDocument({
+    const {models} = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'orders', source: 'orders', primary_key: ['id'],
+          name: 'orders',
+          source: 'orders',
+          primary_key: ['id'],
           unique_keys: [['sku', 'region'], ['external_id']],
           fields: [],
         }],
       }],
     });
-    expect(models[0].entities[0].uniqueKeys).toEqual([['sku', 'region'], ['external_id']]);
-  });
-
-  test('the GOOGLE block is carried verbatim, not interpreted at load time', () => {
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        custom_extensions: [
-          { vendor_name: 'OTHER', data: '{"ignored": true}' },
-          { vendor_name: 'GOOGLE', data: JSON.stringify({
-            deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
-        ],
-        datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }],
-      }],
-    });
-    // GOOGLE gets no special treatment -- it rides along in customExtensions like
-    // any other vendor block; a typed deployment view is a consumer concern.
-    expect(models[0].customExtensions).toEqual([
-      { vendorName: 'OTHER', data: '{"ignored": true}' },
-      { vendorName: 'GOOGLE', data: JSON.stringify({
-        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
+    expect(models[0].entities[0].uniqueKeys).toEqual([
+      ['sku', 'region'], ['external_id']
     ]);
   });
 
-  test('a malformed GOOGLE block is kept verbatim without warning (not parsed)', () => {
-    const { models, warnings } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        custom_extensions: [{ vendor_name: 'GOOGLE', data: '{not json' }],
-        datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }],
-      }],
-    });
-    // The loader never parses the block, so malformed JSON is not its concern.
-    expect(models[0].customExtensions).toEqual([{ vendorName: 'GOOGLE', data: '{not json' }]);
-    expect(warnings).toEqual([]);
-  });
-
-  test('ai_context instructions and synonyms are structural, not folded into description', () => {
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm', description: 'a sales model',
-        ai_context: { instructions: 'Prefer net revenue.', synonyms: ['sales', 'commerce'] },
-        datasets: [{
-          name: 'orders', source: 'orders', primary_key: ['id'],
-          ai_context: { instructions: 'One row per order.', synonyms: ['purchases'] },
-          fields: [{
-            name: 'amount', expression: expr('orders.amount'),
-            ai_context: { instructions: 'Gross, before tax.' },
+  test(
+      'the GOOGLE block is carried verbatim, not interpreted at load time',
+      () => {
+        const {models} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            custom_extensions: [
+              {vendor_name: 'OTHER', data: '{"ignored": true}'},
+              {
+                vendor_name: 'GOOGLE',
+                data: JSON.stringify(
+                    {deploymentTargets: ['projects/p/locations/us/graphs/g']})
+              },
+            ],
+            datasets:
+                [{name: 'a', source: 'a', primary_key: ['id'], fields: []}],
           }],
-        }],
-      }],
-    });
-    const model = models[0];
-    // Description stays the base text; instructions/synonyms live on aiContext.
-    expect(model.description).toBe('a sales model');
-    expect(model.aiContext?.instructions).toBe('Prefer net revenue.');
-    expect(model.aiContext?.synonyms).toEqual(['sales', 'commerce']);
+        });
+        // GOOGLE gets no special treatment -- it rides along in
+        // customExtensions like any other vendor block; a typed deployment view
+        // is a consumer concern.
+        expect(models[0].customExtensions).toEqual([
+          {vendorName: 'OTHER', data: '{"ignored": true}'},
+          {
+            vendorName: 'GOOGLE',
+            data: JSON.stringify(
+                {deploymentTargets: ['projects/p/locations/us/graphs/g']})
+          },
+        ]);
+      });
 
-    // Dataset-level: no base description supplied, so it stays unset; instructions
-    // and synonyms are structural.
-    const entity = model.entities[0];
-    expect(entity.description).toBeUndefined();
-    expect(entity.aiContext?.instructions).toBe('One row per order.');
-    expect(entity.aiContext?.synonyms).toEqual(['purchases']);
+  test(
+      'a malformed GOOGLE block is kept verbatim without warning (not parsed)',
+      () => {
+        const {models, warnings} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            custom_extensions: [{vendor_name: 'GOOGLE', data: '{not json'}],
+            datasets:
+                [{name: 'a', source: 'a', primary_key: ['id'], fields: []}],
+          }],
+        });
+        // The loader never parses the block, so malformed JSON is not its
+        // concern.
+        expect(models[0].customExtensions).toEqual([
+          {vendorName: 'GOOGLE', data: '{not json'}
+        ]);
+        expect(warnings).toEqual([]);
+      });
 
-    // Field-level: instructions structural; no description text was supplied.
-    const field = entity.fields[0];
-    expect(field.description).toBeUndefined();
-    expect(field.aiContext?.instructions).toBe('Gross, before tax.');
-  });
+  test(
+      'ai_context instructions and synonyms are structural, not folded into description',
+      () => {
+        const {models} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            description: 'a sales model',
+            ai_context: {
+              instructions: 'Prefer net revenue.',
+              synonyms: ['sales', 'commerce']
+            },
+            datasets: [{
+              name: 'orders',
+              source: 'orders',
+              primary_key: ['id'],
+              ai_context:
+                  {instructions: 'One row per order.', synonyms: ['purchases']},
+              fields: [{
+                name: 'amount',
+                expression: expr('orders.amount'),
+                ai_context: {instructions: 'Gross, before tax.'},
+              }],
+            }],
+          }],
+        });
+        const model = models[0];
+        // Description stays the base text; instructions/synonyms live on
+        // aiContext.
+        expect(model.description).toBe('a sales model');
+        expect(model.aiContext?.instructions).toBe('Prefer net revenue.');
+        expect(model.aiContext?.synonyms).toEqual(['sales', 'commerce']);
+
+        // Dataset-level: no base description supplied, so it stays unset;
+        // instructions and synonyms are structural.
+        const entity = model.entities[0];
+        expect(entity.description).toBeUndefined();
+        expect(entity.aiContext?.instructions).toBe('One row per order.');
+        expect(entity.aiContext?.synonyms).toEqual(['purchases']);
+
+        // Field-level: instructions structural; no description text was
+        // supplied.
+        const field = entity.fields[0];
+        expect(field.description).toBeUndefined();
+        expect(field.aiContext?.instructions).toBe('Gross, before tax.');
+      });
 });
 
 
@@ -618,9 +962,16 @@ describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
     semantic_model: [{
       name: 'sales',
       description: 'Sales semantic model',
-      ai_context: { instructions: 'Prefer net.', synonyms: ['commerce'], examples: ['revenue by month'] },
-      custom_extensions: [{ vendor_name: 'GOOGLE', data: JSON.stringify({
-        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) }],
+      ai_context: {
+        instructions: 'Prefer net.',
+        synonyms: ['commerce'],
+        examples: ['revenue by month']
+      },
+      custom_extensions: [{
+        vendor_name: 'GOOGLE',
+        data: JSON.stringify(
+            {deploymentTargets: ['projects/p/locations/us/graphs/g']})
+      }],
       datasets: [
         {
           name: 'orders',
@@ -628,35 +979,46 @@ describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
           primary_key: ['order_id'],
           unique_keys: [['external_id']],
           description: 'One row per order',
-          ai_context: { instructions: 'Grain: order.', synonyms: ['purchases'] },
-          custom_extensions: [{ vendor_name: 'DBT', data: '{"model":"orders"}' }],
+          ai_context: {instructions: 'Grain: order.', synonyms: ['purchases']},
+          custom_extensions: [{vendor_name: 'DBT', data: '{"model":"orders"}'}],
           fields: [{
             name: 'amount',
-            expression: { dialects: [{ dialect: 'BIGQUERY', expression: 'orders.amount' }] },
-            dimension: { is_time: false },
+            expression: {
+              dialects: [{dialect: 'BIGQUERY', expression: 'orders.amount'}]
+            },
+            dimension: {is_time: false},
             label: 'Order amount',
             description: 'Gross amount',
             datatype: 'Decimal',
-            ai_context: { instructions: 'Before tax.', synonyms: ['gross'] },
-            custom_extensions: [{ vendor_name: 'SNOWFLAKE', data: '{}' }],
+            ai_context: {instructions: 'Before tax.', synonyms: ['gross']},
+            custom_extensions: [{vendor_name: 'SNOWFLAKE', data: '{}'}],
           }],
         },
-        { name: 'customers', source: 'proj.ds.customers', primary_key: ['customer_id'], fields: [] },
+        {
+          name: 'customers',
+          source: 'proj.ds.customers',
+          primary_key: ['customer_id'],
+          fields: []
+        },
       ],
       relationships: [{
         name: 'orders_customers',
-        from: 'orders', to: 'customers',
-        from_columns: ['customer_id'], to_columns: ['customer_id'],
-        ai_context: { instructions: 'Each order has one customer.' },
-        custom_extensions: [{ vendor_name: 'COMMON', data: '{}' }],
+        from: 'orders',
+        to: 'customers',
+        from_columns: ['customer_id'],
+        to_columns: ['customer_id'],
+        ai_context: {instructions: 'Each order has one customer.'},
+        custom_extensions: [{vendor_name: 'COMMON', data: '{}'}],
       }],
       metrics: [{
         name: 'total_amount',
-        expression: { dialects: [{ dialect: 'BIGQUERY', expression: 'SUM(orders.amount)' }] },
+        expression: {
+          dialects: [{dialect: 'BIGQUERY', expression: 'SUM(orders.amount)'}]
+        },
         description: 'Total sales',
         datatype: 'Decimal',
-        ai_context: { instructions: 'Sum of amounts.', synonyms: ['revenue'] },
-        custom_extensions: [{ vendor_name: 'GOODDATA', data: '{}' }],
+        ai_context: {instructions: 'Sum of amounts.', synonyms: ['revenue']},
+        custom_extensions: [{vendor_name: 'GOODDATA', data: '{}'}],
       }],
     }],
   };
@@ -665,30 +1027,44 @@ describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
     expect(() => fromDocument(doc)).not.toThrow();
   });
 
-  test('nested custom_extensions do not produce warnings (accepted, validated)', () => {
-    const { warnings } = fromDocument(doc);
-    // No vendor extension is acted upon at load time; all are accepted silently.
-    // No dialect fallbacks here either, so no notes.
-    expect(warnings).toEqual([]);
-  });
+  test(
+      'nested custom_extensions do not produce warnings (accepted, validated)',
+      () => {
+        const {warnings} = fromDocument(doc);
+        // No vendor extension is acted upon at load time; all are accepted
+        // silently. No dialect fallbacks here either, so no notes.
+        expect(warnings).toEqual([]);
+      });
 
   test('nested custom_extensions are preserved verbatim at every level', () => {
-    const { models } = fromDocument(doc);
+    const {models} = fromDocument(doc);
     const m = models[0];
     // Model level: the raw GOOGLE block is kept verbatim, uninterpreted.
     expect(m.customExtensions).toEqual([
-      { vendorName: 'GOOGLE', data: JSON.stringify({
-        deploymentTargets: ['projects/p/locations/us/graphs/g'] }) },
+      {
+        vendorName: 'GOOGLE',
+        data: JSON.stringify(
+            {deploymentTargets: ['projects/p/locations/us/graphs/g']})
+      },
     ]);
-    // Dataset / field / relationship / metric levels: kept verbatim, data opaque.
-    expect(m.entities[0].customExtensions).toEqual([{ vendorName: 'DBT', data: '{"model":"orders"}' }]);
-    expect(m.entities[0].fields[0].customExtensions).toEqual([{ vendorName: 'SNOWFLAKE', data: '{}' }]);
-    expect(m.relationships[0].customExtensions).toEqual([{ vendorName: 'COMMON', data: '{}' }]);
-    expect(m.metrics[0].customExtensions).toEqual([{ vendorName: 'GOODDATA', data: '{}' }]);
+    // Dataset / field / relationship / metric levels: kept verbatim, data
+    // opaque.
+    expect(m.entities[0].customExtensions).toEqual([
+      {vendorName: 'DBT', data: '{"model":"orders"}'}
+    ]);
+    expect(m.entities[0].fields[0].customExtensions).toEqual([
+      {vendorName: 'SNOWFLAKE', data: '{}'}
+    ]);
+    expect(m.relationships[0].customExtensions).toEqual([
+      {vendorName: 'COMMON', data: '{}'}
+    ]);
+    expect(m.metrics[0].customExtensions).toEqual([
+      {vendorName: 'GOODDATA', data: '{}'}
+    ]);
   });
 
   test('every supported field maps into the IR', () => {
-    const { models } = fromDocument(doc);
+    const {models} = fromDocument(doc);
     const m = models[0];
     expect(m.name).toBe('sales');
     expect(m.description).toBe('Sales semantic model');
@@ -727,18 +1103,30 @@ describe('Apache OSI v0.2.0.dev0 spec coverage', () => {
   });
 
   test('all seven spec dialects and ten datatypes are accepted', () => {
-    const dialects = ['ANSI_SQL', 'SNOWFLAKE', 'MDX', 'TABLEAU', 'DATABRICKS', 'MAQL', 'BIGQUERY'];
-    const datatypes = [...DATA_TYPES];  // the loader accepts exactly the IR vocabulary
-    const { models } = fromDocument({
+    const dialects = [
+      'ANSI_SQL', 'SNOWFLAKE', 'MDX', 'TABLEAU', 'DATABRICKS', 'MAQL',
+      'BIGQUERY'
+    ];
+    const datatypes =
+        [...DATA_TYPES];  // the loader accepts exactly the IR vocabulary
+    const {models} = fromDocument({
       version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'd', source: 'd', primary_key: ['id'],
+          name: 'd',
+          source: 'd',
+          primary_key: ['id'],
           fields: datatypes.map((dt, i) => ({
-            name: `f${i}`, datatype: dt,
-            expression: { dialects: [{ dialect: dialects[i % dialects.length], expression: `d.c${i}` }] },
-          })),
+                                  name: `f${i}`,
+                                  datatype: dt,
+                                  expression: {
+                                    dialects: [{
+                                      dialect: dialects[i % dialects.length],
+                                      expression: `d.c${i}`
+                                    }]
+                                  },
+                                })),
         }],
       }],
     });
@@ -755,168 +1143,237 @@ function fixture(name: string): string {
 }
 
 describe('gold fixtures parse from disk (real YAML files)', () => {
-  test('star_orders_customer.yaml: happy path (ai_context, time dimension, metrics)', () => {
-    const { models } = loadModels(fixture('star_orders_customer.yaml'));
-    expect(models).toHaveLength(1);
-    const m = models[0];
-    expect(m.name).toBe('sales');
-    expect(m.aiContext?.instructions).toBe('Use this model for order analysis.');
-    expect(m.entities.map(e => e.name)).toEqual(['orders', 'customer']);
-    expect(m.entities[0].keys).toEqual(['o_orderkey']);
-    expect(m.relationships.map(r => r.name)).toEqual(['orders_to_customer']);
+  test(
+      'star_orders_customer.yaml: happy path (ai_context, time dimension, metrics)',
+      () => {
+        const {models} = loadModels(fixture('star_orders_customer.yaml'));
+        expect(models).toHaveLength(1);
+        const m = models[0];
+        expect(m.name).toBe('sales');
+        expect(m.aiContext?.instructions)
+            .toBe('Use this model for order analysis.');
+        expect(m.entities.map(e => e.name)).toEqual(['orders', 'customer']);
+        expect(m.entities[0].keys).toEqual(['o_orderkey']);
+        expect(m.relationships.map(r => r.name)).toEqual([
+          'orders_to_customer'
+        ]);
 
-    const orderdate = m.entities[0].fields.find(f => f.name === 'o_orderdate')!;
-    expect(orderdate.aiContext?.synonyms).toEqual(['order date', 'date']);
-    // label and time-dimension role are structural now, not folded into text.
-    expect(orderdate.label).toBe('Order Date');
-    expect(orderdate.dimension?.isTime).toBe(true);
-    expect(isTimeDimension(orderdate)).toBe(true);
-    expect(orderdate.description).toBeUndefined();
+        const orderdate =
+            m.entities[0].fields.find(f => f.name === 'o_orderdate')!;
+        expect(orderdate.aiContext?.synonyms).toEqual(['order date', 'date']);
+        // label and time-dimension role are structural now, not folded into
+        // text.
+        expect(orderdate.label).toBe('Order Date');
+        expect(orderdate.dimension?.isTime).toBe(true);
+        expect(isTimeDimension(orderdate)).toBe(true);
+        expect(orderdate.description).toBeUndefined();
 
-    const revenue = m.metrics.find(mt => mt.name === 'total_revenue')!;
-    expect(revenue.expression).toBe('SUM(orders.o_totalprice)');
-    expect(revenue.entity).toBe('orders');
-    expect(revenue.aiContext?.synonyms).toEqual(['revenue', 'sales']);
-    // order_count is entity-scoped (COUNT(orders.o_orderkey)) -> attach entity
-    // inferred from the qualifier, so it is a valid single-entity measure.
-    const count = m.metrics.find(mt => mt.name === 'order_count')!;
-    expect(count.entity).toBe('orders');
-    expect(count.expression).toBe('COUNT(orders.o_orderkey)');
-  });
+        const revenue = m.metrics.find(mt => mt.name === 'total_revenue')!;
+        expect(revenue.expression).toBe('SUM(orders.o_totalprice)');
+        expect(revenue.entity).toBe('orders');
+        expect(revenue.aiContext?.synonyms).toEqual(['revenue', 'sales']);
+        // order_count is entity-scoped (COUNT(orders.o_orderkey)) -> attach
+        // entity inferred from the qualifier, so it is a valid single-entity
+        // measure.
+        const count = m.metrics.find(mt => mt.name === 'order_count')!;
+        expect(count.entity).toBe('orders');
+        expect(count.expression).toBe('COUNT(orders.o_orderkey)');
+      });
 
-  test('vendor_dialects.yaml: non-target dialects kept as imported_expression', () => {
-    const { models, warnings } = loadModels(fixture('vendor_dialects.yaml'));
-    const m = models[0];
-    expect(m.name).toBe('vendor_sales');
+  test(
+      'vendor_dialects.yaml: non-target dialects kept as imported_expression',
+      () => {
+        const {models, warnings} = loadModels(fixture('vendor_dialects.yaml'));
+        const m = models[0];
+        expect(m.name).toBe('vendor_sales');
 
-    const label = m.entities[0].fields.find(f => f.name === 'order_status_label')!;
-    expect(label.expression).toBeUndefined();
-    expect(label.importedDialect).toBe('SNOWFLAKE');
-    expect(label.importedExpression).toContain('IFF(');
+        const label =
+            m.entities[0].fields.find(f => f.name === 'order_status_label')!;
+        expect(label.expression).toBeUndefined();
+        expect(label.importedDialect).toBe('SNOWFLAKE');
+        expect(label.importedExpression).toContain('IFF(');
 
-    const fulfilled = m.metrics.find(mt => mt.name === 'fulfilled_revenue')!;
-    expect(fulfilled.expression).toBeUndefined();
-    expect(fulfilled.importedDialect).toBe('SNOWFLAKE');
-    expect(fulfilled.entity).toBe('orders');
+        const fulfilled =
+            m.metrics.find(mt => mt.name === 'fulfilled_revenue')!;
+        expect(fulfilled.expression).toBeUndefined();
+        expect(fulfilled.importedDialect).toBe('SNOWFLAKE');
+        expect(fulfilled.entity).toBe('orders');
 
-    // Portable control metric still resolves to a target expression.
-    const control = m.metrics.find(mt => mt.name === 'total_revenue')!;
-    expect(control.expression).toBe('SUM(orders.o_totalprice)');
+        // Portable control metric still resolves to a target expression.
+        const control = m.metrics.find(mt => mt.name === 'total_revenue')!;
+        expect(control.expression).toBe('SUM(orders.o_totalprice)');
 
-    expect(warnings.some(w =>
-      w.includes("field 'orders.order_status_label'") && w.includes('imported_expression'))).toBe(true);
-  });
+        expect(warnings.some(
+                   w => w.includes('field \'orders.order_status_label\'') &&
+                       w.includes('imported_expression')))
+            .toBe(true);
+      });
 
-  test('lineitem_databricks_ext.yaml: unique_keys + no-primary-key warning', () => {
-    const { models, warnings } = loadModels(fixture('lineitem_databricks_ext.yaml'));
-    const m = models[0];
-    const orders = m.entities.find(e => e.name === 'orders')!;
-    expect(orders.keys).toEqual([]);
-    expect(orders.uniqueKeys).toEqual([['o_orderkey']]);
-    expect(warnings.some(w => w.includes("dataset 'lineitem'") && w.includes('no primary_key'))).toBe(true);
+  test(
+      'lineitem_databricks_ext.yaml: unique_keys + no-primary-key warning',
+      () => {
+        const {models, warnings} =
+            loadModels(fixture('lineitem_databricks_ext.yaml'));
+        const m = models[0];
+        const orders = m.entities.find(e => e.name === 'orders')!;
+        expect(orders.keys).toEqual([]);
+        expect(orders.uniqueKeys).toEqual([['o_orderkey']]);
+        expect(warnings.some(
+                   w => w.includes('dataset \'lineitem\'') &&
+                       w.includes('no primary_key')))
+            .toBe(true);
 
-    // custom_extensions are preserved verbatim at model / field / relationship / metric levels.
-    expect(m.customExtensions?.[0].vendorName).toBe('DATABRICKS');
-    const lineitem = m.entities.find(e => e.name === 'lineitem')!;
-    expect(lineitem.fields[0].customExtensions?.[0].vendorName).toBe('DATABRICKS');
-    expect(m.relationships[0].customExtensions?.[0].vendorName).toBe('DATABRICKS');
-    expect(m.metrics.find(mt => mt.name === 'revenue')!.customExtensions?.[0].data).toContain('currency');
-  });
+        // custom_extensions are preserved verbatim at model / field /
+        // relationship / metric levels.
+        expect(m.customExtensions?.[0].vendorName).toBe('DATABRICKS');
+        const lineitem = m.entities.find(e => e.name === 'lineitem')!;
+        expect(lineitem.fields[0].customExtensions?.[0].vendorName)
+            .toBe('DATABRICKS');
+        expect(m.relationships[0].customExtensions?.[0].vendorName)
+            .toBe('DATABRICKS');
+        expect(
+            m.metrics.find(mt => mt.name === 'revenue')!.customExtensions?.[0]
+                .data)
+            .toContain('currency');
+      });
 
-  test('sales_google_ext.yaml: GOOGLE block verbatim + datatypes + unique_keys', () => {
-    const { models } = loadModels(fixture('sales_google_ext.yaml'));
-    const m = models[0];
-    expect(m.customExtensions).toEqual([{
-      vendorName: 'GOOGLE',
-      data: '{"deploymentTargets": ["projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph"]}',
-    }]);
-    const orders = m.entities[0];
-    expect(orders.uniqueKeys).toEqual([['o_orderkey'], ['o_ordernumber']]);
-    expect(orders.fields.map(f => f.type)).toEqual(['Integer', 'String', 'Date', 'Decimal']);
-    expect(m.metrics[0].type).toBe('Decimal');
-    // Expressions are supplied in the BIGQUERY dialect (the default target), so
-    // they resolve directly as `expression` -- exercising pickDialect's
-    // target-dialect-present path, not the ANSI_SQL fallback. Nothing is left as
-    // an imported (needs-transpile) form.
-    expect(m.metrics[0].expression).toBe('SUM(orders.o_totalprice)');
-    expect(m.metrics[0].importedExpression).toBeUndefined();
-    expect(orders.fields.every(f => f.expression && !f.importedExpression)).toBe(true);
-  });
+  test(
+      'sales_google_ext.yaml: GOOGLE block verbatim + datatypes + unique_keys',
+      () => {
+        const {models} = loadModels(fixture('sales_google_ext.yaml'));
+        const m = models[0];
+        expect(m.customExtensions).toEqual([{
+          vendorName: 'GOOGLE',
+          data:
+              '{"deploymentTargets": ["projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph"]}',
+        }]);
+        const orders = m.entities[0];
+        expect(orders.uniqueKeys).toEqual([['o_orderkey'], ['o_ordernumber']]);
+        expect(orders.fields.map(f => f.type)).toEqual([
+          'Integer', 'String', 'Date', 'Decimal'
+        ]);
+        expect(m.metrics[0].type).toBe('Decimal');
+        // Expressions are supplied in the BIGQUERY dialect (the default
+        // target), so they resolve directly as `expression` -- exercising
+        // pickDialect's target-dialect-present path, not the ANSI_SQL fallback.
+        // Nothing is left as an imported (needs-transpile) form.
+        expect(m.metrics[0].expression).toBe('SUM(orders.o_totalprice)');
+        expect(m.metrics[0].importedExpression).toBeUndefined();
+        expect(orders.fields.every(f => f.expression && !f.importedExpression))
+            .toBe(true);
+      });
 
-  test('ossie/tpcds_semantic_model.yaml: the Apache reference example loads', () => {
-    // The unmodified spec-owner-authored example (interop proof).
-    const { models, warnings } = loadModels(fixture('ossie/tpcds_semantic_model.yaml'));
-    expect(models).toHaveLength(1);
-    const m = models[0];
-    expect(m.name).toBe('tpcds_retail_model');
-    expect(m.entities).toHaveLength(5);
-    expect(m.relationships).toHaveLength(4);
-    expect(m.metrics).toHaveLength(5);
+  test(
+      'ossie/tpcds_semantic_model.yaml: the Apache reference example loads',
+      () => {
+        // The unmodified spec-owner-authored example (interop proof).
+        const {models, warnings} =
+            loadModels(fixture('ossie/tpcds_semantic_model.yaml'));
+        expect(models).toHaveLength(1);
+        const m = models[0];
+        expect(m.name).toBe('tpcds_retail_model');
+        expect(m.entities).toHaveLength(5);
+        expect(m.relationships).toHaveLength(4);
+        expect(m.metrics).toHaveLength(5);
 
-    // A cross-entity metric references more than one entity, so it has no
-    // single attach entity.
-    const clv = m.metrics.find(mt => mt.name === 'customer_lifetime_value')!;
-    expect(clv.entity).toBeUndefined();
+        // A cross-entity metric references more than one entity, so it has no
+        // single attach entity.
+        const clv =
+            m.metrics.find(mt => mt.name === 'customer_lifetime_value')!;
+        expect(clv.entity).toBeUndefined();
 
-    // Every field and metric expression is ANSI_SQL -> resolves to a target
-    // expression, so nothing is left needing transpilation.
-    const needsTranspile = warnings.filter(w => w.includes('imported_expression'));
-    expect(needsTranspile).toEqual([]);
-  });
+        // Every field and metric expression is ANSI_SQL -> resolves to a target
+        // expression, so nothing is left needing transpilation.
+        const needsTranspile =
+            warnings.filter(w => w.includes('imported_expression'));
+        expect(needsTranspile).toEqual([]);
+      });
 });
 
 describe('duplicate names within a model warn (uniqueness checks)', () => {
   test('duplicate field names within a dataset warn', () => {
-    const { warnings } = fromDocument({
+    const {warnings} = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'orders', source: 'orders', primary_key: ['id'],
+          name: 'orders',
+          source: 'orders',
+          primary_key: ['id'],
           fields: [
-            { name: 'amount', expression: expr('orders.amount') },
-            { name: 'amount', expression: expr('orders.amount2') },
+            {name: 'amount', expression: expr('orders.amount')},
+            {name: 'amount', expression: expr('orders.amount2')},
           ],
         }],
       }],
     });
-    expect(warnings.some(w =>
-      w.includes("dataset 'orders'") && w.includes("duplicate field name 'amount'"))).toBe(true);
+    expect(warnings.some(
+               w => w.includes('dataset \'orders\'') &&
+                   w.includes('duplicate field name \'amount\'')))
+        .toBe(true);
   });
 
   test('duplicate metric names within a model warn', () => {
-    const { warnings } = fromDocument({
+    const {warnings} = fromDocument({
       semantic_model: [{
         name: 'm',
-        datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'],
-          fields: [{ name: 'amount', expression: expr('orders.amount') }] }],
+        datasets: [{
+          name: 'orders',
+          source: 'orders',
+          primary_key: ['id'],
+          fields: [{name: 'amount', expression: expr('orders.amount')}]
+        }],
         metrics: [
-          { name: 'total', expression: expr('SUM(orders.amount)') },
-          { name: 'total', expression: expr('AVG(orders.amount)') },
+          {name: 'total', expression: expr('SUM(orders.amount)')},
+          {name: 'total', expression: expr('AVG(orders.amount)')},
         ],
       }],
     });
-    expect(warnings.some(w =>
-      w.includes("model 'm'") && w.includes("duplicate metric name 'total'"))).toBe(true);
+    expect(warnings.some(
+               w => w.includes('model \'m\'') &&
+                   w.includes('duplicate metric name \'total\'')))
+        .toBe(true);
   });
 
   test('duplicate relationship names within a model warn', () => {
-    const { warnings } = fromDocument({
+    const {warnings} = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [
-          { name: 'orders', source: 'orders', primary_key: ['o_id'],
-            fields: [{ name: 'c_id', expression: expr('orders.c_id') }] },
-          { name: 'customer', source: 'customer', primary_key: ['c_id'],
-            fields: [{ name: 'c_id', expression: expr('customer.c_id') }] },
+          {
+            name: 'orders',
+            source: 'orders',
+            primary_key: ['o_id'],
+            fields: [{name: 'c_id', expression: expr('orders.c_id')}]
+          },
+          {
+            name: 'customer',
+            source: 'customer',
+            primary_key: ['c_id'],
+            fields: [{name: 'c_id', expression: expr('customer.c_id')}]
+          },
         ],
         relationships: [
-          { name: 'o2c', from: 'orders', to: 'customer', from_columns: ['c_id'], to_columns: ['c_id'] },
-          { name: 'o2c', from: 'orders', to: 'customer', from_columns: ['c_id'], to_columns: ['c_id'] },
+          {
+            name: 'o2c',
+            from: 'orders',
+            to: 'customer',
+            from_columns: ['c_id'],
+            to_columns: ['c_id']
+          },
+          {
+            name: 'o2c',
+            from: 'orders',
+            to: 'customer',
+            from_columns: ['c_id'],
+            to_columns: ['c_id']
+          },
         ],
       }],
     });
-    expect(warnings.some(w =>
-      w.includes("model 'm'") && w.includes("duplicate relationship name 'o2c'"))).toBe(true);
+    expect(warnings.some(
+               w => w.includes('model \'m\'') &&
+                   w.includes('duplicate relationship name \'o2c\'')))
+        .toBe(true);
   });
 });
 
@@ -924,12 +1381,14 @@ describe('duplicate names within a model warn (uniqueness checks)', () => {
 describe('field label and time-dimension role align with the format models', () => {
   // Builds one field with the given extra props and returns its IR form.
   function field(props: Record<string, unknown>) {
-    const { models } = fromDocument({
+    const {models} = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'd', source: 'd', primary_key: ['id'],
-          fields: [{ name: 'f', expression: expr('d.f'), ...props }],
+          name: 'd',
+          source: 'd',
+          primary_key: ['id'],
+          fields: [{name: 'f', expression: expr('d.f'), ...props}],
         }],
       }],
     });
@@ -937,152 +1396,202 @@ describe('field label and time-dimension role align with the format models', () 
   }
 
   test('label is preserved structurally, separate from description', () => {
-    const f = field({ label: 'Order Date', description: 'The order date' });
+    const f = field({label: 'Order Date', description: 'The order date'});
     expect(f.label).toBe('Order Date');
     expect(f.description).toBe('The order date');
   });
 
   test('a label alone is not mis-mapped into description', () => {
-    const f = field({ label: 'Order Date' });
+    const f = field({label: 'Order Date'});
     expect(f.label).toBe('Order Date');
     expect(f.description).toBeUndefined();
   });
 
   test('an explicit is_time:true makes it a time dimension', () => {
-    const f = field({ dimension: { is_time: true } });
+    const f = field({dimension: {is_time: true}});
     expect(f.dimension?.isTime).toBe(true);
     expect(isTimeDimension(f)).toBe(true);
   });
 
   test('an explicit is_time:false overrides a temporal datatype', () => {
-    const f = field({ dimension: { is_time: false }, datatype: 'Date' });
+    const f = field({dimension: {is_time: false}, datatype: 'Date'});
     expect(f.dimension?.isTime).toBe(false);
     expect(isTimeDimension(f)).toBe(false);
   });
 
-  test('a temporal datatype infers a time dimension when is_time is unset', () => {
-    const f = field({ dimension: {}, datatype: 'Date' });
-    expect(f.dimension?.isTime).toBeUndefined();
-    expect(isTimeDimension(f)).toBe(true);
-  });
+  test(
+      'a temporal datatype infers a time dimension when is_time is unset',
+      () => {
+        const f = field({dimension: {}, datatype: 'Date'});
+        expect(f.dimension?.isTime).toBeUndefined();
+        expect(isTimeDimension(f)).toBe(true);
+      });
 
   test('a temporal datatype with no dimension block is not a dimension', () => {
-    const f = field({ datatype: 'Date' });
+    const f = field({datatype: 'Date'});
     expect(f.dimension).toBeUndefined();
     expect(isTimeDimension(f)).toBe(false);
   });
 
-  test('a non-temporal datatype with an empty dimension is not a time dimension', () => {
-    const f = field({ dimension: {}, datatype: 'String' });
-    expect(isTimeDimension(f)).toBe(false);
-  });
+  test(
+      'a non-temporal datatype with an empty dimension is not a time dimension',
+      () => {
+        const f = field({dimension: {}, datatype: 'String'});
+        expect(isTimeDimension(f)).toBe(false);
+      });
 });
 
 
-describe('authoring sugars: entities alias, bare-string expression, deployment_target', () => {
-  const URI =
-    '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
+describe(
+    'authoring sugars: entities alias, bare-string expression, deployment_target',
+    () => {
+      const URI =
+          '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
 
-  test("'entities:' is an alias for 'datasets:'", () => {
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        entities: [
-          { name: 'a', source: 'proj.ds.tbl', primary_key: ['id'],
-            fields: [{ name: 'id', expression: expr('id') }] },
-        ],
-      }],
+      test('\'entities:\' is an alias for \'datasets:\'', () => {
+        const {models} = fromDocument({
+          semantic_model: [{
+            name: 'm',
+            entities: [
+              {
+                name: 'a',
+                source: 'proj.ds.tbl',
+                primary_key: ['id'],
+                fields: [{name: 'id', expression: expr('id')}]
+              },
+            ],
+          }],
+        });
+        expect(models[0].entities.map(e => e.name)).toEqual(['a']);
+        expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
+      });
+
+      test('declaring both \'entities\' and \'datasets\' is an error', () => {
+        expect(() => fromDocument({
+                 semantic_model: [{
+                   name: 'm',
+                   entities: [{name: 'a', source: 's', fields: []}],
+                   datasets: [{name: 'b', source: 's', fields: []}],
+                 }],
+               }))
+            .toThrow(/set either 'entities' or 'datasets', not both/);
+      });
+
+      test(
+          'a bare-string expression expands to the target-dialect object',
+          () => {
+            const {models} = fromDocument({
+              semantic_model: [{
+                name: 'm',
+                datasets: [{
+                  name: 'a',
+                  source: 'proj.ds.tbl',
+                  primary_key: ['id'],
+                  fields: [{name: 'id', expression: 'id_col'}],
+                }],
+              }],
+            });
+            expect(models[0].entities[0].fields[0].expression).toBe('id_col');
+          });
+
+      test(
+          'a top-level \'deployment_target\' folds into the GOOGLE block form',
+          () => {
+            const sugar = fromDocument({
+              semantic_model: [{
+                name: 'm',
+                deployment_target: URI,
+                datasets: [{
+                  name: 'a',
+                  source: 's',
+                  primary_key: ['id'],
+                  fields: [{name: 'id', expression: 'id'}]
+                }],
+              }],
+            });
+            const explicit = fromDocument({
+              semantic_model: [{
+                name: 'm',
+                custom_extensions: [{
+                  vendor_name: 'GOOGLE',
+                  data: JSON.stringify({deploymentTargets: [URI]})
+                }],
+                datasets: [{
+                  name: 'a',
+                  source: 's',
+                  primary_key: ['id'],
+                  fields: [{name: 'id', expression: 'id'}]
+                }],
+              }],
+            });
+            expect(sugar.models[0].customExtensions)
+                .toEqual(explicit.models[0].customExtensions);
+            expect(sugar.models[0].customExtensions).toEqual([
+              {
+                vendorName: 'GOOGLE',
+                data: JSON.stringify({deploymentTargets: [URI]})
+              },
+            ]);
+          });
+
+      test(
+          '\'deployment_target\' agreeing with a GOOGLE block adds no duplicate',
+          () => {
+            const {models} = fromDocument({
+              semantic_model: [{
+                name: 'm',
+                deployment_target: URI,
+                custom_extensions: [{
+                  vendor_name: 'GOOGLE',
+                  data: JSON.stringify({deploymentTargets: [URI]})
+                }],
+                datasets: [{
+                  name: 'a',
+                  source: 's',
+                  primary_key: ['id'],
+                  fields: [{name: 'id', expression: 'id'}]
+                }],
+              }],
+            });
+            expect(models[0].customExtensions).toEqual([
+              {
+                vendorName: 'GOOGLE',
+                data: JSON.stringify({deploymentTargets: [URI]})
+              },
+            ]);
+          });
+
+      test(
+          '\'deployment_target\' disagreeing with a GOOGLE block is an error',
+          () => {
+            expect(() => fromDocument({
+                     semantic_model: [{
+                       name: 'm',
+                       deployment_target: URI,
+                       custom_extensions: [{
+                         vendor_name: 'GOOGLE',
+                         data: JSON.stringify(
+                             {deploymentTargets: ['//other/target']})
+                       }],
+                       datasets: [{name: 'a', source: 's', fields: []}],
+                     }],
+                   }))
+                .toThrow(/disagrees with the GOOGLE custom_extension/);
+          });
     });
-    expect(models[0].entities.map(e => e.name)).toEqual(['a']);
-    expect(models[0].entities[0].dataSource).toBe('proj.ds.tbl');
-  });
-
-  test("declaring both 'entities' and 'datasets' is an error", () => {
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        entities: [{ name: 'a', source: 's', fields: [] }],
-        datasets: [{ name: 'b', source: 's', fields: [] }],
-      }],
-    })).toThrow(/set either 'entities' or 'datasets', not both/);
-  });
-
-  test('a bare-string expression expands to the target-dialect object', () => {
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{
-          name: 'a', source: 'proj.ds.tbl', primary_key: ['id'],
-          fields: [{ name: 'id', expression: 'id_col' }],
-        }],
-      }],
-    });
-    expect(models[0].entities[0].fields[0].expression).toBe('id_col');
-  });
-
-  test("a top-level 'deployment_target' folds into the GOOGLE block form", () => {
-    const sugar = fromDocument({
-      semantic_model: [{
-        name: 'm', deployment_target: URI,
-        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
-          fields: [{ name: 'id', expression: 'id' }] }],
-      }],
-    });
-    const explicit = fromDocument({
-      semantic_model: [{
-        name: 'm',
-        custom_extensions: [{ vendor_name: 'GOOGLE',
-          data: JSON.stringify({ deploymentTargets: [URI] }) }],
-        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
-          fields: [{ name: 'id', expression: 'id' }] }],
-      }],
-    });
-    expect(sugar.models[0].customExtensions)
-      .toEqual(explicit.models[0].customExtensions);
-    expect(sugar.models[0].customExtensions).toEqual([
-      { vendorName: 'GOOGLE',
-        data: JSON.stringify({ deploymentTargets: [URI] }) },
-    ]);
-  });
-
-  test("'deployment_target' agreeing with a GOOGLE block adds no duplicate", () => {
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm', deployment_target: URI,
-        custom_extensions: [{ vendor_name: 'GOOGLE',
-          data: JSON.stringify({ deploymentTargets: [URI] }) }],
-        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
-          fields: [{ name: 'id', expression: 'id' }] }],
-      }],
-    });
-    expect(models[0].customExtensions).toEqual([
-      { vendorName: 'GOOGLE',
-        data: JSON.stringify({ deploymentTargets: [URI] }) },
-    ]);
-  });
-
-  test("'deployment_target' disagreeing with a GOOGLE block is an error", () => {
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm', deployment_target: URI,
-        custom_extensions: [{ vendor_name: 'GOOGLE',
-          data: JSON.stringify({ deploymentTargets: ['//other/target'] }) }],
-        datasets: [{ name: 'a', source: 's', fields: [] }],
-      }],
-    })).toThrow(/disagrees with the GOOGLE custom_extension/);
-  });
-});
 
 describe('fields may be declared unbound (no physical column)', () => {
   test('an unbound field loads with no expression', () => {
-    const { models } = fromDocument({
+    const {models} = fromDocument({
       semantic_model: [{
         name: 'm',
         datasets: [{
-          name: 'a', source: 's', primary_key: ['id'],
+          name: 'a',
+          source: 's',
+          primary_key: ['id'],
           fields: [
-            { name: 'id', expression: 'id' },
-            { name: 'credit', unbound: true },
+            {name: 'id', expression: 'id'},
+            {name: 'credit', unbound: true},
           ],
         }],
       }],
@@ -1095,23 +1604,35 @@ describe('fields may be declared unbound (no physical column)', () => {
 
   test('a field that is both bound and unbound is an error', () => {
     expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
-          fields: [{ name: 'credit', unbound: true, expression: 'c' }] }],
-      }],
-    })).toThrow(/an unbound field has no column/);
+             semantic_model: [{
+               name: 'm',
+               datasets: [{
+                 name: 'a',
+                 source: 's',
+                 primary_key: ['id'],
+                 fields: [{name: 'credit', unbound: true, expression: 'c'}]
+               }],
+             }],
+           }))
+        .toThrow(/an unbound field has no column/);
   });
 
-  test('a field that is neither bound nor unbound is an error naming the field', () => {
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
-          fields: [{ name: 'credit' }] }],
-      }],
-    })).toThrow(/field 'credit': requires an expression/);
-  });
+  test(
+      'a field that is neither bound nor unbound is an error naming the field',
+      () => {
+        expect(() => fromDocument({
+                 semantic_model: [{
+                   name: 'm',
+                   datasets: [{
+                     name: 'a',
+                     source: 's',
+                     primary_key: ['id'],
+                     fields: [{name: 'credit'}]
+                   }],
+                 }],
+               }))
+            .toThrow(/field 'credit': requires an expression/);
+      });
 });
 
 
@@ -1124,52 +1645,78 @@ describe('a purely logical model loads only under bindingOptional', () => {
     semantic_model: [{
       name: 'm',
       datasets: [{
-        name: 'orders', primary_key: ['id'],
-        fields: [{ name: 'amount' }, { name: 'status' }],
+        name: 'orders',
+        primary_key: ['id'],
+        fields: [{name: 'amount'}, {name: 'status'}],
       }],
     }],
   };
 
-  test('under bindingOptional it loads with an empty source and unbound fields', () => {
-    const { models } = fromDocument(logicalOnly, { bindingOptional: true });
-    const orders = models[0].entities[0];
-    // No source -> empty dataSource (the emitter tolerates this); the fields
-    // carry no expression because there is no binding.
-    expect(orders.dataSource).toBe('');
-    expect(orders.keys).toEqual(['id']);
-    expect(orders.fields.map(f => f.name)).toEqual(['amount', 'status']);
-    expect(orders.fields.every(f => f.expression === undefined)).toBe(true);
-  });
+  test(
+      'under bindingOptional it loads with an empty source and unbound fields',
+      () => {
+        const {models} = fromDocument(logicalOnly, {bindingOptional: true});
+        const orders = models[0].entities[0];
+        // No source -> empty dataSource (the emitter tolerates this); the
+        // fields carry no expression because there is no binding.
+        expect(orders.dataSource).toBe('');
+        expect(orders.keys).toEqual(['id']);
+        expect(orders.fields.map(f => f.name)).toEqual(['amount', 'status']);
+        expect(orders.fields.every(f => f.expression === undefined)).toBe(true);
+      });
 
-  test('without bindingOptional the same model fails for the missing source and expression', () => {
-    let message = '';
-    try {
-      fromDocument(logicalOnly);
-    } catch (e: any) {
-      message = String(e.message ?? e);
-    }
-    // Both binding-completeness checks fire in the default (strict) mode.
-    expect(message).toContain("dataset 'orders': a non-abstract dataset requires a source");
-    expect(message).toContain("field 'amount': requires an expression");
-  });
+  test(
+      'without bindingOptional the same model fails for the missing source and expression',
+      () => {
+        let message = '';
+        try {
+          fromDocument(logicalOnly);
+        } catch (e: any) {
+          message = String(e.message ?? e);
+        }
+        // Both binding-completeness checks fire in the default (strict) mode.
+        expect(message).toContain(
+            'dataset \'orders\': a non-abstract dataset requires a source');
+        expect(message).toContain('field \'amount\': requires an expression');
+      });
 
-  test('bindingOptional still rejects an unbound field that also has an expression', () => {
-    // The contradiction check is independent of binding-completeness, so it
-    // fires even when a source/expression is otherwise optional.
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'a', fields: [{ name: 'c', unbound: true, expression: 'c' }] }],
-      }],
-    }, { bindingOptional: true })).toThrow(/an unbound field has no column/);
-  });
+  test(
+      'bindingOptional still rejects an unbound field that also has an expression',
+      () => {
+        // The contradiction check is independent of binding-completeness, so it
+        // fires even when a source/expression is otherwise optional.
+        expect(
+            () => fromDocument(
+                {
+                  semantic_model: [{
+                    name: 'm',
+                    datasets: [{
+                      name: 'a',
+                      fields: [{name: 'c', unbound: true, expression: 'c'}]
+                    }],
+                  }],
+                },
+                {bindingOptional: true}))
+            .toThrow(/an unbound field has no column/);
+      });
 
-  test('bindingOptional still rejects an abstract dataset that also names a source', () => {
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'Party', abstract: true, source: 'p.d.party', fields: [] }],
-      }],
-    }, { bindingOptional: true })).toThrow(/an abstract dataset has no table/);
-  });
+  test(
+      'bindingOptional still rejects an abstract dataset that also names a source',
+      () => {
+        expect(
+            () => fromDocument(
+                {
+                  semantic_model: [{
+                    name: 'm',
+                    datasets: [{
+                      name: 'Party',
+                      abstract: true,
+                      source: 'p.d.party',
+                      fields: []
+                    }],
+                  }],
+                },
+                {bindingOptional: true}))
+            .toThrow(/an abstract dataset has no table/);
+      });
 });

--- a/toolbox/mdcode/tests/libts/semantic/resolve_profiles.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/resolve_profiles.test.ts
@@ -2,8 +2,8 @@
 // (src/libts/semantic/resolve_profiles.ts): mergeProfile overlays a profile's
 // physical bindings onto a logical model by name and enforces the binding-only
 // contract; pruneUnavailable drops what a binding cannot answer and reports it.
-// Builders are minimal literals in the readable authoring form (mergeProfile) or
-// the IR (pruneUnavailable), mirroring resolve_inheritance.test.ts.
+// Builders are minimal literals in the readable authoring form (mergeProfile)
+// or the IR (pruneUnavailable), mirroring resolve_inheritance.test.ts.
 
 import {describe, expect, test} from 'bun:test';
 
@@ -41,8 +41,11 @@ function logicalDoc(): any {
         },
       ],
       relationships: [{
-        name: 'PlacedBy', from: 'Order', to: 'Customer',
-        from_columns: ['customerKey'], to_columns: ['key'],
+        name: 'PlacedBy',
+        from: 'Order',
+        to: 'Customer',
+        from_columns: ['customerKey'],
+        to_columns: ['key'],
       }],
       metrics: [
         {name: 'order_count', expression: 'COUNT(Order.key)'},
@@ -52,8 +55,8 @@ function logicalDoc(): any {
   };
 }
 
-// The analytical binding: BigQuery sources, lifetimeValue bound, availableCredit
-// explicitly unbound.
+// The analytical binding: BigQuery sources, lifetimeValue bound,
+// availableCredit explicitly unbound.
 function analyticalDoc(): any {
   return {
     semantic_model: [{
@@ -86,15 +89,16 @@ function analyticalDoc(): any {
 
 const modelOf = (doc: any) => doc.semantic_model[0];
 const entityOf = (doc: any, name: string) =>
-    (modelOf(doc).entities ?? modelOf(doc).datasets).find(
-        (e: any) => e.name === name);
+    (modelOf(doc).entities ?? modelOf(doc).datasets)
+        .find((e: any) => e.name === name);
 const fieldOf = (doc: any, entity: string, field: string) =>
     entityOf(doc, entity).fields.find((f: any) => f.name === field);
 
 
 describe('mergeProfile overlays physical bindings by name', () => {
   test('applies source and expression, preserving logical facets', () => {
-    const {doc, error} = mergeProfile(logicalDoc(), analyticalDoc(), 'analytical');
+    const {doc, error} =
+        mergeProfile(logicalDoc(), analyticalDoc(), 'analytical');
     expect(error).toBeUndefined();
     expect(entityOf(doc, 'Customer').source).toBe(TBL('customer'));
     const key = fieldOf(doc, 'Customer', 'key');
@@ -114,8 +118,8 @@ describe('mergeProfile overlays physical bindings by name', () => {
     const profile = analyticalDoc();
     // Drop availableCredit entirely from the profile (silent omission).
     entityOf(profile, 'Customer').fields =
-        entityOf(profile, 'Customer').fields.filter(
-            (f: any) => f.name !== 'availableCredit');
+        entityOf(profile, 'Customer')
+            .fields.filter((f: any) => f.name !== 'availableCredit');
     const {doc, error} = mergeProfile(logicalDoc(), profile, 'analytical');
     expect(error).toBeUndefined();
     expect(fieldOf(doc, 'Customer', 'availableCredit').unbound).toBe(true);
@@ -172,7 +176,9 @@ function irModel(): SemanticModel {
     name: 'commerce',
     entities: [
       {
-        name: 'Customer', dataSource: 'p.d.customer', keys: ['key'],
+        name: 'Customer',
+        dataSource: 'p.d.customer',
+        keys: ['key'],
         fields: [
           {name: 'key', expression: 'c_custkey'},
           {name: 'name', expression: 'c_name'},
@@ -180,7 +186,9 @@ function irModel(): SemanticModel {
         ],
       },
       {
-        name: 'Order', dataSource: 'p.d.orders', keys: ['key'],
+        name: 'Order',
+        dataSource: 'p.d.orders',
+        keys: ['key'],
         fields: [
           {name: 'key', expression: 'o_orderkey'},
           {name: 'customerKey', expression: 'o_custkey'},
@@ -196,7 +204,8 @@ function irModel(): SemanticModel {
       {name: 'order_count', expression: 'COUNT(Order.key)', entity: 'Order'},
       {
         name: 'avg_lifetime_value',
-        expression: 'AVG(Customer.lifetimeValue)', entity: 'Customer',
+        expression: 'AVG(Customer.lifetimeValue)',
+        entity: 'Customer',
       },
     ],
   };
@@ -218,8 +227,8 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
   test('a metric that reads an unbound field is dropped and reported', () => {
     const {model, report} = pruneUnavailable(irModel(), 'operational');
     expect(metricNames(model)).toEqual(['order_count']);
-    const dropped = report.droppedMetrics.find(
-        d => d.name === 'avg_lifetime_value');
+    const dropped =
+        report.droppedMetrics.find(d => d.name === 'avg_lifetime_value');
     expect(dropped?.reason).toMatch(/Customer\.lifetimeValue/);
   });
 
@@ -236,9 +245,8 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
   test('a relationship drops when a join field is unbound', () => {
     const m = irModel();
     // Unbind the FK field the relationship joins on.
-    const customerKey =
-        m.entities.find(e => e.name === 'Order')!.fields.find(
-            f => f.name === 'customerKey')!;
+    const customerKey = m.entities.find(e => e.name === 'Order')!.fields.find(
+        f => f.name === 'customerKey')!;
     customerKey.unbound = true;
     delete customerKey.expression;
     const {model, report} = pruneUnavailable(m, 'operational');
@@ -253,41 +261,86 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
     expect(JSON.stringify(m)).toBe(before);
   });
 
-  test('a field carrying only an imported (untranspiled) expression is bound', () => {
-    // A vendor-dialect field's column lives on `importedExpression` until
-    // transpilation fills `expression`. It is bound -- it names a column -- so
-    // pruning must not mistake it for unbound and drop it (or its metric).
-    const m = irModel();
-    const ltv = m.entities.find(e => e.name === 'Customer')!.fields.find(
-        f => f.name === 'lifetimeValue')!;
-    delete ltv.unbound;
-    delete ltv.expression;
-    ltv.importedExpression = 'c_ltv';
-    ltv.importedDialect = 'SNOWFLAKE';
-    const {model, report} = pruneUnavailable(m, 'operational');
-    expect(fieldNames(model, 'Customer')).toContain('lifetimeValue');
-    expect(report.unboundFields).not.toContain('Customer.lifetimeValue');
-    expect(metricNames(model)).toContain('avg_lifetime_value');
-  });
+  test(
+      'a field carrying only an imported (untranspiled) expression is bound',
+      () => {
+        // A vendor-dialect field's column lives on `importedExpression` until
+        // transpilation fills `expression`. It is bound -- it names a column --
+        // so pruning must not mistake it for unbound and drop it (or its
+        // metric).
+        const m = irModel();
+        const ltv = m.entities.find(e => e.name === 'Customer')!.fields.find(
+            f => f.name === 'lifetimeValue')!;
+        delete ltv.unbound;
+        delete ltv.expression;
+        ltv.importedExpression = 'c_ltv';
+        ltv.importedDialect = 'SNOWFLAKE';
+        const {model, report} = pruneUnavailable(m, 'operational');
+        expect(fieldNames(model, 'Customer')).toContain('lifetimeValue');
+        expect(report.unboundFields).not.toContain('Customer.lifetimeValue');
+        expect(metricNames(model)).toContain('avg_lifetime_value');
+      });
 
-  test('an unbound KEY field drops the whole entity and everything on it', () => {
-    // A graph node must be keyed, so unbinding a key field makes the entire
-    // entity unavailable; the relationship into it and the metric over it fall
-    // with it, while the other entity survives.
-    const m = irModel();
-    const key = m.entities.find(e => e.name === 'Customer')!.fields.find(
-        f => f.name === 'key')!;
-    key.unbound = true;
-    delete key.expression;
-    const {model, report} = pruneUnavailable(m, 'operational');
-    expect(model.entities.map(e => e.name)).toEqual(['Order']);
-    expect(report.droppedEntities.map(d => d.name)).toEqual(['Customer']);
-    expect(report.droppedEntities[0].reason).toMatch(/key field key is unbound/);
-    // The relationship into Customer and the metric over it are gone; a metric
-    // confined to the surviving entity stays.
-    expect(relNames(model)).toEqual([]);
-    expect(report.droppedRelationships[0].reason).toMatch(/Customer is unavailable/);
-    expect(metricNames(model)).toEqual(['order_count']);
-    expect(report.droppedMetrics.map(d => d.name)).toContain('avg_lifetime_value');
-  });
+  test(
+      'an unbound KEY field drops the whole entity and everything on it',
+      () => {
+        // A graph node must be keyed, so unbinding a key field makes the entire
+        // entity unavailable; the relationship into it and the metric over it
+        // fall with it, while the other entity survives.
+        const m = irModel();
+        const key = m.entities.find(e => e.name === 'Customer')!.fields.find(
+            f => f.name === 'key')!;
+        key.unbound = true;
+        delete key.expression;
+        const {model, report} = pruneUnavailable(m, 'operational');
+        expect(model.entities.map(e => e.name)).toEqual(['Order']);
+        expect(report.droppedEntities.map(d => d.name)).toEqual(['Customer']);
+        expect(report.droppedEntities[0].reason)
+            .toMatch(/key field key is unbound/);
+        // The relationship into Customer and the metric over it are gone; a
+        // metric confined to the surviving entity stays.
+        expect(relNames(model)).toEqual([]);
+        expect(report.droppedRelationships[0].reason)
+            .toMatch(/Customer is unavailable/);
+        expect(metricNames(model)).toEqual(['order_count']);
+        expect(report.droppedMetrics.map(d => d.name))
+            .toContain('avg_lifetime_value');
+      });
+
+  test(
+      'an abstract supertype survives pruning with its field names intact',
+      () => {
+        // An abstract entity has no table and no bindings by design: its fields
+        // are column-less on purpose (they name the label its subtypes bind).
+        // Pruning must NOT treat them as "unbound" and drop the entity for its
+        // unbound key, or the shared label loses the signature the emitter
+        // reads.
+        const m: SemanticModel = {
+      name: 'parties',
+      entities: [
+        {
+          name: 'Party', dataSource: '', keys: ['id'], abstract: true,
+          fields: [{name: 'id'}, {name: 'name'}],
+        },
+        {
+          name: 'Customer', dataSource: 'proj.ds.customer', keys: ['id'],
+          extends: ['Party'],
+          fields: [
+            {name: 'id', expression: 'c_custkey'},
+            {name: 'name', expression: 'c_name'},
+          ],
+        },
+      ],
+      relationships: [],
+      metrics: [],
+    };
+        const {model, report} = pruneUnavailable(m, 'default');
+        // Party is kept, not dropped, and its field names remain.
+        expect(model.entities.map(e => e.name)).toEqual(['Party', 'Customer']);
+        expect(report.droppedEntities).toEqual([]);
+        const party = model.entities.find(e => e.name === 'Party')!;
+        expect(party.fields.map(f => f.name)).toEqual(['id', 'name']);
+        // Its column-less fields are not reported as unbound.
+        expect(report.unboundFields).toEqual([]);
+      });
 });

--- a/toolbox/mdcode/tests/libts/semantic/resolve_profiles.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/resolve_profiles.test.ts
@@ -2,8 +2,8 @@
 // (src/libts/semantic/resolve_profiles.ts): mergeProfile overlays a profile's
 // physical bindings onto a logical model by name and enforces the binding-only
 // contract; pruneUnavailable drops what a binding cannot answer and reports it.
-// Builders are minimal literals in the readable authoring form (mergeProfile)
-// or the IR (pruneUnavailable), mirroring resolve_inheritance.test.ts.
+// Builders are minimal literals in the readable authoring form (mergeProfile) or
+// the IR (pruneUnavailable), mirroring resolve_inheritance.test.ts.
 
 import {describe, expect, test} from 'bun:test';
 
@@ -41,11 +41,8 @@ function logicalDoc(): any {
         },
       ],
       relationships: [{
-        name: 'PlacedBy',
-        from: 'Order',
-        to: 'Customer',
-        from_columns: ['customerKey'],
-        to_columns: ['key'],
+        name: 'PlacedBy', from: 'Order', to: 'Customer',
+        from_columns: ['customerKey'], to_columns: ['key'],
       }],
       metrics: [
         {name: 'order_count', expression: 'COUNT(Order.key)'},
@@ -55,8 +52,8 @@ function logicalDoc(): any {
   };
 }
 
-// The analytical binding: BigQuery sources, lifetimeValue bound,
-// availableCredit explicitly unbound.
+// The analytical binding: BigQuery sources, lifetimeValue bound, availableCredit
+// explicitly unbound.
 function analyticalDoc(): any {
   return {
     semantic_model: [{
@@ -89,16 +86,15 @@ function analyticalDoc(): any {
 
 const modelOf = (doc: any) => doc.semantic_model[0];
 const entityOf = (doc: any, name: string) =>
-    (modelOf(doc).entities ?? modelOf(doc).datasets)
-        .find((e: any) => e.name === name);
+    (modelOf(doc).entities ?? modelOf(doc).datasets).find(
+        (e: any) => e.name === name);
 const fieldOf = (doc: any, entity: string, field: string) =>
     entityOf(doc, entity).fields.find((f: any) => f.name === field);
 
 
 describe('mergeProfile overlays physical bindings by name', () => {
   test('applies source and expression, preserving logical facets', () => {
-    const {doc, error} =
-        mergeProfile(logicalDoc(), analyticalDoc(), 'analytical');
+    const {doc, error} = mergeProfile(logicalDoc(), analyticalDoc(), 'analytical');
     expect(error).toBeUndefined();
     expect(entityOf(doc, 'Customer').source).toBe(TBL('customer'));
     const key = fieldOf(doc, 'Customer', 'key');
@@ -118,8 +114,8 @@ describe('mergeProfile overlays physical bindings by name', () => {
     const profile = analyticalDoc();
     // Drop availableCredit entirely from the profile (silent omission).
     entityOf(profile, 'Customer').fields =
-        entityOf(profile, 'Customer')
-            .fields.filter((f: any) => f.name !== 'availableCredit');
+        entityOf(profile, 'Customer').fields.filter(
+            (f: any) => f.name !== 'availableCredit');
     const {doc, error} = mergeProfile(logicalDoc(), profile, 'analytical');
     expect(error).toBeUndefined();
     expect(fieldOf(doc, 'Customer', 'availableCredit').unbound).toBe(true);
@@ -176,9 +172,7 @@ function irModel(): SemanticModel {
     name: 'commerce',
     entities: [
       {
-        name: 'Customer',
-        dataSource: 'p.d.customer',
-        keys: ['key'],
+        name: 'Customer', dataSource: 'p.d.customer', keys: ['key'],
         fields: [
           {name: 'key', expression: 'c_custkey'},
           {name: 'name', expression: 'c_name'},
@@ -186,9 +180,7 @@ function irModel(): SemanticModel {
         ],
       },
       {
-        name: 'Order',
-        dataSource: 'p.d.orders',
-        keys: ['key'],
+        name: 'Order', dataSource: 'p.d.orders', keys: ['key'],
         fields: [
           {name: 'key', expression: 'o_orderkey'},
           {name: 'customerKey', expression: 'o_custkey'},
@@ -204,8 +196,7 @@ function irModel(): SemanticModel {
       {name: 'order_count', expression: 'COUNT(Order.key)', entity: 'Order'},
       {
         name: 'avg_lifetime_value',
-        expression: 'AVG(Customer.lifetimeValue)',
-        entity: 'Customer',
+        expression: 'AVG(Customer.lifetimeValue)', entity: 'Customer',
       },
     ],
   };
@@ -227,8 +218,8 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
   test('a metric that reads an unbound field is dropped and reported', () => {
     const {model, report} = pruneUnavailable(irModel(), 'operational');
     expect(metricNames(model)).toEqual(['order_count']);
-    const dropped =
-        report.droppedMetrics.find(d => d.name === 'avg_lifetime_value');
+    const dropped = report.droppedMetrics.find(
+        d => d.name === 'avg_lifetime_value');
     expect(dropped?.reason).toMatch(/Customer\.lifetimeValue/);
   });
 
@@ -245,8 +236,9 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
   test('a relationship drops when a join field is unbound', () => {
     const m = irModel();
     // Unbind the FK field the relationship joins on.
-    const customerKey = m.entities.find(e => e.name === 'Order')!.fields.find(
-        f => f.name === 'customerKey')!;
+    const customerKey =
+        m.entities.find(e => e.name === 'Order')!.fields.find(
+            f => f.name === 'customerKey')!;
     customerKey.unbound = true;
     delete customerKey.expression;
     const {model, report} = pruneUnavailable(m, 'operational');
@@ -261,61 +253,50 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
     expect(JSON.stringify(m)).toBe(before);
   });
 
-  test(
-      'a field carrying only an imported (untranspiled) expression is bound',
-      () => {
-        // A vendor-dialect field's column lives on `importedExpression` until
-        // transpilation fills `expression`. It is bound -- it names a column --
-        // so pruning must not mistake it for unbound and drop it (or its
-        // metric).
-        const m = irModel();
-        const ltv = m.entities.find(e => e.name === 'Customer')!.fields.find(
-            f => f.name === 'lifetimeValue')!;
-        delete ltv.unbound;
-        delete ltv.expression;
-        ltv.importedExpression = 'c_ltv';
-        ltv.importedDialect = 'SNOWFLAKE';
-        const {model, report} = pruneUnavailable(m, 'operational');
-        expect(fieldNames(model, 'Customer')).toContain('lifetimeValue');
-        expect(report.unboundFields).not.toContain('Customer.lifetimeValue');
-        expect(metricNames(model)).toContain('avg_lifetime_value');
-      });
+  test('a field carrying only an imported (untranspiled) expression is bound', () => {
+    // A vendor-dialect field's column lives on `importedExpression` until
+    // transpilation fills `expression`. It is bound -- it names a column -- so
+    // pruning must not mistake it for unbound and drop it (or its metric).
+    const m = irModel();
+    const ltv = m.entities.find(e => e.name === 'Customer')!.fields.find(
+        f => f.name === 'lifetimeValue')!;
+    delete ltv.unbound;
+    delete ltv.expression;
+    ltv.importedExpression = 'c_ltv';
+    ltv.importedDialect = 'SNOWFLAKE';
+    const {model, report} = pruneUnavailable(m, 'operational');
+    expect(fieldNames(model, 'Customer')).toContain('lifetimeValue');
+    expect(report.unboundFields).not.toContain('Customer.lifetimeValue');
+    expect(metricNames(model)).toContain('avg_lifetime_value');
+  });
 
-  test(
-      'an unbound KEY field drops the whole entity and everything on it',
-      () => {
-        // A graph node must be keyed, so unbinding a key field makes the entire
-        // entity unavailable; the relationship into it and the metric over it
-        // fall with it, while the other entity survives.
-        const m = irModel();
-        const key = m.entities.find(e => e.name === 'Customer')!.fields.find(
-            f => f.name === 'key')!;
-        key.unbound = true;
-        delete key.expression;
-        const {model, report} = pruneUnavailable(m, 'operational');
-        expect(model.entities.map(e => e.name)).toEqual(['Order']);
-        expect(report.droppedEntities.map(d => d.name)).toEqual(['Customer']);
-        expect(report.droppedEntities[0].reason)
-            .toMatch(/key field key is unbound/);
-        // The relationship into Customer and the metric over it are gone; a
-        // metric confined to the surviving entity stays.
-        expect(relNames(model)).toEqual([]);
-        expect(report.droppedRelationships[0].reason)
-            .toMatch(/Customer is unavailable/);
-        expect(metricNames(model)).toEqual(['order_count']);
-        expect(report.droppedMetrics.map(d => d.name))
-            .toContain('avg_lifetime_value');
-      });
+  test('an unbound KEY field drops the whole entity and everything on it', () => {
+    // A graph node must be keyed, so unbinding a key field makes the entire
+    // entity unavailable; the relationship into it and the metric over it fall
+    // with it, while the other entity survives.
+    const m = irModel();
+    const key = m.entities.find(e => e.name === 'Customer')!.fields.find(
+        f => f.name === 'key')!;
+    key.unbound = true;
+    delete key.expression;
+    const {model, report} = pruneUnavailable(m, 'operational');
+    expect(model.entities.map(e => e.name)).toEqual(['Order']);
+    expect(report.droppedEntities.map(d => d.name)).toEqual(['Customer']);
+    expect(report.droppedEntities[0].reason).toMatch(/key field key is unbound/);
+    // The relationship into Customer and the metric over it are gone; a metric
+    // confined to the surviving entity stays.
+    expect(relNames(model)).toEqual([]);
+    expect(report.droppedRelationships[0].reason).toMatch(/Customer is unavailable/);
+    expect(metricNames(model)).toEqual(['order_count']);
+    expect(report.droppedMetrics.map(d => d.name)).toContain('avg_lifetime_value');
+  });
 
-  test(
-      'an abstract supertype survives pruning with its field names intact',
-      () => {
-        // An abstract entity has no table and no bindings by design: its fields
-        // are column-less on purpose (they name the label its subtypes bind).
-        // Pruning must NOT treat them as "unbound" and drop the entity for its
-        // unbound key, or the shared label loses the signature the emitter
-        // reads.
-        const m: SemanticModel = {
+  test('an abstract supertype survives pruning with its field names intact', () => {
+    // An abstract entity has no table and no bindings by design: its fields are
+    // column-less on purpose (they name the label its subtypes bind). Pruning
+    // must NOT treat them as "unbound" and drop the entity for its unbound key,
+    // or the shared label loses the signature the emitter reads.
+    const m: SemanticModel = {
       name: 'parties',
       entities: [
         {
@@ -334,13 +315,13 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
       relationships: [],
       metrics: [],
     };
-        const {model, report} = pruneUnavailable(m, 'default');
-        // Party is kept, not dropped, and its field names remain.
-        expect(model.entities.map(e => e.name)).toEqual(['Party', 'Customer']);
-        expect(report.droppedEntities).toEqual([]);
-        const party = model.entities.find(e => e.name === 'Party')!;
-        expect(party.fields.map(f => f.name)).toEqual(['id', 'name']);
-        // Its column-less fields are not reported as unbound.
-        expect(report.unboundFields).toEqual([]);
-      });
+    const {model, report} = pruneUnavailable(m, 'default');
+    // Party is kept, not dropped, and its field names remain.
+    expect(model.entities.map(e => e.name)).toEqual(['Party', 'Customer']);
+    expect(report.droppedEntities).toEqual([]);
+    const party = model.entities.find(e => e.name === 'Party')!;
+    expect(party.fields.map(f => f.name)).toEqual(['id', 'name']);
+    // Its column-less fields are not reported as unbound.
+    expect(report.unboundFields).toEqual([]);
+  });
 });


### PR DESCRIPTION
## What

Adds `toolbox/mdcode/docs/semantic-model/inheritance.md`, a topic page peer to `profiles.md` and `owl-import.md` that walks through modeling a subtype hierarchy with `extends`:

- declaring an abstract supertype and its subtypes,
- binding each subtype's table so it exposes the inherited columns,
- querying the supertype,
- extending more than one supertype,
- matching the model to how the data is actually stored (table-per-kind vs. single-table vs. base+extension),
- diagnosing and fixing a supertype count that doubles.

The reference already lists the exact generation rules (`reference.md` → *Class hierarchies*); this page is the step-by-step modeling guide and defers to the reference for the rules `push` enforces.

## Wiring

- Added a row to the README "rest of the guide" index.
- Expanded the README `extends` mention to link the new page.
- Cross-linked from the reference's class-hierarchies section back to the modeling guide.

## Notes

Docs only. Draft — please review before merge.