### PR TITLE
docs(model_spec): reframe §3 conformance table as OSI vs Google extension

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -282,36 +282,37 @@ string here (a relaxation); authored documents SHOULD use an Ossie dialect name.
 
 ## 3. Conformance summary
 
-Every construct, at a glance. **In Ossie?** is whether Ossie `0.2.0.dev0` defines
-it (per the vendored core schema — see [§1](#1-status-and-baseline)). **kcmd
-status** is this profile's relationship to it: *as-is* (adopted unchanged),
-*relaxed* (accepted but looser than Ossie, [§4](#4-narrowings-and-relaxations)), *narrowed*
-(accepted but stricter, [§4](#4-narrowings-and-relaxations)), *extension* (added by `kcmd`,
-[§5](#5-extensions)), or *reserved* (recognized internally, not authorable in
-`0.2.0.dev0`).
+Every construct, at a glance, measured against **Ossie `0.2.0.dev0`** — the
+vanilla baseline (see [§1](#1-status-and-baseline)). The **OSI** column is what
+that baseline defines, where a `—` means Ossie does not define the construct at
+all. The **Google extension** column is how this profile differs: *same* (adopted
+unchanged), *optional* (a relaxation, [§4](#4-narrowings-and-relaxations)),
+*stricter* (a narrowing, [§4](#4-narrowings-and-relaxations)), *added* (an
+extension, [§5](#5-extensions)), or *rejected* / *not authorable* (excluded).
+**Why / where** gives the reason and the section with the detail.
 
-| Construct | In Ossie? | kcmd status | Where |
+| Feature | OSI (`0.2.0.dev0`) | Google extension | Why / where |
 |---|---|---|---|
-| `semantic_model`, `name`, `description` | yes | as-is | [§2](#2-document-shape) |
-| `datasets` | yes | as-is | [§2.1](#21-dataset-entity) |
-| `entities` (alias for `datasets`) | no | extension (alias, /google only) | [§5](#5-extensions) |
-| field `name`, `label`, `dimension` (`is_time`) | yes | as-is | [§2.1.1](#211-field) |
-| `datatype` + its vocabulary | yes | as-is (identical, closed) | [§2.1.1](#211-field) |
-| `primary_key`, `unique_keys` | yes | as-is | [§2.1](#21-dataset-entity) |
-| `extends` | no | extension | [§2.1.2](#212-inheritance-extends), [§5](#5-extensions) |
-| `abstract` | no | extension | [§5](#5-extensions) |
-| relationship `name`, `from`, `to` | yes | as-is | [§2.2](#22-relationship) |
-| relationship `from_columns` / `to_columns` | yes (required) | relaxed to optional | [§2.2](#22-relationship), [§4](#4-narrowings-and-relaxations) |
-| relationship M:N (`association`) | no | reserved (IR only) | [§2.2](#22-relationship) |
-| `metrics`, metric `expression` (required) | yes | as-is; graph-bound narrowed | [§2.3](#23-metric), [§4](#4-narrowings-and-relaxations) |
-| `expression.dialects` | yes (closed enum) | as-is; `dialect` string relaxed | [§2.5](#25-expressions) |
-| field `expression` (column binding) | yes (required) | relaxed to optional | [§7](#7-the-binding-layer), [§4](#4-narrowings-and-relaxations) |
-| `source` (dataset table binding) | yes (required) | relaxed to optional | [§7.1](#71-table-sources), [§4](#4-narrowings-and-relaxations) |
-| `ai_context` (`instructions`, `synonyms`, `examples`) | yes | as-is (`examples` relaxed) | [§2.4](#24-ai_context) |
-| `custom_extensions` (`vendor_name`, `data`) | yes | as-is; vanilla-only carrier | [§6](#6-the-extension-mechanism) |
-| `deployment_target` | no | extension (native, /google) | [§5](#5-extensions), [§7.2](#72-deployment-target) |
-| binding profiles | no | extension | [§7.3](#73-binding-profiles) |
-| single model per entry group | — | narrowed | [§4](#4-narrowings-and-relaxations) |
+| `semantic_model`, `name`, `description` | defined | same | [§2](#2-document-shape) |
+| `datasets` | defined | same | [§2.1](#21-dataset-entity) |
+| `entities` (alias for `datasets`) | — | added (alias) | readability; sugar, `/google` only · [§5](#5-extensions) |
+| field `name`, `label`, `dimension` (`is_time`) | defined | same | [§2.1.1](#211-field) |
+| `datatype` + vocabulary | closed enum | same (identical set) | [§2.1.1](#211-field) |
+| `primary_key`, `unique_keys` | defined | same | [§2.1](#21-dataset-entity) |
+| `extends` | — | added | class inheritance; `/google` only · [§2.1.2](#212-inheritance-extends), [§5](#5-extensions) |
+| `abstract` | — | added | supertype with no table; `/google` only · [§5](#5-extensions) |
+| relationship `name`, `from`, `to` | defined | same | [§2.2](#22-relationship) |
+| relationship `from_columns` / `to_columns` | required | optional | model before binding; none = logical edge · [§4.2](#42-relaxations-looser-than-ossie) |
+| relationship M:N (`association`) | — | not authorable (reserved) | no M:N syntax yet · [§2.2](#22-relationship) |
+| `metrics`, metric `expression` | required | same; graph-bound stricter | a graph measure binds one node and aggregate · [§4.1](#41-narrowings-stricter-than-ossie) |
+| `expression.dialects` | closed enum | any dialect string | tolerate imported / newer input · [§4.2](#42-relaxations-looser-than-ossie) |
+| field `expression` (column binding) | required | optional | model before binding; unbound is pruned · [§4.2](#42-relaxations-looser-than-ossie), [§7](#7-the-binding-layer) |
+| `source` (table binding) | required | optional | logical-only models; graph deploy still needs it · [§4.2](#42-relaxations-looser-than-ossie), [§7.1](#71-table-sources) |
+| `ai_context` (`instructions`, `synonyms`, `examples`) | `examples` are strings | same; `examples` any shape | tolerate imports; non-strings dropped · [§2.4](#24-ai_context), [§4.2](#42-relaxations-looser-than-ossie) |
+| `custom_extensions` (`vendor_name`, `data`) | the extension carrier | rejected | `/google` uses native keys; nothing to carry · [§6](#6-the-extension-mechanism) |
+| `deployment_target` | — | added | OSI omits deployment; vanilla carries it in `custom_extensions` · [§5](#5-extensions), [§7.2](#72-deployment-target) |
+| binding profiles | — | added | one model, many stores · [§7.3](#73-binding-profiles) |
+| multiple models per document | a list (many) | exactly one | entry group = model's identity · [§4.1](#41-narrowings-stricter-than-ossie) |
 
 ## 4. Narrowings and relaxations
 

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -36,8 +36,9 @@ top-level `version` (see [Version handling](#1-status-and-baseline)):
   nothing left for it to carry. This profile is readable, but not a vanilla-Ossie
   document — an Ossie-only reader knows neither its version nor its native keys.
 
-The two are the same model written two ways; both parse to the identical IR, so no
-downstream leg sees which was used.
+For a model that avoids the `/google`-only constructs, the two are the same model
+written two ways; both parse to the identical IR, so no downstream leg sees which
+was used.
 
 Ossie compatibility is a property of the **vanilla** version, and the contract
 runs in both directions:
@@ -48,9 +49,10 @@ runs in both directions:
 > Ossie constructs. Strip the `GOOGLE` `custom_extensions` blocks from such a model
 > and it is a valid Ossie document.
 
-Under vanilla, every `kcmd`-specific construct rides in a `custom_extensions` block
-an Ossie-only tool ignores (see [§6](#6-the-extension-mechanism)), so the two never
-fork the document. The extended `0.2.0.dev0/google` profile trades that wire
+Under vanilla, `kcmd`'s deployment and binding additions ride in a `custom_extensions`
+block an Ossie-only tool ignores (see [§6](#6-the-extension-mechanism)), so those never
+fork the document; inheritance and the `entities` spelling have no vanilla form and
+exist only under `0.2.0.dev0/google`. The extended `0.2.0.dev0/google` profile trades that wire
 compatibility for readable native keys; it is `kcmd`'s own surface, converted to or
 from vanilla by choosing the `version`.
 
@@ -316,10 +318,10 @@ extension, [§5](#5-extensions)), or *rejected* / *not authorable* (excluded).
 
 ## 4. Narrowings and relaxations
 
-`kcmd` diverges from Ossie in two directions. **Narrowings** are where `kcmd` is
+This profile diverges from Ossie in two directions. **Narrowings** are where it is
 stricter — rules that can reject an otherwise-valid Ossie document at deploy time.
-**Relaxations** are where `kcmd` is looser — fields Ossie requires that `kcmd`
-makes optional, so a relaxed `kcmd` model is not a valid Ossie document until those
+**Relaxations** are where it is looser — fields Ossie requires that this profile
+makes optional, so a relaxed model is not a valid Ossie document until those
 fields are supplied. Both are the reason the reverse compatibility direction in
 [§1](#1-status-and-baseline) is conditional.
 
@@ -382,7 +384,7 @@ BigQuery `MEASURE` cannot bind to a label shared across subtype tables. See
 
 ### 4.2. Relaxations (looser than Ossie)
 
-`kcmd` relaxes Ossie in two kinds, for two different reasons.
+This profile relaxes Ossie in two kinds, for two different reasons.
 
 **Binding fields made optional — to model before binding.** Ossie marks these
 required; `kcmd` accepts them as optional so a model can be governed before it is


### PR DESCRIPTION
## What

Reframes §3 "Conformance summary" of `docs/semantic-model/model_spec.md` as a proper markdown table comparing the vanilla OSI baseline against the Google extension, and corrects wording elsewhere that attributed format-level facts to the `kcmd` command.

### §3 — new conformance table

Replaces the old prose/label list with a 4-column table:

| Feature | OSI (`0.2.0.dev0`) | Google extension | Why / where |

- **Feature** — the construct (unchanged from before).
- **OSI (`0.2.0.dev0`)** — what the vanilla Ossie baseline defines; `—` means Ossie doesn't define it at all.
- **Google extension** — how this profile differs: *same* / *optional* / *stricter* / *added* / *rejected* / *not authorable*.
- **Why / where** — short reason plus the section with the detail.

This also fixes the earlier category error where the comparison was framed as "kcmd vs Ossie" — the comparison subject is the *format/profile*, not the tool.

### Accuracy fixes (§1, §4)

- §1 no longer claims *every* kcmd construct has a vanilla form. Inheritance (`extends`/`abstract`) and the `entities` alias exist **only** under `0.2.0.dev0/google` — they have no `custom_extensions` vanilla carrier. Only deployment/binding additions ride in `custom_extensions`.
- §4 and §4.2 openings now say "this profile diverges/relaxes" rather than "`kcmd` diverges/relaxes" — divergence is a property of the format, not the command.

## Notes for reviewer

- **"OSI" vs "Ossie" in the column title.** The doc body uses "Ossie" / "Apache Ossie"; the table column header uses "OSI" per request. Happy to unify either direction — flag your preference.
- A fuller "kcmd" → "this profile" sweep across the per-field prose in §4 was **deferred**: those sentences describe genuine tool behavior (parsing, deploy-time rejection, pull emitting `entities`), where "kcmd" is correct. Only the section-opening framing sentences were changed.

Docs-only; no code changes.
