### PR TITLE
feat(mdcode): tighten the semantic-model spec (version gating, fail-fast, unbound-by-omission)

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -82,7 +82,7 @@ business and nothing physical — the entities, their fields, the relationships
 between them, and the metrics computed over them:
 
 ```yaml
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 
 semantic_model:
   - name: sales                      # keep equal to the <model>.yaml filename (pull round-trips to that name)
@@ -111,7 +111,7 @@ semantic_model:
 Field and relationship names are the business vocabulary — `order_id`,
 `placed_by` — never physical column names; the physical binding comes later. A
 metric's `expression` may be a bare formula over the logical fields or the fuller
-per-dialect form. `entities` may also be written `datasets`.
+per-dialect form. `entities` may also be written `datasets` (the two are interchangeable under the `/google` version).
 
 Entities can **extend** other entities (`extends: [Parent]`); push flattens the
 supertype's fields down and expresses the hierarchy as graph labels, so a query
@@ -210,8 +210,9 @@ than one deployment target is rejected at push time (see
 
 For a model that serves more than one store, the target belongs to a
 [binding profile](profiles.md) rather than the model. `deployment_target` is a
-resource URI; it may also be written inside a `GOOGLE` custom extension, and both
-forms mean the same thing.
+resource URI and a native key under the extended `0.2.0.dev0/google` profile; under
+vanilla Ossie the same target is written inside a `GOOGLE` custom extension instead
+(see [model spec §6](model_spec.md#6-the-extension-mechanism)).
 
 ### Table sources
 
@@ -322,7 +323,7 @@ your authored document as the source of truth.
 
 Already have an OWL ontology? `kcmd owl import` converts it into a semantic model
 once — classes → entities, object properties → relationships, datatype
-properties → fields. The converted model is **unbound** (placeholder sources, no
+properties → fields. The converted model is **unbound** (no sources, no
 deployment target), so bind each entity's `source`, fill the relationship join
 columns, and add a deployment target before `kcmd push` will deploy it — then it
 rides the normal push / pull above. See [Importing an OWL ontology](owl-import.md).

--- a/toolbox/mdcode/docs/semantic-model/codelab.md
+++ b/toolbox/mdcode/docs/semantic-model/codelab.md
@@ -61,7 +61,7 @@ relationships between them, and the metric:
 
 ```bash
 cat > catalog/EntryGroups/$DATASET/sales.yaml <<'YAML'
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: sales
     description: Orders, line items, and customers for the codelab
@@ -247,11 +247,11 @@ cat /tmp/sales_osi.yaml
 ```
 
 ```yaml
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
     description: Imported from OWL ontology http://example.com/sales#
-    datasets:
+    entities:
       - name: orders
         primary_key: [order_id]
         description: A customer order
@@ -278,9 +278,9 @@ semantic_model:
 
 This is the hand-authored `sales` model above, reproduced from the ontology: the
 same three entities, the same fields and datatypes, the same primary keys, and
-the same two relationships. (The importer writes entities under `datasets:`, the
-original spelling of the `entities:` key this codelab uses — the two are
-interchangeable.)
+the same two relationships. (The importer emits the extended profile — `entities:`
+under `version: 0.2.0.dev0/google` — the same spelling this codelab's hand-authored
+model uses.)
 
 Two things from the hand-authored model are missing, and both are inherent —
 an ontology has no way to state either:
@@ -394,7 +394,7 @@ TARGET=//bigquery.googleapis.com/$BQ_DS/propertyGraphs/$GRAPH
 
 mkdir -p catalog/EntryGroups/$DATASET/sales.profiles
 cat > catalog/EntryGroups/$DATASET/sales.profiles/analytical.yaml <<YAML
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: sales
     deployment_target: $TARGET
@@ -700,7 +700,7 @@ SPANNER_TARGET=//spanner.googleapis.com/projects/$PROJECT/instances/$SPANNER_INS
 
 mkdir -p catalog/EntryGroups/$DATASET/sales.profiles
 cat > catalog/EntryGroups/$DATASET/sales.profiles/operational.yaml <<YAML
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: sales
     deployment_target: $SPANNER_TARGET
@@ -710,7 +710,7 @@ semantic_model:
         fields:
           - { name: order_id,    expression: OrderId }
           - { name: customer_id, expression: CustomerId }
-          - { name: net_amount,  unbound: true }   # the operational store has no settled total
+          # net_amount is omitted -> unbound: the operational store has no settled total
       - name: customer
         source: Customers
         fields:
@@ -926,7 +926,7 @@ line up under the shared label by that name:
 
 ```bash
 cat > catalog/EntryGroups/$DATASET/sales.yaml <<'YAML'
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: sales
     description: Orders, line items, and customers for the codelab
@@ -999,7 +999,7 @@ its `party` label reads. Rewrite the profile to include `supplier`:
 
 ```bash
 cat > catalog/EntryGroups/$DATASET/sales.profiles/analytical.yaml <<YAML
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: sales
     deployment_target: $TARGET

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -74,17 +74,14 @@ agree on every structural row and differ only where a Spanner target has no
    metadata — BigQuery silently drops graph-statement `OPTIONS`, and Spanner
    carries no `OPTIONS` at all — so the model's `description` and
    `ai_context.instructions` are carried into Knowledge Catalog instead.
-9. **OWL and other custom extensions.** Every other `custom_extensions` block —
-   most notably the OWL constructs the importer carries with no native home yet
-   (`owl:inverseOf`, `owl:oneOf`, `rdfs:subPropertyOf`, `owl:propertyChainAxiom`,
-   the equivalence and disjointness pairs, the set-level axioms
-   `owl:AllDisjointClasses` / `owl:AllDisjointProperties` / `owl:AllDifferent`,
-   the property characteristics, `owl:deprecated` / `owl:versionInfo`, …) — is
-   inert on push and not persisted to Knowledge Catalog, so `pull` never recovers
-   it. It does survive the OSI *document* round-trip verbatim, so it stays intact
-   in your authored file. See
-   [Constructs carried as custom extensions](owl-import.md#constructs-carried-as-custom-extensions-not-yet-native)
-   for the full list and shape.
+9. **Other custom extensions.** Under the vanilla `0.2.0.dev0` profile a
+   `custom_extensions` block (other than a GOOGLE deployment target) is the only
+   carrier for vendor metadata; it is inert on push and not persisted to
+   Knowledge Catalog, so `pull` never recovers it. `pull` also emits the extended
+   `0.2.0.dev0/google` profile, which has no `custom_extensions` carrier, so such
+   a block is not re-serialized either — keep your authored file. The OWL importer
+   emits none: it is import-only (see [Importing an OWL
+   ontology](owl-import.md)).
 10. **Logical (unbound) model.** A model with no bindings still publishes to
     Knowledge Catalog: each entity's `source` is recorded empty (`resources: []`)
     because there is no table behind it, and a relationship that carries no join

--- a/toolbox/mdcode/docs/semantic-model/inheritance.md
+++ b/toolbox/mdcode/docs/semantic-model/inheritance.md
@@ -44,7 +44,7 @@ Each concrete kind declares its own fields and the one `extends` keyword. The
 supertype's fields are inherited, so you do not repeat them:
 
 ```yaml
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: parties
     entities:

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -16,24 +16,43 @@ is the authority on what the tool then does.
 ## 1. Status and baseline
 
 The format is **`kcmd`'s profile of [Apache Ossie](https://ossie.apache.org/)**,
-pinned to Ossie version **`0.2.0.dev0`**. Ossie is the open semantic-model format:
+built on Ossie version **`0.2.0.dev0`**. Ossie is the open semantic-model format:
 it describes a business — datasets, fields, relationships, metrics — *and* binds
 each dataset to a `source` table and each field to a column `expression`. What
-Ossie does not describe is where a model then deploys. This profile is a superset:
-it adds that deployment layer and a few modeling constructs, and it relaxes a few
-of Ossie's required fields so a model can stay purely logical.
+Ossie does not describe is where a model then deploys. `kcmd` adds that deployment
+layer and a few modeling constructs, and it relaxes a few of Ossie's required
+fields so a model can stay purely logical.
 
-The compatibility contract runs in both directions, and they are not symmetric:
+Those additions come in **two versions**, and a document picks one with its
+top-level `version` (see [Version handling](#1-status-and-baseline)):
+
+- **`0.2.0.dev0`** — **vanilla Ossie**. `kcmd`'s additions ride in Ossie's own
+  `custom_extensions` carrier ([§6](#6-the-extension-mechanism)); the native
+  extension keys are not accepted. This profile is a strict superset of Ossie:
+  strip the `GOOGLE` extension blocks and it is a plain Ossie document.
+- **`0.2.0.dev0/google`** — the **extended profile**. The same additions are
+  first-class native keys (`entities`, `deployment_target`, `extends`,
+  `abstract`); the `custom_extensions` carrier is not accepted, because there is
+  nothing left for it to carry. This profile is readable, but not a vanilla-Ossie
+  document — an Ossie-only reader knows neither its version nor its native keys.
+
+The two are the same model written two ways; both parse to the identical IR, so no
+downstream leg sees which was used.
+
+Ossie compatibility is a property of the **vanilla** version, and the contract
+runs in both directions:
 
 > **Every Ossie `0.2.0.dev0` document is a valid `kcmd` model.** The reverse holds
-> for a `kcmd` model that uses no extensions ([§5](#5-extensions)) *and* no
-> relaxations ([§4](#4-narrowings-and-relaxations)) — i.e. a fully-bound model with only Ossie
-> constructs. Strip the extensions from such a model and it is a valid Ossie
-> document.
+> for a vanilla `kcmd` model that uses no extensions ([§5](#5-extensions)) *and* no
+> relaxations ([§4](#4-narrowings-and-relaxations)) — a fully-bound model with only
+> Ossie constructs. Strip the `GOOGLE` `custom_extensions` blocks from such a model
+> and it is a valid Ossie document.
 
-The goal is full Ossie compatibility. Every `kcmd`-specific construct is carried
-in a way an Ossie-only tool ignores (see [§6](#6-the-extension-mechanism)), so the
-two never fork the document.
+Under vanilla, every `kcmd`-specific construct rides in a `custom_extensions` block
+an Ossie-only tool ignores (see [§6](#6-the-extension-mechanism)), so the two never
+fork the document. The extended `0.2.0.dev0/google` profile trades that wire
+compatibility for readable native keys; it is `kcmd`'s own surface, converted to or
+from vanilla by choosing the `version`.
 
 **How to read this document.** This is a *delta* against the Ossie spec. It does
 not restate constructs `kcmd` adopts unchanged — for those, the Ossie spec is
@@ -52,10 +71,13 @@ defines it.
 at load or validation time; the exact operational effect (hard error, skip with a
 warning) is in [Reference → Validation](reference.md#validation).
 
-**Version handling.** `version` is optional and lives at the top of the document
-(not inside a model). A document whose `version` differs from `0.2.0.dev0` loads
-anyway with a warning; the profile does not gate on it. Authored documents SHOULD
-set `version: "0.2.0.dev0"`.
+**Version handling.** `version` is **required** and lives at the top of the
+document (not inside a model). It MUST be one of two values: `0.2.0.dev0` (vanilla
+Ossie) or `0.2.0.dev0/google` (the extended profile). A missing or unrecognized
+`version` is a **hard load error**, not a warning — the value selects which
+extension surface is legal ([§6](#6-the-extension-mechanism)), so it cannot be
+guessed. `kcmd`'s own tools (pull, the OWL importer) emit `0.2.0.dev0/google`;
+hand-authored portable models SHOULD use vanilla `0.2.0.dev0`.
 
 **Baseline.** The Ossie classifications in [§3](#3-conformance-summary) are
 reconciled against the Ossie `0.2.0.dev0` core JSON Schema, a copy of which is
@@ -69,28 +91,30 @@ defines; the parser is the authority only for what `kcmd` accepts.
 A model document is a YAML file with a top-level `semantic_model` list.
 
 ```yaml
-version: "0.2.0.dev0"          # optional; see §1
+version: "0.2.0.dev0"          # required; selects the extension surface (§1)
 semantic_model:                # one or more models; kcmd deploys exactly one per entry group (§4)
   - name: sales
-    datasets: [ … ]            # one or more; the entities (§2.1). `entities:` is an accepted alias (§5)
+    datasets: [ … ]            # one or more; the entities (§2.1). Spelled `entities:` under /google (§5)
     relationships: [ … ]       # optional (§2.2)
     metrics: [ … ]             # optional (§2.3)
     description: "…"           # optional
     ai_context: { … }          # optional (§2.4)
-    custom_extensions: [ … ]   # optional (§6)
-    deployment_target: "…"     # optional; physical binding (§5, §7)
+    custom_extensions: [ … ]   # vanilla only (§6); rejected under /google
+    deployment_target: "…"     # /google only (§5, §7); vanilla carries it in a GOOGLE block
 ```
 
 A document MUST contain at least one model, and each model MUST contain at least
-one dataset. Every named object (dataset, field, relationship, metric) SHOULD
-have a name unique within its scope; a duplicate loads with a warning and produces
-an invalid graph.
+one dataset. Every named object (dataset, field, relationship, metric) MUST have a
+name unique within its scope; a duplicate name is a **hard load error** (agreed
+with Dmitri), because it would make the generated node, property, edge, or measure
+ambiguous.
 
-Objects are **open**: an unknown sibling key inside a validated object is silently
-dropped, not an error. The two exceptions are the sugar conflicts in
-[§5](#5-extensions) (setting both `entities` and `datasets`, or a
-`deployment_target` that disagrees with an existing `GOOGLE` extension), which are
-hard errors.
+Objects are **closed**: an unknown sibling key inside a validated object is a
+**hard error**, not silently dropped (agreed with Dmitri). This is what makes the
+version gate bite — a native key under vanilla, or a `custom_extensions` block
+under `/google`, is an unknown key for that version and is rejected
+([§6](#6-the-extension-mechanism)). Setting both `entities` and `datasets` is
+likewise an error ([§5](#5-extensions)).
 
 The remaining subsections define each object. Names throughout are **logical
 business vocabulary** — `order_id`, `placed_by` — never physical column names; the
@@ -123,8 +147,7 @@ bound for a graph MUST declare one (see [§4](#4-narrowings-and-relaxations) and
 |---|---|---|
 | `name` | string | required |
 | `datatype` | enum | one of the closed vocabulary below |
-| `expression` | [expression](#25-expressions) | physical-column binding (binding — [§7](#7-the-binding-layer)) |
-| `unbound` | boolean | this binding has no column for the field (binding — [§7](#7-the-binding-layer)) |
+| `expression` | [expression](#25-expressions) | physical-column binding; a field with none is *unbound* (binding — [§7](#7-the-binding-layer)) |
 | `label` | string | human display label |
 | `dimension` | object | `{ is_time: boolean }` |
 | `description` | string | |
@@ -142,8 +165,9 @@ String  Integer  Decimal  Float  Boolean  Date  Time  DateTime  DateTimeTz  Opaq
 `kcmd` cannot express natively is represented as `Opaque` plus a `custom_extensions`
 block that carries the real type.
 
-`expression` and `unbound` are the field's binding and are mutually exclusive; see
-[§7](#7-the-binding-layer).
+A field's `expression` is its binding; a field with no `expression` is **unbound**
+(no column under this binding). There is no separate `unbound` flag — absence is
+the signal. See [§7](#7-the-binding-layer).
 
 #### 2.1.2. Inheritance (`extends`)
 
@@ -153,9 +177,11 @@ naming one or more supertype datasets by name. Inheritance is **entity-level
 only** — relationships do not `extends`. A supertype that has no table of its own
 MUST be marked `abstract: true` (also an extension).
 
-The format rule is only that supertypes are named datasets in the same model. The
-resolver breaks cycles with a warning and flattens diamonds (each ancestor
-contributes once, nearest-first); an unknown supertype is ignored with a warning.
+The format rule is only that supertypes are named datasets in the same model. An
+`extends` that names a dataset not defined in the model is a **hard error** (a typo
+must not silently drop inheritance — agreed with Dmitri). The resolver breaks
+cycles with a warning and flattens diamonds (each ancestor contributes once,
+nearest-first).
 How the hierarchy is *lowered* into each store (labels, field flattening) and the
 downstream limits (e.g. a supertype whose label is shared across subtype tables
 cannot carry a measure) are operational — see
@@ -268,7 +294,7 @@ status** is this profile's relationship to it: *as-is* (adopted unchanged),
 |---|---|---|---|
 | `semantic_model`, `name`, `description` | yes | as-is | [§2](#2-document-shape) |
 | `datasets` | yes | as-is | [§2.1](#21-dataset-entity) |
-| `entities` (alias for `datasets`) | no | extension (alias) | [§5](#5-extensions) |
+| `entities` (alias for `datasets`) | no | extension (alias, /google only) | [§5](#5-extensions) |
 | field `name`, `label`, `dimension` (`is_time`) | yes | as-is | [§2.1.1](#211-field) |
 | `datatype` + its vocabulary | yes | as-is (identical, closed) | [§2.1.1](#211-field) |
 | `primary_key`, `unique_keys` | yes | as-is | [§2.1](#21-dataset-entity) |
@@ -281,10 +307,9 @@ status** is this profile's relationship to it: *as-is* (adopted unchanged),
 | `expression.dialects` | yes (closed enum) | as-is; `dialect` string relaxed | [§2.5](#25-expressions) |
 | field `expression` (column binding) | yes (required) | relaxed to optional | [§7](#7-the-binding-layer), [§4](#4-narrowings-and-relaxations) |
 | `source` (dataset table binding) | yes (required) | relaxed to optional | [§7.1](#71-table-sources), [§4](#4-narrowings-and-relaxations) |
-| `unbound` (field) | no | extension | [§5](#5-extensions), [§7](#7-the-binding-layer) |
 | `ai_context` (`instructions`, `synonyms`, `examples`) | yes | as-is (`examples` relaxed) | [§2.4](#24-ai_context) |
-| `custom_extensions` (`vendor_name`, `data`) | yes | as-is (mechanism) | [§6](#6-the-extension-mechanism) |
-| `deployment_target` | no | extension | [§5](#5-extensions), [§7.2](#72-deployment-target) |
+| `custom_extensions` (`vendor_name`, `data`) | yes | as-is; vanilla-only carrier | [§6](#6-the-extension-mechanism) |
+| `deployment_target` | no | extension (native, /google) | [§5](#5-extensions), [§7.2](#72-deployment-target) |
 | binding profiles | no | extension | [§7.3](#73-binding-profiles) |
 | single model per entry group | — | narrowed | [§4](#4-narrowings-and-relaxations) |
 
@@ -328,6 +353,26 @@ Each rule and its reason:
   target, a non-M:N relationship MUST supply both `from_columns` and `to_columns`
   before deploy. *Why:* the edge table needs both keys.
 
+- **Unknown keys are rejected.** Every object is validated closed: an unrecognized
+  sibling key is a hard load error, not silently dropped. Combined with the version
+  gate, this is how a native key under vanilla — or a `custom_extensions` block
+  under `/google` — is caught ([§6](#6-the-extension-mechanism)).
+
+- **Duplicate names are rejected.** A dataset, field, relationship, or metric name
+  repeated within its scope is a hard load error; the generated element would be
+  ambiguous.
+
+- **An unknown supertype is rejected.** An `extends` that names a dataset not in the
+  model is a hard load error (see [§2.1.2](#212-inheritance-extends)).
+
+- **A graph measure binds only to a leaf type.** For a BigQuery target, a metric
+  whose entity is a supertype — one another entity `extends` — cannot become a
+  `MEASURE` and is skipped with a warning: the supertype's label is shared across
+  its subtype tables, and BigQuery forbids a `MEASURE` on a shared label. Like the
+  single-aggregate rule this is a SHOULD, not a MUST — the metric still reaches
+  Knowledge Catalog; it simply has no graph measure. See [Reference → Class
+  hierarchies](reference.md#class-hierarchies-extends--labels).
+
 Not a narrowing, contrary to a common assumption: **diamonds in a class hierarchy
 are not rejected.** The resolver flattens them (each ancestor once) and breaks
 cycles with a warning. What *is* rejected is downstream and store-specific — a
@@ -340,14 +385,18 @@ BigQuery `MEASURE` cannot bind to a label shared across subtype tables. See
 
 **Binding fields made optional — to model before binding.** Ossie marks these
 required; `kcmd` accepts them as optional so a model can be governed before it is
-bound (a purely *logical* model). A graph deploy still requires each one — that
-requirement is the corresponding narrowing in
-[§4.1](#41-narrowings-stricter-than-ossie).
+bound (a purely *logical* model). At graph deploy a non-abstract dataset must
+still declare a `source` — the corresponding narrowing in
+[§4.1](#41-narrowings-stricter-than-ossie). An omitted field `expression` or
+relationship join column is not an error: the field is unbound and the
+availability pass prunes it, and a relationship with no join columns is a
+logical edge.
 
 - **`source` on a dataset** — required in Ossie; optional in `kcmd`. A non-abstract
   dataset bound for a graph MUST still declare one.
-- **`expression` on a field** — required in Ossie; optional in `kcmd` (mark the
-  field `unbound`, or supply the column in a binding profile).
+- **`expression` on a field** — required in Ossie; optional in `kcmd`. A field
+  with no `expression` is unbound and is pruned at graph generation; supply
+  the column in a binding profile to bind it.
 - **`from_columns` / `to_columns` on a relationship** — both required in Ossie;
   `kcmd` allows both omitted (a logical edge).
 
@@ -374,31 +423,32 @@ skip-with-warning, and the exact message) is in
 Constructs `kcmd` adds beyond Ossie. Each is carried so an Ossie-only tool still
 reads the document ([§6](#6-the-extension-mechanism)).
 
-- **`entities` as an alias for `datasets`.** A model MAY spell its datasets
-  `entities:` instead of `datasets:`. Setting both is an error. Pure sugar —
-  identical meaning.
+- **`entities` as an alias for `datasets` (extended profile only).** Under
+  `0.2.0.dev0/google` a model MAY spell its datasets `entities:` instead of
+  `datasets:`; setting both is an error. Pure sugar — identical meaning. Under
+  vanilla Ossie the key is not accepted; use `datasets`. `kcmd`'s pull always emits
+  `entities`.
 
-- **`extends` on a dataset.** Class inheritance — a subtype names its supertype
-  datasets. Ossie `0.2.0.dev0` has no inheritance construct. See
+- **`extends` on a dataset (extended profile only).** Class inheritance — a
+  subtype names its supertype datasets. Ossie `0.2.0.dev0` has no inheritance
+  construct, so it is accepted only under `0.2.0.dev0/google`. See
   [§2.1.2](#212-inheritance-extends).
 
-- **`abstract: true` on a dataset.** Marks a concept with no physical table
-  (typically an `extends` supertype). An abstract dataset produces no node table
-  and MUST NOT declare a `source`.
+- **`abstract: true` on a dataset (extended profile only).** Marks a concept with
+  no physical table (typically an `extends` supertype). An abstract dataset produces
+  no node table and MUST NOT declare a `source`. Accepted only under
+  `0.2.0.dev0/google`.
 
-- **`deployment_target`.** The physical destination — one graph in one store — as
-  a first-class model-level (or profile-level) key. It folds into a `GOOGLE`
-  `custom_extensions` block ([§6](#6-the-extension-mechanism)); the block is the
-  wire form an Ossie-only reader passes through untouched. Grammar in
+- **`deployment_target` (extended profile only).** The physical destination — one
+  graph in one store — as a first-class model-level (or profile-level) key, accepted
+  under `0.2.0.dev0/google`. Under vanilla Ossie there is no native key; the same
+  target is written as a `GOOGLE` `custom_extensions` block carrying
+  `{"deploymentTargets": ["…"]}` ([§6](#6-the-extension-mechanism)). Grammar in
   [§7](#7-the-binding-layer).
 
 - **Binding profiles.** A separate document that supplies only the physical
   bindings, so one logical model serves several stores. Not part of the Ossie
   document; a `kcmd`-specific file alongside it ([§7](#7-the-binding-layer)).
-
-- **`unbound: true` on a field.** Declares that a given binding has no column for
-  the field. A binding-layer concept ([§7](#7-the-binding-layer)); mutually
-  exclusive with `expression`.
 
 Deliberately **not** extensions in `0.2.0.dev0`, to avoid the impression they
 exist: there is **no `actions` block** and **no authorable M:N `association`
@@ -407,8 +457,12 @@ format today.
 
 ## 6. The extension mechanism
 
-Every `kcmd` extension rides in Ossie's own **`custom_extensions`** carrier, which
-is why the profile stays a superset. A `custom_extensions` entry is:
+The `version` selects **one** of two mutually exclusive extension surfaces (agreed
+with Dmitri). A document uses the carrier *or* the native keys, never both — which
+surface applies is a property of the version, not a per-key choice.
+
+**Vanilla `0.2.0.dev0` — the `custom_extensions` carrier.** Under vanilla Ossie
+every `kcmd` extension rides in Ossie's own `custom_extensions` field. An entry is:
 
 ```yaml
 custom_extensions:
@@ -417,25 +471,27 @@ custom_extensions:
 ```
 
 `custom_extensions` MAY appear on the model, a dataset, a field, a relationship,
-and a metric. `data` is opaque at the format level: nothing is interpreted when
-the document is parsed, and it round-trips verbatim. An Ossie-only tool treats a
+and a metric. `data` is opaque at the format level: nothing is interpreted when the
+document is parsed, and it round-trips verbatim. An Ossie-only tool treats a
 `GOOGLE` block as a vendor extension it does not recognize and passes it through
-unchanged — so a `kcmd` model is still a valid Ossie document, and stripping the
-`GOOGLE` blocks yields plain Ossie.
+unchanged — so a vanilla `kcmd` model is still a valid Ossie document, and stripping
+the `GOOGLE` blocks yields plain Ossie. A model's deployment target rides here as a
+`GOOGLE` block carrying `{"deploymentTargets": ["…"]}`. The native keys (`entities`,
+`deployment_target`, `extends`, `abstract`) are **not accepted** under vanilla —
+each is an unknown key and rejected ([§4.1](#41-narrowings-stricter-than-ossie)).
 
-**Native key + `GOOGLE` mirror.** Where a `kcmd` extension has a readable
-first-class spelling, that spelling is *sugar* over a `GOOGLE` block. The
-`deployment_target:` key is the example: it folds into a
-`GOOGLE` block carrying `{"deploymentTargets": ["…"]}`, which is the form the
-deploy path actually reads. Both forms are accepted and mean the same thing; if a
-document sets both and they disagree, that is a hard error. This lets authors
-write the readable key while the document on the wire stays plain Ossie plus one
-opaque vendor block.
+**Extended `0.2.0.dev0/google` — native keys.** Under the extended profile the same
+information is written as first-class keys — `entities`, `deployment_target`,
+`extends`, `abstract` — read directly, with no `data` string to encode. There is
+therefore nothing left for the carrier to carry, and a `custom_extensions` block is
+**not accepted** under `/google` (also an unknown key). This is the profile `kcmd`'s
+own tools emit: readable, but no longer a vanilla-Ossie document.
 
-Extensions with no first-class spelling (for example the OWL constructs the OWL
-importer carries) live directly in `custom_extensions` and survive the document
-round-trip verbatim, even though they are inert on deploy today. What each such
-block does or doesn't reach is in
+**Converting between the two** is the `version` plus a mechanical fold: a vanilla
+`GOOGLE` deployment-target block becomes a native `deployment_target:` key under
+`/google`, and back. Both parse to the identical IR. Constructs that exist only as
+native keys (inheritance, the `entities` spelling) have no vanilla form and are
+simply unavailable there. What survives a push and a pull through each surface is in
 [What push and pull preserve](fidelity.md).
 
 ## 7. The binding layer
@@ -449,8 +505,8 @@ are Ossie-native, not `kcmd` additions. What `kcmd` adds is the layer that says
   extension; Ossie has no deployment construct ([§7.2](#72-deployment-target)).
 - **binding profiles** — a separate document that varies the physical bindings
   per store. A `kcmd` extension ([§7.3](#73-binding-profiles)).
-- **`unbound` on a field** — a field with no column under a given binding. A
-  `kcmd` extension.
+- **an unbound field** — a field with no column under a given binding, expressed
+  by omitting its `expression` (there is no `unbound` flag).
 
 `kcmd` also **relaxes** the Ossie-native bindings — `source`, field `expression`,
 and relationship join columns — from required to optional ([§4.2](#42-relaxations-looser-than-ossie)),
@@ -495,9 +551,10 @@ graph MUST have one.
 ```
 
 The URI MUST match one of these two shapes. A model bound for a graph MUST declare
-exactly one ([§4](#4-narrowings-and-relaxations)). The identifier segments are restricted to
-`[A-Za-z0-9_-]`. As [§6](#6-the-extension-mechanism) notes, the key is sugar over
-a `GOOGLE` `custom_extensions` block; both forms mean the same thing.
+exactly one ([§4](#4-narrowings-and-relaxations)). The identifier segments are
+restricted to `[A-Za-z0-9_-]`. The native `deployment_target:` key shown here is the
+extended-profile form; under vanilla Ossie the same target rides in a `GOOGLE`
+`custom_extensions` block ([§6](#6-the-extension-mechanism)).
 
 ### 7.3. Binding profiles
 
@@ -508,11 +565,11 @@ definition. A profile:
 - is a `semantic_model` document in the **same schema** as the logical model, but
   MUST set only physical-binding keys: at the model level `deployment_target` and
   `datasets`/`entities`; at the dataset level `source` and `fields`; at the field
-  level `expression` and `unbound`. Setting any logical key (a new field,
-  `primary_key`, a relationship, …) in a profile is an error — the logical model
-  owns those.
-- binds by `name` at each level. A field a profile omits is treated as `unbound`
-  for that profile.
+  level `expression`. Setting any logical key (a new field, `primary_key`, a
+  relationship, …) in a profile is an error — the logical model owns those.
+- binds by `name` at each level. A field a profile does not bind is left **unbound**
+  for that profile (selecting a profile clears the logical model's inline column
+  bindings, so the profile alone decides what is bound); there is no `unbound` flag.
 - MUST express a field `expression` as a **bare column reference**, not arbitrary
   SQL — the computation belongs to the logical model.
 
@@ -527,21 +584,23 @@ The full merge behavior and worked examples are in
 
 ## 8. Versioning and compatibility policy
 
-- **What pinning `0.2.0.dev0` guarantees.** The constructs in [§2](#2-document-shape)
-  and the extensions in [§5](#5-extensions) are what `kcmd` reads and writes at
-  this version. `version` is advisory: a document at another version loads with a
-  warning, so pinning is a statement of intent, not a gate.
+- **What declaring a version guarantees.** The constructs in
+  [§2](#2-document-shape) and the extensions in [§5](#5-extensions) are what `kcmd`
+  reads and writes. The `version` is a **gate**, not advice: it is required, must be
+  `0.2.0.dev0` or `0.2.0.dev0/google`, and selects the legal extension surface
+  ([§6](#6-the-extension-mechanism)); any other value is a hard error.
 
 - **When Ossie changes.** A new Ossie construct is added to
   [§3](#3-conformance-summary) as a row — *as-is* if adopted unchanged, *narrowed*
   if constrained. Growth is a table entry, not a rewrite; this document's size
   tracks `kcmd`'s decisions, not Ossie's surface.
 
-- **Forward direction of each extension.** An extension is either a candidate to
-  upstream into Ossie (the readable-key extensions, e.g. `deployment_target`) or
-  intended to stay a `GOOGLE` `custom_extensions` block indefinitely (Google-store
-  specifics). Until an extension is upstreamed it MUST keep its `GOOGLE`-carried
-  form so the superset contract in [§1](#1-status-and-baseline) holds.
+- **Forward direction of each extension.** A native `/google` key is either a
+  candidate to upstream into Ossie (e.g. `deployment_target`, `entities`) or a
+  Google-store specific that stays `kcmd`'s own. The vanilla version stays a strict
+  Ossie superset: its only extension is the `GOOGLE` `custom_extensions` carrier,
+  and constructs with no vanilla form (inheritance, the `entities` spelling) are
+  simply unavailable there — a model that needs them uses `0.2.0.dev0/google`.
 
 - **Reserved constructs.** `association` (M:N) and any `actions`-like write-side
   construct are reserved: recognized as future work, not authorable today. A
@@ -554,7 +613,7 @@ A logical model plus one binding profile.
 ```yaml
 # catalog/EntryGroups/sales/sales.yaml — the logical model (concepts + edge join keys;
 # table and column bindings live in the profile below — see §7)
-version: "0.2.0.dev0"
+version: "0.2.0.dev0"          # vanilla Ossie: uses no native keys, so this file is portable
 semantic_model:
   - name: sales
     datasets:
@@ -583,7 +642,7 @@ semantic_model:
 
 ```yaml
 # catalog/EntryGroups/sales/sales.profiles/analytical.yaml — physical binding only
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"   # native deployment_target key -> extended profile
 semantic_model:
   - name: sales
     deployment_target: "//bigquery.googleapis.com/projects/acme/datasets/sales/propertyGraphs/sales"

--- a/toolbox/mdcode/docs/semantic-model/owl-import.md
+++ b/toolbox/mdcode/docs/semantic-model/owl-import.md
@@ -10,14 +10,13 @@ The converter maps the OWL constructs that have a clean BigQuery Graph shape to
 **native** semantic-model fields — class → node, object property → edge,
 datatype property → property, plus **class hierarchies** (`rdfs:subClassOf` →
 entity `extends`, see [Class hierarchies](#class-hierarchies-rdfssubclassof)).
-Constructs that have **no native home yet** — property inheritance
-(`rdfs:subPropertyOf`), the inverse / equivalence / disjointness cross-references,
-the property characteristics, and per-term annotations (`rdfs:seeAlso`,
-`owl:deprecated`, …) — are not dropped: they **ride along verbatim** as custom
-extensions, lossless and inert, until they earn a first-class concept (see
-[Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)).
-Richer OWL still not read at all (SHACL, cardinality restrictions, the set-level
-disjointness / identity axioms, individuals) is listed in
+Import is **one-way and lossy by design**: constructs with no native
+semantic-model home — property inheritance (`rdfs:subPropertyOf`), the inverse /
+equivalence / disjointness cross-references, the property characteristics, the
+set-level axioms, and per-term annotations (`rdfs:seeAlso`, `owl:deprecated`, …)
+— are **not imported**. The result is a clean semantic model, never an OWL
+document wrapped in opaque metadata. What maps and what drops is listed in [How
+each OWL construct maps](#how-each-owl-construct-maps) and
 [Limitations](#limitations).
 
 ## 1. The OWL file
@@ -152,7 +151,7 @@ emits; the inline `#` comments are annotations added here for the walkthrough �
 the real output has none:
 
 ```yaml
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
     description: "A minimal sales domain: customers and the orders they place.
@@ -162,7 +161,7 @@ semantic_model:
         - Sales domain
       examples:
         - How many orders did each customer place last month?
-    datasets:
+    entities:
       - name: Customer                   # no source: a logical entity
         primary_key:
           - customerId                   # from owl:hasKey
@@ -201,24 +200,16 @@ This is a purely **logical model**: an ontology declares meaning, not physical
 tables, so entities carry no `source`, fields no `expression`, and relationships
 no join columns. Before a graph deploy a [binding profile](profiles.md) supplies
 the sources and field expressions, and you add each edge's join columns to the
-model (they are logical, not a binding). It is also the **clean mapping**: every construct here has a native
-semantic-model home, so the output carries no term IRIs and no
-`custom_extensions`. Two kinds of
-ontology go further — a **class hierarchy** (`rdfs:subClassOf`) and constructs
-with **no native home yet** (inverses, equivalences, property characteristics,
-…). Both are supported; the rest of this page shows them as extensions of *this
-same sales domain* — see [Class hierarchies](#class-hierarchies-rdfssubclassof)
-and [Constructs carried as custom
-extensions](#constructs-carried-as-custom-extensions-not-yet-native).
+model (they are logical, not a binding). The output carries no term IRIs and no
+`custom_extensions`: a term's identity is its name, so a cleanly-mapped construct
+needs nothing more. One kind of ontology goes further — a **class hierarchy**
+(`rdfs:subClassOf`), shown next as an extension of *this same sales domain* (see
+[Class hierarchies](#class-hierarchies-rdfssubclassof)). Everything OWL can say
+that the semantic model cannot is **dropped on import**, not carried.
 
-Why nothing extra appears here: for a cleanly-mapped term its IRI carries nothing
-the model doesn't already have — the term's identity is its name — and the source
-namespace is recorded only when needed: in the model `description` as a fallback
-when the ontology header has no comment of its own, or in an `owl:baseIri`
-extension when an in-namespace reference has to be shortened (the `owl:baseIri`
-form is shown in the advanced example below; the `description` fallback appears
-only when the header carries no comment, which is not the case there either).
-This ontology has a header comment and makes no such references, so the namespace
+The source namespace is recorded only as a human-readable fallback: when the
+ontology header has no comment of its own, the model `description` names the base
+IRI it was imported from. This ontology has a header comment, so the namespace
 appears nowhere above.
 
 ### How each OWL construct maps
@@ -230,7 +221,7 @@ appears nowhere above.
 | `owl:DatatypeProperty` | `fields[]` on **each** domain's dataset | a property with several `rdfs:domain` values lands on each; a logical field — **no `expression`** (a binding profile maps it to a column) |
 | `owl:ObjectProperty` | `relationships[]` | `from` = domain, `to` = range; a **logical edge with no join columns** (you add `from_columns`/`to_columns` to the model before a graph deploy, see [binding](#4-going-from-ontology-to-a-running-graph-binding)); with several `rdfs:domain`/`rdfs:range` values only the first of each is kept (a relationship is one source → one destination) and the rest are warned |
 | `rdfs:subClassOf` (named superclass) | dataset `extends[]` | **entity-level inheritance only** — records the parent(s) in document order; not read on object properties (see [Class hierarchies](#class-hierarchies-rdfssubclassof)) |
-| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, `owl:AllDisjointClasses`, `owl:AllDisjointProperties`, `owl:AllDifferent`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | `custom_extensions` (GOOGLE) | **no native home yet** — carried verbatim, inert on push (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
+| `rdfs:subPropertyOf`, `owl:inverseOf`, `owl:equivalentClass`, `owl:disjointWith`, `owl:oneOf`, `owl:equivalentProperty`, `owl:propertyDisjointWith`, `owl:propertyChainAxiom`, `owl:AllDisjointClasses`, `owl:AllDisjointProperties`, `owl:AllDifferent`, the property characteristics, `rdfs:seeAlso`, `rdfs:isDefinedBy`, `owl:deprecated`, `owl:versionInfo` | *(dropped)* | **no native home** — not imported (see [Limitations](#limitations)) |
 | `rdfs:range xsd:*` | field `datatype` | see [Datatypes](#datatypes-rdfsrange) |
 | `owl:hasKey ( ... )` | dataset `primary_key` | single or composite, in list order |
 | `owl:InverseFunctionalProperty` | dataset `unique_keys` | a uniquely-identifying property; omitted when it is already the `primary_key`; a lone one on a keyless class is promoted to `primary_key` instead |
@@ -239,7 +230,7 @@ appears nowhere above.
 | extra `rdfs:label` / `skos:altLabel` / `prefLabel` / `hiddenLabel` | `ai_context.synonyms` | genuinely alternate names; feed NL search |
 | `skos:example` | `ai_context.examples` | sample questions / values |
 | `rdfs:comment`, `skos:definition`, `dcterms:`/`dc:description` | `description` | first present wins, in that order; on an object property (which has no `description` slot) the comment rides in `ai_context.instructions` |
-| term IRIs, `@prefix` | a term's own IRI is dropped (base IRI kept as the model's `owl:baseIri` custom-extension key **when any reference was shortened**, and in `description` **only when the header has no comment of its own**) | reconstructable as `<base><name>`; a *carried cross-reference* to another namespace keeps its full IRI (see [Constructs carried as custom extensions](#constructs-carried-as-custom-extensions-not-yet-native)) |
+| term IRIs, `@prefix` | dropped (base IRI named in `description` **only when the header has no comment of its own**) | a term's identity is its local name; the source namespace is not otherwise carried |
 
 A datatype property whose domain is not a class, or an object property missing an
 endpoint, cannot be placed; it is **skipped with a warning** rather than failing
@@ -314,11 +305,11 @@ ex:Customer a owl:Class ;
 # ... Customer's own datatype properties: customerId, email, customerName, … ...
 ```
 
-the `Person` and `Customer` datasets come out as (`Customer` carrying
+the `Person` and `Customer` entities come out as (`Customer` carrying
 `extends: [Person]`):
 
 ```yaml
-  # Person is its own dataset:
+  # Person is its own entity:
   - name: Person
     description: A human being.
     fields:
@@ -354,250 +345,10 @@ Two boundaries to be clear about:
   labels)](reference.md#class-hierarchies-extends--labels). The **Knowledge Catalog** push is
   unchanged: it still publishes each entry with exactly the fields it declares
   (KC-side inheritance is a separate, later opt-in).
-- **Native inheritance is entity-level only.** `extends` lives on `datasets`,
+- **Native inheritance is entity-level only.** `extends` lives on `entities`,
   never on relationships — the boundary is structural. `rdfs:subPropertyOf`
   (property / relationship inheritance) has no such native slot, so it is **not
-  dropped but carried verbatim** as a custom extension on the field or
-  relationship (see [Constructs carried as custom
-  extensions](#constructs-carried-as-custom-extensions-not-yet-native)).
-
-### Constructs carried as custom extensions (not yet native)
-
-Some OWL constructs have no native slot in the semantic model — a class is one
-entity, so it has nowhere to record that it *equals* another class; an edge is
-directed, so it has nowhere to record its *inverse*. Rather than drop these, the
-converter **carries them verbatim** in a `GOOGLE` custom extension on the object
-they describe. Carriage is a holding pattern with three deliberate properties:
-
-- **Lossless for carried facts.** Every fact the converter *carries* is preserved
-  exactly: the imported OSI document holds each carried construct as imported, and
-  it survives a local load → serialize round-trip verbatim. (This is not a blanket
-  guarantee that nothing the converter reads is ever dropped — some constructs are
-  reduced with a warning, e.g. an object property's extra domains/ranges or a
-  duplicate declaration; see [How each OWL construct
-  maps](#how-each-owl-construct-maps).) Carriage is **not** yet persisted to
-  Knowledge Catalog, though, so a `kcmd pull` does not return these facts today
-  (push writes no aspect for them — see
-  [What push and pull preserve](fidelity.md)).
-- **Inert.** A carried fact changes **nothing** downstream — the BigQuery Graph
-  push and the Knowledge Catalog push read none of it, so it never alters a node,
-  an edge, or a query. (Contrast `extends`, which *does* change the graph by
-  adding node labels — that is why it earned a native slot and these have not.)
-- **Promotable.** When a construct proves it needs to be first-class, it moves
-  out of carriage into a native concept; the extension is the seam where that
-  happens.
-
-**The shape.** Each carried construct is one key in a flat JSON object under the
-`GOOGLE` vendor. **The key *is* the source construct, prefixed with its
-vocabulary** (`owl:` or `rdfs:`); the value mirrors the construct faithfully.
-`data` is a pretty-printed (2-space) JSON string, so it appears as a YAML block
-scalar (`data: |-`). This is the block the `customerName` field gets from its
-`rdfs:subPropertyOf` and `owl:equivalentProperty` (real output, verbatim):
-
-```yaml
-custom_extensions:
-  - vendor_name: GOOGLE
-    data: |-
-      {
-        "rdfs:subPropertyOf": [
-          "fullName"
-        ],
-        "owl:equivalentProperty": [
-          "http://xmlns.com/foaf/0.1/name"
-        ]
-      }
-```
-
-The prefix carries the namespace, which does two jobs: it keeps a carried fact
-from colliding with Google's own keys in the same block (a deployment target is
-`deploymentTargets`, unprefixed), and it disambiguates a short name that means
-different things in different standards (`subPropertyOf` is RDFS; `inverseOf` is
-OWL). A reader treats **any key containing a `:`** as a carried ontology fact (a convention for future consumers — nothing reads these keys back today).
-Values are mirrored, not invented — a symmetric property is `"owl:SymmetricProperty":
-true`, not a synthesized `characteristics` list — so no information about the
-original construct is lost in translation.
-
-**What is carried, and where it attaches:**
-
-The JSON key is the OWL construct itself (see **The shape** above), so it is not
-repeated as its own column. Rows are grouped by what they attach to. Most attach
-to the term they describe (an entity, a field, a relationship, or *any* term);
-the **set-level axioms** are the exception — `owl:AllDisjointClasses`,
-`owl:AllDisjointProperties`, and `owl:AllDifferent` are each asserted on an
-anonymous node about a *set* of terms, belonging to no single class or property,
-so they attach to the **model** (the top-level `custom_extensions`, beside
-`owl:baseIri`). Each is an array of member sets — one per axiom — so two separate
-disjointness axioms stay two entries rather than merging into one flat list.
-
-| OWL construct | Attaches to | Value | Meaning |
-|---|---|---|---|
-| `owl:equivalentClass` | entity | `string[]` (equivalent class refs) | this class denotes the same set as another |
-| `owl:disjointWith` | entity | `string[]` (disjoint class refs) | no individual is in both classes |
-| `owl:oneOf` | entity | `string[]` (member refs; an enumeration is a **set** — deduped, order not significant) | the class is exactly this enumerated set of members |
-| `rdfs:subPropertyOf` | field / relationship | `string[]` (super-property refs) | this property refines a broader one |
-| `owl:equivalentProperty` | field / relationship | `string[]` (equivalent property refs) | this property means the same as another |
-| `owl:propertyDisjointWith` | field / relationship | `string[]` (disjoint property refs) | the two properties never both hold |
-| `owl:FunctionalProperty` | field / relationship | `true` | at most one value / destination per subject |
-| `owl:propertyChainAxiom` | relationship | `string[][]` (one ordered chain per axiom — **in chain order, duplicates kept**; a property may carry several chain axioms) | this edge is the ordered composition of the listed ones (`hasParent` then `hasBrother` ⇒ `hasUncle`) |
-| `owl:inverseOf` | relationship | `string` (the inverse edge's ref) | the same edge read the other way |
-| `owl:SymmetricProperty` | relationship | `true` | the edge holds both ways (`a→b` ⇒ `b→a`) |
-| `owl:TransitiveProperty` | relationship | `true` | the edge chains (`a→b`, `b→c` ⇒ `a→c`) |
-| `owl:ReflexiveProperty` | relationship | `true` | every subject relates to itself (`a→a`) |
-| `owl:IrreflexiveProperty` | relationship | `true` | no subject relates to itself |
-| `owl:AsymmetricProperty` | relationship | `true` | `a→b` rules out `b→a` |
-| `owl:AllDisjointClasses` | model | `string[][]` (one member **set** per axiom — deduped, order not significant) | the listed classes are pairwise disjoint |
-| `owl:AllDisjointProperties` | model | `string[][]` (one member set per axiom) | the listed properties are pairwise disjoint |
-| `owl:AllDifferent` | model | `string[][]` (one member set per axiom; members are individuals, names only, like `owl:oneOf`) | the listed individuals are pairwise distinct |
-| `rdfs:seeAlso` | any | `string[]` of N-Triples terms — an IRI as `<iri>`, a literal as `"text"` (with any `@lang` / `^^<datatype>` preserved) | pointer to further information (kept distinguishable, see below) |
-| `rdfs:isDefinedBy` | any | `string[]` (IRIs, verbatim) | the resource that defines this term |
-| `owl:deprecated` | any | `true` | the term is deprecated (carried only when true) |
-| `owl:versionInfo` | any | `string` | a term-level version string |
-
-When more than one fact applies to the same object they share **one** block, in a
-fixed key order (cross-references, then characteristics, then the per-term
-annotations) so the output is stable.
-
-**Names vs. full IRIs (namespace-aware).** A carried cross-reference points at
-another OWL term, which has an IRI. When that IRI lives in **this ontology's own
-namespace**, it is shortened to the plain local name (`"fullName"`, `"places"`) —
-the same name the referenced entity/property carries in the model, so a consumer
-can resolve it by name. When it lives in **another namespace**, the **full IRI**
-is kept (`"http://xmlns.com/foaf/0.1/Person"`) — a shortened name would be
-ambiguous and resolve to nothing. Nothing is lost either way: whenever any reference is
-shortened, the base IRI is carried as structured metadata on the model — an
-`owl:baseIri` key in the model-level GOOGLE `custom_extensions` block — so an
-in-namespace name reconstructs mechanically as `<base><name>`, and a
-cross-namespace IRI is already complete. (The base also appears in the model
-`description` for humans, but the structured key is what a consumer reads.)
-`rdfs:seeAlso` / `rdfs:isDefinedBy` point *outside* the model by definition, so
-they are **always** kept verbatim; `rdfs:seeAlso` additionally wraps each value
-as an N-Triples term (`<iri>` vs `"text"`, with any language tag `@en` or
-datatype `^^<iri>` preserved) so an IRI stays distinguishable from a literal — and
-a tagged/typed literal from a plain one — on round-trip. A carried reference is
-**not** validated against the model — it is a fact to carry, not a resolved link.
-
-**Example.** A slice of the sales domain that exercises every kind of carried
-construct at once — a cross-namespace equivalence, a native-and-carried duality,
-in-namespace and external references side by side, an inverse, and property
-characteristics. Each `#` comment names where the construct lands:
-
-```turtle
-# Person is equivalent to the EXTERNAL foaf:Person -> carried as a full IRI.
-ex:Person a owl:Class ;
-    owl:equivalentClass foaf:Person .
-
-# email is inverse-functional (-> unique_keys, native) AND single-valued
-# (owl:FunctionalProperty -> carried): one construct maps, the other rides along.
-ex:email a owl:DatatypeProperty,
-        owl:InverseFunctionalProperty,
-        owl:FunctionalProperty ;
-    rdfs:domain ex:Customer ;
-    rdfs:range xsd:string .
-
-# customerName refines the in-namespace ex:fullName (-> "fullName") and equals
-# the external foaf:name (-> full IRI).
-ex:customerName a owl:DatatypeProperty ;
-    rdfs:domain ex:Customer ;
-    rdfs:range xsd:string ;
-    rdfs:subPropertyOf ex:fullName ;
-    owl:equivalentProperty foaf:name .
-
-# placedBy's inverse is the in-namespace ex:places (-> "places").
-ex:placedBy a owl:ObjectProperty ;
-    rdfs:domain ex:Order ;
-    rdfs:range ex:Customer ;
-    owl:inverseOf ex:places .
-
-# referredBy is one-way and never self -- both characteristics carried.
-ex:referredBy a owl:ObjectProperty,
-        owl:AsymmetricProperty,
-        owl:IrreflexiveProperty ;
-    rdfs:domain ex:Customer ;
-    rdfs:range ex:Customer .
-```
-
-Below is the resulting model, trimmed to the carried blocks — each `data` value
-is the real emitted output, verbatim; the `# ...` lines stand in for elided
-structure. It attaches at three levels: on an **entity** (`Person`), on a
-**field** (`Customer.email`), and on a **relationship** (`referredBy`).
-(`customerName`'s field block is the one under **The shape** above; `placedBy`
-carries `{"owl:inverseOf": "places"}`.)
-
-```yaml
-datasets:
-  # entity level -- cross-namespace equivalence, on the Person entity:
-  - name: Person
-    # ... fields ...
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: |-
-          {
-            "owl:equivalentClass": [
-              "http://xmlns.com/foaf/0.1/Person"
-            ]
-          }
-  - name: Customer
-    # ... primary_key, unique_keys, other fields ...
-    fields:
-      # field level -- the single-valued flag on email, which is ALSO a native
-      # unique key (email is inverse-functional):
-      - name: email
-        # ... expression, datatype ...
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "owl:FunctionalProperty": true
-              }
-relationships:
-  # relationship level -- characteristics on the referredBy edge:
-  - name: referredBy
-    # ... endpoints ...
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: |-
-          {
-            "owl:IrreflexiveProperty": true,
-            "owl:AsymmetricProperty": true
-          }
-```
-
-Because the in-namespace references (`fullName`, `places`) were shortened, the
-**model header** also carries the base IRI so they can be reconstructed
-(`<base><name>` → `http://example.com/sales#fullName`):
-
-```yaml
-semantic_model:
-  - name: sales
-    # ... description, ai_context ...
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: |-
-          {
-            "owl:baseIri": "http://example.com/sales#"
-          }
-```
-
-A reference to an **external** vocabulary keeps its full IRI instead — as
-`Person`'s `owl:equivalentClass foaf:Person` and `customerName`'s
-`owl:equivalentProperty foaf:name` both show above
-(`"http://xmlns.com/foaf/0.1/Person"`, `"http://xmlns.com/foaf/0.1/name"`); no
-base IRI is needed to rebuild them.
-
-**Prefix → namespace** (the `owl:` / `rdfs:` on the *keys*; reconstruct an
-in-namespace *value* as `<base><name>`, where `<base>` is the model's
-`owl:baseIri` custom-extension key — a cross-namespace value is already a full
-IRI):
-
-| Prefix | Namespace IRI |
-|---|---|
-| `owl:` | `http://www.w3.org/2002/07/owl#` |
-| `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` |
-
-Blank-node forms are **not** carried: an `owl:equivalentClass` (or
-`rdfs:subClassOf`) whose object is a class *expression* (`owl:intersectionOf`, an
-`owl:Restriction`, …) is a definition rather than a plain cross-reference, so it
-is out of scope (see [Limitations](#limitations)).
+  imported** (see [Limitations](#limitations)).
 
 ## 4. Going from ontology to a running graph (binding)
 
@@ -639,13 +390,14 @@ and they belong in different places:
    [binding profile](profiles.md): a document in the same schema, kept beside the
    model as `<model>.profiles/<name>.yaml`, that adds *only* the binding and
    leaves the logical model untouched. A profile may set `source`, field
-   `expression`, `unbound`, and `deployment_target` — nothing logical (a
-   `relationships` block in a profile is rejected). The model and the profile
-   merge by name at push time:
+   `expression`, and `deployment_target` — nothing logical (a `relationships`
+   block in a profile is rejected). A field the profile does not bind is left
+   unbound; there is no separate flag. The model and the profile merge by name at
+   push time:
 
    ```yaml
    # sales.profiles/warehouse.yaml — physical binding for the sales model
-   version: 0.2.0.dev0
+   version: 0.2.0.dev0/google
    semantic_model:
      - name: sales
        deployment_target: //bigquery.googleapis.com/projects/myproj/datasets/sales/propertyGraphs/sales
@@ -680,38 +432,39 @@ Three different situations hide in "not covered": constructs already read but no
 yet resolved all the way downstream, constructs not read but reachable next, and
 constructs out of scope.
 
-**Read now — only downstream resolution is pending.** These are not dropped; the
-importer handles them today, and the remaining work is a later step, not in the
-import:
+**Read now — only downstream resolution is pending.** The **class hierarchy**
+(`rdfs:subClassOf`) maps to entity `extends` (see [Class
+hierarchies](#class-hierarchies-rdfssubclassof)); the importer handles it today
+and the remaining work is downstream, not in the import:
 
-- **Class hierarchy** (`rdfs:subClassOf`) maps to dataset `extends` (see
-  [Class hierarchies](#class-hierarchies-rdfssubclassof)). Downstream:
-  - **BigQuery** push resolves it into node-table labels, inherited fields
-    flattened down (see [Class hierarchies (`extends` →
-    labels)](reference.md#class-hierarchies-extends--labels)).
-  - **Knowledge Catalog** is the follow-on — KC push still publishes each entry
-    with only its own fields.
-- **Constructs with no native home** are **carried verbatim** as
-  `custom_extensions` rather than dropped — inert on push, and promoting any to a
-  native concept is the follow-on (see [Constructs carried as custom
-  extensions](#constructs-carried-as-custom-extensions-not-yet-native)):
-  - **Property inheritance** — `rdfs:subPropertyOf`.
-  - **Cross-references** — `owl:inverseOf`, `owl:equivalentClass`,
-    `owl:disjointWith`, `owl:equivalentProperty`, `owl:propertyDisjointWith`.
-  - **Property characteristics** — symmetric / transitive / functional /
-    reflexive / irreflexive / asymmetric.
-  - **Enumerations** (`owl:oneOf`) and **property chains**
-    (`owl:propertyChainAxiom`).
-  - **Set-level axioms** — `owl:AllDisjointClasses`,
-    `owl:AllDisjointProperties`, `owl:AllDifferent` (carried on the model).
-  - **Per-term annotations** — `rdfs:seeAlso`, `rdfs:isDefinedBy`,
-    `owl:deprecated`, `owl:versionInfo`.
+- **BigQuery** push resolves it into node-table labels, inherited fields
+  flattened down (see [Class hierarchies (`extends` →
+  labels)](reference.md#class-hierarchies-extends--labels)).
+- **Knowledge Catalog** is the follow-on — KC push still publishes each entry
+  with only its own fields.
 
-**Not read yet — the next candidate for carriage.** Cardinality
-(`owl:minCardinality` / `owl:maxCardinality`) lives on an anonymous
-`owl:Restriction` reached through `rdfs:subClassOf` — the last blank-node shape
-the converter does not yet read. Carrying it needs an `owl:Restriction` reader
-joined back to its class.
+**Not imported — dropped.** OWL can state things the semantic model has no native
+slot for. The importer reads them but does **not** carry them (an earlier version
+rode them along as `custom_extensions`; that was removed so an imported model is a
+clean semantic model). To keep any of these, model them natively after import.
+Dropped:
+
+- **Property inheritance** — `rdfs:subPropertyOf`.
+- **Cross-references** — `owl:inverseOf`, `owl:equivalentClass`,
+  `owl:disjointWith`, `owl:equivalentProperty`, `owl:propertyDisjointWith`.
+- **Property characteristics** — symmetric / transitive / functional /
+  reflexive / irreflexive / asymmetric.
+- **Enumerations** (`owl:oneOf`) and **property chains**
+  (`owl:propertyChainAxiom`).
+- **Set-level axioms** — `owl:AllDisjointClasses`, `owl:AllDisjointProperties`,
+  `owl:AllDifferent`.
+- **Per-term annotations** — `rdfs:seeAlso`, `rdfs:isDefinedBy`,
+  `owl:deprecated`, `owl:versionInfo`.
+
+**Not read yet.** Cardinality (`owl:minCardinality` / `owl:maxCardinality`)
+lives on an anonymous `owl:Restriction` reached through `rdfs:subClassOf` — the
+last blank-node shape the converter does not yet read. Reading it needs an
+`owl:Restriction` reader joined back to its class.
 
 **Not read — out of scope.** Richer OWL/RDF beyond the schema-shaped subset this
 converter targets:

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -133,16 +133,18 @@ that reads it is unavailable there rather than reading a null. Keeping the two
 apart is what lets a query fail against a store that cannot answer it instead of
 returning a blank that reads like real data.
 
-**Leaving a field unbound is explicit.** A profile leaves a field unbound in one
-of two ways. The logical model declares the field, and no profile that omits a
-column for it has it until one binds it. Alternatively, a profile that would
-otherwise inherit a column sets `unbound: true` on the field to drop it. Silently
-omitting a field that another profile binds does neither — the field stays
-declared and simply has no column under the omitting profile, which is caught if
-a metric needs it. When the source table a profile binds is missing or
+**A profile binds only what its store serves; the rest is unbound.** A profile
+is authoritative for the model's physical bindings: a field the profile gives an
+`expression` is bound, and a field the profile omits is unbound — there is no
+separate flag. (Selecting a named profile also clears any column binding written
+inline in the logical model, so the profile alone decides what is bound; the
+logical model stays where meaning is declared, the profile where columns are.) So
+the operational profile below binds `availableCredit` and omits `lifetimeValue`,
+and the analytical profile does the reverse. A field's absence is not silent: a
+metric or relationship that needs an unbound field is reported as unavailable
+under that profile. When the source table a profile binds is missing or
 inaccessible, validation fails and names it; a mistyped column name resolves to a
 real table and so surfaces at deploy, when BigQuery rejects the generated graph.
-So a forgotten binding is caught, and an intentional non-binding is written down.
 
 ## File layout
 
@@ -176,7 +178,7 @@ declared here, though no single store carries both:
 
 ```yaml
 # commerce.yaml — logical model
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     entities:
@@ -208,11 +210,11 @@ semantic_model:
 
 The analytical binding points the model at the BigQuery warehouse. The warehouse
 carries the modeled `lifetimeValue` and does not hold live credit, so
-`availableCredit` is `unbound`:
+`availableCredit` is left unbound (omitted below):
 
 ```yaml
 # commerce.profiles/analytical.yaml — BigQuery bindings
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     deployment_target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce
@@ -223,7 +225,7 @@ semantic_model:
           - { name: key,             expression: c_custkey }
           - { name: name,            expression: c_name }
           - { name: lifetimeValue,   expression: c_ltv }
-          - { name: availableCredit, unbound: true }
+          # availableCredit is omitted -> unbound under this profile
       - name: Order
         source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
         fields:
@@ -238,7 +240,7 @@ holds the same customers under different table and column names, binds the live
 
 ```yaml
 # commerce.profiles/operational.yaml — Spanner bindings
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     deployment_target: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/propertyGraphs/commerce
@@ -249,7 +251,7 @@ semantic_model:
           - { name: key,             expression: CustomerId }
           - { name: name,            expression: FullName }
           - { name: availableCredit, expression: AvailableCredit }
-          - { name: lifetimeValue,   unbound: true }
+          # lifetimeValue is omitted -> unbound under this profile
       - name: Order
         source: //spanner.googleapis.com/projects/acme-ops/instances/prod-us/databases/commerce/tables/Orders
         fields:
@@ -267,8 +269,8 @@ picks its own backend. The two bindings answer different parts of the same model
 - `order_count` depends only on `Order.key`, bound under both bindings, so it is
   available under either.
 - `avg_lifetime_value` depends on `Customer.lifetimeValue`. The warehouse binds
-  it, so the metric is available analytically; the operational store marks it
-  unbound, so the metric is unavailable there.
+  it, so the metric is available analytically; the operational store omits it, so
+  it is unbound there and the metric is unavailable.
 - `availableCredit` is bound only operationally, so it — and any metric written
   on top of it — is available under the operational binding and absent under the
   analytical one.
@@ -279,12 +281,14 @@ picks its own backend. The two bindings answer different parts of the same model
   `fields`; these merge onto the logical model **by `name`**. A profile never
   carries a `relationship` or a `metric` — those are logical, so they live once
   in the model and a profile that sets one is rejected.
-- An entity or field named only in the logical model is carried through
-  unchanged; a profile element whose `name` is not in the logical model is
-  rejected.
+- An entity or field named only in the logical model keeps its declaration,
+  but any inline column binding is cleared unless the profile re-declares it;
+  a profile element whose `name` is not in the logical model is rejected.
 - Scalars — `source`, `expression`, `deployment_target` — **replace**.
-- A field with `unbound: true` in a profile **drops** any column for that field
-  under that profile.
+- A field the profile does not bind is **unbound** under that profile — selecting
+  a profile clears the logical model's inline column bindings, so only what the
+  profile binds is bound. There is no `unbound` flag; omission is how a field is
+  left unbound.
 - Profiles are **binding-only**: a profile sets physical facets and may leave a
   field unbound. It cannot add or remove entities, fields, or metrics, change
   the grain or graph shape, or change what anything means.
@@ -353,10 +357,13 @@ writes nothing.
 
 ## Notes
 
-**The deployment target is a first-class key.** So a profile can set it readably,
-`deployment_target:` is a model key rather than a JSON string inside a `GOOGLE
-custom_extensions` block. The custom-extension form is still accepted and means
-the same thing.
+**The deployment target is a first-class key.** Under the extended
+`0.2.0.dev0/google` profile — the version these binding examples use —
+`deployment_target:` is a native model key, so a profile sets it readably. The
+vanilla `0.2.0.dev0` profile has no native key for it; there the target rides in a
+`GOOGLE` `custom_extensions` block instead. The two are the same target written
+two ways, chosen by the document's `version` (see [model
+spec](model_spec.md#1-status-and-baseline)).
 
 **Bare-string expressions.** A field's `expression` may be written as a one-line
 string (`expression: c_name`) instead of the full per-dialect object. The two

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -195,8 +195,8 @@ only as a `LABEL` on its concrete descendants. Its field names still flatten
 down, and each concrete subtype supplies the column for each of those names, so
 the shared label's signature is present on every subtype table. An abstract
 entity that no concrete entity extends has nothing to attach to and is dropped
-with a warning. `abstract` is an explicit marker: an entity left with an unbound
-`source` placeholder is treated as a binding error and fails the push, never
+with a warning. `abstract` is an explicit marker: a non-abstract entity with no
+`source` is treated as a binding error and fails the push, never
 silently dropped as if it were table-less. The Knowledge Catalog leg does not
 model inheritance today, so an abstract entity has no physical resource to
 catalog and is skipped there (with a warning); its concrete subtypes are
@@ -291,6 +291,17 @@ touched**, so a model that cannot deploy fails fast instead of half-deploying.
 Each check enforces a rule the [model specification](model_spec.md) *defines*;
 this section is the operational side of it — what the tool does when the rule is
 broken — and links to the definition it enforces:
+
+Before these checks even run, the document must **load**, and the loader is strict:
+`version` is required and must be `0.2.0.dev0` (vanilla Ossie) or
+`0.2.0.dev0/google` (the extended profile); every object is closed, so an unknown
+key — including a native key under vanilla, or a `custom_extensions` block under
+`/google` — is rejected; names must be unique within their scope; and every
+`extends` must name an entity defined in the model. A load failure is reported the
+same way as a validation failure — nothing is touched, non-zero exit — and is
+defined in [model spec §1](model_spec.md#1-status-and-baseline),
+[§2](model_spec.md#2-document-shape), [§6](model_spec.md#6-the-extension-mechanism),
+and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
 
 * **A graph push declares exactly one deployment target per model, and it must
   be a valid BigQuery Graph or Spanner Graph URI.** A model with more than one is

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -83,17 +83,6 @@ export function generatePropertyGraph(
   const abstractNames =
       new Set(entities.filter(e => e.abstract).map(e => e.name));
 
-  // A metric lowers to a MEASURE on its target's DEFAULT LABEL, and BigQuery
-  // forbids a MEASURE on a label carried by more than one element table. A
-  // supertype's label is shared with every subtype's table, so a measure is
-  // allowed only on a LEAF type -- one that no other entity extends (agreed with
-  // Dmitri). Inheritance is already resolved, so each entity's `extends` is its
-  // full transitive ancestor set; every non-leaf name therefore appears in some
-  // entity's list, computed here across ALL entities (abstract included).
-  const supertypeNames = new Set<string>();
-  for (const e of entities) {
-    for (const a of e.extends ?? []) supertypeNames.add(a);
-  }
 
   // A graph node table requires a non-empty KEY. An entity whose primary key is
   // empty cannot form a valid node, so skip it (and, below, any edge that
@@ -117,9 +106,16 @@ export function generatePropertyGraph(
     return false;
   });
 
-  // An abstract class exists only to be a supertype; one that is no concrete
-  // (valid) entity's ancestor produces no graph element at all, so warn and
-  // drop it rather than let it vanish silently.
+  // The ancestors carried by a table-emitting entity. Two uses. First, the
+  // leaf-measure rule: a metric lowers to a MEASURE on its target's DEFAULT
+  // LABEL, and BigQuery forbids a MEASURE on a label shared by more than one
+  // element table, so a measure is allowed only on a LEAF type -- one that no
+  // *table-emitting* entity extends (agreed with Dmitri). Building this from
+  // validEntities (not all entities) is deliberate: an abstract or empty-KEY
+  // subtype emits no table, so it does not duplicate its parent's label and
+  // must not mark the parent non-leaf. Second, the orphan check below: an
+  // abstract class that is no concrete entity's ancestor produces no graph
+  // element at all, so warn and drop it rather than let it vanish silently.
   const ancestorsUsed = new Set<string>();
   for (const entity of validEntities) {
     for (const a of entity.extends ?? []) ancestorsUsed.add(a);
@@ -164,7 +160,7 @@ export function generatePropertyGraph(
   const loweringByEntity = new Map<string, MeasureLowering>();
   for (const metric of metrics) {
     placeMetric(
-        metric, resolved.model, entityByName, skipped, supertypeNames,
+        metric, resolved.model, entityByName, skipped, ancestorsUsed,
         metricsByEntity, loweringByEntity, warnings);
   }
 
@@ -271,7 +267,7 @@ function newLowering(entity: Entity): MeasureLowering {
 // single supported aggregate over one operand.
 function placeMetric(
     metric: Metric, model: SemanticModel, entityByName: Map<string, Entity>,
-    skipped: Set<string>, supertypeNames: Set<string>,
+    skipped: Set<string>, ancestorsUsed: Set<string>,
     metricsByEntity: Map<string, string[]>,
     loweringByEntity: Map<string, MeasureLowering>, warnings: string[]): void {
   // The IR keeps at most two expression forms; a measure is emitted from the
@@ -353,7 +349,7 @@ function placeMetric(
   // carried by more than one element table (verified live: "defined as MEASURE,
   // but there are other declarations with the same name"). Drop it with a
   // warning rather than emit DDL BigQuery rejects.
-  if (supertypeNames.has(entityName)) {
+  if (ancestorsUsed.has(entityName)) {
     warnings.push(
         `metric '${metric.name}' targets entity '${entityName}', which is not ` +
         `a leaf type (another entity extends it); a measure is allowed only on ` +
@@ -712,8 +708,9 @@ function renderNodeTable(
   for (const ancestorName of entity.extends ?? []) {
     const ancestor = labelByName.get(ancestorName);
     if (!ancestor) {
-      // The ancestor exists in the model (resolveInheritance already dropped
-      // unknown parents) but is not a label carrier -- it was dropped for an
+      // The ancestor exists in the model (an unknown parent hard-fails in
+      // resolveInheritance, so it never reaches here) but is not a label
+      // carrier -- it was dropped for an
       // empty KEY. Its fields still flattened onto this node (they render as
       // own properties above); it just forms no queryable label, so omit the
       // LABEL and say so rather than reference a class reported as gone.

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -83,6 +83,18 @@ export function generatePropertyGraph(
   const abstractNames =
       new Set(entities.filter(e => e.abstract).map(e => e.name));
 
+  // A metric lowers to a MEASURE on its target's DEFAULT LABEL, and BigQuery
+  // forbids a MEASURE on a label carried by more than one element table. A
+  // supertype's label is shared with every subtype's table, so a measure is
+  // allowed only on a LEAF type -- one that no other entity extends (agreed with
+  // Dmitri). Inheritance is already resolved, so each entity's `extends` is its
+  // full transitive ancestor set; every non-leaf name therefore appears in some
+  // entity's list, computed here across ALL entities (abstract included).
+  const supertypeNames = new Set<string>();
+  for (const e of entities) {
+    for (const a of e.extends ?? []) supertypeNames.add(a);
+  }
+
   // A graph node table requires a non-empty KEY. An entity whose primary key is
   // empty cannot form a valid node, so skip it (and, below, any edge that
   // references it) rather than emit `KEY()` — invalid DDL. The loader already
@@ -152,7 +164,7 @@ export function generatePropertyGraph(
   const loweringByEntity = new Map<string, MeasureLowering>();
   for (const metric of metrics) {
     placeMetric(
-        metric, resolved.model, entityByName, skipped, ancestorsUsed,
+        metric, resolved.model, entityByName, skipped, supertypeNames,
         metricsByEntity, loweringByEntity, warnings);
   }
 
@@ -259,7 +271,7 @@ function newLowering(entity: Entity): MeasureLowering {
 // single supported aggregate over one operand.
 function placeMetric(
     metric: Metric, model: SemanticModel, entityByName: Map<string, Entity>,
-    skipped: Set<string>, ancestorsUsed: Set<string>,
+    skipped: Set<string>, supertypeNames: Set<string>,
     metricsByEntity: Map<string, string[]>,
     loweringByEntity: Map<string, MeasureLowering>, warnings: string[]): void {
   // The IR keeps at most two expression forms; a measure is emitted from the
@@ -335,17 +347,18 @@ function placeMetric(
         entityName}', which has no KEY and was skipped; metric dropped`);
     return;
   }
-  // A metric lowers to a MEASURE on the target entity's DEFAULT LABEL. When
-  // that entity is a supertype, its label is shared with every subclass table,
-  // and BigQuery forbids binding a MEASURE to a label carried by more than one
-  // element table (a measure cannot be replicated across tables -- verified
-  // live "defined as MEASURE, but there are other declarations with the same
-  // name"). Drop it with a warning rather than emit DDL BigQuery rejects.
-  if (ancestorsUsed.has(entityName)) {
+  // A measure is allowed only on a LEAF type. A metric lowers to a MEASURE on
+  // the target's DEFAULT LABEL; when that entity is a supertype its label is
+  // shared with every subtype table, and BigQuery forbids a MEASURE on a label
+  // carried by more than one element table (verified live: "defined as MEASURE,
+  // but there are other declarations with the same name"). Drop it with a
+  // warning rather than emit DDL BigQuery rejects.
+  if (supertypeNames.has(entityName)) {
     warnings.push(
-        `metric '${metric.name}' targets entity '${entityName}', which is a ` +
-        `supertype whose label is shared across subclass tables; skipped ` +
-        `(BigQuery cannot bind a MEASURE to a shared label)`);
+        `metric '${metric.name}' targets entity '${entityName}', which is not ` +
+        `a leaf type (another entity extends it); a measure is allowed only on ` +
+        `a leaf type, because a supertype's label is shared across its ` +
+        `subtype tables; skipped`);
     return;
   }
 

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/model.ts
@@ -28,9 +28,10 @@
 // guide.
 
 /**
- * Per-term annotations carried verbatim on any class or property -- links to
+ * Per-term annotations parsed from any class or property -- links to
  * related/defining resources and lifecycle metadata. None has a native OSI
- * home, so all ride along as custom extensions (see to_ir.commonTerms). Shared
+ * home, and the importer is import-only, so none is carried into the model:
+ * they are dropped (the earlier custom-extension carriage was removed). Shared
  * by OwlClass, OwlDatatypeProperty, and OwlObjectProperty.
  */
 export interface OwlCommonAnnotations {

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -18,29 +18,16 @@
 //   skos:example                  -> ai_context.examples
 //   owl:Ontology header           -> model description / ai_context
 //
-// Constructs with no native OSI home ride along verbatim in a GOOGLE custom
-// extension (see googleOntologyExtension). It is inert on push (the BigQuery /
-// KC legs read none of it) and preserved across the OSI document round-trip
-// (loader + osi_converter keep custom_extensions verbatim); it is NOT yet
-// persisted to Knowledge Catalog, so a KC pull does not recover it today.
-// Each line is kept short so a comment reflow cannot run the columns together:
-//   rdfs:subPropertyOf -> field / relationship (property inheritance)
-//   owl:inverseOf -> relationship (the edge, reversed)
-//   owl:equivalentClass -> entity (class equivalence)
-//   owl:disjointWith -> entity (class disjointness)
-//   owl:equivalentProperty -> field / relationship
-//   owl:propertyDisjointWith -> field / relationship
-//   property characteristics -> relationship (symmetric, transitive, ...)
-//   owl:oneOf -> entity (enumerated class members)
-//   owl:propertyChainAxiom -> relationship (ordered property composition)
-//   owl:AllDisjointClasses -> model (a set of pairwise-disjoint classes)
-//   owl:AllDisjointProperties -> model (pairwise-disjoint properties)
-//   owl:AllDifferent -> model (a set of distinct individuals)
-//   rdfs:seeAlso, rdfs:isDefinedBy -> any (external pointers, verbatim)
-//   owl:deprecated, owl:versionInfo -> any (lifecycle metadata)
-//
-// A carried cross-reference keeps the full referent IRI unless it is in this
-// ontology's own namespace, when it shortens to a local name (see refValue).
+// The importer is IMPORT-ONLY: it maps the constructs above and DROPS every
+// other OWL construct rather than carrying it. Facts with no native OSI home --
+// rdfs:subPropertyOf, owl:inverseOf, owl:equivalentClass / owl:disjointWith /
+// owl:equivalentProperty / owl:propertyDisjointWith, the property
+// characteristics (symmetric, transitive, ...), owl:oneOf,
+// owl:propertyChainAxiom, the owl:AllDisjoint* / owl:AllDifferent set axioms,
+// rdfs:seeAlso / isDefinedBy, and owl:deprecated / versionInfo -- are NOT
+// imported. An earlier version carried them verbatim in a GOOGLE custom
+// extension; that was removed so an imported model is a clean OSI model with no
+// opaque carrier. The user guide's table documents what maps and what drops.
 //
 // The result is a purely LOGICAL model: an ontology declares meaning, not
 // physical tables, so entities carry no source, fields no expression, and
@@ -52,10 +39,9 @@
 // binding profile, see the user guide, "Going from ontology to a running
 // graph").
 
-import {AiContext, CustomExtension, Entity, Field, Relationship, SemanticModel,} from '../../ir';
+import {AiContext, Entity, Field, Relationship, SemanticModel,} from '../../ir';
 
-import {OwlCommonAnnotations, OwlModel, OwlOntology} from './model';
-import {localName, namespace} from './parse';
+import {OwlModel, OwlOntology} from './model';
 
 export interface ToIrResult {
   model: SemanticModel;
@@ -69,93 +55,6 @@ export interface ToIrResult {
   // even when some elements were warned and skipped.
   stats:
       {classes: number; datatypeProperties: number; objectProperties: number};
-}
-
-// --- Seams: the isolated change-points for later work. ----------------------
-
-// The GOOGLE custom-extensions vendor name. OWL constructs OSI can't express
-// natively (rdfs:subPropertyOf, owl:inverseOf, owl:equivalentClass, property
-// characteristics) ride in this vendor's block -- Google's choice to support
-// OWL, so it sits in the GOOGLE block alongside deployment targets, not a new
-// "OWL" vendor. See deploy_bigquery.googleDeploymentTargets, which safely
-// ignores a GOOGLE block that carries no deploymentTargets.
-const GOOGLE_VENDOR = 'GOOGLE';
-
-/**
- * Builds a GOOGLE custom-extension block carrying OWL constructs that have no
- * native OSI home, verbatim.
- *
- * The payload is a FLAT object whose keys ARE the source constructs, prefixed
- * with their vocabulary (`owl:inverseOf`, `rdfs:subPropertyOf`, ...): the
- * prefix carries the namespace, so the same short name from a different
- * standard can't collide and the reader always knows which vocabulary a fact
- * came from. This is the deliberate mirror of the deployment-target block,
- * whose own keys are Google's (`deploymentTargets`, unprefixed) -- the two
- * kinds of key coexist in one GOOGLE block without clashing, and a consumer
- * reads "any key with a `:`" as a carried ontology fact.
- *
- * The values mirror the construct faithfully rather than inventing a shape:
- * `owl:SymmetricProperty: true` (not a synthesized `characteristics` list), the
- * raw superproperty names for `rdfs:subPropertyOf`, and so on. Carriage is
- * inert on push (the BigQuery / KC legs read none of it) and survives the OSI
- * document round-trip verbatim (loader + osi_converter preserve
- * custom_extensions); it is NOT yet persisted to / recovered from Knowledge
- * Catalog. Promoting a construct to a native OSI concept later means changing
- * this seam and its callers, nothing downstream.
- *
- * Returns undefined when `terms` is empty, so a caller can attach the result
- * unconditionally without emitting an empty block.
- */
-export function googleOntologyExtension(terms: Record<string, unknown>):
-    CustomExtension|undefined {
-  if (!Object.keys(terms).length) return undefined;
-  return {
-    vendorName: GOOGLE_VENDOR,
-    // Pretty-printed (2-space) so the carried block reads as a legible JSON
-    // object in the serialized YAML -- the `yaml` serializer renders a
-    // newline-bearing string as a block scalar -- instead of one long quoted
-    // line. `data` is opaque and every consumer JSON.parses it, so the added
-    // whitespace is insignificant on the wire.
-    data: JSON.stringify(terms, null, 2),
-  };
-}
-
-// Appends a carried-ontology GOOGLE block to an IR object (entity / field /
-// relationship), leaving any existing custom extensions in place. A no-op when
-// there is nothing to carry, so callers can attach unconditionally.
-function attachOntology(
-    target: {customExtensions?: CustomExtension[]},
-    terms: Record<string, unknown>): void {
-  const ext = googleOntologyExtension(terms);
-  if (!ext) return;
-  (target.customExtensions ??= []).push(ext);
-}
-
-// How a carried CROSS-REFERENCE IRI is rendered: shortened to its local name
-// when it lives in this ontology's own namespace (an in-model reference a
-// consumer resolves by name), kept as the full IRI otherwise (a cross-ontology
-// reference that points outside the model). Shortening is lossless because the
-// base IRI is carried as structured metadata (`owl:baseIri`) on the model
-// whenever any reference is shortened, so an in-namespace localName is
-// reconstructable as `<baseIri><localName>`; "when in doubt, keep the full IRI"
-// falls out for free.
-function refValue(iri: string, baseIri: string|undefined): string {
-  return baseIri !== undefined && namespace(iri) === baseIri ? localName(iri) :
-                                                               iri;
-}
-
-// The per-term carried annotations shared by entities, fields, and
-// relationships (rdfs:seeAlso / isDefinedBy, owl:deprecated / versionInfo), in
-// a fixed key order. seeAlso/isDefinedBy are external pointers, so they are
-// kept verbatim (never shortened). Returns the entries to merge into a term's
-// carried block; empty when the term has none.
-function commonTerms(a: OwlCommonAnnotations): Record<string, unknown> {
-  const terms: Record<string, unknown> = {};
-  if (a.seeAlso.length) terms['rdfs:seeAlso'] = dedupe(a.seeAlso);
-  if (a.isDefinedBy.length) terms['rdfs:isDefinedBy'] = dedupe(a.isDefinedBy);
-  if (a.deprecated) terms['owl:deprecated'] = true;
-  if (a.versionInfo) terms['owl:versionInfo'] = a.versionInfo;
-  return terms;
 }
 
 // --- Datatype mapping. ------------------------------------------------------
@@ -323,28 +222,6 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
   const warnings: string[] = [];
   const classNames = new Set(owl.classes.map(c => c.localName));
 
-  // refValue over a list, deduped, recording whether any referent was actually
-  // shortened. When one was, the base IRI is carried on the model
-  // (`owl:baseIri` below) so the shortened localName is mechanically
-  // reconstructable. Mapping before dedupe collapses a referent stated more
-  // than once (its shortened form is identical), so a repeated identical triple
-  // never looks like a conflict.
-  let shortenedRef = false;
-  const refs = (iris: string[]): string[] => dedupe(iris.map(iri => {
-    const v = refValue(iri, owl.baseIri);
-    if (v !== iri) shortenedRef = true;
-    return v;
-  }));
-
-  // Like refs(), but preserves order AND duplicates -- for an ORDERED construct
-  // (a property chain) where a repeated referent is meaningful (e.g.
-  // hasParent/hasParent == grandparent), so deduping would silently corrupt it.
-  const refSeq = (iris: string[]): string[] => iris.map(iri => {
-    const v = refValue(iri, owl.baseIri);
-    if (v !== iri) shortenedRef = true;
-    return v;
-  });
-
   // Entities, one per class, in class-declaration order. Fields are attached in
   // datatype-property-declaration order below. Two classes can share a local
   // name (e.g. same name in different namespaces); OSI dataset names must be
@@ -374,9 +251,8 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     // local names, deduped); parents are not flattened here -- a later
     // resolution pass expands inherited fields (see ir.ts Entity.extends). A
     // parent that is not an owl:Class in this ontology (a typo, or a superclass
-    // imported from another ontology) is still recorded, but warned about -- as
-    // every other cross-reference here is -- so a dangling `extends` is never
-    // emitted silently.
+    // imported from another ontology) is still recorded, but warned about, so
+    // a dangling `extends` is never emitted silently.
     if (c.subClassOf.length) {
       const parents = dedupe(c.subClassOf);
       entity.extends = parents;
@@ -390,23 +266,6 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
             `ontology).`);
       }
     }
-    // OWL facts with no native OSI home, carried verbatim on the entity, in a
-    // fixed key order. owl:equivalentClass / owl:disjointWith are class
-    // cross-references (a class is one entity, so these are facts ABOUT it, not
-    // structural links); owl:oneOf enumerates the class's members (usually
-    // individuals, which are not modeled, so only the names are kept) -- an
-    // enumeration is a set, so refs() (which dedupes) is correct here, unlike
-    // the ordered propertyChainAxiom which uses refSeq; blank-node class
-    // expressions were dropped in the parser. commonTerms adds any per-term
-    // annotations (seeAlso, deprecated, ...).
-    const entityTerms: Record<string, unknown> = {};
-    if (c.equivalentClass.length)
-      entityTerms['owl:equivalentClass'] = refs(c.equivalentClass);
-    if (c.disjointWith.length)
-      entityTerms['owl:disjointWith'] = refs(c.disjointWith);
-    if (c.oneOf.length) entityTerms['owl:oneOf'] = refs(c.oneOf);
-    Object.assign(entityTerms, commonTerms(c));
-    attachOntology(entity, entityTerms);
     entitiesByName.set(c.localName, entity);
     entities.push(entity);
   }
@@ -421,24 +280,6 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `(a field must belong to a class).`);
       continue;
     }
-    // OWL facts with no native OSI home, carried verbatim on the field, in a
-    // fixed key order. Built once and attached to the field on each domain (the
-    // facts are the property's, independent of which class it lands on). Each
-    // mapping line is kept short so a comment reflow cannot mangle it:
-    //   rdfs:subPropertyOf -> property inheritance (kept as a fact, no
-    //     entity-style flattening)
-    //   owl:equivalentProperty, owl:propertyDisjointWith -> cross-references
-    //   owl:FunctionalProperty -> single-valued
-    //   commonTerms adds any per-term annotations
-    const fieldTerms: Record<string, unknown> = {};
-    if (p.subPropertyOf.length)
-      fieldTerms['rdfs:subPropertyOf'] = refs(p.subPropertyOf);
-    if (p.equivalentProperty.length)
-      fieldTerms['owl:equivalentProperty'] = refs(p.equivalentProperty);
-    if (p.propertyDisjointWith.length)
-      fieldTerms['owl:propertyDisjointWith'] = refs(p.propertyDisjointWith);
-    if (p.functional) fieldTerms['owl:FunctionalProperty'] = true;
-    Object.assign(fieldTerms, commonTerms(p));
     // A property counts as converted once if it produces at least one field,
     // regardless of how many domains it lands on.
     let produced = false;
@@ -469,7 +310,6 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
         description: p.comment,
         aiContext: fieldAiContext(p.synonyms, p.localName, p.examples),
       };
-      attachOntology(field, fieldTerms);
       entity.fields.push(field);
       produced = true;
       // An inverse-functional property uniquely identifies its subject -> a
@@ -560,51 +400,6 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
           `name; skipped (relationship names must be unique).`);
       continue;
     }
-    // OWL facts with no native OSI home, carried verbatim on the relationship,
-    // in a fixed key order so the emitted block is stable. rdfs:subPropertyOf
-    // -> relationship inheritance (kept as a fact, no flattening);
-    // owl:propertyChainAxiom -> this edge as an ordered composition of other
-    // properties; owl:inverseOf -> the edge read the other way;
-    // owl:equivalentProperty / propertyDisjointWith -> property
-    // cross-references; then the edge's characteristics (symmetric / transitive
-    // / functional / reflexive / irreflexive / asymmetric); commonTerms adds
-    // any per-term annotations.
-    const relTerms: Record<string, unknown> = {};
-    if (p.subPropertyOf.length)
-      relTerms['rdfs:subPropertyOf'] = refs(p.subPropertyOf);
-    // One list per chain axiom (a property may carry several). Each is ordered
-    // and repetition-sensitive, so refSeq (not refs): a chain may name the same
-    // property twice (e.g. hasParent/hasParent for a grandparent). Emitted as a
-    // list of chains so distinct axioms are not fused into one flat sequence.
-    if (p.propertyChain.length)
-      relTerms['owl:propertyChainAxiom'] = p.propertyChain.map(refSeq);
-    if (p.inverseOf.length) {
-      // owl:inverseOf pairs two properties; one DISTINCT statement is the norm.
-      // refs() shortens and dedupes first, so a repeated identical triple isn't
-      // mistaken for a genuine conflict. If more than one distinct inverse
-      // remains, carry the first and say what was dropped rather than emitting
-      // an array the reader would have to disambiguate.
-      const inverses = refs(p.inverseOf);
-      relTerms['owl:inverseOf'] = inverses[0];
-      if (inverses.length > 1) {
-        warnings.push(
-            `object property '${p.localName}' declares owl:inverseOf more ` +
-            `than once (${inverses.join(', ')}); a relationship has one ` +
-            `inverse, so only '${inverses[0]}' is carried.`);
-      }
-    }
-    if (p.equivalentProperty.length)
-      relTerms['owl:equivalentProperty'] = refs(p.equivalentProperty);
-    if (p.propertyDisjointWith.length)
-      relTerms['owl:propertyDisjointWith'] = refs(p.propertyDisjointWith);
-    if (p.symmetric) relTerms['owl:SymmetricProperty'] = true;
-    if (p.transitive) relTerms['owl:TransitiveProperty'] = true;
-    if (p.functional) relTerms['owl:FunctionalProperty'] = true;
-    if (p.reflexive) relTerms['owl:ReflexiveProperty'] = true;
-    if (p.irreflexive) relTerms['owl:IrreflexiveProperty'] = true;
-    if (p.asymmetric) relTerms['owl:AsymmetricProperty'] = true;
-    Object.assign(relTerms, commonTerms(p));
-
     const relationship: Relationship = {
       name: p.localName,
       // A logical edge: direction only, no join columns. The source
@@ -617,7 +412,6 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       aiContext: relationshipAiContext(
           p.label, p.localName, p.synonyms, p.comment, p.examples),
     };
-    attachOntology(relationship, relTerms);
     relationships.push(relationship);
   }
 
@@ -629,27 +423,6 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
     relationships,
     metrics: [],
   };
-  // Model-level carried facts, in a fixed key order so the block is stable. The
-  // set-level axioms come first (each an array of member SETS -- one per axiom
-  // -- so refs() per set, which dedupes; order within a set is not meaningful).
-  // owl:baseIri comes last and only WHEN a cross-reference was shortened to a
-  // local name (refValue), so a consumer can rebuild the full IRI as
-  // `<baseIri><localName>` mechanically instead of parsing it from the prose
-  // description; a model with no shortened reference stays clean. The set-level
-  // members are shortened through refs() too, so they alone can require the
-  // base IRI -- computed before the check below relies on that side effect.
-  const modelTerms: Record<string, unknown> = {};
-  if (owl.allDisjointClasses.length)
-    modelTerms['owl:AllDisjointClasses'] =
-        owl.allDisjointClasses.map(set => refs(set));
-  if (owl.allDisjointProperties.length)
-    modelTerms['owl:AllDisjointProperties'] =
-        owl.allDisjointProperties.map(set => refs(set));
-  if (owl.allDifferent.length)
-    modelTerms['owl:AllDifferent'] = owl.allDifferent.map(set => refs(set));
-  if (shortenedRef && owl.baseIri) modelTerms['owl:baseIri'] = owl.baseIri;
-  attachOntology(model, modelTerms);
-
   return {
     model,
     warnings,

--- a/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/converters/owl/to_ir.ts
@@ -247,23 +247,25 @@ export function owlToIr(owl: OwlModel, modelName: string): ToIrResult {
       aiContext: synonymAiContext(c.label, c.localName, c.synonyms, c.examples),
       fields: [],
     };
-    // rdfs:subClassOf -> entity-level `extends`. Recorded AS DECLARED (parent
+    // rdfs:subClassOf -> entity-level `extends`. Kept AS DECLARED (parent
     // local names, deduped); parents are not flattened here -- a later
-    // resolution pass expands inherited fields (see ir.ts Entity.extends). A
-    // parent that is not an owl:Class in this ontology (a typo, or a superclass
-    // imported from another ontology) is still recorded, but warned about, so
-    // a dangling `extends` is never emitted silently.
+    // resolution pass expands inherited fields (see ir.ts Entity.extends). Only
+    // parents defined as an owl:Class in this ontology are kept: an unknown
+    // parent (a typo, or a superclass imported from another ontology) cannot be
+    // resolved, and the loader hard-fails on an unknown supertype, so it is
+    // DROPPED here with a warning rather than emitted into a model that could
+    // not be pushed.
     if (c.subClassOf.length) {
       const parents = dedupe(c.subClassOf);
-      entity.extends = parents;
+      const known = parents.filter(name => classNames.has(name));
       const unknown = parents.filter(name => !classNames.has(name));
+      if (known.length) entity.extends = known;
       if (unknown.length) {
         warnings.push(
             `class '${c.localName}' declares rdfs:subClassOf a non-class ` +
             `superclass (${
-                unknown.join(', ')}); the extends link is recorded ` +
-            `as declared but cannot be resolved (not an owl:Class in this ` +
-            `ontology).`);
+                unknown.join(', ')}); dropped, as it is not an owl:Class in ` +
+            `this ontology and cannot be resolved.`);
       }
     }
     entitiesByName.set(c.localName, entity);

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -141,17 +141,15 @@ export interface Field {
   expression?: string;             // target/canonical (GoogleSQL-valid) SQL
   importedExpression?: string;     // original vendor SQL, verbatim
   importedDialect?: string;        // dialect of `importedExpression` (e.g. 'SNOWFLAKE')
-  // Marks a field declared logically but with NO physical column under the
-  // current binding: structurally absent, not null. A metric, relationship, or
-  // action that reads it is unavailable here rather than reading a null (see
-  // the binding-profiles guide). An unbound field carries no `expression`.
-  //
-  // This is the field-level analogue of an entity's `abstract` (a whole class
-  // with no table) and, like the OWL importer's `unbound:` source placeholder,
-  // means "should be bound by some binding, and reading it where it is not is an
-  // error" -- distinct from a bound field whose value merely happens to be null.
-  unbound?: boolean;
+  // A field with NO physical column under the current binding is UNBOUND:
+  // structurally absent, not null. There is no explicit flag -- a field is
+  // unbound exactly when it carries no `expression` (and no
+  // `importedExpression`); see fieldBinding. A metric, relationship, or action
+  // that reads an unbound field is unavailable here rather than reading a null
+  // (see the binding-profiles guide). This is the field-level analogue of an
+  // entity's `abstract` (a whole class with no table).
   dimension?: Dimension;           // dimension metadata (e.g. temporal role)
+
   label?: string;                  // human display label (distinct from name/description)
   description?: string;
   type?: DataType;                 // logical datatype (the open format's `datatype`)
@@ -196,13 +194,14 @@ export function isTimeDimension(field: Field): boolean {
 // undefined when the field is unbound (structurally absent -- no column). A
 // field's target/canonical `expression` wins; a field awaiting transpilation
 // falls back to its imported vendor expression, which still names a real column,
-// so it is bound rather than unbound. `unbound: true` means no column at all.
-// This is the single source of truth for "is this field bound"; availability
-// pruning and the BigQuery generator both consult it so they never disagree.
+// so it is bound rather than unbound. A field with neither is unbound (no
+// column at all). This is the single source of truth for "is this field bound";
+// availability pruning and the BigQuery generator both consult it so they never
+// disagree.
 export function fieldBinding(field: Field): string | undefined {
-  if (field.unbound) return undefined;
   return field.expression ?? field.importedExpression;
 }
+
 
 /**
  * A relationship: a directed foreign-key edge in the semantic graph, from

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -4,29 +4,30 @@
 // The format describes a semantic model as datasets (entities), foreign-key
 // relationships, and model-level metrics, with entity-qualified SQL expressions
 // (`Entity.column`) supplied per SQL dialect. This module reads the subset of
-// that logical layer needed to normalize a model into the IR, so the rest of the
-// toolbox (e.g. the BigQuery property-graph generator) can consume models
+// that logical layer needed to normalize a model into the IR, so the rest of
+// the toolbox (e.g. the BigQuery property-graph generator) can consume models
 // authored in it. Fields outside the supported subset are accepted and ignored.
 //
 
 import * as yaml from 'yaml';
 import * as z from 'zod';
-import {
-  SemanticModel, Entity, Field, Relationship, Metric, AiContext, CustomExtension,
-  DATA_TYPES,
-} from './ir';
-import { referencedEntityNames } from './sql_expr_utils';
+
+import {AiContext, CustomExtension, DATA_TYPES, Entity, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {referencedEntityNames} from './sql_expr_utils';
 
 export interface LoadOptions {
-  dialect?: string;         // preferred expression dialect; default 'BIGQUERY'
-  defaultProject?: string;  // fallback when a dataset `source` omits the project
-  defaultDataset?: string;  // fallback when a dataset `source` omits the dataset
+  dialect?: string;  // preferred expression dialect; default 'BIGQUERY'
+  defaultProject?:
+      string;  // fallback when a dataset `source` omits the project
+  defaultDataset?:
+      string;  // fallback when a dataset `source` omits the dataset
   // Accept a purely logical model: do not require a `source` on each concrete
-  // dataset or an `expression` on each field. Set for a Knowledge-Catalog-only
-  // push, which governs the logical model (meaning) and needs no physical
-  // binding. Graph legs (BigQuery/Spanner) never set it -- they cannot generate
-  // a graph without bindings. Contradiction checks (unbound+expression,
-  // abstract+source) stay enforced regardless.
+  // dataset. Set for a Knowledge-Catalog-only push, which governs the logical
+  // model (meaning) and needs no physical binding. Graph legs
+  // (BigQuery/Spanner) never set it -- a concrete dataset with no table cannot
+  // back a graph. A field's `expression` is never required either way: a field
+  // with none is unbound and the availability pass prunes it. The
+  // abstract+source contradiction stays enforced regardless.
   bindingOptional?: boolean;
 }
 
@@ -37,9 +38,21 @@ export interface LoadResult {
 
 const DEFAULT_DIALECT = 'BIGQUERY';
 const FALLBACK_DIALECT = 'ANSI_SQL';
-// The logical-layer schema version this loader was written against; a document
-// declaring a different version is loaded anyway, with a warning.
-const SUPPORTED_VERSION = '0.2.0.dev0';
+// The two accepted format versions. Every document MUST declare one at the top
+// level (a missing or unrecognized `version` is a load error). The value
+// selects which extension surface is legal:
+//   - OSSIE_VERSION: vanilla Apache Ossie. kcmd's extensions ride ONLY in
+//     Ossie's `custom_extensions` carrier; the native extension keys
+//     (`entities` alias, `extends`, `abstract`, `deployment_target`) are not
+//     accepted.
+//   - GOOGLE_VERSION: kcmd's extended profile. The native extension keys are
+//     first-class; Ossie's `custom_extensions` field is not accepted (its
+//     content is expressed natively instead).
+// Both parse into the same IR, so a downstream leg never sees the difference.
+const OSSIE_VERSION = '0.2.0.dev0';
+const GOOGLE_VERSION = '0.2.0.dev0/google';
+const ACCEPTED_VERSIONS = [OSSIE_VERSION, GOOGLE_VERSION];
+
 
 
 // An expression is supplied as one or more per-dialect variants; we collapse it
@@ -52,14 +65,14 @@ const SUPPORTED_VERSION = '0.2.0.dev0';
 // only ever sees the per-dialect object.
 const expressionObjectSchema = z.object({
   dialects: z.array(z.object({
-    dialect: z.string(),
-    expression: z.string(),
-  })).min(1),
+               dialect: z.string(),
+               expression: z.string(),
+             })).min(1),
 });
 const expressionSchema = z.union([
   z.string().transform((s): z.infer<typeof expressionObjectSchema> => ({
-    dialects: [{ dialect: DEFAULT_DIALECT, expression: s }],
-  })),
+                         dialects: [{dialect: DEFAULT_DIALECT, expression: s}],
+                       })),
   expressionObjectSchema,
 ]);
 
@@ -79,8 +92,9 @@ const aiContextSchema = z.union([
 // A vendor-scoped extension block: opaque `data` (a JSON string) tagged by
 // `vendor_name`. The spec allows these at every level (model, dataset, field,
 // relationship, metric). All are preserved verbatim on the IR (see
-// toCustomExtensions) for lossless round-trip; no vendor block is interpreted at
-// load time -- typed views (e.g. off the GOOGLE block) are a consumer concern.
+// toCustomExtensions) for lossless round-trip; no vendor block is interpreted
+// at load time -- typed views (e.g. off the GOOGLE block) are a consumer
+// concern.
 const customExtensionSchema = z.object({
   vendor_name: z.string(),
   data: z.string(),
@@ -91,26 +105,25 @@ const dimensionSchema = z.object({
   is_time: z.boolean().optional(),
 });
 
-// The field object shape, WITHOUT the binding-completeness refinement. The
-// refinement is applied per-load by makeDocumentSchema, so a
-// Knowledge-Catalog-only push (bindingOptional) can accept a purely logical
-// field. A superRefine does not change a schema's inferred type, so FieldDoc is
-// inferred from this base.
+// The canonical (superset) field shape, for TYPE inference only. The actual
+// validation schemas are rebuilt per-load by buildDocumentSchema, which is
+// strict, gates `custom_extensions` on the version, and applies the
+// source-completeness refinement. A field is BOUND when it names a physical
+// column via `expression`; a field with no `expression` is UNBOUND (no column
+// under this binding). A field is never required to be bound -- an unbound
+// field loads and the availability pass prunes it before generation.
 const fieldBase = z.object({
   name: z.string(),
-  // A bound field names its physical column via `expression`; an `unbound`
-  // field has no column under this binding. Whether a field must be bound (or
-  // explicitly `unbound`) is decided per-load by makeDocumentSchema; a purely
-  // logical field carries neither.
   expression: expressionSchema.optional(),
-  unbound: z.boolean().optional(),
-  datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
+  datatype: z.enum(DATA_TYPES).optional(),  // closed, case-sensitive
+                                            // vocabulary; see DATA_TYPES
   description: z.string().optional(),
   label: z.string().optional(),
   dimension: dimensionSchema.optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
+
 
 // The dataset object shape, WITHOUT the source-required refinement (applied
 // per-load by makeDocumentSchema). DatasetDoc is inferred from this base.
@@ -138,27 +151,32 @@ const datasetBase = z.object({
 });
 
 const relationshipSchema = z.object({
-  name: z.string(),
-  from: z.string(),
-  to: z.string(),
-  // Join columns are the physical binding of the edge and are OPTIONAL, so a
-  // purely logical relationship (an ontology edge, direction only) loads. When
-  // present they must be non-empty; either both endpoints are bound or neither
-  // is (a half-bound edge is a malformed join, caught below). A graph push still
-  // requires both (see validatePushRequirements).
-  from_columns: z.array(z.string()).min(1).optional(),
-  to_columns: z.array(z.string()).min(1).optional(),
-  description: z.string().optional(),
-  ai_context: aiContextSchema.optional(),
-  custom_extensions: z.array(customExtensionSchema).optional(),
-}).superRefine((r, ctx) => {
+                              name: z.string(),
+                              from: z.string(),
+                              to: z.string(),
+                              // Join columns are the physical binding of the
+                              // edge and are OPTIONAL, so a purely logical
+                              // relationship (an ontology edge, direction only)
+                              // loads. When present they must be non-empty;
+                              // either both endpoints are bound or neither is
+                              // (a half-bound edge is a malformed join, caught
+                              // below). A graph push still requires both (see
+                              // validatePushRequirements).
+                              from_columns:
+                                  z.array(z.string()).min(1).optional(),
+                              to_columns: z.array(z.string()).min(1).optional(),
+                              description: z.string().optional(),
+                              ai_context: aiContextSchema.optional(),
+                              custom_extensions:
+                                  z.array(customExtensionSchema).optional(),
+                            }).superRefine((r, ctx) => {
   if ((r.from_columns === undefined) !== (r.to_columns === undefined)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message:
-        `relationship '${r.name}': from_columns and to_columns must be given ` +
-        `together (both bind the edge) or both omitted (a logical edge); one ` +
-        `without the other is a half-bound join.`,
+      message: `relationship '${
+                   r.name}': from_columns and to_columns must be given ` +
+          `together (both bind the edge) or both omitted (a logical edge); one ` +
+          `without the other is a half-bound join.`,
     });
   }
 });
@@ -166,7 +184,8 @@ const relationshipSchema = z.object({
 const metricSchema = z.object({
   name: z.string(),
   expression: expressionSchema,
-  datatype: z.enum(DATA_TYPES).optional(),   // closed, case-sensitive vocabulary; see DATA_TYPES
+  datatype: z.enum(DATA_TYPES).optional(),  // closed, case-sensitive
+                                            // vocabulary; see DATA_TYPES
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
@@ -180,87 +199,183 @@ const modelBase = z.object({
   datasets: z.array(datasetBase).min(1),
   relationships: z.array(relationshipSchema).optional(),
   metrics: z.array(metricSchema).optional(),
+  // A native deployment-target key (GOOGLE_VERSION only). Folded into a GOOGLE
+  // `custom_extensions` block on the IR after validation (see convertModel).
+  deployment_target: z.string().optional(),
 });
 
-// Builds the document schema with the binding-completeness refinement applied
-// according to `bindingOptional`. When false (the default -- any push that
-// includes a graph leg), each concrete dataset must name a `source` and each
-// field must be bound or explicitly `unbound`. When true (a
-// Knowledge-Catalog-only push, which governs the logical model), those two
-// requirements are dropped so a purely logical model loads. The contradiction
-// checks (unbound+expression, abstract+source) are enforced either way.
-function buildDocumentSchema(bindingOptional: boolean) {
-  const field = fieldBase.superRefine((f, ctx) => {
-    if (f.unbound && f.expression !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['expression'],
-        message: `field '${f.name}': an unbound field has no column; remove ` +
-            `'expression', or drop 'unbound: true' to bind it to that column`,
-      });
-    }
-    // The expression-required check is applied at the dataset level (below),
-    // not here, so it can skip a dataset marked `abstract`: an abstract
-    // supertype has no table and its fields carry no expression, surviving only
-    // as labels on its concrete descendants.
-  });
-  const dataset = datasetBase.extend({ fields: z.array(field).optional() })
-    .superRefine((ds, ctx) => {
-      // A concrete (non-abstract) dataset must name its backing table; only an
-      // abstract one may omit `source`. Relaxed under bindingOptional, where a
-      // logical dataset has no source.
-      if (!bindingOptional && !ds.abstract && ds.source === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['source'],
-          message: `dataset '${ds.name}': a non-abstract dataset requires a ` +
-              `source; set 'source', or mark it 'abstract: true' if it has no table`,
-        });
-      }
-      // The converse is always contradictory: an abstract dataset has no
-      // physical table, so a `source` on it would be silently ignored by the
-      // BigQuery leg. Reject it regardless of bindingOptional.
-      if (ds.abstract && ds.source !== undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['source'],
-          message: `dataset '${ds.name}': an abstract dataset has no table; ` +
-              `remove 'source', or drop 'abstract: true' to bind it to that table`,
-        });
-      }
-      // Each concrete dataset's fields must be bound (or explicitly `unbound`)
-      // under a graph leg. An abstract dataset is skipped: it has no table, so
-      // its fields carry no column. Checked here rather than per-field because
-      // abstractness is a dataset-level fact.
-      if (!bindingOptional && !ds.abstract) {
-        (ds.fields ?? []).forEach((f, i) => {
-          if (!f.unbound && f.expression === undefined) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ['fields', i, 'expression'],
-              message: `field '${f.name}': requires an expression; set ` +
-                  `'expression', or mark it 'unbound: true' if this ` +
-                  `binding has no column for it`,
-            });
-          }
-        });
-      }
-    });
-  const model = modelBase.extend({ datasets: z.array(dataset).min(1) });
-  return z.object({
-    version: z.string().optional(),
-    semantic_model: z.array(model).min(1),
-  });
+
+// The vendor-scoped `custom_extensions` field, present in the validation schema
+// ONLY under vanilla Ossie. Under the extended profile the same information is
+// carried by native keys, so a `custom_extensions` field is rejected as unknown
+// (§6; agreed with Dmitri). Spread into each object shape below.
+function ceField(extended: boolean) {
+  return extended ?
+      {} :
+      {custom_extensions: z.array(customExtensionSchema).optional()};
 }
 
-// Only two schema shapes exist (strict vs binding-optional) and each is
-// immutable, so build both once at module load and select between them rather
-// than reconstructing the whole field/dataset/model/document graph -- with fresh
-// superRefine closures -- on every fromDocument call.
-const strictDocumentSchema = buildDocumentSchema(false);
-const logicalDocumentSchema = buildDocumentSchema(true);
-function makeDocumentSchema(bindingOptional: boolean) {
-  return bindingOptional ? logicalDocumentSchema : strictDocumentSchema;
+// Builds the document schema for one (bindingOptional, extended) combination.
+// Every object is `.strict()`, so an unknown key is a hard error rather than
+// silently dropped. Two axes shape it:
+//   - `extended` selects the version's extension surface: under the extended
+//     profile the native keys (`extends`, `abstract`, `deployment_target`) are
+//     accepted and `custom_extensions` is rejected; under vanilla Ossie the
+//     reverse. (`entities` is folded to `datasets` before validation, so it is
+//     never a schema key -- see normalizeDocumentSugars.)
+//   - `bindingOptional` relaxes the source rule: when false (any push with a
+//     graph leg) each concrete dataset must name a `source`; when true (a
+//     Knowledge-Catalog-only push) it is optional, so a purely logical model
+//     loads. The abstract+source contradiction is rejected either way. Fields
+//     are never required to carry an `expression`: a field with no `expression`
+//     is simply unbound (there is no separate flag), and the availability pass
+//     prunes it before generation -- so it is not a load error under either
+//     `bindingOptional`.
+function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
+  const ce = ceField(extended);
+
+  const field =
+      z.object({
+         name: z.string(),
+         expression: expressionSchema.optional(),
+         datatype: z.enum(DATA_TYPES).optional(),  // closed, case-sensitive
+                                                   // vocabulary; see DATA_TYPES
+         description: z.string().optional(),
+         label: z.string().optional(),
+         dimension: dimensionSchema.optional(),
+         ai_context: aiContextSchema.optional(),
+         ...ce,
+       }).strict();
+
+  const dataset =
+      z.object({
+         name: z.string(),
+         source: z.string().optional(),
+         primary_key: z.array(z.string()).optional(),
+         unique_keys: z.array(z.array(z.string())).optional(),
+         description: z.string().optional(),
+         ai_context: aiContextSchema.optional(),
+         fields: z.array(field).optional(),
+         ...ce,
+         // Inheritance is a native extension: only the extended profile accepts
+         // it.
+         ...(extended ? {
+           extends: z.array(z.string()).optional(),
+           abstract: z.boolean().optional(),
+         } :
+                        {}),
+       })
+          .strict()
+          .superRefine((ds: any, ctx) => {
+            const abstract = ds.abstract === true;
+            // A concrete (non-abstract) dataset must name its backing table;
+            // only an abstract one may omit `source`. Relaxed under
+            // bindingOptional.
+            if (!bindingOptional && !abstract && ds.source === undefined) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['source'],
+                message:
+                    `dataset '${ds.name}': a non-abstract dataset requires a ` +
+                    `source; set 'source', or mark it 'abstract: true' if it has no table`,
+              });
+            }
+            // The converse is always contradictory: an abstract dataset has no
+            // physical table, so a `source` on it would be silently ignored.
+            // Reject it always.
+            if (abstract && ds.source !== undefined) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['source'],
+                message:
+                    `dataset '${ds.name}': an abstract dataset has no table; ` +
+                    `remove 'source', or drop 'abstract: true' to bind it to that table`,
+              });
+            }
+            // A field with no `expression` is unbound -- there is no separate
+            // flag. A graph leg does not reject it: the availability pass
+            // (pruneUnavailable) drops each unbound field, and whatever depends
+            // on it, before generation, so a deployed graph presents only what
+            // its binding answers. This is how one logical model serves several
+            // stores from different profiles, so it is not a load error under
+            // either `bindingOptional`.
+          });
+
+  const relationship =
+      z.object({
+         name: z.string(),
+         from: z.string(),
+         to: z.string(),
+         from_columns: z.array(z.string()).min(1).optional(),
+         to_columns: z.array(z.string()).min(1).optional(),
+         description: z.string().optional(),
+         ai_context: aiContextSchema.optional(),
+         ...ce,
+       })
+          .strict()
+          .superRefine((r, ctx) => {
+            if ((r.from_columns === undefined) !==
+                (r.to_columns === undefined)) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                    `relationship '${
+                        r.name}': from_columns and to_columns must be given ` +
+                    `together (both bind the edge) or both omitted (a logical edge); one ` +
+                    `without the other is a half-bound join.`,
+              });
+            }
+          });
+
+  const metric =
+      z.object({
+         name: z.string(),
+         expression: expressionSchema,
+         datatype: z.enum(DATA_TYPES).optional(),  // closed, case-sensitive
+                                                   // vocabulary; see DATA_TYPES
+         description: z.string().optional(),
+         ai_context: aiContextSchema.optional(),
+         ...ce,
+       }).strict();
+
+  const model =
+      z.object({
+         name: z.string(),
+         description: z.string().optional(),
+         ai_context: aiContextSchema.optional(),
+         datasets: z.array(dataset).min(1),
+         relationships: z.array(relationship).optional(),
+         metrics: z.array(metric).optional(),
+         ...ce,
+         // `deployment_target` is a native extension key: extended profile
+         // only.
+         ...(extended ? {deployment_target: z.string().optional()} : {}),
+       }).strict();
+
+  return z
+      .object({
+        version: z.string(),
+        semantic_model: z.array(model).min(1),
+      })
+      .strict();
+}
+
+// Four immutable schema shapes exist -- (bindingOptional) x (extended) -- so
+// build all four once at module load and select between them rather than
+// reconstructing the whole field/dataset/model/document graph (with fresh
+// superRefine closures) on every fromDocument call.
+const documentSchemas = {
+  'false-false': buildDocumentSchema(false, false),
+  'false-true': buildDocumentSchema(false, true),
+  'true-false': buildDocumentSchema(true, false),
+  'true-true': buildDocumentSchema(true, true),
+};
+// Returns z.ZodTypeAny so the four distinct strict object types collapse to one
+// static type here; the document is re-typed as DocumentDoc after a successful
+// parse (see fromDocument), which the convert functions consume.
+function makeDocumentSchema(
+    bindingOptional: boolean, extended: boolean): z.ZodTypeAny {
+  return documentSchemas[`${bindingOptional}-${extended}` as keyof typeof documentSchemas];
 }
 
 type ExpressionDoc = z.infer<typeof expressionSchema>;
@@ -270,19 +385,28 @@ type RelationshipDoc = z.infer<typeof relationshipSchema>;
 type MetricDoc = z.infer<typeof metricSchema>;
 type ModelDoc = z.infer<typeof modelBase>;
 type CustomExtensionDoc = z.infer<typeof customExtensionSchema>;
+// The whole document, as the convert functions see it: `version` plus the
+// superset model shape (every version's keys, each optional -- modelBase is the
+// superset). Each of the four strict schemas validates to a subset of this, so
+// they share this one static type once parsed.
+type DocumentDoc = {
+  version: string; semantic_model: ModelDoc[]
+};
 type AiContextDoc = z.infer<typeof aiContextSchema>;
 
 // The AI-first `ai_context` normalized to the IR's common shape: a bare string
 // is read as `instructions`; a structured object keeps its parts. `examples` is
 // filtered to strings (producers vary; non-string examples are dropped).
-function normalizeAiContext(ai: AiContextDoc | undefined): AiContext {
+function normalizeAiContext(ai: AiContextDoc|undefined): AiContext {
   if (ai === undefined) return {};
-  if (typeof ai === 'string') return { instructions: ai };
+  if (typeof ai === 'string') return {instructions: ai};
   const out: AiContext = {};
   if (ai.instructions) out.instructions = ai.instructions;
-  if (ai.synonyms && ai.synonyms.length) out.synonyms = [...new Set(ai.synonyms)];
+  if (ai.synonyms && ai.synonyms.length)
+    out.synonyms = [...new Set(ai.synonyms)];
   if (ai.examples && ai.examples.length) {
-    const strings = ai.examples.filter((e): e is string => typeof e === 'string');
+    const strings =
+        ai.examples.filter((e): e is string => typeof e === 'string');
     if (strings.length) out.examples = strings;
   }
   return out;
@@ -290,7 +414,7 @@ function normalizeAiContext(ai: AiContextDoc | undefined): AiContext {
 
 // Normalizes `ai_context` and returns it only when it carries something, so the
 // IR omits empty aiContext objects.
-function aiContextOrUndefined(ai: AiContextDoc | undefined): AiContext | undefined {
+function aiContextOrUndefined(ai: AiContextDoc|undefined): AiContext|undefined {
   const ctx = normalizeAiContext(ai);
   return (ctx.instructions || ctx.synonyms || ctx.examples) ? ctx : undefined;
 }
@@ -299,22 +423,21 @@ function aiContextOrUndefined(ai: AiContextDoc | undefined): AiContext | undefin
 // `vendorName`; `data` kept as the opaque, vendor-serialized string) so nothing
 // is lost and a 1P round-trip stays lossless. Typed views over specific vendors
 // are derived by the consumers that need them, not here.
-function toCustomExtensions(
-    exts: CustomExtensionDoc[] | undefined): CustomExtension[] | undefined {
+function toCustomExtensions(exts: CustomExtensionDoc[]|undefined):
+    CustomExtension[]|undefined {
   if (!exts || !exts.length) return undefined;
-  return exts.map(e => ({ vendorName: e.vendor_name, data: e.data }));
+  return exts.map(e => ({vendorName: e.vendor_name, data: e.data}));
 }
 
 // Composes a single description string from ordered parts, dropping empties.
 // Parts are separated by blank lines so a base description and derived markers
 // read as distinct paragraphs in the emitted metadata. AI-first annotations
-// (instructions / synonyms / examples) are NOT folded in here — they are carried
-// structurally on the IR (aiContext) so an emitter can route them to their own
-// aspects.
-function composeDescription(...parts: (string | undefined)[]): string | undefined {
-  const kept = parts
-    .map(p => (p === undefined ? undefined : p.trim()))
-    .filter((p): p is string => !!p);
+// (instructions / synonyms / examples) are NOT folded in here — they are
+// carried structurally on the IR (aiContext) so an emitter can route them to
+// their own aspects.
+function composeDescription(...parts: (string|undefined)[]): string|undefined {
+  const kept = parts.map(p => (p === undefined ? undefined : p.trim()))
+                   .filter((p): p is string => !!p);
   return kept.length ? kept.join('\n\n') : undefined;
 }
 
@@ -325,89 +448,70 @@ const GOOGLE_VENDOR = 'GOOGLE';
 
 // Rewrites the author-friendly sugar forms into the canonical wire shape the
 // schema validates, so the guide's readable syntax and the underlying format
-// are one code path: `entities:` is an alias for `datasets:`, and a model-level
-// `deployment_target:` URI folds into a GOOGLE `custom_extensions` block (the
-// form the deploy leg reads). Conflicts -- both `entities` and `datasets`, or a
-// `deployment_target` that disagrees with an existing GOOGLE block -- are load
-// errors, named here. Operates on the parsed document before schema validation.
-function normalizeDocumentSugars(doc: unknown): unknown {
+// are one code path. Today that is the `entities:` alias for `datasets:`, which
+// is a native extension accepted only under the extended profile. A model-level
+// `deployment_target:` is a native key under the extended profile too, but it
+// is left in place here and folded into a GOOGLE `custom_extensions` block on
+// the IR after validation (see convertModel), so the strict schema can accept
+// (and reject) it natively. Operates on the parsed document before validation.
+function normalizeDocumentSugars(doc: unknown, extended: boolean): unknown {
   if (!doc || typeof doc !== 'object') return doc;
   const cloned = structuredClone(doc) as any;
   const models = cloned.semantic_model;
   if (!Array.isArray(models)) return cloned;
   for (const m of models) {
-    if (m && typeof m === 'object') normalizeModelSugars(m);
+    if (m && typeof m === 'object') normalizeModelSugars(m, extended);
   }
   return cloned;
 }
 
-function normalizeModelSugars(m: any): void {
+function normalizeModelSugars(m: any, extended: boolean): void {
   const label = typeof m.name === 'string' ? `model '${m.name}'` : 'model';
 
+  // `entities` is a native alias for `datasets`, accepted only under the
+  // extended profile. Under vanilla Ossie the key is unknown; surface a clear
+  // message here rather than the strict schema's generic "unrecognized key".
   if (m.entities !== undefined) {
+    if (!extended) {
+      throw new Error(
+          `Semantic model load error: ${label}: 'entities' is a ` +
+          `'${GOOGLE_VERSION}' extension; use 'datasets', or set the document ` +
+          `version to '${GOOGLE_VERSION}'.`);
+    }
     if (m.datasets !== undefined) {
-      throw new Error(`Semantic model load error: ${label}: set either ` +
+      throw new Error(
+          `Semantic model load error: ${label}: set either ` +
           `'entities' or 'datasets', not both (they are the same key).`);
     }
     m.datasets = m.entities;
     delete m.entities;
   }
-
-  if (m.deployment_target !== undefined) {
-    const target = m.deployment_target;
-    if (typeof target !== 'string') {
-      throw new Error(`Semantic model load error: ${label}: ` +
-          `'deployment_target' must be a URI string.`);
-    }
-    foldDeploymentTarget(m, target, label);
-    delete m.deployment_target;
-  }
 }
 
-// Merges a `deployment_target` URI into the model's GOOGLE custom_extensions.
-// If a GOOGLE block already declares deploymentTargets, the URI must be among
-// them (the two forms mean the same thing and must agree); otherwise a fresh
-// GOOGLE block is appended.
-function foldDeploymentTarget(m: any, target: string, label: string): void {
-  const exts = Array.isArray(m.custom_extensions) ? m.custom_extensions : [];
-  for (const ext of exts) {
-    if (!ext || ext.vendor_name !== GOOGLE_VENDOR ||
-        typeof ext.data !== 'string') {
-      continue;
-    }
-    let data: any;
-    try {
-      data = JSON.parse(ext.data);
-    } catch {
-      continue;  // a malformed block is the deploy leg's error to report
-    }
-    const list = data?.deploymentTargets;
-    if (Array.isArray(list) && list.length) {
-      if (!list.includes(target)) {
-        throw new Error(`Semantic model load error: ${label}: ` +
-            `'deployment_target' disagrees with the GOOGLE custom_extension ` +
-            `already on this model; set one, or make them match.`);
-      }
-      return;  // agree: nothing to add
-    }
-  }
-  exts.push({
-    vendor_name: GOOGLE_VENDOR,
-    data: JSON.stringify({ deploymentTargets: [target] }),
-  });
-  m.custom_extensions = exts;
+// Builds the GOOGLE custom-extension block that carries a model's
+// `deployment_target` URI on the IR (the form the deploy leg reads). The native
+// `deployment_target:` key (extended profile only) is folded into one after
+// validation (see convertModel); the extended profile does not accept a
+// `custom_extensions` carrier, so there is never a pre-existing GOOGLE block to
+// reconcile with.
+function deploymentTargetExtension(target: string): CustomExtension {
+  return {
+    vendorName: GOOGLE_VENDOR,
+    data: JSON.stringify({deploymentTargets: [target]}),
+  };
 }
 
 /**
- * Loads YAML or JSON text (a document in the AI-first semantics format) into the
- * Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
+ * Loads YAML or JSON text (a document in the AI-first semantics format) into
+ * the Semantic Model IR. `yaml.parse` accepts JSON too, so both are supported.
  */
 export function loadModels(text: string, opts: LoadOptions = {}): LoadResult {
   let doc: unknown;
   try {
     doc = yaml.parse(text);
   } catch (err: any) {
-    throw new Error(`Semantic model load error: could not parse input: ${err?.message ?? err}`);
+    throw new Error(`Semantic model load error: could not parse input: ${
+        err?.message ?? err}`);
   }
   return fromDocument(doc, opts);
 }
@@ -418,76 +522,110 @@ export function loadModels(text: string, opts: LoadOptions = {}): LoadResult {
  * `warnings` rather than thrown.
  */
 export function fromDocument(doc: unknown, opts: LoadOptions = {}): LoadResult {
-  const normalized = normalizeDocumentSugars(doc);
-  const result =
-      makeDocumentSchema(opts.bindingOptional ?? false).safeParse(normalized);
+  const version = readVersion(doc);
+  const extended = version === GOOGLE_VERSION;
+
+  const normalized = normalizeDocumentSugars(doc, extended);
+  const result = makeDocumentSchema(opts.bindingOptional ?? false, extended)
+                     .safeParse(normalized);
   if (!result.success) {
     throw new Error(`Semantic model load error: ${result.error.message}`);
   }
 
   const warnings: string[] = [];
-  const parsed = result.data;
+  const parsed = result.data as DocumentDoc;
 
-  if (parsed.version && parsed.version !== SUPPORTED_VERSION) {
-    warnings.push(
-      `document version '${parsed.version}' differs from the supported '${SUPPORTED_VERSION}'; ` +
-      `loading anyway`);
+  const models =
+      parsed.semantic_model.map(m => convertModel(m, opts, warnings));
+  return {models, warnings: [...new Set(warnings)]};
+}
+
+// Reads and validates the top-level `version`. It is REQUIRED and must be one
+// of the accepted values: the version selects which extension surface is legal,
+// so it cannot be guessed, and a missing or unrecognized version is a hard load
+// error rather than a warning (agreed with Dmitri).
+function readVersion(doc: unknown): string {
+  const version =
+      (doc && typeof doc === 'object') ? (doc as any).version : undefined;
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error(
+        `Semantic model load error: missing 'version'; declare ` +
+        `'${OSSIE_VERSION}' (vanilla Ossie) or '${GOOGLE_VERSION}' (the ` +
+        `extended profile) at the top level.`);
   }
-
-  const models = parsed.semantic_model.map(m => convertModel(m, opts, warnings));
-  return { models, warnings: [...new Set(warnings)] };
+  if (!ACCEPTED_VERSIONS.includes(version)) {
+    throw new Error(
+        `Semantic model load error: unknown version ` +
+        `'${version}'; expected '${OSSIE_VERSION}' or '${GOOGLE_VERSION}'.`);
+  }
+  return version;
 }
 
 
-// Flags names that appear more than once within a scope. Uniqueness is required
-// for a valid graph: a duplicate dataset, field, metric, or relationship name
-// makes the generated nodes, properties, or edges ambiguous. Reported as
-// warnings (the loader stays lenient and never rejects a valid document); a
-// strict `validate` gate can promote these to errors later.
-function warnDuplicateNames(
-    names: string[], kind: string, scope: string, warnings: string[]): void {
+// Rejects names that appear more than once within a scope. Uniqueness is
+// required for a valid graph: a duplicate dataset, field, metric, or
+// relationship name makes the generated nodes, properties, or edges ambiguous,
+// so a duplicate is a hard load error (agreed with Dmitri) rather than a
+// warning.
+function rejectDuplicateNames(
+    names: string[], kind: string, scope: string): void {
   const seen = new Set<string>();
   for (const n of names) {
     if (seen.has(n)) {
-      warnings.push(
-        `${scope}: duplicate ${kind} '${n}'; names must be unique ` +
-        `(the generated graph will be invalid)`);
+      throw new Error(
+          `${scope}: duplicate ${kind} '${n}'; names must be unique.`);
     }
     seen.add(n);
   }
 }
 
-function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): SemanticModel {
+function convertModel(
+    m: ModelDoc, opts: LoadOptions, warnings: string[]): SemanticModel {
   const dialect = opts.dialect ?? DEFAULT_DIALECT;
 
-  const entities = m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
-  warnDuplicateNames(entities.map(e => e.name), 'dataset name', `model '${m.name}'`, warnings);
+  const entities =
+      m.datasets.map(ds => convertDataset(ds, opts, warnings, dialect));
+  rejectDuplicateNames(
+      entities.map(e => e.name), 'dataset name', `model '${m.name}'`);
 
   const entityNames = entities.map(e => e.name);
   const entityNameSet = new Set(entityNames);
 
-  const relationships = (m.relationships ?? []).map(
-    r => convertRelationship(r, entityNameSet));
-  warnDuplicateNames(
-    relationships.map(r => r.name), 'relationship name', `model '${m.name}'`, warnings);
+  const relationships =
+      (m.relationships ?? []).map(r => convertRelationship(r, entityNameSet));
+  rejectDuplicateNames(
+      relationships.map(r => r.name), 'relationship name', `model '${m.name}'`);
 
-  const metrics = (m.metrics ?? []).map(
-    mt => convertMetric(mt, entityNames, warnings, dialect));
-  warnDuplicateNames(metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`, warnings);
+  const metrics =
+      (m.metrics ??
+       []).map(mt => convertMetric(mt, entityNames, warnings, dialect));
+  rejectDuplicateNames(
+      metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`);
 
   const description = composeDescription(m.description);
 
-  const model: SemanticModel = { name: m.name, entities, relationships, metrics };
+  const model: SemanticModel = {name: m.name, entities, relationships, metrics};
   if (description) model.description = description;
   const ai = aiContextOrUndefined(m.ai_context);
   if (ai) model.aiContext = ai;
+  // Custom extensions ride vanilla Ossie's `custom_extensions` carrier or,
+  // under the extended profile, come from folding the native
+  // `deployment_target` key into a GOOGLE block (the two are mutually exclusive
+  // by version).
   const ce = toCustomExtensions(m.custom_extensions);
   if (ce) model.customExtensions = ce;
+  if (m.deployment_target !== undefined) {
+    model.customExtensions = [
+      ...(model.customExtensions ?? []),
+      deploymentTargetExtension(m.deployment_target),
+    ];
+  }
   return model;
 }
 
-function convertDataset(ds: DatasetDoc, opts: LoadOptions,
-                        warnings: string[], dialect: string): Entity {
+function convertDataset(
+    ds: DatasetDoc, opts: LoadOptions, warnings: string[],
+    dialect: string): Entity {
   const ctxLabel = `dataset '${ds.name}'`;
   // An abstract entity has no physical table, so it carries no source (empty
   // dataSource) and no key -- both are meaningless for a class never
@@ -497,13 +635,17 @@ function convertDataset(ds: DatasetDoc, opts: LoadOptions,
       '';
   const keys = ds.primary_key ?? [];
   if (!keys.length && !ds.abstract) {
-    warnings.push(`${ctxLabel}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
+    warnings.push(`${
+        ctxLabel}: no primary_key; the entity's KEY will be empty (invalid for graph generation)`);
   }
-  const fields = (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
-  warnDuplicateNames(fields.map(f => f.name), 'field name', `dataset '${ds.name}'`, warnings);
+  const fields =
+      (ds.fields ?? []).map(f => convertField(f, ds.name, warnings, dialect));
+  rejectDuplicateNames(
+      fields.map(f => f.name), 'field name', `dataset '${ds.name}'`);
 
-  const entity: Entity = { name: ds.name, dataSource, keys, fields };
-  if (ds.unique_keys && ds.unique_keys.length) entity.uniqueKeys = ds.unique_keys;
+  const entity: Entity = {name: ds.name, dataSource, keys, fields};
+  if (ds.unique_keys && ds.unique_keys.length)
+    entity.uniqueKeys = ds.unique_keys;
   if (ds.extends && ds.extends.length) entity.extends = ds.extends;
   if (ds.abstract) entity.abstract = true;
   const description = composeDescription(ds.description);
@@ -515,34 +657,36 @@ function convertDataset(ds: DatasetDoc, opts: LoadOptions,
   return entity;
 }
 
-function convertField(f: FieldDoc, entityName: string, warnings: string[], dialect: string): Field {
+function convertField(
+    f: FieldDoc, entityName: string, warnings: string[],
+    dialect: string): Field {
   // `label`, `dimension`, and AI-first annotations are carried structurally on
   // the IR (not folded into `description`) so an emitter can route each to its
   // own destination and a 1P round-trip stays lossless.
   const description = composeDescription(f.description);
 
-  const field: Field = { name: f.name };
-  if (f.unbound) {
-    // Declared but not bound under this binding: no column, no expression (the
-    // schema guarantees `expression` is absent here). See Field.unbound.
-    field.unbound = true;
-  } else if (f.expression !== undefined) {
+  const field: Field = {name: f.name};
+  if (f.expression !== undefined) {
     const picked = pickDialect(
-      f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
+        f.expression, dialect, `field '${entityName}.${f.name}'`, warnings);
     if (picked.expression !== undefined) field.expression = picked.expression;
     if (picked.importedExpression !== undefined) {
       field.importedExpression = picked.importedExpression;
       field.importedDialect = picked.importedDialect;
     }
   }
-  // else: a purely logical field (no expression, not explicitly unbound). Only
-  // reachable under bindingOptional -- strict loading requires one or the other
-  // -- so the field carries meaning with no physical column for a KC-only push.
+  // else: an unbound field. It carries meaning (label, description, AI context)
+  // but names no physical column. A field is unbound exactly when it has no
+  // `expression` -- there is no separate flag. A graph leg does not reject it:
+  // the availability pass (pruneUnavailable) drops each unbound field, and
+  // whatever depends on it, before generation, so one logical model can serve
+  // stores that bind different subsets of columns.
   if (f.datatype) field.type = f.datatype;
   if (f.label) field.label = f.label;
   if (f.dimension) {
     field.dimension = {};
-    if (f.dimension.is_time !== undefined) field.dimension.isTime = f.dimension.is_time;
+    if (f.dimension.is_time !== undefined)
+      field.dimension.isTime = f.dimension.is_time;
   }
   if (description) field.description = description;
   const ai = aiContextOrUndefined(f.ai_context);
@@ -552,35 +696,41 @@ function convertField(f: FieldDoc, entityName: string, warnings: string[], diale
   return field;
 }
 
-// Maps an OSI foreign-key relationship onto the IR edge. `source.columns` are the
-// FK columns on the `from` table (`from_columns`); `destination.columns` are the
-// referenced key columns on the `to` table (`to_columns`), paired positionally.
-// A logical relationship carries no columns (both endpoints empty); a graph
-// push requires them and rejects a column-less edge (see validatePushRequirements).
-// The source entity's own primary key is not duplicated here -- downstream
-// consumers look it up from the entity. A malformed relationship (an endpoint not
-// declared in the model, or mismatched column arity) is a hard error, not a
-// warning: the resulting edge would be structurally invalid.
-function convertRelationship(r: RelationshipDoc, entityNames: Set<string>): Relationship {
+// Maps an OSI foreign-key relationship onto the IR edge. `source.columns` are
+// the FK columns on the `from` table (`from_columns`); `destination.columns`
+// are the referenced key columns on the `to` table (`to_columns`), paired
+// positionally. A logical relationship carries no columns (both endpoints
+// empty); a graph push requires them and rejects a column-less edge (see
+// validatePushRequirements). The source entity's own primary key is not
+// duplicated here -- downstream consumers look it up from the entity. A
+// malformed relationship (an endpoint not declared in the model, or mismatched
+// column arity) is a hard error, not a warning: the resulting edge would be
+// structurally invalid.
+function convertRelationship(
+    r: RelationshipDoc, entityNames: Set<string>): Relationship {
   const ctx = `relationship '${r.name}'`;
   if (!entityNames.has(r.from)) {
-    throw new Error(`${ctx}: 'from' dataset '${r.from}' is not defined in the model`);
+    throw new Error(
+        `${ctx}: 'from' dataset '${r.from}' is not defined in the model`);
   }
   if (!entityNames.has(r.to)) {
-    throw new Error(`${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
+    throw new Error(
+        `${ctx}: 'to' dataset '${r.to}' is not defined in the model`);
   }
   const fromColumns = r.from_columns ?? [];
   const toColumns = r.to_columns ?? [];
   if (fromColumns.length !== toColumns.length) {
     throw new Error(
-      `${ctx}: from_columns (${fromColumns.length}) and to_columns ` +
-      `(${toColumns.length}) have different lengths; the join keys are mismatched`);
+        `${ctx}: from_columns (${fromColumns.length}) and to_columns ` +
+        `(${
+            toColumns
+                .length}) have different lengths; the join keys are mismatched`);
   }
 
   const relationship: Relationship = {
     name: r.name,
-    source: { entity: r.from, columns: fromColumns },
-    destination: { entity: r.to, columns: toColumns },
+    source: {entity: r.from, columns: fromColumns},
+    destination: {entity: r.to, columns: toColumns},
   };
   const description = composeDescription(r.description);
   if (description) relationship.description = description;
@@ -591,8 +741,9 @@ function convertRelationship(r: RelationshipDoc, entityNames: Set<string>): Rela
   return relationship;
 }
 
-function convertMetric(mt: MetricDoc, entityNames: string[],
-                       warnings: string[], dialect: string): Metric {
+function convertMetric(
+    mt: MetricDoc, entityNames: string[], warnings: string[],
+    dialect: string): Metric {
   const ctx = `metric '${mt.name}'`;
   const picked = pickDialect(mt.expression, dialect, ctx, warnings);
   // Infer referenced entities from whichever expression form we have; the
@@ -600,11 +751,13 @@ function convertMetric(mt: MetricDoc, entityNames: string[],
   const exprForRefs = picked.expression ?? picked.importedExpression ?? '';
   const referenced = referencedEntityNames(exprForRefs, entityNames);
   if (!referenced.length) {
-    warnings.push(`${ctx}: expression references no known entity; it may not be placeable downstream`);
+    warnings.push(`${
+        ctx}: expression references no known entity; it may not be placeable downstream`);
   }
-  const metric: Metric = { name: mt.name };
-  // Attach only when the reference is unambiguous; a cross-entity metric is left
-  // unattached (its qualifiers stay inline in the expression for consumers).
+  const metric: Metric = {name: mt.name};
+  // Attach only when the reference is unambiguous; a cross-entity metric is
+  // left unattached (its qualifiers stay inline in the expression for
+  // consumers).
   if (referenced.length === 1) metric.entity = referenced[0];
   if (picked.expression !== undefined) metric.expression = picked.expression;
   if (picked.importedExpression !== undefined) {
@@ -622,13 +775,15 @@ function convertMetric(mt: MetricDoc, entityNames: string[],
 }
 
 // Collapses an expression's per-dialect variants into at most two forms:
-//   - `expression`: a target/canonical form valid against the target. Preference
+//   - `expression`: a target/canonical form valid against the target.
+//   Preference
 //     is the requested dialect, else the portable canonical dialect (ANSI_SQL).
 //   - `importedExpression` (+ `importedDialect`): the original vendor SQL, kept
 //     verbatim so nothing is lost and a later transpile pass (see ./transpile)
 //     can fill `expression` from it.
 // Dialect names are compared case-insensitively. No transpilation is performed
-// here; chosen expressions are passed through verbatim. At least one form is set.
+// here; chosen expressions are passed through verbatim. At least one form is
+// set.
 //
 // The fallbacks differ in risk, so they are surfaced differently:
 //   - ANSI_SQL is the AI-first format's default expression language (ANSI
@@ -645,16 +800,18 @@ interface PickedExpression {
   importedDialect?: string;
 }
 
-function pickDialect(expr: ExpressionDoc, preferred: string,
-                     ctx: string, warnings: string[]): PickedExpression {
+function pickDialect(
+    expr: ExpressionDoc, preferred: string, ctx: string,
+    warnings: string[]): PickedExpression {
   const upper = (s: string) => s.toUpperCase();
   const byName = (name: string) =>
-    expr.dialects.find(d => upper(d.dialect) === upper(name));
+      expr.dialects.find(d => upper(d.dialect) === upper(name));
 
   // The original vendor variant, if any: the first dialect that is neither the
   // target nor the portable canonical. Kept as `importedExpression`.
   const vendor = expr.dialects.find(
-    d => upper(d.dialect) !== upper(preferred) && upper(d.dialect) !== FALLBACK_DIALECT);
+      d => upper(d.dialect) !== upper(preferred) &&
+          upper(d.dialect) !== FALLBACK_DIALECT);
 
   const out: PickedExpression = {};
   if (vendor) {
@@ -672,17 +829,21 @@ function pickDialect(expr: ExpressionDoc, preferred: string,
   if (canonical) {
     out.expression = canonical.expression;
     warnings.push(
-      `note: no '${preferred}' dialect for one or more expressions; using the portable ` +
-      `'${FALLBACK_DIALECT}' dialect verbatim ('${preferred}' accepts the ANSI core subset — ` +
-      `supply '${preferred}' variants only for ${preferred}-specific SQL)`);
+        `note: no '${
+            preferred}' dialect for one or more expressions; using the portable ` +
+        `'${FALLBACK_DIALECT}' dialect verbatim ('${
+            preferred}' accepts the ANSI core subset — ` +
+        `supply '${preferred}' variants only for ${preferred}-specific SQL)`);
     return out;
   }
 
   // Neither target nor canonical: keep only the imported vendor form; the
   // target `expression` awaits a transpile pass.
   warnings.push(
-    `${ctx}: no '${preferred}' or '${FALLBACK_DIALECT}' dialect; keeping the ` +
-    `'${out.importedDialect}' expression as imported_expression (needs transpilation to '${preferred}')`);
+      `${ctx}: no '${preferred}' or '${
+          FALLBACK_DIALECT}' dialect; keeping the ` +
+      `'${out.importedDialect}' expression as imported_expression (needs transpilation to '${
+          preferred}')`);
   return out;
 }
 
@@ -690,16 +851,18 @@ function pickDialect(expr: ExpressionDoc, preferred: string,
 // reference. Each identifier segment is unquoted, and a short reference has its
 // leading qualifiers prepended from options (a bare `table` gets both defaults;
 // a `dataset.table` gets the project). References that already carry three or
-// more segments are passed through untouched, so an already-qualified name keeps
-// whatever shape the source system gave it rather than being forced into fixed
-// slots. A source that looks like a query (contains whitespace) cannot be
+// more segments are passed through untouched, so an already-qualified name
+// keeps whatever shape the source system gave it rather than being forced into
+// fixed slots. A source that looks like a query (contains whitespace) cannot be
 // qualified, so it is kept verbatim.
-function parseSource(source: string, opts: LoadOptions,
-                     warnings: string[], ctx: string): string {
+function parseSource(
+    source: string, opts: LoadOptions, warnings: string[],
+    ctx: string): string {
   const trimmed = source.trim();
 
   if (/\s/.test(trimmed)) {
-    warnings.push(`${ctx}: source looks like a query, not a table reference; keeping it verbatim`);
+    warnings.push(`${
+        ctx}: source looks like a query, not a table reference; keeping it verbatim`);
     return trimmed;
   }
 
@@ -719,8 +882,10 @@ function parseSource(source: string, opts: LoadOptions,
   }
 
   const parts = trimmed.split('.').map(unquote);
-  if (parts.length === 1 && opts.defaultDataset) parts.unshift(opts.defaultDataset);
-  if (parts.length < 3 && opts.defaultProject) parts.unshift(opts.defaultProject);
+  if (parts.length === 1 && opts.defaultDataset)
+    parts.unshift(opts.defaultDataset);
+  if (parts.length < 3 && opts.defaultProject)
+    parts.unshift(opts.defaultProject);
   return parts.join('.');
 }
 

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -28,10 +28,13 @@
 //     are re-emitted, each under a single dialect label.
 //   * comments and key ordering are not preserved.
 // What the loader DOES keep on the IR round-trips here: names, descriptions,
-// `ai_context` (instructions / synonyms / examples), `custom_extensions`
-// (verbatim), keys and unique keys, data sources, field datatypes / labels /
-// dimension flags, expressions, and relationship join columns. See
-// serialize.test.ts.
+// `ai_context` (instructions / synonyms / examples), keys and unique keys, data
+// sources, field datatypes / labels / dimension flags, expressions, and
+// relationship join columns. Output is the extended profile ('/google'), which
+// uses native extension keys and has no `custom_extensions` carrier: a model's
+// GOOGLE deployment target is re-emitted as a native `deployment_target`, and
+// any other vendor extension on the IR is dropped with a warning (its carrier's
+// fate under '/google' is still open). See serialize.test.ts.
 //
 // An `association` (junction-table) relationship has no open-format syntax (the
 // loader cannot produce one), so only its direct foreign-key view (from/to +
@@ -41,10 +44,16 @@ import * as yaml from 'yaml';
 
 import {AiContext, CustomExtension, Entity, Field, Metric, Relationship, SemanticModel,} from './ir';
 
-// The schema version the loader was written against; re-emitted verbatim so a
-// serialized document loads without a version-mismatch warning. Mirrors
-// loader.SUPPORTED_VERSION.
-const SERIALIZED_VERSION = '0.2.0.dev0';
+// The version stamped on every serialized document. Pull emits kcmd's extended
+// profile: it uses native extension keys (`entities`, `deployment_target`)
+// rather than Ossie's `custom_extensions` carrier, so the version MUST be the
+// `/google` variant for the output to load. Mirrors loader.GOOGLE_VERSION.
+const SERIALIZED_VERSION = '0.2.0.dev0/google';
+
+// The vendor tag for Google-specific extension blocks on the IR (kept in sync
+// with loader.GOOGLE_VENDOR). A model-level deployment target rides in one and
+// is re-emitted as the native `deployment_target` key.
+const GOOGLE_VENDOR = 'GOOGLE';
 
 // The dialect label for the IR's target/canonical `expression`. The IR does not
 // record which authored dialect that string came from (the loader picked it
@@ -129,7 +138,8 @@ function renderCompact(document: Record<string, any>): string {
     Seq(_, node) {
       if (!node.items.every(item => yaml.isScalar(item))) return;
       // `[` + each `item, ` + `]`, approximated for the width gate.
-      const width = node.items.reduce((n, item) => n + scalarWidth(item) + 2, 2);
+      const width =
+          node.items.reduce((n, item) => n + scalarWidth(item) + 2, 2);
       if (width <= FLOW_WIDTH_BUDGET) node.flow = true;
     },
     Map(_, node) {
@@ -171,12 +181,18 @@ function modelDoc(model: SemanticModel, warnings: string[], logical: boolean):
             model.name}': no datasets (entities); the document requires ` +
         `at least one and will not load until an entity is present.`);
   }
+  // The extended profile has no `custom_extensions` carrier: the one kcmd
+  // understands -- the GOOGLE deployment target -- is emitted as the native
+  // `deployment_target` key; any other vendor extension has no representation
+  // and is dropped with a warning (see extractDeploymentTarget).
+  const deploymentTarget =
+      extractDeploymentTarget(model.customExtensions, model.name, warnings);
   return compact({
     name: model.name,
     description: model.description,
     ai_context: aiContextDoc(model.aiContext),
-    custom_extensions: customExtensionsDoc(model.customExtensions),
-    datasets,
+    deployment_target: deploymentTarget,
+    entities: datasets,
     relationships: nonEmpty(
         (model.relationships ?? []).map(r => relationshipDoc(r, warnings))),
     metrics: nonEmpty((model.metrics ?? []).map(m => metricDoc(m, warnings))),
@@ -197,6 +213,7 @@ function datasetDoc(
         `entity '${entity.name}' has no source and is not abstract; the ` +
         `serialized document will not reload until a source is set`);
   }
+  dropExtensions(entity.customExtensions, `entity '${entity.name}'`, warnings);
   return compact({
     name: entity.name,
     // An abstract entity has no physical table, so its source is empty; omit
@@ -213,7 +230,6 @@ function datasetDoc(
     ai_context: aiContextDoc(entity.aiContext),
     fields: nonEmpty(
         (entity.fields ?? []).map(f => fieldDoc(f, warnings, logical))),
-    custom_extensions: customExtensionsDoc(entity.customExtensions),
   });
 }
 
@@ -229,6 +245,7 @@ function fieldDoc(
         `field '${field.name}': no expression; the loader requires one per ` +
         `field and the document will not load until it is set.`);
   }
+  dropExtensions(field.customExtensions, `field '${field.name}'`, warnings);
   return compact({
     name: field.name,
     expression,
@@ -237,7 +254,6 @@ function fieldDoc(
     dimension: dimensionDoc(field),
     description: field.description,
     ai_context: aiContextDoc(field.aiContext),
-    custom_extensions: customExtensionsDoc(field.customExtensions),
   });
 }
 
@@ -251,13 +267,13 @@ function metricDoc(metric: Metric, warnings: string[]): Record<string, any> {
         `metric '${metric.name}': no expression; the loader requires one per ` +
         `metric and the document will not load until it is set.`);
   }
+  dropExtensions(metric.customExtensions, `metric '${metric.name}'`, warnings);
   return compact({
     name: metric.name,
     expression,
     datatype: metric.type,
     description: metric.description,
     ai_context: aiContextDoc(metric.aiContext),
-    custom_extensions: customExtensionsDoc(metric.customExtensions),
   });
 }
 
@@ -274,6 +290,7 @@ function relationshipDoc(
         `open-format representation and is not serialized; only its foreign-key ` +
         `endpoints are written.`);
   }
+  dropExtensions(rel.customExtensions, `relationship '${rel.name}'`, warnings);
   return compact({
     name: rel.name,
     from: rel.source.entity,
@@ -282,7 +299,6 @@ function relationshipDoc(
     to_columns: nonEmpty(rel.destination.columns),
     description: rel.description,
     ai_context: aiContextDoc(rel.aiContext),
-    custom_extensions: customExtensionsDoc(rel.customExtensions),
   });
 }
 
@@ -290,8 +306,8 @@ function relationshipDoc(
 // array of {dialect, expression}). Emits the target/canonical form under
 // CANONICAL_DIALECT and the imported vendor form under its own dialect, so the
 // loader re-picks each into the same IR field. Returns undefined when neither
-// form is present (the loader requires an expression, but a pathological field
-// with none is dropped rather than fabricated).
+// form is present: a field with no expression is unbound, so it emits no
+// `expression` block rather than a fabricated one.
 function expressionDoc(
     expression: string|undefined, importedExpression: string|undefined,
     importedDialect: string|undefined): Record<string, any>|undefined {
@@ -336,12 +352,56 @@ function aiContextDoc(ai: AiContext|undefined): Record<string, any>|undefined {
   return Object.keys(doc).length ? doc : undefined;
 }
 
-// Emits vendor `custom_extensions` verbatim (`vendorName` -> `vendor_name`),
-// inverting loader.toCustomExtensions. Returns undefined when there are none.
-function customExtensionsDoc(exts: CustomExtension[]|undefined):
-    Record<string, any>[]|undefined {
+// Pulls a model's deployment target out of its GOOGLE custom_extension block
+// and returns it as the value for the native `deployment_target` key (the
+// extended profile's representation; the loader folds the reverse direction).
+// The native key is a single URI, so the first target is emitted; any further
+// targets, and any non-deployment-target vendor extension, have no `/google`
+// representation and are counted as dropped and warned about once.
+function extractDeploymentTarget(
+    exts: CustomExtension[]|undefined, modelName: string,
+    warnings: string[]): string|undefined {
   if (!exts || !exts.length) return undefined;
-  return exts.map(e => ({vendor_name: e.vendorName, data: e.data}));
+  let target: string|undefined;
+  let dropped = 0;
+  for (const ext of exts) {
+    let targets: unknown;
+    if (ext.vendorName === GOOGLE_VENDOR) {
+      try {
+        targets = JSON.parse(ext.data)?.deploymentTargets;
+      } catch {
+        targets = undefined;
+      }
+    }
+    if (Array.isArray(targets) && targets.length) {
+      if (target === undefined && typeof targets[0] === 'string') {
+        target = targets[0];
+      }
+      if (targets.length > 1) dropped += targets.length - 1;
+    } else {
+      dropped += 1;  // a non-GOOGLE block, or a GOOGLE block without targets
+    }
+  }
+  if (dropped) {
+    warnings.push(
+        `model '${modelName}': ${dropped} custom_extension value(s) have no ` +
+        `representation under '${SERIALIZED_VERSION}' and are not serialized`);
+  }
+  return target;
+}
+
+// The extended profile has no `custom_extensions` carrier, so a vendor
+// extension on a non-model element cannot be serialized. Warn (once per
+// element) and drop it. The model-level GOOGLE deployment target is handled
+// separately (extractDeploymentTarget) and is NOT dropped.
+function dropExtensions(
+    exts: CustomExtension[]|undefined, where: string,
+    warnings: string[]): void {
+  if (exts && exts.length) {
+    warnings.push(
+        `${where}: ${exts.length} custom_extension(s) have no representation ` +
+        `under '${SERIALIZED_VERSION}' and are not serialized`);
+  }
 }
 
 // Drops undefined-valued keys so the emitted YAML only shows fields the model

--- a/toolbox/mdcode/src/libts/semantic/resolve_inheritance.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_inheritance.ts
@@ -137,16 +137,15 @@ function localizeInheritedField(field: Field, ancestor: string): Field {
 // read from the pre-mutation snapshot so resolution is order-independent.
 //
 // A parent edge that points back to `start` is a cycle (warned, skipped so the
-// walk terminates); a parent that is not an entity in the model is warned and
-// excluded (an emitter cannot label with a signature it does not have). A node
-// re-reached through a second path (a diamond) is simply skipped -- it is
-// already included at its nearest distance.
+// walk terminates); a parent that is not an entity in the model is a hard error
+// (an emitter cannot label with a signature it does not have, and a typo must
+// not silently drop inheritance). A node re-reached through a second path (a
+// diamond) is simply skipped -- it is already included at its nearest distance.
 function transitiveAncestors(
     start: string, byName: Map<string, Entity>,
     directParents: Map<string, string[]>, warnings: string[]): string[] {
   const result: string[] = [];
   const seen = new Set<string>([start]);
-  const missingWarned = new Set<string>();
 
   // Queue of (child that declared the edge, parent) so a cycle warning can name
   // the offending child. Seeded with `start`'s direct parents in declared
@@ -163,13 +162,9 @@ function transitiveAncestors(
       continue;
     }
     if (!byName.has(name)) {
-      if (!missingWarned.has(name)) {
-        missingWarned.add(name);
-        warnings.push(
-            `entity '${from}' extends unknown entity '${name}'; it is not ` +
-            `defined in the model, so it is ignored`);
-      }
-      continue;
+      throw new Error(
+          `entity '${from}' extends unknown entity '${name}'; it is not ` +
+          `defined in the model`);
     }
     if (seen.has(name)) continue;  // diamond: already included at its nearest
     seen.add(name);

--- a/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
@@ -51,7 +51,7 @@ const PROFILE_MODEL_KEYS = new Set([
   'name', 'version', 'deployment_target', 'entities', 'datasets',
 ]);
 const PROFILE_ENTITY_KEYS = new Set(['name', 'source', 'fields']);
-const PROFILE_FIELD_KEYS = new Set(['name', 'expression', 'unbound']);
+const PROFILE_FIELD_KEYS = new Set(['name', 'expression']);
 
 /**
  * Overlays `profileDoc` onto `logicalDoc`, matching models, entities, fields by
@@ -89,6 +89,10 @@ export function mergeProfile(
     }
   }
 
+  // Clear the logical clone's inline field bindings before overlaying the
+  // profile, so the profile alone decides what is bound (see below).
+  stripInlineFieldExpressions(merged);
+
   for (const pm of profile.semantic_model) {
     if (!pm || typeof pm !== 'object') continue;
     const lm = logicalByName.get(pm.name);
@@ -103,10 +107,6 @@ export function mergeProfile(
     if (err) return {doc: merged, warnings, error: err};
   }
 
-  // A field the profile neither bound nor marked unbound is carried through from
-  // the logical model with no column -- unbound under this profile. Mark it so
-  // the merged document is self-describing and the availability pass sees it.
-  markOmittedFieldsUnbound(merged);
   return {doc: merged, warnings};
 }
 
@@ -173,11 +173,6 @@ function mergeField(
       return declError(profileName, `field '${entityName}.${pf.name}'`, k);
     }
   }
-  if (pf.unbound === true) {
-    lf.unbound = true;
-    delete lf.expression;
-    return undefined;
-  }
   if (pf.expression !== undefined) {
     if (!isBareColumnRef(pf.expression)) {
       return `profile '${profileName}': field '${entityName}.${
@@ -185,15 +180,16 @@ function mergeField(
           `SQL; the computation is the logical model's to define`;
     }
     lf.expression = pf.expression;
-    delete lf.unbound;
   }
+  // A field the profile does not bind keeps no expression -- unbound under this
+  // profile (a field is unbound exactly when it carries no expression).
   return undefined;
 }
 
 function declError(profileName: string, where: string, key: string): string {
   return `profile '${profileName}': ${where} sets '${key}', a logical ` +
       `declaration the model owns; a profile may set only physical bindings ` +
-      `(source, expression, unbound, deployment_target)`;
+      `(source, expression, deployment_target)`;
 }
 
 // A profile's field expression must be a BARE column reference (e.g. `c_name`),
@@ -228,17 +224,22 @@ function indexByName(list: unknown): Map<string, any> {
   return m;
 }
 
-function markOmittedFieldsUnbound(doc: any): void {
+// A profile is authoritative for a model's physical bindings, so a field is
+// bound under the merged model only if the profile binds it. This clears every
+// inline field expression from the logical clone before the profile is
+// overlaid, so a field the profile does not bind is left unbound (§7.3,
+// "omitted is unbound"). Only the per-field column binding is cleared; the
+// logical model's meaning -- names, types, relationships, metric formulas -- is
+// untouched. A field is unbound exactly when it carries no expression; there is
+// no separate flag.
+function stripInlineFieldExpressions(doc: any): void {
   for (const m of doc.semantic_model ?? []) {
     if (!m || typeof m !== 'object') continue;
     const entities = m.entities ?? m.datasets ?? [];
     for (const e of entities) {
       if (!e || typeof e !== 'object' || !Array.isArray(e.fields)) continue;
       for (const f of e.fields) {
-        if (!f || typeof f !== 'object') continue;
-        if (f.expression === undefined && f.unbound !== true) {
-          f.unbound = true;
-        }
+        if (f && typeof f === 'object') delete f.expression;
       }
     }
   }

--- a/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
+++ b/toolbox/mdcode/src/libts/semantic/resolve_profiles.ts
@@ -90,8 +90,16 @@ export function mergeProfile(
   }
 
   // Clear the logical clone's inline field bindings before overlaying the
-  // profile, so the profile alone decides what is bound (see below).
-  stripInlineFieldExpressions(merged);
+  // profile, so for the models the profile targets the profile alone decides
+  // what is bound (see below). A model the profile does not name keeps its
+  // inline bindings untouched.
+  const profileModelNames = new Set<string>();
+  for (const pm of profile.semantic_model) {
+    if (pm && typeof pm === 'object' && typeof pm.name === 'string') {
+      profileModelNames.add(pm.name);
+    }
+  }
+  stripInlineFieldExpressions(merged, profileModelNames);
 
   for (const pm of profile.semantic_model) {
     if (!pm || typeof pm !== 'object') continue;
@@ -232,9 +240,10 @@ function indexByName(list: unknown): Map<string, any> {
 // logical model's meaning -- names, types, relationships, metric formulas -- is
 // untouched. A field is unbound exactly when it carries no expression; there is
 // no separate flag.
-function stripInlineFieldExpressions(doc: any): void {
+function stripInlineFieldExpressions(
+    doc: any, modelNames: Set<string>): void {
   for (const m of doc.semantic_model ?? []) {
-    if (!m || typeof m !== 'object') continue;
+    if (!m || typeof m !== 'object' || !modelNames.has(m.name)) continue;
     const entities = m.entities ?? m.datasets ?? [];
     for (const e of entities) {
       if (!e || typeof e !== 'object' || !Array.isArray(e.fields)) continue;

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.e2e.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.e2e.test.ts
@@ -366,10 +366,12 @@ describe(
 //   - profile_binding + operational: the SAME logical base bound a second way --
 //     one model, two physical realizations, a different field unbound in each.
 //   - partial_binding + prod       : a combined single-file model (already fully
-//     bound inline) whose profile overrides only the sources + deployment target
-//     and inherits every column it omits (an environment swap).
+//     bound inline) whose profile re-declares every column over new tables and a
+//     new deployment target (an environment swap); selecting it clears the inline
+//     bindings, so the profile is authoritative.
 //   - partial_binding + remap      : the same combined base, a profile that
-//     renames one column and unbinds another, inheriting the rest.
+//     re-declares its columns -- renaming one and omitting another, which leaves
+//     that field unbound.
 function buildProfile(logicalFixture: string, profile: string) {
   const dir = path.join(FIXTURES, 'profiles');
   const logicalText = fs.readFileSync(path.join(dir, logicalFixture), 'utf8');
@@ -505,20 +507,20 @@ describe('binding profiles resolve physical columns and availability', () => {
       });
 
   test(
-      'a profile that overrides a model with inline bindings inherits every ' +
-          'field it omits',
+      'a profile that re-declares every column deploys the whole model over ' +
+          'new tables (an environment swap)',
       () => {
-        // prod names no fields at all -- only the sources and the target. Every
-        // column binding must come through from the base unchanged, and every
-        // metric must survive (nothing is unbound). The tables move to the prod
-        // project; the columns do not change.
+        // prod re-declares every column -- the same names -- over the prod
+        // tables and a new target. Nothing is unbound, so every metric survives.
+        // Selecting the profile clears the base's inline bindings; the profile's
+        // own bindings are what deploy.
         const {ddl, model, report} = buildProfile('partial_binding.yaml', 'prod');
         expect(report.unboundFields).toEqual([]);
         expect(report.droppedMetrics).toEqual([]);
         expect((model.metrics ?? []).map(m => m.name).sort()).toEqual([
           'order_count', 'total_amount', 'total_discount'
         ]);
-        // Inherited base columns, emitted over the prod tables.
+        // The re-declared columns, emitted over the prod tables.
         expect(ddl).toContain('`acme-prod.sales.customers` AS Customer');
         expect(ddl).toContain('customer_name AS name');
         // A field whose column equals its logical name emits bare, no AS.
@@ -526,12 +528,12 @@ describe('binding profiles resolve physical columns and availability', () => {
         expect(ddl).not.toContain('acme-dev');
       });
 
-  test('a partial override renames one column and unbinds another', () => {
-    // remap changes only Customer.name's column and drops Order.discount; the
-    // rest is inherited from the combined base.
+  test('a profile renames one column and omits another, unbinding it', () => {
+    // remap re-declares its columns: Customer.name maps to a different column,
+    // and Order.discount is omitted -- so it is unbound and total_discount prunes.
     const {ddl, report} = buildProfile('partial_binding.yaml', 'remap');
-    expect(ddl).toContain('full_name AS name');   // overridden
-    expect(ddl).toContain('order_id AS id');       // inherited
+    expect(ddl).toContain('full_name AS name');   // remapped column
+    expect(ddl).toContain('order_id AS id');       // re-declared
     expect(report.unboundFields).toEqual(['Order.discount']);
     expect(report.droppedMetrics.map(d => d.name)).toEqual(['total_discount']);
   });

--- a/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/bigquery.test.ts
@@ -778,7 +778,7 @@ describe('supertype shared-label constraints (inheritance)', () => {
     expect(ddl).not.toContain('total_people');
     expect(warnings.some(
                w => w.includes(`metric 'total_people'`) &&
-                   w.includes('shared label')))
+                   w.includes('not a leaf type')))
         .toBe(true);
   });
 

--- a/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
@@ -52,12 +52,30 @@ function entryName(id: string, project = 'dest'): string {
   return `projects/${project}/locations/us/entryGroups/eg/entries/${id}`;
 }
 
-// The same loader-valid model, but its GOOGLE custom_extension carries invalid
-// JSON: the doc parses, yet the emitter (via bigQueryGraphTargets) throws while
-// building the semantic-model aspect. Surgically swap only the `data:` value so
-// the rest of the document stays valid.
-const MALFORMED_EXTENSION =
-    OSSIE.replace(/data: '[^\n]*'/, 'data: \'not valid json\'');
+// A loader-valid VANILLA (0.2.0.dev0) model whose model-level GOOGLE
+// custom_extension carries invalid JSON: the doc parses, yet the emitter (via
+// googleDeploymentTargets) throws while building the semantic-model aspect.
+// Under the extended profile the deployment target is a native key with no JSON
+// to corrupt, so the malformed-carrier case is a vanilla document (which is the
+// version that carries the target in a GOOGLE custom_extension at all).
+const MALFORMED_EXTENSION = `
+version: "0.2.0.dev0"
+semantic_model:
+  - name: sales
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: 'not valid json'
+    datasets:
+      - name: orders
+        source: demo.sales.orders
+        primary_key: [o_orderkey]
+        fields:
+          - { name: o_orderkey, expression: o_orderkey }
+          - { name: o_totalprice, expression: o_totalprice }
+    metrics:
+      - name: total_revenue
+        expression: SUM(orders.o_totalprice)
+`;
 
 // entryCreateTries: 1 keeps the propagation-retry loop from sleeping in tests.
 const OPTS = {

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/hierarchy_graph.yaml
@@ -13,15 +13,13 @@
 # Person LABEL and its fields, but not its relationships. `extends` is a
 # deliberate superset of released OSI (see osi_schema.test.ts).
 
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 
 semantic_model:
   - name: people
     description: People and organizations, as a class hierarchy
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/people"]}'
-    datasets:
+    deployment_target: //bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/people
+    entities:
       - name: Person
         source: sqlgen-testing.demo.person
         primary_key: [id]

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/carriage.osi.golden.yaml
@@ -1,33 +1,8 @@
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: carriage
     description: Imported from OWL ontology http://example.com/people#
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: |-
-          {
-            "owl:AllDisjointClasses": [
-              [
-                "Person",
-                "Robot",
-                "LifeStage"
-              ]
-            ],
-            "owl:AllDisjointProperties": [
-              [
-                "personId",
-                "name"
-              ]
-            ],
-            "owl:AllDifferent": [
-              [
-                "Infant",
-                "Adult"
-              ]
-            ],
-            "owl:baseIri": "http://example.com/people#"
-          }
-    datasets:
+    entities:
       - name: Person
         primary_key:
           - personId
@@ -39,98 +14,16 @@ semantic_model:
             datatype: String
           - name: legalName
             datatype: String
-            custom_extensions:
-              - vendor_name: GOOGLE
-                data: |-
-                  {
-                    "rdfs:subPropertyOf": [
-                      "name"
-                    ],
-                    "owl:equivalentProperty": [
-                      "http://xmlns.com/foaf/0.1/name"
-                    ],
-                    "owl:FunctionalProperty": true,
-                    "rdfs:seeAlso": [
-                      "\"See the naming policy doc.\""
-                    ],
-                    "owl:deprecated": true,
-                    "owl:versionInfo": "2.0"
-                  }
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "owl:equivalentClass": [
-                  "http://xmlns.com/foaf/0.1/Person"
-                ],
-                "owl:disjointWith": [
-                  "Robot"
-                ],
-                "rdfs:seeAlso": [
-                  "<https://schema.org/Person>"
-                ],
-                "rdfs:isDefinedBy": [
-                  "http://example.com/people"
-                ]
-              }
       - name: Robot
         description: A machine, never a person.
       - name: LifeStage
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "owl:oneOf": [
-                  "Infant",
-                  "Adult"
-                ]
-              }
     relationships:
       - name: ancestorOf
         from: Person
         to: Person
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "rdfs:subPropertyOf": [
-                  "relatedTo"
-                ],
-                "owl:inverseOf": "descendantOf",
-                "owl:propertyDisjointWith": [
-                  "descendantOf"
-                ],
-                "owl:TransitiveProperty": true,
-                "owl:IrreflexiveProperty": true,
-                "owl:AsymmetricProperty": true,
-                "rdfs:isDefinedBy": [
-                  "http://example.com/people"
-                ]
-              }
       - name: relatedTo
         from: Person
         to: Person
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "owl:equivalentProperty": [
-                  "http://xmlns.com/foaf/0.1/knows"
-                ],
-                "owl:SymmetricProperty": true,
-                "owl:ReflexiveProperty": true
-              }
       - name: uncleOf
         from: Person
         to: Person
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "owl:propertyChainAxiom": [
-                  [
-                    "ancestorOf",
-                    "relatedTo"
-                  ]
-                ]
-              }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/hierarchy.osi.golden.yaml
@@ -1,14 +1,8 @@
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: hierarchy
     description: Imported from OWL ontology http://example.com/hr#
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: |-
-          {
-            "owl:baseIri": "http://example.com/hr#"
-          }
-    datasets:
+    entities:
       - name: Person
         description: A human being.
         fields:
@@ -21,14 +15,6 @@ semantic_model:
             datatype: String
           - name: legalName
             datatype: String
-            custom_extensions:
-              - vendor_name: GOOGLE
-                data: |-
-                  {
-                    "rdfs:subPropertyOf": [
-                      "fullName"
-                    ]
-                  }
       - name: Customer
         extends:
           - Person
@@ -45,14 +31,6 @@ semantic_model:
       - name: managedBy
         from: Employee
         to: Manager
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "rdfs:subPropertyOf": [
-                  "worksWith"
-                ]
-              }
       - name: worksWith
         from: Employee
         to: Employee

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/org.osi.golden.yaml
@@ -1,9 +1,9 @@
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: org
     description: "An org chart: employees, the departments they work in, and the
       projects they staff."
-    datasets:
+    entities:
       - name: Employee
         primary_key:
           - employeeId

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales-advanced.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales-advanced.osi.golden.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
     description: "A sales domain: customers (a kind of person) and their orders.
@@ -6,26 +6,12 @@ semantic_model:
     ai_context:
       synonyms:
         - Sales domain
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: |-
-          {
-            "owl:baseIri": "http://example.com/sales#"
-          }
-    datasets:
+    entities:
       - name: Person
         description: A human being.
         fields:
           - name: fullName
             datatype: String
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "owl:equivalentClass": [
-                  "http://xmlns.com/foaf/0.1/Person"
-                ]
-              }
       - name: Customer
         extends:
           - Person
@@ -43,26 +29,9 @@ semantic_model:
           - name: email
             datatype: String
             description: The customer's unique email address.
-            custom_extensions:
-              - vendor_name: GOOGLE
-                data: |-
-                  {
-                    "owl:FunctionalProperty": true
-                  }
           - name: customerName
             datatype: String
             label: name
-            custom_extensions:
-              - vendor_name: GOOGLE
-                data: |-
-                  {
-                    "rdfs:subPropertyOf": [
-                      "fullName"
-                    ],
-                    "owl:equivalentProperty": [
-                      "http://xmlns.com/foaf/0.1/name"
-                    ]
-                  }
           - name: signupDate
             datatype: Date
             dimension:
@@ -89,21 +58,8 @@ semantic_model:
         to: Customer
         ai_context:
           instructions: Links an order to the customer who placed it.
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "owl:inverseOf": "places"
-              }
       - name: referredBy
         from: Customer
         to: Customer
         ai_context:
           instructions: The customer who referred this one.
-        custom_extensions:
-          - vendor_name: GOOGLE
-            data: |-
-              {
-                "owl:IrreflexiveProperty": true,
-                "owl:AsymmetricProperty": true
-              }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/owl/sales.osi.golden.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
     description: "A minimal sales domain: customers and the orders they place.
@@ -8,7 +8,7 @@ semantic_model:
         - Sales domain
       examples:
         - How many orders did each customer place last month?
-    datasets:
+    entities:
       - name: Customer
         primary_key:
           - customerId

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.prod.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.prod.yaml
@@ -1,15 +1,21 @@
-# Environment swap: the same schema in a different project/dataset. The profile
-# overrides only the deployment target and each entity's source table; it names
-# no fields, so every column binding is INHERITED from the base unchanged. The
-# golden shows the prod tables with the identical column set and all three
-# metrics intact -- proof that a field a profile omits keeps its base binding
-# (omission inherits, it does not drop).
-version: "0.2.0.dev0"
+# Environment swap: the same schema in a different project/dataset. Selecting a
+# profile clears the model's inline bindings, so this profile re-declares every
+# column -- here to the same column names, over the prod tables. The golden shows
+# the prod tables with the identical column set and all three metrics intact.
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: sales
     deployment_target: //bigquery.googleapis.com/projects/acme-prod/datasets/sales/propertyGraphs/sales
     entities:
       - name: Customer
         source: //bigquery.googleapis.com/projects/acme-prod/datasets/sales/tables/customers
+        fields:
+          - { name: id, expression: customer_id }
+          - { name: name, expression: customer_name }
       - name: Order
         source: //bigquery.googleapis.com/projects/acme-prod/datasets/sales/tables/orders
+        fields:
+          - { name: id, expression: order_id }
+          - { name: customerId, expression: customer_id }
+          - { name: amount, expression: amount }
+          - { name: discount, expression: discount }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.remap.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.remap.yaml
@@ -1,10 +1,10 @@
-# A store that renamed one column and does not carry `discount`. The profile
-# overrides just those two facets -- `Customer.name` maps to a different column,
-# and `discount` is marked unbound -- and inherits everything else from the base
-# (the other columns, the keys, the graph shape). The golden shows the remapped
-# column beside the inherited base columns, and `discount` + `total_discount`
-# pruned. This is a partial override of a model that already carries bindings.
-version: "0.2.0.dev0"
+# A store that renamed one column and does not carry `discount`. Selecting a
+# profile clears the model's inline bindings, so this profile re-declares the
+# columns it serves: `Customer.name` maps to a different column, and `discount`
+# is omitted -- so it is unbound here, and `total_discount` prunes with it. The
+# golden shows the remapped column beside the re-declared columns, and `discount`
+# + `total_discount` pruned.
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: sales
     deployment_target: //bigquery.googleapis.com/projects/acme-eu/datasets/sales/propertyGraphs/sales
@@ -12,8 +12,11 @@ semantic_model:
       - name: Customer
         source: //bigquery.googleapis.com/projects/acme-eu/datasets/sales/tables/customers
         fields:
+          - { name: id, expression: customer_id }
           - { name: name, expression: full_name }
       - name: Order
         source: //bigquery.googleapis.com/projects/acme-eu/datasets/sales/tables/orders
         fields:
-          - { name: discount, unbound: true }
+          - { name: id, expression: order_id }
+          - { name: customerId, expression: customer_id }
+          - { name: amount, expression: amount }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/partial_binding.yaml
@@ -1,13 +1,14 @@
 # A COMBINED single-file model: the logical declarations AND an inline physical
 # binding (the implicit `default` profile) in one file -- the form a model has
 # before any profile exists. Every field is bound to a column here, so this file
-# deploys on its own with a bare `kcmd push`. The profiles beside it override
-# only the physical facets that differ elsewhere:
-#   - prod:  an environment swap -- same columns, a different project/dataset.
+# deploys on its own with a bare `kcmd push`. Selecting a profile clears these
+# inline bindings, so a profile is authoritative -- it alone decides what is
+# bound. The profiles beside it re-declare the columns each store serves:
+#   - prod:  an environment swap -- the same columns, a different project/dataset.
 #   - remap: a store that renamed a column and does not carry `discount`.
-# Together they show that a profile overriding a model that already has bindings
-# replaces only what it names and INHERITS every field it omits.
-version: "0.2.0.dev0"
+# Together they show that selecting a profile clears the inline bindings, so a
+# field the profile does not name is unbound under it (there is no `unbound` flag).
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: sales
     deployment_target: //bigquery.googleapis.com/projects/acme-dev/datasets/sales/propertyGraphs/sales

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.analytical.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.analytical.yaml
@@ -3,7 +3,7 @@
 # every structural site (node KEY, edge SOURCE KEY / DESTINATION KEY /
 # REFERENCES) and as each MEASURE operand -- never the logical field name.
 # `segment` is explicitly unbound, which prunes it and the segment_count metric.
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     deployment_target: //bigquery.googleapis.com/projects/acme/datasets/sales/propertyGraphs/commerce
@@ -13,7 +13,6 @@ semantic_model:
         fields:
           - { name: id, expression: cust_id }
           - { name: name, expression: full_name }
-          - { name: segment, unbound: true }
       - name: Order
         source: //bigquery.googleapis.com/projects/acme/datasets/sales/tables/orders
         fields:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.operational.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.operational.yaml
@@ -5,7 +5,7 @@
 # pruned under `analytical`, is available here) and leaves `amount` unbound (so
 # `total_amount`, available under `analytical`, is pruned here). Read this golden
 # beside the analytical one: the two answer different questions from one model.
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     deployment_target: //bigquery.googleapis.com/projects/acme-ops/datasets/ops/propertyGraphs/commerce
@@ -21,4 +21,3 @@ semantic_model:
         fields:
           - { name: id, expression: order_key }
           - { name: customerId, expression: cust_key }
-          - { name: amount, unbound: true }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/profiles/profile_binding.yaml
@@ -3,7 +3,7 @@
 # bindings. `segment` is declared but left for a profile to bind (the analytical
 # profile leaves it unbound), and `segment_count` depends on it -- so the golden
 # shows both the field and the metric pruned when the binding withholds it.
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     entities:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words_inherit.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/reserved_words_inherit.yaml
@@ -3,10 +3,10 @@
 # bare `LABEL Order` that would be a syntax error. Complements reserved_words.yaml
 # (which covers the direct-FK edge, property, and measure positions) with the
 # inheritance-LABEL position.
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 semantic_model:
   - name: reserved_words_inherit
-    datasets:
+    entities:
       # `Order` is reserved -> the ancestor label is quoted everywhere it appears.
       - name: Order
         source: proj.ds.orders

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bad_target.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bad_target.yaml
@@ -5,14 +5,12 @@
 # misspelled). Exercises the deploy leg's "declared but unparseable" path: the
 # error must name the bad URI rather than claim no target was declared.
 
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 
 semantic_model:
   - name: sales
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraph/sales_graph"]}'
-    datasets:
+    deployment_target: //bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraph/sales_graph
+    entities:
       - name: orders
         source: demo.sales.orders
         primary_key: [o_orderkey]

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.osi.golden.yaml
@@ -1,11 +1,8 @@
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets":
-          ["//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph"]}'
-    datasets:
+    deployment_target: //bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph
+    entities:
       - name: orders
         source: demo.sales.orders
         primary_key:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.pull.golden.yaml
@@ -1,11 +1,9 @@
 # (no warnings)
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets":["//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph"]}'
-    datasets:
+    deployment_target: //bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph
+    entities:
       - name: orders
         source: demo.sales.orders
         primary_key:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_bq_graph_target.yaml
@@ -5,14 +5,12 @@
 # This is the happy-path document for the deploy leg: loader -> IR -> generator
 # -> BigQuery Graph. The target resolves to `demo.sales.sales_graph`.
 
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 
 semantic_model:
   - name: sales
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph"]}'
-    datasets:
+    deployment_target: //bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph
+    entities:
       - name: orders
         source: demo.sales.orders
         primary_key: [o_orderkey]

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_google_ext.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_google_ext.yaml
@@ -7,15 +7,13 @@
 # is the fixture that exercises pickDialect's target-dialect-present path rather
 # than the ANSI_SQL fallback the other fixtures rely on.
 
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 
 semantic_model:
   - name: sales_typed
     description: Sales orders with typed fields and a deployment target
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph"]}'
-    datasets:
+    deployment_target: projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph
+    entities:
       - name: orders
         source: demo.sales.orders
         primary_key: [o_orderkey]

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_spanner_graph_target.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_spanner_graph_target.yaml
@@ -7,14 +7,12 @@
 # `commerce` of instance `prod` in project `demo`. The metric is dropped by the
 # Spanner generator (Spanner Graph has no MEASURE).
 
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 
 semantic_model:
   - name: sales
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["//spanner.googleapis.com/projects/demo/instances/prod/databases/commerce/propertyGraphs/sales_graph"]}'
-    datasets:
+    deployment_target: //spanner.googleapis.com/projects/demo/instances/prod/databases/commerce/propertyGraphs/sales_graph
+    entities:
       - name: orders
         source: demo.sales.Orders
         primary_key: [o_orderkey]

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/sales_unqualified_source.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/sales_unqualified_source.yaml
@@ -5,14 +5,12 @@
 # `defaultProject`, so this fixture exercises which project the deploy leg feeds
 # the loader -- the scope's declared project, not the ambient gcloud project.
 
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 
 semantic_model:
   - name: sales
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph"]}'
-    datasets:
+    deployment_target: //bigquery.googleapis.com/projects/demo/datasets/sales/propertyGraphs/sales_graph
+    entities:
       - name: orders
         source: sales.orders
         primary_key: [o_orderkey]

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.osi.golden.yaml
@@ -1,14 +1,11 @@
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
     description: Sales orders with customer attributes
     ai_context:
       instructions: Use this model for order analysis.
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets":
-          ["//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales"]}'
-    datasets:
+    deployment_target: //bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales
+    entities:
       - name: orders
         source: samples.tpch.orders
         primary_key:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.pull.golden.yaml
@@ -1,14 +1,12 @@
 # (no warnings)
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
     description: Sales orders with customer attributes
     ai_context:
       instructions: Use this model for order analysis.
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets":["//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales"]}'
-    datasets:
+    deployment_target: //bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales
+    entities:
       - name: orders
         source: samples.tpch.orders
         primary_key:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/star_orders_customer.yaml
@@ -5,17 +5,15 @@
 # ai_context at model / field / metric level, a time dimension (is_time), a
 # field label, and an entity-scoped COUNT metric.
 
-version: "0.2.0.dev0"
+version: "0.2.0.dev0/google"
 
 semantic_model:
   - name: sales
     description: Sales orders with customer attributes
-    custom_extensions:
-      - vendor_name: GOOGLE
-        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales"]}'
+    deployment_target: //bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales
     ai_context:
       instructions: "Use this model for order analysis."
-    datasets:
+    entities:
       - name: orders
         source: samples.tpch.orders
         primary_key: [o_orderkey]

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.osi.golden.yaml
@@ -1,8 +1,8 @@
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: tpcds_model
     description: TPC-DS retail model
-    datasets:
+    entities:
       - name: store_sales
         source: tpcds.public.store_sales
         primary_key:
@@ -183,10 +183,6 @@ semantic_model:
       - name: date_dim
         source: sqlgen-testing.demo.date_dim
         description: Date dimension with calendar attributes
-        custom_extensions:
-          - vendor_name: GOODDATA
-            data: '{"date_dimension": true, "granularities": ["DAY", "WEEK", "MONTH",
-              "QUARTER", "YEAR"]}'
     relationships:
       - name: store_sales_to_date_dim
         from: store_sales

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/tpcds_date_edge.pull.golden.yaml
@@ -1,9 +1,9 @@
 # (no warnings)
-version: 0.2.0.dev0
+version: 0.2.0.dev0/google
 semantic_model:
   - name: tpcds_model
     description: TPC-DS retail model
-    datasets:
+    entities:
       - name: store_sales
         source: tpcds.public.store_sales
         primary_key:

--- a/toolbox/mdcode/tests/libts/semantic/load_semantic_models.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/load_semantic_models.test.ts
@@ -14,7 +14,8 @@ import {loadSemanticModels} from '../../../src/libts/semantic/loader';
 // A minimal loader-valid document: one model, one dataset (with a primary key
 // so it does not warn), no metrics.
 function doc(modelName: string, source = 'proj.ds.tbl'): string {
-  return `semantic_model:
+  return `version: 0.2.0.dev0
+semantic_model:
   - name: ${modelName}
     datasets:
       - name: orders
@@ -45,7 +46,8 @@ describe('loadSemanticModels', () => {
   test('prefixes loader warnings with the originating document name', () => {
     // A dataset with no primary_key makes the loader warn; the warning must
     // carry the document name so a multi-document push stays diagnosable.
-    const noKey = `semantic_model:
+    const noKey = `version: 0.2.0.dev0
+semantic_model:
   - name: sales
     datasets:
       - name: orders

--- a/toolbox/mdcode/tests/libts/semantic/loader.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/loader.test.ts
@@ -21,7 +21,7 @@ function expr(expression: string, dialect = 'BIGQUERY') {
 
 
 describe('dataset source strings normalize to fully-qualified references', () => {
-  const { models } = fromDocument({
+  const { models } = fromDocument({ version: '0.2.0.dev0',
     semantic_model: [{
       name: 'm',
       datasets: [
@@ -46,7 +46,7 @@ describe('dataset source strings normalize to fully-qualified references', () =>
   });
 
   test('a query-like source is kept verbatim with a warning', () => {
-    const { models, warnings } = fromDocument({
+    const { models, warnings } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{ name: 'm', datasets: [
         { name: 'a', source: 'SELECT 1 FROM t', primary_key: ['id'], fields: [] }] }],
     });
@@ -55,7 +55,7 @@ describe('dataset source strings normalize to fully-qualified references', () =>
   });
 
   test('a dataset without a primary key warns (its KEY would be empty)', () => {
-    const { warnings } = fromDocument({
+    const { warnings } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{ name: 'm', datasets: [
         { name: 'a', source: 'a', fields: [] }] }],
     });
@@ -63,7 +63,7 @@ describe('dataset source strings normalize to fully-qualified references', () =>
   });
 
   test('backtick- or double-quoted identifiers are unquoted', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{ name: 'm', datasets: [
         { name: 'a', source: '`proj`.`ds`.`tbl`', primary_key: ['id'], fields: [] }] }],
     });
@@ -71,7 +71,7 @@ describe('dataset source strings normalize to fully-qualified references', () =>
   });
 
   test('a four-part Lakehouse catalog name passes through untouched', () => {
-    const { models, warnings } = fromDocument({
+    const { models, warnings } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{ name: 'm', datasets: [
         { name: 'a', source: 'proj.cat.ns.tbl', primary_key: ['id'], fields: [] }] }],
     }, { defaultProject: 'P', defaultDataset: 'D' });
@@ -80,7 +80,7 @@ describe('dataset source strings normalize to fully-qualified references', () =>
   });
 
   test('an explicit project/dataset in the source is not overridden by defaults', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{ name: 'm', datasets: [
         { name: 'a', source: 'realproj.realds.tbl', primary_key: ['id'], fields: [] }] }],
     }, { defaultProject: 'P', defaultDataset: 'D' });
@@ -92,6 +92,7 @@ describe('dataset source strings normalize to fully-qualified references', () =>
 describe('per-dialect expressions collapse to a single string', () => {
   function metricDoc(dialectList: Array<{ dialect: string; expression: string }>) {
     return {
+      version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
@@ -150,7 +151,7 @@ describe('per-dialect expressions collapse to a single string', () => {
   });
 
   test('field expressions select their dialect independently of metrics', () => {
-    const { models, warnings } = fromDocument({
+    const { models, warnings } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -183,7 +184,7 @@ describe('per-dialect expressions collapse to a single string', () => {
 
 
 describe('relationships map onto the direct-FK IR convention', () => {
-  const { models } = fromDocument({
+  const { models } = fromDocument({ version: '0.2.0.dev0',
     semantic_model: [{
       name: 'm',
       datasets: [
@@ -207,7 +208,7 @@ describe('relationships map onto the direct-FK IR convention', () => {
   });
 
   test('a composite foreign key maps column-for-column', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -229,7 +230,7 @@ describe('relationships map onto the direct-FK IR convention', () => {
     // The FK columns are taken straight from from_columns; the source entity's own
     // primary key is looked up from the entity by downstream consumers, never
     // duplicated onto the relationship (so a missing from-PK is irrelevant here).
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -247,7 +248,7 @@ describe('relationships map onto the direct-FK IR convention', () => {
   });
 
   test('an unresolved to dataset is a hard error', () => {
-    expect(() => fromDocument({
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'orders', source: 'orders', primary_key: ['order_id'], fields: [] }],
@@ -260,7 +261,7 @@ describe('relationships map onto the direct-FK IR convention', () => {
   });
 
   test('an unresolved from dataset is a hard error', () => {
-    expect(() => fromDocument({
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'customers', source: 'customers', primary_key: ['customer_id'], fields: [] }],
@@ -273,7 +274,7 @@ describe('relationships map onto the direct-FK IR convention', () => {
   });
 
   test('mismatched from_columns/to_columns arity is a hard error', () => {
-    expect(() => fromDocument({
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -291,7 +292,7 @@ describe('relationships map onto the direct-FK IR convention', () => {
 
 describe('abstract datasets and their source constraint', () => {
   test('a non-abstract dataset with no source is a hard error', () => {
-    expect(() => fromDocument({
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'orders', primary_key: ['id'], fields: [] }],
@@ -302,7 +303,7 @@ describe('abstract datasets and their source constraint', () => {
   test('an abstract dataset that also declares a source is a hard error', () => {
     // abstract == no physical table; a source would be silently ignored by the
     // BigQuery leg, dropping a table the author intended, so reject the combo.
-    expect(() => fromDocument({
+    expect(() => fromDocument({ version: '0.2.0.dev0/google',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -314,7 +315,7 @@ describe('abstract datasets and their source constraint', () => {
   });
 
   test('an abstract dataset with no source loads and is marked abstract', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0/google',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'Party', abstract: true, fields: [] }],
@@ -328,7 +329,7 @@ describe('abstract datasets and their source constraint', () => {
     // The supertype has no table, so its fields carry no column -- they name
     // the label its subtypes bind. The strict (graph-leg) schema must accept
     // them even though a concrete dataset's field would require an expression.
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0/google',
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -353,10 +354,11 @@ describe('abstract datasets and their source constraint', () => {
     expect(party.fields.every(f => f.expression === undefined)).toBe(true);
   });
 
-  test('a concrete dataset\'s expression-less field still fails under a graph leg', () => {
-    // The abstract exemption must not leak to concrete datasets: a real
-    // table's field still needs a column (or an explicit `unbound`).
-    expect(() => fromDocument({
+  test('a concrete dataset\'s expression-less field loads as unbound under a graph leg', () => {
+    // A field with no expression is unbound, not an error: the availability
+    // pass drops it (and whatever depends on it) before generation. The
+    // dataset's own `source` is a separate constraint and is still required.
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -366,14 +368,17 @@ describe('abstract datasets and their source constraint', () => {
           fields: [{ name: 'id', expression: 'o_id' }, { name: 'total' }],
         }],
       }],
-    })).toThrow(/field 'total': requires an expression/);
+    });
+    const [id, total] = models[0].entities[0].fields;
+    expect(id.expression).toBe('o_id');
+    expect(total.expression).toBeUndefined();
   });
 });
 
 
 describe('metrics infer their referenced entities from the expression', () => {
   test('a single referenced entity becomes the metric attach entity', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
@@ -386,7 +391,7 @@ describe('metrics infer their referenced entities from the expression', () => {
   test('a metric spanning multiple entities has no single attach entity', () => {
     // A cross-entity metric references known entities but cannot hang off one
     // node, so `entity` is left undefined -- not a missing-entity warning.
-    const { models, warnings } = fromDocument({
+    const { models, warnings } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -404,7 +409,7 @@ describe('metrics infer their referenced entities from the expression', () => {
   });
 
   test('a metric referencing no known entity warns', () => {
-    const { warnings } = fromDocument({
+    const { warnings } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'order_items', source: 'order_items', primary_key: ['id'], fields: [] }],
@@ -417,7 +422,7 @@ describe('metrics infer their referenced entities from the expression', () => {
   test('a qualifier inside a string literal is not counted as a reference', () => {
     // 'customers.region' is data, not a column reference, so the metric must be
     // attributed only to order_items.
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -436,7 +441,7 @@ describe('metrics infer their referenced entities from the expression', () => {
   test('a backtick-quoted entity qualifier is recognized (BigQuery quoting)', () => {
     // BigQuery quotes identifiers with backticks; `orders`.amount must still be
     // attributed to the orders entity, not dropped as unqualified.
-    const { models, warnings } = fromDocument({
+    const { models, warnings } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
@@ -450,37 +455,31 @@ describe('metrics infer their referenced entities from the expression', () => {
 
 
 describe('document-level handling', () => {
-  test('a mismatched version warns but still loads', () => {
-    const { models, warnings } = fromDocument({
+  test('an unknown version is a hard load error', () => {
+    expect(() => fromDocument({
       version: '9.9.9',
       semantic_model: [{ name: 'm', datasets: [
         { name: 'a', source: 'a', primary_key: ['id'], fields: [] }] }],
-    });
-    expect(models).toHaveLength(1);
-    expect(warnings.some(w => w.includes('differs from the supported'))).toBe(true);
+    })).toThrow(/unknown version '9.9.9'/);
   });
 
-  test('unknown/extra fields outside the subset are ignored, not errors', () => {
-    const { models } = fromDocument({
+  test('an unknown key is a hard load error (objects are strict)', () => {
+    // Objects are `.strict()`: an unrecognized key is rejected rather than
+    // silently dropped, so a typo cannot slip through unnoticed.
+    expect(() => fromDocument({
+      version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
-        ai_context: { instructions: 'ignored' },
-        custom_extensions: [{ vendor_name: 'X', data: '{}' }],
         datasets: [{
           name: 'a', source: 'a', primary_key: ['id'],
-          unique_keys: [['id']],
-          fields: [{
-            name: 'id', label: 'ignored', dimension: { is_time: false },
-            expression: expr('a.id'),
-          }],
+          fields: [{ name: 'id', expression: expr('a.id'), bogus: true }],
         }],
       }],
-    });
-    expect(models[0].entities[0].fields[0].name).toBe('id');
+    })).toThrow(/Semantic model load error/);
   });
 
-  test('duplicate dataset names warn (only one node table can carry the label)', () => {
-    const { warnings } = fromDocument({
+  test('duplicate dataset names are a hard load error', () => {
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -488,12 +487,11 @@ describe('document-level handling', () => {
           { name: 'orders', source: 'b', primary_key: ['id'], fields: [] },
         ],
       }],
-    });
-    expect(warnings.some(w => w.includes("duplicate dataset name 'orders'"))).toBe(true);
+    })).toThrow(/duplicate dataset name 'orders'/);
   });
 
   test('each semantic_model entry becomes its own IR model', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [
         { name: 'first', datasets: [{ name: 'a', source: 'a', primary_key: ['id'], fields: [] }] },
         { name: 'second', datasets: [{ name: 'b', source: 'b', primary_key: ['id'], fields: [] }] },
@@ -503,7 +501,7 @@ describe('document-level handling', () => {
   });
 
   test('model and metric descriptions carry through to the IR', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm', description: 'a sales model',
         datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'], fields: [] }],
@@ -516,6 +514,7 @@ describe('document-level handling', () => {
 
   test('JSON text loads identically to YAML (yaml.parse accepts JSON)', () => {
     const json = JSON.stringify({
+      version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'a', source: 'proj.ds.tbl', primary_key: ['id'], fields: [] }],
@@ -526,11 +525,11 @@ describe('document-level handling', () => {
   });
 
   test('a document without semantic_model throws', () => {
-    expect(() => fromDocument({ foo: 'bar' })).toThrow(/Semantic model load error/);
+    expect(() => fromDocument({ version: '0.2.0.dev0', foo: 'bar' })).toThrow(/Semantic model load error/);
   });
 
   test('an empty semantic_model array throws (min one model required)', () => {
-    expect(() => fromDocument({ semantic_model: [] })).toThrow(/Semantic model load error/);
+    expect(() => fromDocument({ version: '0.2.0.dev0', semantic_model: [] })).toThrow(/Semantic model load error/);
   });
 
   test('unparseable input throws', () => {
@@ -541,7 +540,7 @@ describe('document-level handling', () => {
 
 describe('richer IR fields carry through from the format', () => {
   test('field and metric datatype populate the IR type', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -558,7 +557,7 @@ describe('richer IR fields carry through from the format', () => {
   test('an off-vocabulary datatype is rejected (closed, case-sensitive enum)', () => {
     // Lowercase 'date' is not in the vocabulary (only 'Date' is); the closed
     // enum makes this a hard parse error rather than a silently mis-typed field.
-    expect(() => fromDocument({
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -570,7 +569,7 @@ describe('richer IR fields carry through from the format', () => {
   });
 
   test('a dataset unique_keys becomes Entity.uniqueKeys', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -584,7 +583,7 @@ describe('richer IR fields carry through from the format', () => {
   });
 
   test('the GOOGLE block is carried verbatim, not interpreted at load time', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         custom_extensions: [
@@ -605,7 +604,7 @@ describe('richer IR fields carry through from the format', () => {
   });
 
   test('a malformed GOOGLE block is kept verbatim without warning (not parsed)', () => {
-    const { models, warnings } = fromDocument({
+    const { models, warnings } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         custom_extensions: [{ vendor_name: 'GOOGLE', data: '{not json' }],
@@ -618,7 +617,7 @@ describe('richer IR fields carry through from the format', () => {
   });
 
   test('ai_context instructions and synonyms are structural, not folded into description', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm', description: 'a sales model',
         ai_context: { instructions: 'Prefer net revenue.', synonyms: ['sales', 'commerce'] },
@@ -873,7 +872,7 @@ describe('gold fixtures parse from disk (real YAML files)', () => {
     const m = models[0];
     expect(m.customExtensions).toEqual([{
       vendorName: 'GOOGLE',
-      data: '{"deploymentTargets": ["projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph"]}',
+      data: JSON.stringify({ deploymentTargets: ['projects/demo/locations/us/entryGroups/@bigquery/entries/sales_graph'] }),
     }]);
     const orders = m.entities[0];
     expect(orders.uniqueKeys).toEqual([['o_orderkey'], ['o_ordernumber']]);
@@ -910,9 +909,9 @@ describe('gold fixtures parse from disk (real YAML files)', () => {
   });
 });
 
-describe('duplicate names within a model warn (uniqueness checks)', () => {
-  test('duplicate field names within a dataset warn', () => {
-    const { warnings } = fromDocument({
+describe('duplicate names within a model are hard errors (uniqueness checks)', () => {
+  test('duplicate field names within a dataset are a hard error', () => {
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -923,13 +922,11 @@ describe('duplicate names within a model warn (uniqueness checks)', () => {
           ],
         }],
       }],
-    });
-    expect(warnings.some(w =>
-      w.includes("dataset 'orders'") && w.includes("duplicate field name 'amount'"))).toBe(true);
+    })).toThrow(/duplicate field name 'amount'/);
   });
 
-  test('duplicate metric names within a model warn', () => {
-    const { warnings } = fromDocument({
+  test('duplicate metric names within a model are a hard error', () => {
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'orders', source: 'orders', primary_key: ['id'],
@@ -939,13 +936,11 @@ describe('duplicate names within a model warn (uniqueness checks)', () => {
           { name: 'total', expression: expr('AVG(orders.amount)') },
         ],
       }],
-    });
-    expect(warnings.some(w =>
-      w.includes("model 'm'") && w.includes("duplicate metric name 'total'"))).toBe(true);
+    })).toThrow(/duplicate metric name 'total'/);
   });
 
-  test('duplicate relationship names within a model warn', () => {
-    const { warnings } = fromDocument({
+  test('duplicate relationship names within a model are a hard error', () => {
+    expect(() => fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [
@@ -959,9 +954,7 @@ describe('duplicate names within a model warn (uniqueness checks)', () => {
           { name: 'o2c', from: 'orders', to: 'customer', from_columns: ['c_id'], to_columns: ['c_id'] },
         ],
       }],
-    });
-    expect(warnings.some(w =>
-      w.includes("model 'm'") && w.includes("duplicate relationship name 'o2c'"))).toBe(true);
+    })).toThrow(/duplicate relationship name 'o2c'/);
   });
 });
 
@@ -969,7 +962,7 @@ describe('duplicate names within a model warn (uniqueness checks)', () => {
 describe('field label and time-dimension role align with the format models', () => {
   // Builds one field with the given extra props and returns its IR form.
   function field(props: Record<string, unknown>) {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -1029,7 +1022,7 @@ describe('authoring sugars: entities alias, bare-string expression, deployment_t
     '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
 
   test("'entities:' is an alias for 'datasets:'", () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0/google',
       semantic_model: [{
         name: 'm',
         entities: [
@@ -1043,7 +1036,7 @@ describe('authoring sugars: entities alias, bare-string expression, deployment_t
   });
 
   test("declaring both 'entities' and 'datasets' is an error", () => {
-    expect(() => fromDocument({
+    expect(() => fromDocument({ version: '0.2.0.dev0/google',
       semantic_model: [{
         name: 'm',
         entities: [{ name: 'a', source: 's', fields: [] }],
@@ -1053,7 +1046,7 @@ describe('authoring sugars: entities alias, bare-string expression, deployment_t
   });
 
   test('a bare-string expression expands to the target-dialect object', () => {
-    const { models } = fromDocument({
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
@@ -1066,14 +1059,14 @@ describe('authoring sugars: entities alias, bare-string expression, deployment_t
   });
 
   test("a top-level 'deployment_target' folds into the GOOGLE block form", () => {
-    const sugar = fromDocument({
+    const sugar = fromDocument({ version: '0.2.0.dev0/google',
       semantic_model: [{
         name: 'm', deployment_target: URI,
         datasets: [{ name: 'a', source: 's', primary_key: ['id'],
           fields: [{ name: 'id', expression: 'id' }] }],
       }],
     });
-    const explicit = fromDocument({
+    const explicit = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         custom_extensions: [{ vendor_name: 'GOOGLE',
@@ -1090,72 +1083,44 @@ describe('authoring sugars: entities alias, bare-string expression, deployment_t
     ]);
   });
 
-  test("'deployment_target' agreeing with a GOOGLE block adds no duplicate", () => {
-    const { models } = fromDocument({
-      semantic_model: [{
-        name: 'm', deployment_target: URI,
-        custom_extensions: [{ vendor_name: 'GOOGLE',
-          data: JSON.stringify({ deploymentTargets: [URI] }) }],
-        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
-          fields: [{ name: 'id', expression: 'id' }] }],
-      }],
-    });
-    expect(models[0].customExtensions).toEqual([
-      { vendorName: 'GOOGLE',
-        data: JSON.stringify({ deploymentTargets: [URI] }) },
-    ]);
-  });
-
-  test("'deployment_target' disagreeing with a GOOGLE block is an error", () => {
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm', deployment_target: URI,
-        custom_extensions: [{ vendor_name: 'GOOGLE',
-          data: JSON.stringify({ deploymentTargets: ['//other/target'] }) }],
-        datasets: [{ name: 'a', source: 's', fields: [] }],
-      }],
-    })).toThrow(/disagrees with the GOOGLE custom_extension/);
-  });
 });
 
-describe('fields may be declared unbound (no physical column)', () => {
+describe('a field is unbound exactly when it has no expression', () => {
   test('an unbound field loads with no expression', () => {
-    const { models } = fromDocument({
+    // There is no separate flag: a field is unbound simply by carrying no
+    // expression. This holds on either leg -- a graph leg does not reject an
+    // unbound field; the availability pass drops it before generation.
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{
           name: 'a', source: 's', primary_key: ['id'],
           fields: [
             { name: 'id', expression: 'id' },
-            { name: 'credit', unbound: true },
+            { name: 'credit' },
           ],
         }],
       }],
-    });
+    }, { bindingOptional: true });
     const [id, credit] = models[0].entities[0].fields;
-    expect(id.unbound).toBeUndefined();
-    expect(credit.unbound).toBe(true);
+    expect(id.expression).toBe('id');
     expect(credit.expression).toBeUndefined();
   });
 
-  test('a field that is both bound and unbound is an error', () => {
-    expect(() => fromDocument({
+  test('an expression-less field is not a load error under a graph leg', () => {
+    // A missing expression is an unbound field, not a validation failure: the
+    // availability pass prunes it (and any metric that reads it) before the
+    // graph is generated, so one logical model can serve stores that lack a
+    // given column.
+    const { models } = fromDocument({ version: '0.2.0.dev0',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'a', source: 's', primary_key: ['id'],
-          fields: [{ name: 'credit', unbound: true, expression: 'c' }] }],
+          fields: [{ name: 'id', expression: 'id' }, { name: 'credit' }] }],
       }],
-    })).toThrow(/an unbound field has no column/);
-  });
-
-  test('a field that is neither bound nor unbound is an error naming the field', () => {
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'a', source: 's', primary_key: ['id'],
-          fields: [{ name: 'credit' }] }],
-      }],
-    })).toThrow(/field 'credit': requires an expression/);
+    });
+    const credit = models[0].entities[0].fields.find(f => f.name === 'credit')!;
+    expect(credit.expression).toBeUndefined();
   });
 });
 
@@ -1166,6 +1131,7 @@ describe('a purely logical model loads only under bindingOptional', () => {
   // Knowledge-Catalog-only push case -- KC governs the logical layer and needs
   // no table or column to point at.
   const logicalOnly = {
+    version: '0.2.0.dev0',
     semantic_model: [{
       name: 'm',
       datasets: [{
@@ -1186,31 +1152,22 @@ describe('a purely logical model loads only under bindingOptional', () => {
     expect(orders.fields.every(f => f.expression === undefined)).toBe(true);
   });
 
-  test('without bindingOptional the same model fails for the missing source and expression', () => {
+  test('without bindingOptional the same model fails for the missing source', () => {
     let message = '';
     try {
       fromDocument(logicalOnly);
     } catch (e: any) {
       message = String(e.message ?? e);
     }
-    // Both binding-completeness checks fire in the default (strict) mode.
+    // A non-abstract dataset in a graph leg still requires a source. The
+    // expression-less fields are unbound, not errors -- the availability pass
+    // drops them -- so only the missing-source check fires here.
     expect(message).toContain("dataset 'orders': a non-abstract dataset requires a source");
-    expect(message).toContain("field 'amount': requires an expression");
-  });
-
-  test('bindingOptional still rejects an unbound field that also has an expression', () => {
-    // The contradiction check is independent of binding-completeness, so it
-    // fires even when a source/expression is otherwise optional.
-    expect(() => fromDocument({
-      semantic_model: [{
-        name: 'm',
-        datasets: [{ name: 'a', fields: [{ name: 'c', unbound: true, expression: 'c' }] }],
-      }],
-    }, { bindingOptional: true })).toThrow(/an unbound field has no column/);
+    expect(message).not.toContain("requires an expression");
   });
 
   test('bindingOptional still rejects an abstract dataset that also names a source', () => {
-    expect(() => fromDocument({
+    expect(() => fromDocument({ version: '0.2.0.dev0/google',
       semantic_model: [{
         name: 'm',
         datasets: [{ name: 'Party', abstract: true, source: 'p.d.party', fields: [] }],

--- a/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
@@ -6,7 +6,7 @@
 // the IR, serialize it, load the serialized text again, and assert the two IRs
 // are identical. That pins IR-level fidelity across every feature the loader
 // produces (datasets, fields, datatypes, dimensions, labels, ai_context,
-// custom_extensions, relationships, metrics, imported expressions) without
+// deployment targets, relationships, metrics, imported expressions) without
 // hard-coding YAML text. Targeted structural tests cover the mapping details a
 // round trip cannot isolate.
 
@@ -29,15 +29,16 @@ function loadFixture(name: string): SemanticModel[] {
 
 describe('loader <-> serialize round trip is IR-stable', () => {
   // Each fixture exercises a different slice of the format: relationships +
-  // ai_context + synonyms + label + dimension; the full tpc-ds corpus with
-  // custom_extensions + unique_keys; explicit datatypes; and imported
-  // (vendor-dialect) expressions.
+  // ai_context + synonyms + label + dimension; a GOOGLE deployment target;
+  // unique_keys; explicit datatypes; and imported (vendor-dialect) expressions.
+  // Fixtures carrying non-GOOGLE `custom_extensions` (tpcds_retail,
+  // lineitem_databricks_ext) are NOT round-tripped here: the '/google'
+  // serializer drops those (see the "lossy edges" test below), so they cannot
+  // survive an IR-stable round trip.
   const fixtures = [
     'star_orders_customer.yaml',
-    'tpcds_retail.yaml',
     'sales_google_ext.yaml',
     'vendor_dialects.yaml',
-    'lineitem_databricks_ext.yaml',
     'sales_bq_graph_target.yaml',
   ];
 
@@ -64,20 +65,20 @@ describe('serialized document structure', () => {
   const sm = doc.semantic_model[0];
 
   test('emits the supported version and a single model', () => {
-    expect(doc.version).toBe('0.2.0.dev0');
+    expect(doc.version).toBe('0.2.0.dev0/google');
     expect(doc.semantic_model).toHaveLength(1);
     expect(sm.name).toBe(model.name);
   });
 
   test('a dataset source is the opaque dataSource string, verbatim', () => {
-    const orders = sm.datasets.find((d: any) => d.name === 'orders');
+    const orders = sm.entities.find((d: any) => d.name === 'orders');
     const entity = model.entities.find(e => e.name === 'orders')!;
     expect(orders.source).toBe(entity.dataSource);
     expect(typeof orders.source).toBe('string');
   });
 
   test('primary_key mirrors the entity keys', () => {
-    const orders = sm.datasets.find((d: any) => d.name === 'orders');
+    const orders = sm.entities.find((d: any) => d.name === 'orders');
     const entity = model.entities.find(e => e.name === 'orders')!;
     expect(orders.primary_key).toEqual(entity.keys);
   });
@@ -88,7 +89,7 @@ describe('serialized document structure', () => {
     const entity = model.entities.find(
         e => e.fields.some(f => f.aiContext?.synonyms?.length))!;
     const field = entity.fields.find(f => f.aiContext?.synonyms?.length)!;
-    const dsDoc = sm.datasets.find((d: any) => d.name === entity.name);
+    const dsDoc = sm.entities.find((d: any) => d.name === entity.name);
     const fieldDoc = dsDoc.fields.find((f: any) => f.name === field.name);
     expect(fieldDoc.ai_context.synonyms).toEqual(field.aiContext!.synonyms);
   });
@@ -128,7 +129,7 @@ describe('expression + datatype + dimension mapping', () => {
       metrics: [],
     };
     const doc = modelDocument(model) as any;
-    const fieldDoc = doc.semantic_model[0].datasets[0].fields[0];
+    const fieldDoc = doc.semantic_model[0].entities[0].fields[0];
     expect(fieldDoc.dimension).toEqual({});
     // And it reloads back to a dimension field.
     const reloaded = loadModels(serializeModel(model).yaml).models[0];
@@ -151,7 +152,7 @@ describe('expression + datatype + dimension mapping', () => {
     };
     const doc = modelDocument(model) as any;
     const dialects =
-        doc.semantic_model[0].datasets[0].fields[0].expression.dialects;
+        doc.semantic_model[0].entities[0].fields[0].expression.dialects;
     const labels = dialects.map((d: any) => d.dialect);
     expect(labels).toContain('SNOWFLAKE');
     // The canonical form is labeled BIGQUERY so the loader re-picks it exactly.
@@ -227,6 +228,27 @@ describe('lossy edges are flagged', () => {
         expect(relDoc.to).toBe('course');
         expect(relDoc.from_columns).toEqual(['id']);
       });
+
+  test('a non-GOOGLE vendor extension is dropped with a warning', () => {
+    // The extended ('/google') profile has no custom_extensions carrier, so a
+    // non-deployment-target vendor extension has no representation and is
+    // dropped with a warning rather than serialized.
+    const model: SemanticModel = {
+      name: 'm',
+      customExtensions: [{vendorName: 'SALESFORCE', data: '{"crm": true}'}],
+      entities: [{
+        name: 'orders',
+        dataSource: 'p.d.t',
+        keys: ['id'],
+        fields: [{name: 'id', expression: 'orders.id'}],
+      }],
+      relationships: [],
+      metrics: [],
+    };
+    const {yaml: text, warnings} = serializeModel(model);
+    expect(warnings.some(w => /no representation under/i.test(w))).toBe(true);
+    expect(text).not.toContain('custom_extensions');
+  });
 });
 
 
@@ -300,7 +322,7 @@ describe('serialize flags loader-invalid reconstructions', () => {
         };
         const doc = modelDocument(model) as any;
         const labels: string[] =
-            doc.semantic_model[0].datasets[0].fields[0].expression.dialects.map(
+            doc.semantic_model[0].entities[0].fields[0].expression.dialects.map(
                 (d: any) => d.dialect);
         // No duplicate dialect label: the imported form is relabeled off
         // BIGQUERY so the loader does not pick between two BIGQUERY entries.

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -27,7 +27,7 @@ function yamlFixtures(dir: string): string[] {
     const p = join(dir, ent.name);
     // The profiles/ subtree holds binding-profile authoring input, a
     // deliberate pre-OSI superset -- a logical model declares fields with no
-    // `expression`, and a profile carries `deployment_target`/`unbound` sugars
+    // `expression`, and a profile carries a `deployment_target` sugar
     // -- so it is not a standalone OSI document. The loader, merge, and
     // profile-golden tests validate it instead.
     if (ent.isDirectory()) {
@@ -115,6 +115,31 @@ function onlyLogicalGoldenDeviations(errors: typeof validate.errors): boolean {
     });
 }
 
+// Released Apache OSI (osi-schema.json) is vanilla `0.2.0.dev0`: it pins the
+// `version` const, requires `datasets`, and knows no native `deployment_target`
+// key. Many fixtures declare the extended `0.2.0.dev0/google` profile, whose
+// surface deltas -- the version suffix, the `entities` alias for `datasets`, and
+// the native `deployment_target` key -- are deliberate supersets, not drift.
+// Fold those back to the vanilla surface before validating, so the released
+// schema still checks the deep content (dialects, datatypes, field/metric
+// shapes); the remaining deep supersets (`extends`/`abstract`) and the logical
+// goldens' omitted bindings are tolerated by the checks below, exactly as they
+// were for vanilla fixtures.
+function toSchemaShape(doc: any): any {
+  if (!doc || typeof doc !== 'object') return doc;
+  const d = structuredClone(doc);
+  if (d.version === '0.2.0.dev0/google') d.version = '0.2.0.dev0';
+  for (const m of Array.isArray(d.semantic_model) ? d.semantic_model : []) {
+    if (!m || typeof m !== 'object') continue;
+    if (m.entities !== undefined && m.datasets === undefined) {
+      m.datasets = m.entities;
+      delete m.entities;
+    }
+    delete m.deployment_target;
+  }
+  return d;
+}
+
 describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () => {
   test('at least one fixture is discovered', () => {
     expect(fixtures.length).toBeGreaterThan(0);
@@ -123,7 +148,7 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
   for (const path of fixtures) {
     const rel = path.slice(fixturesDir.length + 1);
     test(`${rel} validates against the OSI schema`, () => {
-      const doc = yaml.parse(readFileSync(path, 'utf8'));
+      const doc = toSchemaShape(yaml.parse(readFileSync(path, 'utf8')));
       const ok = validate(doc);
       if (!ok) {
         // A .pull.golden.yaml from an expression-free push is a known #290 gap

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -20,7 +20,6 @@ import * as path from 'node:path';
 import * as yaml from 'yaml';
 
 import {convertOwlToOsi} from '../../../src/libts/semantic/converters/owl/convert';
-import {googleOntologyExtension} from '../../../src/libts/semantic/converters/owl/to_ir';
 import {isTimeDimension} from '../../../src/libts/semantic/ir';
 import {loadModels} from '../../../src/libts/semantic/loader';
 import {owl} from '../../../src/tool/commands';
@@ -42,16 +41,6 @@ function load(yaml: string) {
 // focused rule tests below.
 function loadOwl(ttl: string) {
   return load(convertOwlToOsi(ttl, 'x').yaml).models[0];
-}
-
-// The carried OWL facts on an IR object: the parsed payload of its single
-// GOOGLE custom extension (the flat, prefixed-key block the converter emits).
-// Returns undefined when there is no GOOGLE block, so a test can assert
-// "nothing carried" too.
-function ontologyTerms(exts: {vendorName: string; data: string}[]|undefined):
-    Record<string, unknown>|undefined {
-  const google = exts?.find(e => e.vendorName === 'GOOGLE');
-  return google ? JSON.parse(google.data) : undefined;
 }
 
 const PREFIXES = `
@@ -131,7 +120,7 @@ describe('the OWL import is a purely logical model', () => {
     const {yaml: text} = convertOwlToOsi(ttl, 'sales');
     const doc = yaml.parse(text);
     for (const model of doc.semantic_model ?? []) {
-      for (const ds of model.datasets ?? []) {
+      for (const ds of model.entities ?? []) {
         expect(ds).not.toHaveProperty('source');
         for (const f of ds.fields ?? []) {
           expect(f).not.toHaveProperty('expression');
@@ -176,7 +165,8 @@ describe('sales-advanced is the user-guide unified advanced example', () => {
   });
 
   test(
-      'carries the guide highlights: extends, carriage, both ref forms', () => {
+      'carries the guide highlights: extends and native keys (carriage dropped)',
+      () => {
         const model = load(convertOwlToOsi(ttl, 'sales').yaml).models[0];
         const byName = Object.fromEntries(model.entities.map(e => [e.name, e]));
 
@@ -186,39 +176,22 @@ describe('sales-advanced is the user-guide unified advanced example', () => {
         expect(byName['Customer'].fields.some(f => f.name === 'fullName'))
             .toBe(false);
 
-        // Carriage on an entity: a cross-namespace equivalentClass keeps its
-        // full IRI.
-        expect(ontologyTerms(byName['Person'].customExtensions)).toEqual({
-          'owl:equivalentClass': ['http://xmlns.com/foaf/0.1/Person'],
-        });
-
-        // email maps natively (inverse-functional -> unique key) AND carries
-        // owl:FunctionalProperty -- one construct native, the other along for
-        // the ride.
+        // email maps natively (inverse-functional -> unique key).
         expect(byName['Customer'].uniqueKeys).toEqual([['email']]);
-        const email = byName['Customer'].fields.find(f => f.name === 'email')!;
-        expect(ontologyTerms(email.customExtensions)).toEqual({
-          'owl:FunctionalProperty': true
-        });
 
-        // One field block mixes an in-namespace ref (shortened to a local name)
-        // and a cross-namespace one (kept as a full IRI).
+        // The non-native OWL facts on these terms (equivalentClass,
+        // FunctionalProperty, subPropertyOf/equivalentProperty, inverseOf, and
+        // the owl:baseIri provenance) are import-only drops: each term maps
+        // natively but carries no custom extension.
+        expect(byName['Person'].customExtensions).toBeUndefined();
+        const email = byName['Customer'].fields.find(f => f.name === 'email')!;
+        expect(email.customExtensions).toBeUndefined();
         const customerName =
             byName['Customer'].fields.find(f => f.name === 'customerName')!;
-        expect(ontologyTerms(customerName.customExtensions)).toEqual({
-          'rdfs:subPropertyOf': ['fullName'],
-          'owl:equivalentProperty': ['http://xmlns.com/foaf/0.1/name'],
-        });
-
-        // Relationship carriage: an in-namespace inverse is shortened, so the
-        // model carries owl:baseIri to make the short form reversible.
+        expect(customerName.customExtensions).toBeUndefined();
         const placedBy = model.relationships.find(r => r.name === 'placedBy')!;
-        expect(ontologyTerms(placedBy.customExtensions)).toEqual({
-          'owl:inverseOf': 'places'
-        });
-        expect(ontologyTerms(model.customExtensions)).toEqual({
-          'owl:baseIri': 'http://example.com/sales#'
-        });
+        expect(placedBy.customExtensions).toBeUndefined();
+        expect(model.customExtensions).toBeUndefined();
       });
 });
 
@@ -337,29 +310,24 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
   });
 
   test(
-      'property inheritance (rdfs:subPropertyOf) is carried verbatim, not dropped',
-      () => {
+      'property inheritance (rdfs:subPropertyOf) is dropped, not carried', () => {
         // Only entity-level inheritance (rdfs:subClassOf -> extends) is native.
         // A datatype/object property's rdfs:subPropertyOf has no native OSI
-        // home, so it rides along verbatim as a GOOGLE custom extension -- no
-        // warning, nothing lost.
+        // home, so the importer drops it -- the field and relationship still
+        // map, with no custom extension and no warning.
         const {warnings} = convertOwlToOsi(ttl, 'hierarchy');
         expect(warnings).toEqual([]);
         const model = load(convertOwlToOsi(ttl, 'hierarchy').yaml).models[0];
 
-        // The field survives AND carries its superproperty as a fact.
+        // The field survives but carries no superproperty fact.
         const employee = model.entities.find(e => e.name === 'Employee')!;
         const legalName = employee.fields.find(f => f.name === 'legalName')!;
-        expect(ontologyTerms(legalName.customExtensions)).toEqual({
-          'rdfs:subPropertyOf': ['fullName']
-        });
+        expect(legalName.customExtensions).toBeUndefined();
 
-        // The relationship survives AND carries its superproperty as a fact.
+        // The relationship survives but carries no superproperty fact.
         const managedBy =
             model.relationships.find(r => r.name === 'managedBy')!;
-        expect(ontologyTerms(managedBy.customExtensions)).toEqual({
-          'rdfs:subPropertyOf': ['worksWith']
-        });
+        expect(managedBy.customExtensions).toBeUndefined();
       });
 
   test('an extends parent that is not a class is recorded but warned', () => {
@@ -910,588 +878,80 @@ describe('mapping table rules (labels, comments, skips)', () => {
 });
 
 
-// The GOOGLE ontology extension carries OWL constructs OSI has no native home
-// for. The payload is FLAT, its keys the prefixed source constructs -- the
-// prefix is the namespace, so a carried fact never collides with Google's own
-// keys (deploymentTargets) or with a same-named construct from another
-// vocabulary.
-describe('the GOOGLE ontology extension seam', () => {
-  test('emits a flat, prefixed-key GOOGLE block', () => {
-    const ext = googleOntologyExtension(
-        {'owl:inverseOf': 'hasChild', 'owl:SymmetricProperty': true})!;
-    expect(ext.vendorName).toBe('GOOGLE');
-    // No `data`/`ontology` wrapper: the keys ARE the constructs, verbatim.
-    expect(JSON.parse(ext.data))
-        .toEqual({'owl:inverseOf': 'hasChild', 'owl:SymmetricProperty': true});
+// The carriage fixture exercises every non-native OWL construct. The importer
+// is import-only: it maps the native constructs and DROPS the rest, so the
+// fixture's golden shows only native mappings, with no custom_extensions
+// carrier anywhere.
+describe('the carriage fixture imports only its native constructs', () => {
+  test('produces exactly the documented OSI (golden)', () => {
+    const {yaml, warnings, stats} =
+        convertOwlToOsi(readFixture('carriage.owl.ttl'), 'carriage');
+    expect(yaml).toEqual(readFixture('carriage.osi.golden.yaml'));
+    // Dropping a non-native construct is never a warning.
+    expect(warnings).toEqual([]);
+    expect(stats).toEqual({classes: 3, datatypeProperties: 3, objectProperties: 3});
+    // Stays schema-valid and loadable (a logical model, under bindingOptional).
+    expect(() => load(yaml)).not.toThrow();
+    // No custom_extensions carrier anywhere in the output.
+    expect(yaml).not.toContain('custom_extensions');
   });
-
-  test('returns undefined for an empty term set (nothing to carry)', () => {
-    expect(googleOntologyExtension({})).toBeUndefined();
-  });
-
-  test(
-      'is not emitted by the sales example (every construct maps natively)',
-      () => {
-        const {yaml} = convertOwlToOsi(readFixture('sales.owl.ttl'), 'sales');
-        expect(yaml).not.toContain('custom_extensions');
-        expect(yaml).not.toContain('GOOGLE');
-      });
 });
 
 
-// Tier 2 carriage: constructs with no native OSI home ride along verbatim in a
-// GOOGLE custom extension. They are inert on push and lossless on round-trip;
-// each is pinned here at the level it attaches to.
-describe('OWL constructs carried as custom extensions', () => {
-  // The exhaustive carriage fixture: every carried construct, at each level it
-  // attaches to, and both the cross-namespace (full IRI) and in-namespace
-  // (shortened) reference forms. The user guide shows a sales-domain subset
-  // (sales-advanced above); this pins the full surface. Golden-tested so the
-  // emitted YAML cannot drift from what the converter produces.
-  test(
-      'the carriage fixture produces exactly the documented OSI (golden)',
-      () => {
-        const {yaml, warnings, stats} =
-            convertOwlToOsi(readFixture('carriage.owl.ttl'), 'carriage');
-        expect(yaml).toEqual(readFixture('carriage.osi.golden.yaml'));
-        // Carriage is never a warning -- nothing is dropped.
-        expect(warnings).toEqual([]);
-        expect(stats).toEqual(
-            {classes: 3, datatypeProperties: 3, objectProperties: 3});
-        // And the result stays schema-valid and loadable with the blocks
-        // attached (a logical model, loaded under bindingOptional).
-        expect(() => load(yaml)).not.toThrow();
-      });
-
-  test('owl:inverseOf on an object property -> relationship', () => {
+// Every OWL construct with no native OSI home is DROPPED -- not carried in a
+// GOOGLE custom extension, as an earlier version did. The term it hangs off
+// still maps natively; it simply carries no customExtensions, and the drop is
+// silent (no warning).
+describe('non-native OWL constructs are dropped (import-only)', () => {
+  test('entity-level constructs are dropped from the entity', () => {
+    // equivalentClass, disjointWith, versionInfo, deprecated, seeAlso.
     const ttl = `${PREFIXES}
-      ex:Parent a owl:Class ; owl:hasKey ( ex:pid ) .
-      ex:pid a owl:DatatypeProperty ; rdfs:domain ex:Parent ; rdfs:range xsd:string .
-      ex:hasChild a owl:ObjectProperty ;
-          rdfs:domain ex:Parent ; rdfs:range ex:Parent ;
-          owl:inverseOf ex:hasParent .`;
-    const rel = loadOwl(ttl).relationships.find(r => r.name === 'hasChild')!;
-    expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:inverseOf': 'hasParent'
-    });
+      ex:Person a owl:Class ;
+          owl:equivalentClass ex:Human ;
+          owl:disjointWith ex:Robot ;
+          owl:versionInfo "3.1" ;
+          owl:deprecated true ;
+          rdfs:seeAlso <https://schema.org/Person> .
+      ex:Human a owl:Class .
+      ex:Robot a owl:Class .`;
+    const {warnings} = convertOwlToOsi(ttl, 'x');
+    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
+    expect(person.customExtensions).toBeUndefined();
+    expect(warnings).toEqual([]);
   });
 
-  test('multiple owl:inverseOf keeps the first and warns', () => {
-    const ttl = `${PREFIXES}
-      ex:A a owl:Class . ex:B a owl:Class .
-      ex:rel a owl:ObjectProperty ;
-          rdfs:domain ex:A ; rdfs:range ex:B ;
-          owl:inverseOf ex:inv1 ; owl:inverseOf ex:inv2 .`;
-    const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
-    expect(warnings.some(w => w.includes('inverseOf') && w.includes('inv1')))
-        .toBe(true);
-    const rel = load(yaml).models[0].relationships[0];
-    expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:inverseOf': 'inv1'
-    });
-  });
-
-  test('a repeated identical owl:inverseOf is not a conflict', () => {
-    // The same inverse stated twice is one distinct fact, not a genuine
-    // multi-inverse conflict: dedupe before counting so no spurious warning.
-    const ttl = `${PREFIXES}
-      ex:A a owl:Class . ex:B a owl:Class .
-      ex:rel a owl:ObjectProperty ;
-          rdfs:domain ex:A ; rdfs:range ex:B ;
-          owl:inverseOf ex:inv ; owl:inverseOf ex:inv .`;
-    const {yaml, warnings} = convertOwlToOsi(ttl, 'x');
-    expect(warnings.some(w => w.includes('inverseOf'))).toBe(false);
-    const rel = load(yaml).models[0].relationships[0];
-    expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:inverseOf': 'inv'
-    });
-  });
-
-  test(
-      'property characteristics -> relationship, faithful boolean keys', () => {
-        const ttl = `${PREFIXES}
-      ex:A a owl:Class . ex:B a owl:Class .
-      ex:knows a owl:ObjectProperty, owl:SymmetricProperty, owl:TransitiveProperty ;
-          rdfs:domain ex:A ; rdfs:range ex:B .`;
-        const rel = loadOwl(ttl).relationships.find(r => r.name === 'knows')!;
-        // The construct is mirrored (SymmetricProperty: true), not folded into
-        // an invented `characteristics` list.
-        expect(ontologyTerms(rel.customExtensions)).toEqual({
-          'owl:SymmetricProperty': true,
-          'owl:TransitiveProperty': true,
-        });
-      });
-
-  test('owl:FunctionalProperty on a datatype property -> field', () => {
+  test('field-level constructs are dropped from the field', () => {
+    // FunctionalProperty, subPropertyOf, equivalentProperty.
     const ttl = `${PREFIXES}
       ex:Person a owl:Class .
-      ex:ssn a owl:DatatypeProperty, owl:FunctionalProperty ;
-          rdfs:domain ex:Person ; rdfs:range xsd:string .`;
-    const field = loadOwl(ttl).entities[0].fields.find(f => f.name === 'ssn')!;
-    expect(ontologyTerms(field.customExtensions)).toEqual({
-      'owl:FunctionalProperty': true
-    });
+      ex:name a owl:DatatypeProperty, owl:FunctionalProperty ;
+          rdfs:domain ex:Person ; rdfs:range xsd:string ;
+          rdfs:subPropertyOf ex:base ; owl:equivalentProperty foaf:name .`;
+    const field = loadOwl(ttl).entities[0].fields.find(f => f.name === 'name')!;
+    expect(field.customExtensions).toBeUndefined();
   });
 
-  test('owl:equivalentClass -> entity (named classes only)', () => {
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class ; owl:equivalentClass ex:Human .
-      ex:Human a owl:Class .`;
-    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
-    expect(ontologyTerms(person.customExtensions)).toEqual({
-      'owl:equivalentClass': ['Human']
-    });
-  });
-
-  test('a blank-node owl:equivalentClass expression is not carried', () => {
-    // An equivalentClass to a class expression (owl:intersectionOf, ...) is a
-    // class definition, not a plain cross-reference -- out of scope, so nothing
-    // is carried (no empty block either).
-    const ttl = `${PREFIXES}
-      ex:Parent a owl:Class ;
-          owl:equivalentClass [ a owl:Restriction ;
-                                owl:onProperty ex:hasChild ;
-                                owl:minCardinality 1 ] .
-      ex:hasChild a owl:ObjectProperty ; rdfs:domain ex:Parent ; rdfs:range ex:Parent .`;
-    const parent = loadOwl(ttl).entities.find(e => e.name === 'Parent')!;
-    expect(ontologyTerms(parent.customExtensions)).toBeUndefined();
-  });
-
-  test('several facts on one relationship share a single ordered block', () => {
+  test('relationship-level constructs are dropped from the relationship', () => {
+    // inverseOf, characteristics, subPropertyOf, propertyDisjointWith.
     const ttl = `${PREFIXES}
       ex:A a owl:Class . ex:B a owl:Class .
-      ex:rel a owl:ObjectProperty, owl:SymmetricProperty ;
+      ex:rel a owl:ObjectProperty, owl:SymmetricProperty, owl:TransitiveProperty ;
           rdfs:domain ex:A ; rdfs:range ex:B ;
-          rdfs:subPropertyOf ex:base ;
-          owl:inverseOf ex:invRel .`;
-    const rel = loadOwl(ttl).relationships[0];
-    // One GOOGLE block carries every fact; key order is fixed for a stable
-    // golden (subPropertyOf, inverseOf, then characteristics). Assert the order
-    // explicitly -- toEqual on the parsed object is order-insensitive, so only
-    // Object.keys (insertion order, mirroring the serialized JSON) pins it.
-    expect(rel.customExtensions).toHaveLength(1);
-    const carried = JSON.parse(rel.customExtensions![0].data);
-    expect(Object.keys(carried)).toEqual([
-      'rdfs:subPropertyOf', 'owl:inverseOf', 'owl:SymmetricProperty'
-    ]);
-    expect(carried).toEqual({
-      'rdfs:subPropertyOf': ['base'],
-      'owl:inverseOf': 'invRel',
-      'owl:SymmetricProperty': true,
-    });
-  });
-
-  test('carriage round-trips losslessly through the loader', () => {
-    // The generated YAML re-parses to the same carried facts -- the guarantee
-    // that pull recovers what import carried.
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class ; owl:equivalentClass ex:Human .
-      ex:Human a owl:Class .`;
-    const yaml = convertOwlToOsi(ttl, 'x').yaml;
-    const reloaded = load(yaml).models[0];
-    const person = reloaded.entities.find(e => e.name === 'Person')!;
-    expect(ontologyTerms(person.customExtensions)).toEqual({
-      'owl:equivalentClass': ['Human']
-    });
-  });
-
-  // --- Namespace-aware cross-references. ------------------------------------
-  // The showcase carriage fixture above already exercises the namespace
-  // decision end to end (foaf:/schema.org cross-references kept as full IRIs,
-  // ex: references shortened, model-level owl:baseIri); these unit tests pin
-  // each branch in isolation.
-
-  test('an in-namespace reference is shortened to its local name', () => {
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class ; owl:equivalentClass ex:Human .
-      ex:Human a owl:Class .`;
-    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
-    expect(ontologyTerms(person.customExtensions)).toEqual({
-      'owl:equivalentClass': ['Human']
-    });
-  });
-
-  test('a cross-namespace reference keeps the full IRI', () => {
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class ; owl:equivalentClass foaf:Person .`;
-    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
-    expect(ontologyTerms(person.customExtensions)).toEqual({
-      'owl:equivalentClass': ['http://xmlns.com/foaf/0.1/Person']
-    });
-  });
-
-  // --- Additional cross-reference constructs. -------------------------------
-
-  test('owl:disjointWith -> entity', () => {
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class ; owl:disjointWith ex:Robot .
-      ex:Robot a owl:Class .`;
-    const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
-    expect(ontologyTerms(person.customExtensions)).toEqual({
-      'owl:disjointWith': ['Robot']
-    });
-  });
-
-  test('owl:equivalentProperty -> field and relationship', () => {
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class . ex:Org a owl:Class .
-      ex:name a owl:DatatypeProperty ; rdfs:domain ex:Person ;
-          rdfs:range xsd:string ; owl:equivalentProperty foaf:name .
-      ex:member a owl:ObjectProperty ; rdfs:domain ex:Org ;
-          rdfs:range ex:Person ; owl:equivalentProperty foaf:member .`;
-    const model = loadOwl(ttl);
-    const field = model.entities.find(e => e.name === 'Person')!.fields.find(
-        f => f.name === 'name')!;
-    expect(ontologyTerms(field.customExtensions)).toEqual({
-      'owl:equivalentProperty': ['http://xmlns.com/foaf/0.1/name']
-    });
-    const rel = model.relationships.find(r => r.name === 'member')!;
-    expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:equivalentProperty': ['http://xmlns.com/foaf/0.1/member']
-    });
-  });
-
-  test('owl:propertyDisjointWith -> relationship', () => {
-    const ttl = `${PREFIXES}
-      ex:A a owl:Class . ex:B a owl:Class .
-      ex:rel a owl:ObjectProperty ; rdfs:domain ex:A ; rdfs:range ex:B ;
+          rdfs:subPropertyOf ex:base ; owl:inverseOf ex:invRel ;
           owl:propertyDisjointWith ex:other .`;
     const rel = loadOwl(ttl).relationships[0];
-    expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:propertyDisjointWith': ['other']
-    });
+    expect(rel.customExtensions).toBeUndefined();
   });
 
-  // --- List-valued axioms on a named term (reuse the RDF-list walker). -------
-
-  test('owl:oneOf on a named class -> entity (enumerated members)', () => {
-    // The class is defined by listing its members. The members are individuals
-    // (which the converter does not model), so the enumeration rides along
-    // verbatim, keeping the member names in list order.
-    const ttl = `${PREFIXES}
-      ex:Suit a owl:Class ;
-          owl:oneOf ( ex:Hearts ex:Diamonds ex:Clubs ex:Spades ) .`;
-    const suit = loadOwl(ttl).entities.find(e => e.name === 'Suit')!;
-    expect(ontologyTerms(suit.customExtensions)).toEqual({
-      'owl:oneOf': ['Hearts', 'Diamonds', 'Clubs', 'Spades']
-    });
-  });
-
-  test('owl:propertyChainAxiom -> relationship (ordered composition)', () => {
-    // hasUncle == hasParent then hasBrother. Chain order is significant, so the
-    // members are kept in document order. A single axiom is carried as a list
-    // of one chain (a chain is itself a list), so the shape is stable whether a
-    // property has one axiom or several.
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class .
-      ex:hasParent a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
-      ex:hasBrother a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
-      ex:hasUncle a owl:ObjectProperty ;
-          rdfs:domain ex:Person ; rdfs:range ex:Person ;
-          owl:propertyChainAxiom ( ex:hasParent ex:hasBrother ) .`;
-    const rel = loadOwl(ttl).relationships.find(r => r.name === 'hasUncle')!;
-    expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:propertyChainAxiom': [['hasParent', 'hasBrother']]
-    });
-  });
-
-  test('owl:propertyChainAxiom keeps a repeated member (not deduped)', () => {
-    // hasGrandparent == hasParent then hasParent. Repetition is meaningful, so
-    // unlike a set-valued cross-reference the chain is neither reordered nor
-    // deduped -- refSeq, not refs.
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class .
-      ex:hasParent a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
-      ex:hasGrandparent a owl:ObjectProperty ;
-          rdfs:domain ex:Person ; rdfs:range ex:Person ;
-          owl:propertyChainAxiom ( ex:hasParent ex:hasParent ) .`;
-    const rel =
-        loadOwl(ttl).relationships.find(r => r.name === 'hasGrandparent')!;
-    expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:propertyChainAxiom': [['hasParent', 'hasParent']]
-    });
-  });
-
-  test('multiple owl:propertyChainAxiom axioms are kept separate', () => {
-    // OWL 2 lets one property carry several chain axioms: an uncle is a
-    // father's brother OR a mother's brother. The two chains must not be fused
-    // into one flat list (that would be indistinguishable from a single 4-link
-    // chain), so each rides as its own ordered chain, in declaration order.
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class .
-      ex:hasFather a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
-      ex:hasMother a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
-      ex:hasBrother a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Person .
-      ex:hasUncle a owl:ObjectProperty ;
-          rdfs:domain ex:Person ; rdfs:range ex:Person ;
-          owl:propertyChainAxiom ( ex:hasFather ex:hasBrother ) ;
-          owl:propertyChainAxiom ( ex:hasMother ex:hasBrother ) .`;
-    const rel = loadOwl(ttl).relationships.find(r => r.name === 'hasUncle')!;
-    expect(ontologyTerms(rel.customExtensions)).toEqual({
-      'owl:propertyChainAxiom':
-          [['hasFather', 'hasBrother'], ['hasMother', 'hasBrother']]
-    });
-  });
-
-  // --- Set-level axioms (carried at the MODEL level). -----------------------
-  // These hang off an anonymous node and are ABOUT a set of terms, not any one
-  // named class/property, so they ride on the model rather than an
-  // entity/field/ relationship. Each is an array of member SETS (one per
-  // axiom).
-
-  test('owl:AllDisjointClasses -> model (a set of disjoint classes)', () => {
-    // The three classes are pairwise disjoint. In-namespace members shorten to
-    // local names, so the model carries owl:baseIri to make that reversible.
-    const ttl = `${PREFIXES}
-      ex:Cat a owl:Class .
-      ex:Dog a owl:Class .
-      ex:Fish a owl:Class .
-      [] a owl:AllDisjointClasses ; owl:members ( ex:Cat ex:Dog ex:Fish ) .`;
-    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
-      'owl:AllDisjointClasses': [['Cat', 'Dog', 'Fish']],
-      'owl:baseIri': 'http://example.com/x#',
-    });
-  });
-
-  test('owl:AllDisjointProperties -> model (a set of disjoint props)', () => {
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class .
-      ex:homePhone a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
-      ex:workPhone a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
-      [] a owl:AllDisjointProperties ; owl:members ( ex:homePhone ex:workPhone ) .`;
-    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
-      'owl:AllDisjointProperties': [['homePhone', 'workPhone']],
-      'owl:baseIri': 'http://example.com/x#',
-    });
-  });
-
-  test('owl:AllDifferent -> model (distinct individuals, owl:members)', () => {
-    // Members are individuals (not modeled), so only the names are kept -- like
-    // owl:oneOf. ex:Person merely anchors the base namespace so the individual
-    // names shorten.
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class .
-      [] a owl:AllDifferent ; owl:members ( ex:Alice ex:Bob ) .`;
-    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
-      'owl:AllDifferent': [['Alice', 'Bob']],
-      'owl:baseIri': 'http://example.com/x#',
-    });
-  });
-
-  test('owl:AllDifferent accepts the legacy owl:distinctMembers list', () => {
-    // OWL 1 spelled the list owl:distinctMembers; it must resolve identically.
-    const ttl = `${PREFIXES}
-      ex:Person a owl:Class .
-      [] a owl:AllDifferent ; owl:distinctMembers ( ex:Alice ex:Bob ) .`;
-    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
-      'owl:AllDifferent': [['Alice', 'Bob']],
-      'owl:baseIri': 'http://example.com/x#',
-    });
-  });
-
-  test('multiple set-level axioms of one kind are kept separate', () => {
-    // Each owl:AllDisjointClasses is its own set; they must not be merged into
-    // one flat list. Kept in document order.
+  test('set-level axioms are dropped from the model', () => {
+    // AllDisjointClasses / AllDifferent, and the owl:baseIri provenance that
+    // used to ride along with a shortened reference.
     const ttl = `${PREFIXES}
       ex:Cat a owl:Class . ex:Dog a owl:Class .
-      ex:Car a owl:Class . ex:Truck a owl:Class .
       [] a owl:AllDisjointClasses ; owl:members ( ex:Cat ex:Dog ) .
-      [] a owl:AllDisjointClasses ; owl:members ( ex:Car ex:Truck ) .`;
-    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
-      'owl:AllDisjointClasses': [['Cat', 'Dog'], ['Car', 'Truck']],
-      'owl:baseIri': 'http://example.com/x#',
-    });
+      [] a owl:AllDifferent ; owl:members ( ex:Alice ex:Bob ) .`;
+    expect(loadOwl(ttl).customExtensions).toBeUndefined();
   });
-
-  test(
-      'set-level members outside the namespace stay full IRIs (no baseIri)',
-      () => {
-        // Cross-namespace members are not shortened, so nothing is shortened
-        // and the model carries no owl:baseIri (ex:Anchor only anchors the base
-        // namespace; it names no cross-reference).
-        const ttl = `${PREFIXES}
-      ex:Anchor a owl:Class .
-      [] a owl:AllDisjointClasses ; owl:members ( foaf:Person foaf:Agent ) .`;
-        expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
-          'owl:AllDisjointClasses': [[
-            'http://xmlns.com/foaf/0.1/Person',
-            'http://xmlns.com/foaf/0.1/Agent',
-          ]],
-        });
-      });
-
-  test('owl:distinctMembers is ignored on a non-AllDifferent axiom', () => {
-    // owl:distinctMembers is the legacy OWL 1 spelling for owl:AllDifferent
-    // only; it has no meaning on owl:AllDisjointClasses. A node that carries it
-    // there (and no owl:members) contributes no member set, so nothing is
-    // carried at all (no shortened reference, hence no owl:baseIri either).
-    const ttl = `${PREFIXES}
-      ex:Cat a owl:Class . ex:Dog a owl:Class .
-      [] a owl:AllDisjointClasses ; owl:distinctMembers ( ex:Cat ex:Dog ) .`;
-    expect(ontologyTerms(loadOwl(ttl).customExtensions)).toBeUndefined();
-  });
-
-  test(
-      'an anonymous node typed as two axiom kinds is carried under both',
-      () => {
-        // A single blank node typed as both owl:AllDisjointClasses and
-        // owl:AllDifferent is unusual but legal RDF; its one owl:members list
-        // must surface under each kind, not be dropped for the second.
-        const ttl = `${PREFIXES}
-      ex:Cat a owl:Class . ex:Dog a owl:Class .
-      [] a owl:AllDisjointClasses, owl:AllDifferent ;
-         owl:members ( ex:Cat ex:Dog ) .`;
-        expect(ontologyTerms(loadOwl(ttl).customExtensions)).toEqual({
-          'owl:AllDisjointClasses': [['Cat', 'Dog']],
-          'owl:AllDifferent': [['Cat', 'Dog']],
-          'owl:baseIri': 'http://example.com/x#',
-        });
-      });
-
-  test(
-      'reflexive / irreflexive / asymmetric characteristics -> relationship',
-      () => {
-        const ttl = `${PREFIXES}
-      ex:A a owl:Class . ex:B a owl:Class .
-      ex:rel a owl:ObjectProperty, owl:ReflexiveProperty,
-               owl:IrreflexiveProperty, owl:AsymmetricProperty ;
-          rdfs:domain ex:A ; rdfs:range ex:B .`;
-        const rel = loadOwl(ttl).relationships[0];
-        expect(ontologyTerms(rel.customExtensions)).toEqual({
-          'owl:ReflexiveProperty': true,
-          'owl:IrreflexiveProperty': true,
-          'owl:AsymmetricProperty': true,
-        });
-      });
-
-  // --- Per-term annotations. ------------------------------------------------
-
-  test(
-      'rdfs:seeAlso (IRI and literal) and rdfs:isDefinedBy -> any term', () => {
-        // An IRI seeAlso is carried as `<iri>` and a literal as `"text"`, so
-        // the two stay distinguishable on round-trip even when a literal
-        // happens to look like an IRI. A quote/backslash inside a literal is
-        // escaped so the wrapping is unambiguous. A language tag (`@en`) and a
-        // non-string datatype (`^^<iri>`) are preserved; a plain xsd:string
-        // carries no suffix.
-        const ttl = `${PREFIXES}
-      ex:Person a owl:Class ;
-          rdfs:seeAlso <https://schema.org/Person> ;
-          rdfs:seeAlso "A note." ;
-          rdfs:seeAlso "https://looks-like-an-iri.example/but-a-literal" ;
-          rdfs:seeAlso "she said \\"hi\\"" ;
-          rdfs:seeAlso "une note"@fr ;
-          rdfs:seeAlso "42"^^xsd:integer ;
-          rdfs:seeAlso "plain"^^xsd:string ;
-          rdfs:isDefinedBy <http://example.com/x> .`;
-        const person = loadOwl(ttl).entities.find(e => e.name === 'Person')!;
-        expect(ontologyTerms(person.customExtensions)).toEqual({
-          'rdfs:seeAlso': [
-            '<https://schema.org/Person>',
-            '"A note."',
-            '"https://looks-like-an-iri.example/but-a-literal"',
-            '"she said \\"hi\\""',
-            '"une note"@fr',
-            '"42"^^<http://www.w3.org/2001/XMLSchema#integer>',
-            // An explicit xsd:string is the implicit default, so no `^^`
-            // suffix.
-            '"plain"',
-          ],
-          'rdfs:isDefinedBy': ['http://example.com/x'],
-        });
-      });
-
-  test('owl:deprecated is carried only for the boolean true', () => {
-    const yes = `${PREFIXES}
-      ex:Person a owl:Class ; owl:deprecated true .`;
-    // `"1"^^xsd:boolean` is the other lexical form of true and is accepted.
-    const one = `${PREFIXES}
-      ex:Person a owl:Class ; owl:deprecated "1"^^xsd:boolean .`;
-    const no = `${PREFIXES}
-      ex:Person a owl:Class ; owl:deprecated false .`;
-    // `"0"^^xsd:boolean` is the other lexical form of false; nothing carried.
-    const zero = `${PREFIXES}
-      ex:Person a owl:Class ; owl:deprecated "0"^^xsd:boolean .`;
-    // A non-boolean `"true"` string literal is malformed, not a deprecation.
-    const str = `${PREFIXES}
-      ex:Person a owl:Class ; owl:deprecated "true" .`;
-    const carried = loadOwl(yes).entities[0].customExtensions;
-    expect(ontologyTerms(carried)).toEqual({'owl:deprecated': true});
-    expect(ontologyTerms(loadOwl(one).entities[0].customExtensions)).toEqual({
-      'owl:deprecated': true
-    });
-    // An explicit `false`/`0` restates the default, so nothing is carried.
-    expect(ontologyTerms(loadOwl(no).entities[0].customExtensions))
-        .toBeUndefined();
-    expect(ontologyTerms(loadOwl(zero).entities[0].customExtensions))
-        .toBeUndefined();
-    expect(ontologyTerms(loadOwl(str).entities[0].customExtensions))
-        .toBeUndefined();
-  });
-
-  test(
-      'owl:versionInfo on a class/property is carried (not just the header)',
-      () => {
-        const ttl = `${PREFIXES}
-      ex:Person a owl:Class ; owl:versionInfo "3.1" .`;
-        const person = loadOwl(ttl).entities[0];
-        expect(ontologyTerms(person.customExtensions)).toEqual({
-          'owl:versionInfo': '3.1'
-        });
-      });
-
-  // --- Base IRI: makes a shortened in-namespace reference reconstructable. ---
-
-  test(
-      'owl:baseIri is carried on the model when a reference is shortened',
-      () => {
-        // ex:knows -> ex:friendOf is an in-namespace inverse, so it shortens to
-        // "friendOf"; the base IRI must ride along so <base>friendOf rebuilds.
-        const ttl = `${PREFIXES}
-      ex:Person a owl:Class .
-      ex:friendOf a owl:ObjectProperty ;
-          rdfs:domain ex:Person ; rdfs:range ex:Person .
-      ex:knows a owl:ObjectProperty ;
-          rdfs:domain ex:Person ; rdfs:range ex:Person ;
-          owl:inverseOf ex:friendOf .`;
-        const model = loadOwl(ttl);
-        expect(ontologyTerms(model.customExtensions)).toEqual({
-          'owl:baseIri': 'http://example.com/x#',
-        });
-      });
-
-  test(
-      'owl:baseIri is omitted when no reference is shortened (all cross-ns)',
-      () => {
-        // The only reference points OUTSIDE the ontology (foaf), so nothing is
-        // shortened and the base IRI is not needed to reconstruct anything.
-        const ttl = `${PREFIXES}
-      ex:Person a owl:Class ; owl:equivalentClass foaf:Person .`;
-        const model = loadOwl(ttl);
-        expect(ontologyTerms(model.customExtensions)).toBeUndefined();
-      });
-
-  test(
-      'the base IRI is the dominant namespace, not the first typed term',
-      () => {
-        // A foreign class is typed FIRST; the base must still be the ontology's
-        // own (ex:) namespace, shared by most terms, so an in-namespace ref
-        // shortens and a foaf ref stays a full IRI -- not the other way round.
-        const ttl = `${PREFIXES}
-      foaf:Agent a owl:Class .
-      ex:Person a owl:Class ; owl:disjointWith ex:Robot ;
-          owl:equivalentClass foaf:Agent .
-      ex:Robot a owl:Class .`;
-        const model = loadOwl(ttl);
-        expect(ontologyTerms(model.customExtensions)).toEqual({
-          'owl:baseIri': 'http://example.com/x#',
-        });
-        const person = model.entities.find(e => e.name === 'Person')!;
-        expect(ontologyTerms(person.customExtensions)).toEqual({
-          'owl:equivalentClass': ['http://xmlns.com/foaf/0.1/Agent'],
-          'owl:disjointWith': ['Robot'],
-        });
-      });
 });
 
 

--- a/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/owl_converter.test.ts
@@ -330,11 +330,11 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
         expect(managedBy.customExtensions).toBeUndefined();
       });
 
-  test('an extends parent that is not a class is recorded but warned', () => {
+  test('an extends parent that is not a class is dropped with a warning', () => {
     // subClassOf a superclass that is not an owl:Class in this ontology (a
-    // typo, or an external superclass) is still recorded as `extends`, but --
-    // like every other unresolved cross-reference in the converter -- it is
-    // warned about rather than emitted silently.
+    // typo, or an external superclass) cannot be resolved, and the loader
+    // hard-fails on an unknown supertype -- so the importer drops the link,
+    // warning about it, rather than emit a model that could not be pushed.
     const ttl = [
       '@prefix owl:  <http://www.w3.org/2002/07/owl#> .',
       '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
@@ -346,10 +346,28 @@ describe('class hierarchies map rdfs:subClassOf to entity extends', () => {
                w => w.includes('Customer') && w.includes('Persn') &&
                    w.includes('subClassOf')))
         .toBe(true);
-    // Still recorded as declared -- the warning does not drop the link.
+    // Dropped -- the unresolvable link is not emitted, so the model loads.
     const customer =
         load(yaml).models[0].entities.find(e => e.name === 'Customer')!;
-    expect(customer.extends).toEqual(['Persn']);
+    expect(customer.extends).toBeUndefined();
+  });
+
+  test('extends keeps the known parents and drops only the unknown one', () => {
+    // A class extending both a real owl:Class and an unresolvable superclass
+    // keeps the resolvable link and drops the other (warning about it), so the
+    // model still loads with the inheritance it can honour.
+    const ttl = [
+      '@prefix owl:  <http://www.w3.org/2002/07/owl#> .',
+      '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
+      '@prefix ex:   <http://example.com/hr#> .',
+      'ex:Person a owl:Class .',
+      'ex:Customer a owl:Class ; rdfs:subClassOf ex:Person, ex:Persn .',
+    ].join('\n');
+    const {yaml, warnings} = convertOwlToOsi(ttl, 'mixed');
+    expect(warnings.some(w => w.includes('Persn'))).toBe(true);
+    const customer =
+        load(yaml).models[0].entities.find(e => e.name === 'Customer')!;
+    expect(customer.extends).toEqual(['Person']);
   });
 
   test(

--- a/toolbox/mdcode/tests/libts/semantic/push_plan.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/push_plan.test.ts
@@ -76,11 +76,13 @@ describe('checkPushSelection', () => {
 
 describe('declaresGraphTarget', () => {
   const withSugar = `
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
     deployment_target: //bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g
 `;
   const withExtension = `
+version: 0.2.0.dev0
 semantic_model:
   - name: sales
     custom_extensions:
@@ -88,6 +90,7 @@ semantic_model:
         data: '{"deploymentTargets":["//spanner.googleapis.com/projects/p/instances/i/databases/db/propertyGraphs/g"]}'
 `;
   const logicalOnly = `
+version: 0.2.0.dev0
 semantic_model:
   - name: sales
     datasets:
@@ -108,6 +111,7 @@ semantic_model:
 
   test('an empty deployment_target string is not a target', () => {
     expect(declaresGraphTarget(`
+version: 0.2.0.dev0/google
 semantic_model:
   - name: sales
     deployment_target: '   '
@@ -116,6 +120,7 @@ semantic_model:
 
   test('a non-GOOGLE extension is ignored', () => {
     expect(declaresGraphTarget(`
+version: 0.2.0.dev0
 semantic_model:
   - name: sales
     custom_extensions:
@@ -131,6 +136,7 @@ semantic_model:
   test('malformed GOOGLE data resolves to true so the strict load reports it',
        () => {
          expect(declaresGraphTarget(`
+version: 0.2.0.dev0
 semantic_model:
   - name: sales
     custom_extensions:

--- a/toolbox/mdcode/tests/libts/semantic/resolve_inheritance.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/resolve_inheritance.test.ts
@@ -119,13 +119,12 @@ describe('robustness', () => {
     expect(warnings.some(w => w.includes('cycle'))).toBe(true);
   });
 
-  test('an unknown parent is warned and excluded from the ancestor set', () => {
-    const {model: r, warnings} = resolveInheritance(model([
+  test('an unknown parent is a hard error', () => {
+    // A typo in `extends` must not silently drop inheritance: an emitter cannot
+    // label with a signature it does not have, so an unknown supertype throws.
+    expect(() => resolveInheritance(model([
       entity('Customer', ['id'], ['Ghost']),
-    ]));
-    expect(entityOf(r, 'Customer').extends).toBeUndefined();
-    expect(warnings.some(w => w.includes('unknown entity \'Ghost\'')))
-        .toBe(true);
+    ]))).toThrow(/extends unknown entity 'Ghost'/);
   });
 });
 

--- a/toolbox/mdcode/tests/libts/semantic/resolve_profiles.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/resolve_profiles.test.ts
@@ -67,7 +67,7 @@ function analyticalDoc(): any {
             {name: 'key', expression: 'c_custkey'},
             {name: 'name', expression: 'c_name'},
             {name: 'lifetimeValue', expression: 'c_ltv'},
-            {name: 'availableCredit', unbound: true},
+            {name: 'availableCredit'},
           ],
         },
         {
@@ -103,10 +103,12 @@ describe('mergeProfile overlays physical bindings by name', () => {
     expect(modelOf(doc).deployment_target).toBe(GRAPH);
   });
 
-  test('an explicit unbound field drops its column', () => {
+  test('a field the profile does not bind has no column', () => {
+    // availableCredit is present in the profile but carries no expression, so
+    // the merge leaves it unbound (a field is unbound exactly when it has no
+    // expression -- there is no separate flag).
     const {doc} = mergeProfile(logicalDoc(), analyticalDoc(), 'analytical');
     const credit = fieldOf(doc, 'Customer', 'availableCredit');
-    expect(credit.unbound).toBe(true);
     expect(credit.expression).toBeUndefined();
   });
 
@@ -118,7 +120,23 @@ describe('mergeProfile overlays physical bindings by name', () => {
             (f: any) => f.name !== 'availableCredit');
     const {doc, error} = mergeProfile(logicalDoc(), profile, 'analytical');
     expect(error).toBeUndefined();
-    expect(fieldOf(doc, 'Customer', 'availableCredit').unbound).toBe(true);
+    expect(fieldOf(doc, 'Customer', 'availableCredit').expression).toBeUndefined();
+  });
+
+  test('selecting a profile clears an inline logical binding it omits', () => {
+    // Selecting a profile makes it authoritative for physical bindings: an
+    // inline column binding in the logical model is cleared before the profile
+    // is overlaid, so a field the profile does not rebind is left unbound
+    // (omission is unbound).
+    const logical = logicalDoc();
+    fieldOf(logical, 'Customer', 'name').expression = 'inline_name';
+    const profile = analyticalDoc();
+    entityOf(profile, 'Customer').fields =
+        entityOf(profile, 'Customer').fields.filter(
+            (f: any) => f.name !== 'name');
+    const {doc, error} = mergeProfile(logical, profile, 'analytical');
+    expect(error).toBeUndefined();
+    expect(fieldOf(doc, 'Customer', 'name').expression).toBeUndefined();
   });
 
   test('the inputs are never mutated', () => {
@@ -176,7 +194,7 @@ function irModel(): SemanticModel {
         fields: [
           {name: 'key', expression: 'c_custkey'},
           {name: 'name', expression: 'c_name'},
-          {name: 'lifetimeValue', unbound: true},
+          {name: 'lifetimeValue'},
         ],
       },
       {
@@ -239,7 +257,6 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
     const customerKey =
         m.entities.find(e => e.name === 'Order')!.fields.find(
             f => f.name === 'customerKey')!;
-    customerKey.unbound = true;
     delete customerKey.expression;
     const {model, report} = pruneUnavailable(m, 'operational');
     expect(relNames(model)).toEqual([]);
@@ -260,7 +277,6 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
     const m = irModel();
     const ltv = m.entities.find(e => e.name === 'Customer')!.fields.find(
         f => f.name === 'lifetimeValue')!;
-    delete ltv.unbound;
     delete ltv.expression;
     ltv.importedExpression = 'c_ltv';
     ltv.importedDialect = 'SNOWFLAKE';
@@ -277,7 +293,6 @@ describe('pruneUnavailable drops what a binding cannot answer', () => {
     const m = irModel();
     const key = m.entities.find(e => e.name === 'Customer')!.fields.find(
         f => f.name === 'key')!;
-    key.unbound = true;
     delete key.expression;
     const {model, report} = pruneUnavailable(m, 'operational');
     expect(model.entities.map(e => e.name)).toEqual(['Order']);

--- a/toolbox/mdcode/tests/tool/profiles.test.ts
+++ b/toolbox/mdcode/tests/tool/profiles.test.ts
@@ -15,7 +15,7 @@ import {profiles} from '../../src/tool/commands';
 
 const CTX = new ApiContext('test-project', 'us', 'test-token');
 
-const LOGICAL = `version: "0.2.0.dev0"
+const LOGICAL = `version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     entities:
@@ -36,7 +36,7 @@ semantic_model:
         expression: AVG(Customer.lifetimeValue)
 `;
 
-const ANALYTICAL = `version: "0.2.0.dev0"
+const ANALYTICAL = `version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     deployment_target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce
@@ -46,14 +46,14 @@ semantic_model:
         fields:
           - { name: key, expression: c_custkey }
           - { name: lifetimeValue, expression: c_ltv }
-          - { name: availableCredit, unbound: true }
+          - { name: availableCredit }
       - name: Order
         source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
         fields:
           - { name: key, expression: o_orderkey }
 `;
 
-const OPERATIONAL = `version: "0.2.0.dev0"
+const OPERATIONAL = `version: "0.2.0.dev0/google"
 semantic_model:
   - name: commerce
     deployment_target: //spanner.googleapis.com/projects/acme-ops/instances/prod/databases/commerce/propertyGraphs/commerce
@@ -63,7 +63,7 @@ semantic_model:
         fields:
           - { name: key, expression: CustomerId }
           - { name: availableCredit, expression: AvailableCredit }
-          - { name: lifetimeValue, unbound: true }
+          - { name: lifetimeValue }
       - name: Order
         source: //spanner.googleapis.com/projects/acme-ops/instances/prod/databases/commerce/tables/Orders
         fields:


### PR DESCRIPTION
## What

Tightens the mdcode semantic-model loader and tooling to the behaviors we
settled in review, and updates the user guides to match. Each settled item is
its own commit.

### Settled behaviors implemented

1. **Version is required.** Every document must declare `version`. A missing or
   unknown version is a hard error (not a warning). Two accepted values:
   `0.2.0.dev0` (vanilla Apache Ossie) and `0.2.0.dev0/google` (kcmd's extended
   profile).
2. **Fail-fast validation.** Duplicate names throw, an unknown `extends`
   supertype throws, and every object is `.strict()` so an unknown/misspelled
   key is an error.
3. **No `unbound` flag.** A field is unbound exactly when it has no
   `expression`. See the design note below.
4. **Measures only on leaf types.** A supertype that is extended by another type
   may not carry measures.
5. **`entities:` alias gated to `/google`.** The alias for `datasets:` is
   accepted only under the extended profile, and pull emits `entities:` (and
   the `/google` version).
6. **OWL importer is import-only.** OWL/RDF-specific constructs are no longer
   carried through as round-trippable custom extensions; pull never re-emits
   them.
7. **Version gates the extension surface.** Vanilla accepts `datasets:` +
   `custom_extensions:` and rejects native keys; `/google` accepts the native
   keys (`entities`, `extends`, `abstract`, `deployment_target`) and rejects
   `custom_extensions:`.

Open/unsettled items from the thread are intentionally left untouched.

### Design note (the one non-trivial interpretation)

Removing the `unbound` flag (#3) collapses "a field you forgot to bind" and "a
field this store legitimately lacks" into one syntactic thing: a field with no
`expression`. The two ways to resolve that:

- **(A)** an expression-less field is a hard error on a graph leg (unbound
  fields allowed only on a Knowledge-Catalog-only push), or
- **(B)** an expression-less field is unbound and pruned before generation.

This PR takes **(B)**. It preserves the binding-profiles value prop -- one
logical model serving several stores, each binding a different subset of
columns, with a metric reported unavailable where its field is unbound -- which
(A) would remove. A profile is authoritative: selecting it clears the base
model's inline bindings, so a field the profile does not re-declare is unbound
under it. The only binding-completeness error left in strict/graph mode is a
non-abstract dataset with no `source` at all.

## Testing

`bun test` -- 585 pass, 0 fail across 30 files. (Local `tsc` typecheck is
unavailable in this environment -- TypeScript is not installed offline -- but
`bun` transpiles and runs every touched file.)
