### PR TITLE
mdcode: model-level constraints, published to Knowledge Catalog

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -129,6 +129,14 @@ parameter is an object reference rather than a bare string. Actions have no grap
 representation and are governed in Knowledge Catalog. See
 [Modeling write operations](actions.md).
 
+A model can also state **constraints**: named boolean invariants over the
+ontology that hold for every instance, whatever writes to the model. A
+constraint is part of what the model asserts, written in the same expression
+language as a metric, and `Account.balance >= 0` is as much a fact about an
+account as the fields beside it. Constraints have no graph representation
+either; they are validated, published to Knowledge Catalog, and read back by
+`pull`. Nothing checks one against live data yet.
+
 This model names no table and no store, so it is complete enough to govern in
 Knowledge Catalog as-is (step 2). Where each entity reads from — the store and the
 columns — is a binding you add in step 3.

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -125,17 +125,17 @@ A model can also declare **actions**: model-level write operations, the
 write-side counterpart to a metric. An action names a business operation, points
 at the executor that carries it out (an MCP tool, a REST endpoint, or a gRPC
 method), and types each parameter against the ontology, so an entity-typed
-parameter is an object reference rather than a bare string. Actions have no graph
-representation and are governed in Knowledge Catalog. See
+parameter is an object reference rather than a bare string. Knowledge Catalog is
+the only system an action reaches, and where it is governed. See
 [Modeling write operations](actions.md).
 
 A model can also state **constraints**: named boolean invariants over the
 ontology that hold for every instance, whatever writes to the model. A
 constraint is part of what the model asserts, written in the same expression
 language as a metric, and `Account.balance >= 0` is as much a fact about an
-account as the fields beside it. Constraints have no graph representation
-either; they are validated, published to Knowledge Catalog, and read back by
-`pull`. Nothing checks one against live data yet.
+account as the fields beside it. A constraint reaches Knowledge Catalog only: it
+is validated, published there, and read back by `pull`. No component checks one
+against live data yet.
 
 This model names no table and no store, so it is complete enough to govern in
 Knowledge Catalog as-is (step 2). Where each entity reads from — the store and the

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -125,12 +125,12 @@ document is parsed, so the message above is what a blank one produces.
 kcmd push
 ```
 
-An action has no graph construct. It is write-side, and a property graph is a
-read surface, so the push emits no node, edge, or measure for it and warns once:
+Knowledge Catalog is the only system an action reaches. Every other push
+target deploys nothing for it and warns once:
 
 ```
-model 'payments': 1 action(s) published as semantic-action entries
-(actions have no BigQuery Graph representation).
+Warning: [payments] 1 action(s) reach Knowledge Catalog only; the BigQuery
+push deploys none of them.
 ```
 
 Knowledge Catalog is where actions land. Each action becomes its own entry,
@@ -196,11 +196,11 @@ knowing which they are decides how much you can lean on it.
 
 - **An action declares no precondition and no effects.** `precondition` (what
   has to hold before the call) and `affects` (what the call changes) are out of
-  scope here. A separate change adds model-level **constraints** and a runtime
-  that checks them against a write before it commits.
-- **Nothing checks the write.** Until that change lands, an action is a
-  declaration, and the correctness of what the executor does is the executor's
-  business.
+  scope here. Model-level **constraints** state the invariants a model requires,
+  and no constraint is attached to an action.
+- **Nothing checks the write.** No component evaluates a constraint, so an action
+  is a declaration and the correctness of what the executor does belongs to the
+  executor.
 - **`kcmd` does not call the executor.** Push publishes the action. Dispatching
   it is the job of whatever reads the model, which is why the executor names
   coordinates rather than a statement.

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -36,6 +36,7 @@ agree on every structural row and differ only where a Spanner target has no
 | Relationship (M:N / `association`)                             | — not stored                    | —                                              | `EDGE TABLE` (via junction table)                                    | `EDGE TABLE` (via junction table)                                    |
 | Entity `extends`                                               | — not modelled                  | —                                              | `LABEL` clauses + flattened fields                                   | `LABEL` clauses + flattened fields                                   |
 | Action                                                         | `semantic-action` entry¹²       | ✓¹²                                            | — not represented (write-side)                                       | — not represented (write-side)                                       |
+| Constraint                                                     | `semantic-constraint` entry¹³   | ✓¹³                                            | — not represented (write-side)                                       | — not represented (write-side)                                       |
 | `description` (entity / metric / field / relationship)         | entry description / aspect      | ✓                                              | `OPTIONS(description)`                                               | — dropped                                                            |
 | `ai_context.synonyms`                                          | — not stored                    | —                                              | `OPTIONS(synonyms=[...])`                                            | — dropped                                                            |
 | `ai_context.instructions`                                      | `guidelines` aspect⁷            | ✓⁷                                             | into `OPTIONS(description)`                                          | — dropped                                                            |
@@ -103,13 +104,19 @@ agree on every structural row and differ only where a Spanner target has no
     scope: an action's `precondition` and `affects` are not modelled, so nothing
     about them is stored either way. See
     [Modeling write operations](actions.md).
+13. **Constraints.** A constraint states an invariant rather than a read-side
+    structure, so neither graph has a construct for it either: the push emits
+    nothing and warns once. Each is published to Knowledge Catalog as one
+    `semantic-constraint` entry under the model entry, and `pull` reads it back.
+    Publishing a constraint is all that happens to it; nothing checks one
+    against live data.
 
 ## To Knowledge Catalog
 
 The catalog holds metadata rather than a full copy of your model. Every resource
 type it uses is a built-in system type under `dataplex-types/global`, apart from
-the custom `semantic-action` pair that `kcmd init` provisions — push references
-types, it never creates them (see
+the custom `semantic-action` and `semantic-constraint` pairs that `kcmd init`
+provisions — push references types, it never creates them (see
 [Reference → What gets created in Knowledge Catalog](reference.md#what-gets-created-in-knowledge-catalog)).
 
 What is recorded depends on the push. A catalog-only push (`--no-profile`), or a
@@ -142,6 +149,13 @@ through `pull` (name, description, executor, typed parameters, and
 `instructions`). Their `precondition` / `affects` are out of scope for this
 prototype and are not stored. The entry type is custom, so `kcmd init` creates
 it; a model that declares no action never needs it.
+
+**Constraints** publish the same way: each becomes a `semantic-constraint` entry
+under the model entry, with the expression and any `instructions` in a
+`semantic-constraint` aspect and the `description` as the entry's own summary.
+Name, expression, description, and instructions round-trip losslessly through
+`pull`. That entry type is custom too, and a model that declares no constraint
+never needs it.
 
 ¹⁰ What you author is the `expression.dialects[]` list; the graph builds from the canonical (BigQuery/ANSI) variant. `importedExpression` / `importedDialect` are not authored keys — the loader *derives* them from a non-canonical dialect entry (e.g. the MAQL or Snowflake form a metric was imported from) and uses that verbatim as the fallback when no canonical variant exists. See [Model spec §2.5](model_spec.md#25-expressions).
 
@@ -192,8 +206,9 @@ design:
 Everything else — keys, relationships, the label hierarchy — matches the
 **→ BigQuery** column above.
 
-**Actions** reach neither graph. They are published to Knowledge Catalog as one
-`semantic-action` entry each and round-trip losslessly through `pull` — see
+**Actions and constraints** reach neither graph. They are published to
+Knowledge Catalog as one `semantic-action` or `semantic-constraint` entry each
+and round-trip losslessly through `pull` — see
 [To Knowledge Catalog](#to-knowledge-catalog).
 
 ## What pull recovers

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -35,8 +35,8 @@ agree on every structural row and differ only where a Spanner target has no
 | Relationship (1:1 / 1:N)                                       | `schema-join` link              | ✓ (name normalized⁶)                           | `EDGE TABLE`                                                         | `EDGE TABLE`                                                         |
 | Relationship (M:N / `association`)                             | — not stored                    | —                                              | `EDGE TABLE` (via junction table)                                    | `EDGE TABLE` (via junction table)                                    |
 | Entity `extends`                                               | — not modelled                  | —                                              | `LABEL` clauses + flattened fields                                   | `LABEL` clauses + flattened fields                                   |
-| Action                                                         | `semantic-action` entry¹²       | ✓¹²                                            | — not represented (write-side)                                       | — not represented (write-side)                                       |
-| Constraint                                                     | `semantic-constraint` entry¹³   | ✓¹³                                            | — not represented (write-side)                                       | — not represented (write-side)                                       |
+| Action                                                         | `semantic-action` entry¹²       | ✓¹²                                            | — not deployed¹²                                                     | — not deployed¹²                                                     |
+| Constraint                                                     | `semantic-constraint` entry¹³   | ✓¹³                                            | — not deployed¹³                                                     | — not deployed¹³                                                     |
 | `description` (entity / metric / field / relationship)         | entry description / aspect      | ✓                                              | `OPTIONS(description)`                                               | — dropped                                                            |
 | `ai_context.synonyms`                                          | — not stored                    | —                                              | `OPTIONS(synonyms=[...])`                                            | — dropped                                                            |
 | `ai_context.instructions`                                      | `guidelines` aspect⁷            | ✓⁷                                             | into `OPTIONS(description)`                                          | — dropped                                                            |
@@ -97,26 +97,24 @@ agree on every structural row and differ only where a Spanner target has no
     Snowflake form a metric was imported from) and uses that verbatim as the
     fallback when no canonical variant exists. See
     [Model spec §2.5](model_spec.md#25-expressions).
-12. **Actions.** Actions are write-side, so neither graph has a construct for
-    them: the push emits nothing for an action and warns once. They are
-    published to Knowledge Catalog as one `semantic-action` entry each, under
-    the model entry, and `pull` reads them back from those entries. Prototype
-    scope: an action's `precondition` and `affects` are not modelled, so nothing
-    about them is stored either way. See
+12. **Actions.** An action reaches Knowledge Catalog only, as one
+    `semantic-action` entry under the model entry, and `pull` reads it back from
+    that entry. Every other push target deploys nothing for it and warns once.
+    Prototype scope: an action's `precondition` and `affects` are not modelled,
+    so nothing about them is stored. See
     [Modeling write operations](actions.md).
-13. **Constraints.** A constraint states an invariant rather than a read-side
-    structure, so neither graph has a construct for it either: the push emits
-    nothing and warns once. Each is published to Knowledge Catalog as one
+13. **Constraints.** A constraint reaches Knowledge Catalog only, as one
     `semantic-constraint` entry under the model entry, and `pull` reads it back.
-    Publishing a constraint is all that happens to it; nothing checks one
-    against live data.
+    Every other push target deploys nothing for it and warns once. Publishing is
+    all that happens to a constraint; no component checks one against live
+    data.
 
 ## To Knowledge Catalog
 
 The catalog holds metadata rather than a full copy of your model. Every resource
 type it uses is a built-in system type under `dataplex-types/global`, apart from
 the custom `semantic-action` and `semantic-constraint` pairs that `kcmd init`
-provisions — push references types, it never creates them (see
+provisions. A push references those types and never creates them (see
 [Reference → What gets created in Knowledge Catalog](reference.md#what-gets-created-in-knowledge-catalog)).
 
 What is recorded depends on the push. A catalog-only push (`--no-profile`), or a

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -99,6 +99,8 @@ semantic_model:                # one or more models; kcmd deploys exactly one pe
     datasets: [ … ]            # one or more; the entities (§2.1). Spelled `entities:` under /google (§5)
     relationships: [ … ]       # optional (§2.2)
     metrics: [ … ]             # optional (§2.3)
+    actions: [ … ]             # optional; /google only (§5)
+    constraints: [ … ]         # optional; /google only (§5)
     description: "…"           # optional
     ai_context: { … }          # optional (§2.4)
     custom_extensions: [ … ]   # vanilla only (§6); rejected under /google
@@ -106,10 +108,10 @@ semantic_model:                # one or more models; kcmd deploys exactly one pe
 ```
 
 A document MUST contain at least one model, and each model MUST contain at least
-one dataset. Every named object (dataset, field, relationship, metric) MUST have a
-name unique within its scope; a duplicate name is a **hard load error** (agreed
-with Dmitri), because it would make the generated node, property, edge, or measure
-ambiguous.
+one dataset. Every named object (dataset, field, relationship, metric,
+action, constraint) MUST have a name unique within its scope. A duplicate name is
+a **hard load error** (agreed with Dmitri), because nothing reading the model can
+tell two objects of the same name apart.
 
 Objects are **closed**: an unknown sibling key inside a validated object is a
 **hard error**, not silently dropped (agreed with Dmitri). This is what makes the
@@ -308,6 +310,8 @@ extension, [§5](#5-extensions)), or *rejected* / *not authorable* (excluded).
 | relationship M:N (`association`) | — | not authorable (reserved) | no M:N syntax yet · [§2.2](#22-relationship) |
 | `metrics`, metric `expression` | required | same; graph-bound stricter | a graph measure binds one node and aggregate · [§4.1](#41-narrowings-stricter-than-ossie) |
 | `expression.dialects` | closed enum | any dialect string | tolerate imported / newer input · [§4.2](#42-relaxations-looser-than-ossie) |
+| `actions` | — | added | write operations declared over the ontology; `/google` only · [§5](#5-extensions) |
+| `constraints` | — | added | named invariants over the ontology; `/google` only · [§5](#5-extensions) |
 | field `expression` (column binding) | required | optional | model before binding; unbound is pruned · [§4.2](#42-relaxations-looser-than-ossie), [§7](#7-the-binding-layer) |
 | `source` (table binding) | required | optional | logical-only models; graph deploy still needs it · [§4.2](#42-relaxations-looser-than-ossie), [§7.1](#71-table-sources) |
 | `ai_context` (`instructions`, `synonyms`, `examples`) | `examples` are strings | same; `examples` any shape | tolerate imports; non-strings dropped · [§2.4](#24-ai_context), [§4.2](#42-relaxations-looser-than-ossie) |
@@ -449,14 +453,27 @@ reads the document ([§6](#6-the-extension-mechanism)).
   `{"deploymentTargets": ["…"]}` ([§6](#6-the-extension-mechanism)). Grammar in
   [§7](#7-the-binding-layer).
 
+- **`actions` (extended profile only).** Model-level write operations, the
+  write-side counterpart to a metric. An action names an operation, points at the
+  executor that performs it, and types each parameter against the ontology, so an
+  entity-typed parameter is an object reference. Accepted only under
+  `0.2.0.dev0/google`. `kcmd` publishes an action and never calls its executor.
+  See [Modeling write operations](actions.md).
+
+- **`constraints` (extended profile only).** Model-level named boolean
+  invariants over the ontology, written in the same expression language as a
+  metric — `Account.balance >= 0`. Accepted only under `0.2.0.dev0/google`.
+  Status: authored, validated and published; no component evaluates a constraint,
+  so nothing today rejects a write that would break one. Rules in
+  [Reference → Validation](reference.md#validation).
+
 - **Binding profiles.** A separate document that supplies only the physical
   bindings, so one logical model serves several stores. Not part of the Ossie
   document; a `kcmd`-specific file alongside it ([§7](#7-the-binding-layer)).
 
-Deliberately **not** extensions in `0.2.0.dev0`, to avoid the impression they
-exist: there is **no `actions` block** and **no authorable M:N `association`
-syntax**. Both are reserved for future consideration; neither is part of the
-format today.
+One construct is reserved rather than added. `0.2.0.dev0` has **no authorable
+M:N `association` syntax**. The construct is under consideration for a future
+version and is not part of the format today.
 
 ## 6. The extension mechanism
 
@@ -605,9 +622,9 @@ The full merge behavior and worked examples are in
   and constructs with no vanilla form (inheritance, the `entities` spelling) are
   simply unavailable there — a model that needs them uses `0.2.0.dev0/google`.
 
-- **Reserved constructs.** `association` (M:N) and any `actions`-like write-side
-  construct are reserved: recognized as future work, not authorable today. A
-  document MUST NOT rely on either in `0.2.0.dev0`.
+- **Reserved constructs.** `association` (M:N) is reserved. It is under
+  consideration for a future version and cannot be authored today, so a document
+  MUST NOT rely on it in `0.2.0.dev0`.
 
 ## Appendix: annotated example
 

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -76,8 +76,8 @@ becomes one part of that graph:
 | Relationship | `EDGE TABLE` | connects the two entities' node tables |
 | Metric | `MEASURE` on a node table | must resolve to a single entity (otherwise the push is rejected — see [Validation](#validation)) and reduce to one supported aggregate over one operand (otherwise that metric is skipped with a warning) |
 | Entity `extends` | extra `LABEL` clauses on the subclass node table | the subclass also matches its supertypes; the supertypes' fields flatten down (see [Class hierarchies](#class-hierarchies-extends--labels)) |
-| Action | *nothing* | actions are write-side and have no graph construct; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
-| Constraint | *nothing* | a constraint states an invariant rather than a read-side structure; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
+| Action | *nothing* | an action reaches Knowledge Catalog only (see below); the BigQuery push deploys none and warns once |
+| Constraint | *nothing* | a constraint reaches Knowledge Catalog only (see below); the BigQuery push deploys none and warns once |
 
 `push` reads the target dataset's location (`bigquery.datasets.get`) so the
 statement runs in the right region; without that permission it falls back to
@@ -293,10 +293,10 @@ ships, the entries move to it and their shape does not change. (This is the
 prototype scope — an action's `precondition` and `affects` are not modeled
 yet.)
 
-A **constraint** entry carries its expression, and the whole of any
-`ai_context` declared on it, in a `semantic-constraint` aspect; the constraint's
-`description` is the entry's own summary, because that sentence is what a caller
-refused by the rule reads. Its type is provisioned alongside the action pair and
+A **constraint** entry carries its expression in a `semantic-constraint`
+aspect, together with the whole of any `ai_context` declared on it. The
+constraint's `description` is the entry's own summary, because that sentence is
+what a caller refused by the rule reads. Its type is provisioned alongside the action pair and
 for the same reason. All three parts of `ai_context` survive, unlike an element
 routed to the built-in `guidelines` aspect, which has a home for `instructions`
 alone: `kcmd` defines the constraint aspect itself, so it has no reason to keep
@@ -357,15 +357,14 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   validates them but has nowhere to put them, and warns that they will not be
   deployed. *(static)*
 * **Every constraint is checkable.** A constraint's `expression` must be
-  non-empty, and when it opens with an `<Entity>.<field>` qualifier naming a
-  **known** entity, that entity must actually declare the field — this catches a
+  non-empty. When the expression opens with an `<Entity>.<field>` qualifier
+  naming a **known** entity, that entity must declare the field; this catches a
   typo that would otherwise surface only when something tries to check the rule.
-  A leading qualifier that is not a known entity (a relationship-qualified name
-  like `OrderedAs.quantity`, a metric reference, or compound logic) is left
-  alone rather than guessed at, so a valid constraint is never falsely
-  rejected. Like actions, constraints deploy **only** through the Knowledge
-  Catalog leg, and a `--no-kc` push warns that they will not be deployed.
-  *(static)*
+  A leading qualifier that is not a known entity — a relationship-qualified name
+  like `OrderedAs.quantity`, a metric reference, or compound logic — is left
+  alone rather than guessed at, so a valid constraint is never falsely rejected.
+  Like an action, a constraint reaches Knowledge Catalog only, and a `--no-kc`
+  push warns that it will not be deployed. *(static)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it
   exactly as the deploy will — a three-part `project.dataset.table`, a four-part

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -293,11 +293,14 @@ ships, the entries move to it and their shape does not change. (This is the
 prototype scope — an action's `precondition` and `affects` are not modeled
 yet.)
 
-A **constraint** entry carries its expression, and its
-`ai_context.instructions`, in a `semantic-constraint` aspect; the constraint's
+A **constraint** entry carries its expression, and the whole of any
+`ai_context` declared on it, in a `semantic-constraint` aspect; the constraint's
 `description` is the entry's own summary, because that sentence is what a caller
 refused by the rule reads. Its type is provisioned alongside the action pair and
-for the same reason.
+for the same reason. All three parts of `ai_context` survive, unlike an element
+routed to the built-in `guidelines` aspect, which has a home for `instructions`
+alone: `kcmd` defines the constraint aspect itself, so it has no reason to keep
+that limit.
 
 Push to Knowledge Catalog is lossy — the catalog holds metadata, not a full copy
 of your model. For exactly what is stored, what is gated behind

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -77,6 +77,7 @@ becomes one part of that graph:
 | Metric | `MEASURE` on a node table | must resolve to a single entity (otherwise the push is rejected — see [Validation](#validation)) and reduce to one supported aggregate over one operand (otherwise that metric is skipped with a warning) |
 | Entity `extends` | extra `LABEL` clauses on the subclass node table | the subclass also matches its supertypes; the supertypes' fields flatten down (see [Class hierarchies](#class-hierarchies-extends--labels)) |
 | Action | *nothing* | actions are write-side and have no graph construct; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
+| Constraint | *nothing* | constraints are checked when an action runs, not read-side structure; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
 
 `push` reads the target dataset's location (`bigquery.datasets.get`) so the
 statement runs in the right region; without that permission it falls back to
@@ -345,6 +346,16 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   deploy **only** through the Knowledge Catalog leg — a graph-only `--no-kc` push
   validates them but has nowhere to put them, and warns that they will not be
   deployed. *(static)*
+* **Every constraint is checkable.** A constraint's `expression` must be
+  non-empty, and when it opens with an `<Entity>.<field>` qualifier naming a
+  **known** entity, that entity must actually declare the field — this catches a
+  typo that would otherwise surface only inside an agent's rejected action. A
+  leading qualifier that is not a known entity (a relationship-qualified name
+  like `OrderedAs.quantity`, a metric reference, or compound logic) is left to
+  the evaluator rather than guessed at, so a valid constraint is never falsely
+  rejected. Like actions, constraints deploy **only** through the Knowledge
+  Catalog leg, and a `--no-kc` push warns that they will not be deployed.
+  *(static)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it
   exactly as the deploy will — a three-part `project.dataset.table`, a four-part

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -77,7 +77,7 @@ becomes one part of that graph:
 | Metric | `MEASURE` on a node table | must resolve to a single entity (otherwise the push is rejected — see [Validation](#validation)) and reduce to one supported aggregate over one operand (otherwise that metric is skipped with a warning) |
 | Entity `extends` | extra `LABEL` clauses on the subclass node table | the subclass also matches its supertypes; the supertypes' fields flatten down (see [Class hierarchies](#class-hierarchies-extends--labels)) |
 | Action | *nothing* | actions are write-side and have no graph construct; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
-| Constraint | *nothing* | constraints are checked when an action runs, not read-side structure; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
+| Constraint | *nothing* | a constraint states an invariant rather than a read-side structure; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
 
 `push` reads the target dataset's location (`bigquery.datasets.get`) so the
 statement runs in the right region; without that permission it falls back to
@@ -260,10 +260,10 @@ are **not** probed before deploy — the live pre-flight is BigQuery-only (see
 ## What gets created in Knowledge Catalog
 
 Each element of your model maps to one catalog resource. Every resource type
-below except `semantic-action` is a built-in system type under
-`dataplex-types/global` — push references them, it never creates them.
-`semantic-action` is custom, and `kcmd init --semantic-model` creates it in your
-own project at `global`; push still writes only entries.
+below except `semantic-action` and `semantic-constraint` is a built-in system
+type under `dataplex-types/global` — push references them, it never creates
+them. Those two are custom, and `kcmd init --semantic-model` creates them in
+your own project at `global`; push still writes only entries.
 
 > Set `KC_TYPE_PROJECT` to read these system types from another project, and
 > `DATAPLEX_ENDPOINT` to target a non-prod Dataplex host; both default to
@@ -276,6 +276,7 @@ own project at `global`; push still writes only entries.
 | Metric | `semantic-metric` | entry | `<model>.metrics.<metric>` |
 | Relationship | `schema-join` | entry link between the two entity entries | derived from the model and relationship names |
 | Action | `semantic-action` (custom type) | entry | `<model>.actions.<action>` |
+| Constraint | `semantic-constraint` (custom type) | entry | `<model>.constraints.<constraint>` |
 
 An entity entry carries its columns in the `schema` aspect (name, data type,
 description, and any `label` per field), plus the entity's keys and unique keys
@@ -291,6 +292,12 @@ That aspect type is provisioned in your project rather than referenced from
 ships, the entries move to it and their shape does not change. (This is the
 prototype scope — an action's `precondition` and `affects` are not modeled
 yet.)
+
+A **constraint** entry carries its expression, and its
+`ai_context.instructions`, in a `semantic-constraint` aspect; the constraint's
+`description` is the entry's own summary, because that sentence is what a caller
+refused by the rule reads. Its type is provisioned alongside the action pair and
+for the same reason.
 
 Push to Knowledge Catalog is lossy — the catalog holds metadata, not a full copy
 of your model. For exactly what is stored, what is gated behind
@@ -349,10 +356,10 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
 * **Every constraint is checkable.** A constraint's `expression` must be
   non-empty, and when it opens with an `<Entity>.<field>` qualifier naming a
   **known** entity, that entity must actually declare the field — this catches a
-  typo that would otherwise surface only inside an agent's rejected action. A
-  leading qualifier that is not a known entity (a relationship-qualified name
-  like `OrderedAs.quantity`, a metric reference, or compound logic) is left to
-  the evaluator rather than guessed at, so a valid constraint is never falsely
+  typo that would otherwise surface only when something tries to check the rule.
+  A leading qualifier that is not a known entity (a relationship-qualified name
+  like `OrderedAs.quantity`, a metric reference, or compound logic) is left
+  alone rather than guessed at, so a valid constraint is never falsely
   rejected. Like actions, constraints deploy **only** through the Knowledge
   Catalog leg, and a `--no-kc` push warns that they will not be deployed.
   *(static)*
@@ -414,7 +421,8 @@ and each aspect type attached, so a push needs, on the destination entry group:
   `dataplex.entryGroups.useSemanticModelAspect`, `useSemanticEntityAspect`, and
   `useSemanticMetricAspect`
 * `dataplex.aspectTypes.use` on the `semantic-action` aspect type, when the
-  model declares actions — that type is custom rather than built-in, so it is
+  model declares actions, and on `semantic-constraint` when it declares
+  constraints — those types are custom rather than built-in, so they are
   authorized on the type resource instead of through an entry-group
   use-permission
 
@@ -430,16 +438,16 @@ needs more than push does, in the destination project:
 
 * `dataplex.entryGroups.create` — the destination entry group
 * `dataplex.aspectTypes.create` / `dataplex.aspectTypes.update` and
-  `dataplex.entryTypes.create` — the custom `semantic-action` pair. Init patches
-  an aspect type that is already there, so a project set up by an older `kcmd`
-  picks up template additions; an entry type that is already there is left
-  alone.
+  `dataplex.entryTypes.create` — the custom `semantic-action` and
+  `semantic-constraint` pairs. Init patches an aspect type that is already
+  there, so a project set up by an older `kcmd` picks up template additions; an
+  entry type that is already there is left alone.
 
-Only the entry-group permission is required. Actions are one optional
-construct, so init reports a refusal to create their types as a warning and
-carries on; every model that declares no action still pushes and pulls. Any
-other failure to create a type stops init, rather than leaving a later push to
-hit an opaque parsing error.
+Only the entry-group permission is required. Actions and constraints are
+optional constructs, so init reports a refusal to create their types as a
+warning and carries on; every model that declares neither still pushes and
+pulls. Any other failure to create a type stops init, rather than leaving a
+later push to hit an opaque parsing error.
 
 `kcmd pull` needs read access to the same entry group instead — to list its
 entries and fetch each `semantic-*` entry with its aspects.

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -76,31 +76,22 @@ export function generatePropertyGraph(
   const relationships = resolved.model.relationships ?? [];
   const metrics = resolved.model.metrics ?? [];
 
-  // Actions are write-side operations with no read-side graph construct (no
-  // NODE TABLE / EDGE TABLE / MEASURE), so the BigQuery leg emits nothing for
-  // them. Warn once so an author who declared actions is not surprised they are
-  // absent from the graph. Their only destination is Knowledge Catalog (see
-  // kc_actions.ts) -- but that leg runs only when
-  // the KC destination is in the push, so the message stays conditional (a
-  // bq-only push warns separately that actions go nowhere; see commands.ts).
+  // Knowledge Catalog is the only system an action or a constraint reaches
+  // (kc_actions.ts, kc_constraints.ts), so this leg emits nothing for either.
+  // Warn once each, so an author who declared them learns where they go. A push
+  // that leaves Knowledge Catalog out warns separately that they reach nothing
+  // at all (see commands.ts).
   const actions = resolved.model.actions ?? [];
   if (actions.length) {
     warnings.push(
-        `${actions.length} action(s) are not represented in the BigQuery ` +
-        `property graph (actions are write-side); they are published to ` +
-        `Knowledge Catalog when that destination is included in the push.`);
+        `${actions.length} action(s) reach Knowledge Catalog only; the ` +
+        `BigQuery push deploys none of them.`);
   }
-
-  // Constraints are invariants checked at action time, not read-side graph
-  // structure, so the BigQuery leg emits nothing for them either. Same
-  // reasoning and same catalog home as actions above.
   const constraints = resolved.model.constraints ?? [];
   if (constraints.length) {
     warnings.push(
-        `${constraints.length} constraint(s) are not represented in the ` +
-        `BigQuery property graph (constraints are checked when an action ` +
-        `runs); they are published to Knowledge Catalog when that destination ` +
-        `is included in the push.`);
+        `${constraints.length} constraint(s) reach Knowledge Catalog only; ` +
+        `the BigQuery push deploys none of them.`);
   }
 
   // An abstract entity is conceptual: it has no physical table and produces no

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -91,6 +91,18 @@ export function generatePropertyGraph(
         `Knowledge Catalog when that destination is included in the push.`);
   }
 
+  // Constraints are invariants checked at action time, not read-side graph
+  // structure, so the BigQuery leg emits nothing for them either. Same
+  // reasoning and same catalog home as actions above.
+  const constraints = resolved.model.constraints ?? [];
+  if (constraints.length) {
+    warnings.push(
+        `${constraints.length} constraint(s) are not represented in the ` +
+        `BigQuery property graph (constraints are checked when an action ` +
+        `runs); they are published to Knowledge Catalog when that destination ` +
+        `is included in the push.`);
+  }
+
   // An abstract entity is conceptual: it has no physical table and produces no
   // NODE TABLE, surviving only as a LABEL on its concrete descendants (whose
   // node tables carry its flattened fields). Collect the abstract names so the

--- a/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
@@ -700,8 +700,9 @@ async function writeEntry(
 // The aspects the emitter attaches CONDITIONALLY. `guidelines` (only when an
 // object carries ai_context.instructions) can ride any entry, so it is
 // reconciled everywhere. Every other aspect the emitter writes (semantic-*,
-// schema, semantic-action) is unconditional on the entry that carries it, so it
-// is always present on a re-push and never needs explicit clearing.
+// schema, semantic-action, semantic-constraint) is unconditional on the entry
+// that carries it, so it is always present on a re-push and never needs
+// explicit clearing.
 const OPTIONAL_ASPECT_TYPES = ['guidelines'] as const;
 
 // The aspect keys to reconcile when updating an existing entry. A Dataplex

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -64,10 +64,9 @@ export interface SemanticModel {
   // absent on models authored before actions existed, so consumers read it as
   // `actions ?? []`. See Action.
   actions?: Action[];
-  // Named invariants over the ontology -- a boolean `expression` that must hold
-  // for every instance (e.g. `Customer.accountBalance >= 0`). Model-level like
-  // metrics and actions; checked before an action commits, so a write that would
-  // break one is rejected. Optional and absent on models authored before
+  // Named invariants over the ontology: a boolean `expression` that must hold
+  // for every instance (e.g. `Customer.accountBalance >= 0`). Model-level, like
+  // metrics and actions. Optional, and absent on models authored before
   // constraints existed, so consumers read it as `constraints ?? []`. See
   // Constraint.
   constraints?: Constraint[];
@@ -374,24 +373,31 @@ export interface GrpcExecutor {
 
 /**
  * A constraint: a model-level, named invariant over the ontology -- a boolean
- * `expression` that must hold for every instance. Written in the same
+ * `expression` that must hold for every instance. It is written in the same
  * expression language as a metric (`Customer.accountBalance >= 0`,
- * `OrderedAs.quantity > 0`), and it may reference a metric by name when the
- * check needs an aggregate.
+ * `OrderedAs.quantity > 0`), and may reference a metric by name when the rule
+ * needs an aggregate.
  *
- * Constraints matter because actions change state: an operational agent running
- * an action writes to a live store, and a bad write corrupts data. A constraint
- * is checked before the action commits; if the write would leave any instance
- * violating it, the action is rejected and the state is left untouched.
+ * STATUS: authored, validated and published; not yet enforced. kcmd carries a
+ * constraint to Knowledge Catalog, where an agent can read the rules a model
+ * requires. No component evaluates one, so nothing today rejects a write that
+ * would break it. Enforcement is the point of declaring them: an operational
+ * agent running an action writes to a live store, and a bad write corrupts
+ * data. The rule has to be stated and governed before it can be checked.
  *
- * `description` doubles as the error surfaced on a violation, so it is written
- * to steer an agent's next move ("reduce the order quantity or choose another
- * customer") rather than merely label the rule.
+ * `description` is the error text a violation would surface, so write it to
+ * steer an agent's next move -- "reduce the order quantity or choose another
+ * customer" -- rather than to label the rule.
  */
 export interface Constraint {
   name: string;
   expression: string;     // boolean invariant in the model's expression language
-  description?: string;   // human-readable; doubles as the violation error
+  description?: string;   // human-readable summary; also the violation error
   aiContext?: AiContext;
-  customExtensions?: CustomExtension[];
+  // No `customExtensions`. Every other IR object has one because vanilla Ossie
+  // accepts `custom_extensions` on it. A constraint is unreachable that way:
+  // `constraints` is an extended-profile-only key, and the extended profile
+  // rejects `custom_extensions` outright (ceField in loader.ts), so no document
+  // can carry both. Should vanilla Ossie ever gain constraints, add the field
+  // back with `...ce` on the schema.
 }

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -64,6 +64,13 @@ export interface SemanticModel {
   // absent on models authored before actions existed, so consumers read it as
   // `actions ?? []`. See Action.
   actions?: Action[];
+  // Named invariants over the ontology -- a boolean `expression` that must hold
+  // for every instance (e.g. `Customer.accountBalance >= 0`). Model-level like
+  // metrics and actions; checked before an action commits, so a write that would
+  // break one is rejected. Optional and absent on models authored before
+  // constraints existed, so consumers read it as `constraints ?? []`. See
+  // Constraint.
+  constraints?: Constraint[];
   // Vendor extension blocks carried verbatim (round-trip fidelity), including the
   // model-level GOOGLE block. A typed deployment-target view is derived by the
   // consumer that acts on it (e.g. the CLI push), not surfaced on the IR yet.
@@ -363,4 +370,28 @@ export interface RestExecutor {
 export interface GrpcExecutor {
   service: string;
   method: string;
+}
+
+/**
+ * A constraint: a model-level, named invariant over the ontology -- a boolean
+ * `expression` that must hold for every instance. Written in the same
+ * expression language as a metric (`Customer.accountBalance >= 0`,
+ * `OrderedAs.quantity > 0`), and it may reference a metric by name when the
+ * check needs an aggregate.
+ *
+ * Constraints matter because actions change state: an operational agent running
+ * an action writes to a live store, and a bad write corrupts data. A constraint
+ * is checked before the action commits; if the write would leave any instance
+ * violating it, the action is rejected and the state is left untouched.
+ *
+ * `description` doubles as the error surfaced on a violation, so it is written
+ * to steer an agent's next move ("reduce the order quantity or choose another
+ * customer") rather than merely label the rule.
+ */
+export interface Constraint {
+  name: string;
+  expression: string;     // boolean invariant in the model's expression language
+  description?: string;   // human-readable; doubles as the violation error
+  aiContext?: AiContext;
+  customExtensions?: CustomExtension[];
 }

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -23,10 +23,9 @@
 // `description` rides the entry source rather than the aspect: a violation
 // quotes it back to the caller as the error, which makes it the entry's
 // human-readable summary, and it is where a pull of an action already looks for
-// the same field. `instructions` rides the constraint's own aspect for the
-// reason kc_actions.ts gives: a pull derives which aspect types to hydrate from
-// the project the ENTRY type lives in, and the built-in `guidelines` type does
-// not exist there.
+// the same field. `ai_context` rides the constraint's own aspect, whole -- see
+// aiContextField in kc_custom_types.ts for why it is carried there, and why
+// every part of it is carried rather than `instructions` alone.
 //
 // The helpers at the bottom duplicate a few lines from the modules above on
 // purpose. This module imports only the IR, the entry shape and the type
@@ -34,8 +33,8 @@
 
 import {Entry} from '../gcp/dataplex';
 
-import {AiContext, Constraint, SemanticModel} from './ir';
-import {CONSTRAINT_TYPE_ID, customAspectKey, customAspectTypeName, customEntryTypeName} from './kc_custom_types';
+import {Constraint, SemanticModel} from './ir';
+import {aiContextAspectValue, aiContextFromAspect, CONSTRAINT_TYPE_ID, customAspectKey, customAspectTypeName, customEntryTypeName} from './kc_custom_types';
 
 // Full resource name of the constraint entry type for a destination.
 export function constraintEntryTypeName(dest: {project: string}): string {
@@ -130,12 +129,12 @@ export function constraintEntries(
   return entries;
 }
 
-// The aspect payload for one constraint: the invariant, and any AI
-// instructions.
+// The aspect payload for one constraint: the invariant, and the whole of any
+// `ai_context` declared on it.
 function constraintAspectData(constraint: Constraint): Record<string, any> {
   return compact({
     expression: constraint.expression,
-    instructions: constraint.aiContext?.instructions || undefined,
+    aiContext: aiContextAspectValue(constraint.aiContext),
   });
 }
 
@@ -185,8 +184,8 @@ export function readConstraint(entry: Entry, warnings: string[]): Constraint|
   const description = entry.entrySource?.description;
   if (description !== undefined && description !== '')
     constraint.description = description;
-  if (typeof data.instructions === 'string' && data.instructions !== '')
-    constraint.aiContext = {instructions: data.instructions} as AiContext;
+  const aiContext = aiContextFromAspect(data.aiContext);
+  if (aiContext) constraint.aiContext = aiContext;
   return constraint;
 }
 

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -1,33 +1,31 @@
 // How a model's CONSTRAINTS are encoded in Knowledge Catalog.
 //
-// A constraint is published exactly the way an action is: one entry per
-// constraint, parented to the model anchor, carrying one aspect that holds the
-// invariant. Its type is custom for the same reason an action's is -- Dataplex
-// has no built-in constraint type -- so it uses the `semantic-constraint` pair
-// DECLARED IN kc_custom_types.ts and created there by
-// `kcmd init --semantic-model`. That file is the list of what is custom; this
-// one is only the encoding that fills the aspect.
+// One entry per constraint, parented to the model anchor, carrying one aspect
+// that holds the invariant. An action is published the same way. Dataplex has
+// no built-in constraint type, so the entry and aspect types are the custom
+// `semantic-constraint` pair, declared in kc_custom_types.ts and created by
+// `kcmd init --semantic-model`. That file lists what is custom; this one holds
+// the encoding that fills the aspect.
 //
 // An entry of its own is what makes the invariant governable. A search can list
-// every rule a model enforces, the expression is a typed field rather than
-// prose, and dropping a constraint from the model deletes its entry, so the
-// catalog never advertises a rule the model stopped requiring.
+// every rule a model states. The expression is a typed field rather than prose.
+// Dropping a constraint from the model deletes its entry, so the catalog never
+// advertises a rule the model stopped requiring.
+//
+// The three authored fields land in two places. `expression` and `ai_context`
+// go on the aspect, the latter whole -- aiContextField in kc_custom_types.ts
+// says why. `description` goes on the entry source, where a pull of an action
+// already reads it, and because a violation quotes that sentence back to the
+// caller as the error, which makes it the entry's summary.
+//
+// Call sites: knowledge_catalog.ts emits the entries, kc_converter.ts reads
+// them back, pull_kc.ts hydrates the aspect.
 //
 // WHEN A BUILT-IN CONSTRAINT TYPE SHIPS, follow the instructions at the top of
-// kc_custom_types.ts. Nothing in this file changes: the readers below match a
-// type by its id suffix, so they do not care which project it lives in.
+// kc_custom_types.ts. Nothing in this file changes, because the readers below
+// match a type by its id suffix and ignore the project it lives in.
 //
-// The call sites are `knowledge_catalog.ts` (emit the entries),
-// `kc_converter.ts` (read them back), and `pull_kc.ts` (hydrate the aspect).
-//
-// `description` rides the entry source rather than the aspect: a violation
-// quotes it back to the caller as the error, which makes it the entry's
-// human-readable summary, and it is where a pull of an action already looks for
-// the same field. `ai_context` rides the constraint's own aspect, whole -- see
-// aiContextField in kc_custom_types.ts for why it is carried there, and why
-// every part of it is carried rather than `instructions` alone.
-//
-// The helpers at the bottom duplicate a few lines from the modules above on
+// The helpers at the bottom repeat a few lines from the modules above on
 // purpose. This module imports only the IR, the entry shape and the type
 // registry, so it can be swapped or deleted as a unit.
 
@@ -143,10 +141,10 @@ function constraintAspectData(constraint: Constraint): Record<string, any> {
 // Read side: a constraint entry -> the IR.
 // ---------------------------------------------------------------------------
 
-// True when an entry is one of a model's constraints, matched by the entry
-// type's id suffix so the project the type lives in need not be known -- which
-// is what lets a pull keep working when the custom type is replaced by a
-// built-in one.
+// True when an entry is one of a model's constraints. The match is on the entry
+// type's id suffix, so the project the type lives in need not be known. That is
+// what lets a pull keep working once the custom type is replaced by a built-in
+// one.
 export function isConstraintEntry(entry: Entry): boolean {
   return entry.entryType?.endsWith(`/entryTypes/${CONSTRAINT_TYPE_ID}`) ??
       false;

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -1,0 +1,230 @@
+// How a model's CONSTRAINTS are encoded in Knowledge Catalog.
+//
+// A constraint is published exactly the way an action is: one entry per
+// constraint, parented to the model anchor, carrying one aspect that holds the
+// invariant. Its type is custom for the same reason an action's is -- Dataplex
+// has no built-in constraint type -- so it uses the `semantic-constraint` pair
+// DECLARED IN kc_custom_types.ts and created there by
+// `kcmd init --semantic-model`. That file is the list of what is custom; this
+// one is only the encoding that fills the aspect.
+//
+// An entry of its own is what makes the invariant governable. A search can list
+// every rule a model enforces, the expression is a typed field rather than
+// prose, and dropping a constraint from the model deletes its entry, so the
+// catalog never advertises a rule the model stopped requiring.
+//
+// WHEN A BUILT-IN CONSTRAINT TYPE SHIPS, follow the instructions at the top of
+// kc_custom_types.ts. Nothing in this file changes: the readers below match a
+// type by its id suffix, so they do not care which project it lives in.
+//
+// The call sites are `knowledge_catalog.ts` (emit the entries),
+// `kc_converter.ts` (read them back), and `pull_kc.ts` (hydrate the aspect).
+//
+// `description` rides the entry source rather than the aspect: a violation
+// quotes it back to the caller as the error, which makes it the entry's
+// human-readable summary, and it is where a pull of an action already looks for
+// the same field. `instructions` rides the constraint's own aspect for the
+// reason kc_actions.ts gives: a pull derives which aspect types to hydrate from
+// the project the ENTRY type lives in, and the built-in `guidelines` type does
+// not exist there.
+//
+// The helpers at the bottom duplicate a few lines from the modules above on
+// purpose. This module imports only the IR, the entry shape and the type
+// registry, so it can be swapped or deleted as a unit.
+
+import {Entry} from '../gcp/dataplex';
+
+import {AiContext, Constraint, SemanticModel} from './ir';
+import {CONSTRAINT_TYPE_ID, customAspectKey, customAspectTypeName, customEntryTypeName} from './kc_custom_types';
+
+// Full resource name of the constraint entry type for a destination.
+export function constraintEntryTypeName(dest: {project: string}): string {
+  return customEntryTypeName(CONSTRAINT_TYPE_ID, dest);
+}
+
+// Full resource name of the constraint aspect type for a destination.
+export function constraintAspectTypeName(dest: {project: string}): string {
+  return customAspectTypeName(CONSTRAINT_TYPE_ID, dest);
+}
+
+// Aspect-map key: the `project.location.type` reference form the client keys an
+// entry's aspects by.
+export function constraintAspectKey(dest: {project: string}): string {
+  return customAspectKey(CONSTRAINT_TYPE_ID, dest);
+}
+
+
+// ---------------------------------------------------------------------------
+// Write side: the IR -> one entry per constraint.
+// ---------------------------------------------------------------------------
+
+// What the emitter supplies so this file need not rebuild entry names or repeat
+// the id-collision bookkeeping it already does for entities and metrics.
+export interface ConstraintEmitContext {
+  // The destination project, which is where the custom types live.
+  project: string;
+  // Full entry resource name for an entry id (Namer.entry).
+  entry(entryId: string): string;
+  // Full entry resource name of the model anchor, the parent of every
+  // constraint.
+  anchor: string;
+  // Reserves an entry id, returning false when it collides with one already
+  // emitted (knowledge_catalog.claim).
+  claim(entryId: string, label: string): boolean;
+}
+
+// The entry id of one constraint: `<model>.constraints.<name>`, alongside
+// `<model>.metrics.<name>` and `<model>.actions.<name>`.
+export function constraintEntryId(
+    modelId: string, constraintName: string): string {
+  return `${modelId}.constraints.${slug(constraintName)}`;
+}
+
+// The entry-id prefix a model's constraints occupy, so delete reconciliation
+// removes the entry of a constraint dropped from the model.
+export function constraintOwnedPrefix(modelId: string): string {
+  return `${modelId}.constraints.`;
+}
+
+/**
+ * One entry per constraint, to append to the model's entries.
+ *
+ * Empty when the model declares no constraints, so a model without them is
+ * unchanged from before constraints existed. Warns once when it is non-empty:
+ * constraints reach Knowledge Catalog and nowhere else, which is worth saying
+ * out loud on a push that also deploys a graph.
+ */
+export function constraintEntries(
+    model: SemanticModel, modelId: string, ctx: ConstraintEmitContext,
+    warnings: string[]): Entry[] {
+  const constraints = model.constraints ?? [];
+  if (!constraints.length) return [];
+
+  const entries: Entry[] = [];
+  for (const constraint of constraints) {
+    const id = constraintEntryId(modelId, constraint.name);
+    if (!ctx.claim(id, `constraint '${constraint.name}'`)) continue;
+    entries.push({
+      name: ctx.entry(id),
+      entryType: constraintEntryTypeName(ctx),
+      parentEntry: ctx.anchor,
+      entrySource: compact({
+                     displayName: constraint.name,
+                     description: constraint.description,
+                   }) as Entry['entrySource'],
+      aspects: {
+        [constraintAspectKey(ctx)]: {
+          aspectType: constraintAspectTypeName(ctx),
+          data: constraintAspectData(constraint),
+        },
+      },
+    });
+  }
+  // Counted from what was emitted rather than from the model, so a name
+  // collision that skipped a constraint does not inflate the number.
+  if (entries.length)
+    warnings.push(
+        `model '${model.name}': ${entries.length} constraint(s) published as ` +
+        `${CONSTRAINT_TYPE_ID} entries (constraints have no BigQuery Graph ` +
+        `representation).`);
+  return entries;
+}
+
+// The aspect payload for one constraint: the invariant, and any AI
+// instructions.
+function constraintAspectData(constraint: Constraint): Record<string, any> {
+  return compact({
+    expression: constraint.expression,
+    instructions: constraint.aiContext?.instructions || undefined,
+  });
+}
+
+
+// ---------------------------------------------------------------------------
+// Read side: a constraint entry -> the IR.
+// ---------------------------------------------------------------------------
+
+// True when an entry is one of a model's constraints, matched by the entry
+// type's id suffix so the project the type lives in need not be known -- which
+// is what lets a pull keep working when the custom type is replaced by a
+// built-in one.
+export function isConstraintEntry(entry: Entry): boolean {
+  return entry.entryType?.endsWith(`/entryTypes/${CONSTRAINT_TYPE_ID}`) ??
+      false;
+}
+
+// The aspect type resource names to hydrate for a constraint entry. Named
+// through the entry type's own project so the pull follows the type wherever it
+// lives.
+export function constraintAspectTypes(entryTypeBase: string): string[] {
+  return [`${entryTypeBase}/aspectTypes/${CONSTRAINT_TYPE_ID}`];
+}
+
+/**
+ * Recovers one constraint from its entry, the inverse of constraintEntries.
+ *
+ * Returns undefined, with a warning, for an entry whose expression is missing
+ * or blank: an invariant that states nothing would be pulled into a model that
+ * then fails its own push-side validation, so one bad entry degrades itself
+ * rather than the pull.
+ */
+export function readConstraint(entry: Entry, warnings: string[]): Constraint|
+    undefined {
+  const name = entry.entrySource?.displayName || idOf(entry.name);
+  const data = constraintAspectDataOf(entry);
+  const expression =
+      typeof data.expression === 'string' ? data.expression.trim() : '';
+  if (!expression) {
+    warnings.push(
+        `constraint '${name}': the ${CONSTRAINT_TYPE_ID} aspect has no ` +
+        `expression; the constraint is skipped`);
+    return undefined;
+  }
+
+  const constraint: Constraint = {name, expression};
+  const description = entry.entrySource?.description;
+  if (description !== undefined && description !== '')
+    constraint.description = description;
+  if (typeof data.instructions === 'string' && data.instructions !== '')
+    constraint.aiContext = {instructions: data.instructions} as AiContext;
+  return constraint;
+}
+
+
+// ---------------------------------------------------------------------------
+// Local helpers (see the file header on why they are not shared).
+// ---------------------------------------------------------------------------
+
+// The constraint aspect's `data` from an entry, matched by the aspect key's
+// `.semantic-constraint` suffix or the aspectType's
+// `/aspectTypes/semantic-constraint` suffix, so it is found whichever project
+// the type was provisioned in.
+function constraintAspectDataOf(entry: Entry): Record<string, any> {
+  for (const [key, aspect] of Object.entries(entry.aspects ?? {})) {
+    if (key.endsWith(`.${CONSTRAINT_TYPE_ID}`) ||
+        aspect.aspectType?.endsWith(`/aspectTypes/${CONSTRAINT_TYPE_ID}`)) {
+      return aspect.data ?? {};
+    }
+  }
+  return {};
+}
+
+// Entry ids allow letters, numbers, underscores, hyphens, and periods.
+function slug(s: string): string {
+  return s.replace(/[^A-Za-z0-9_.-]/g, '_');
+}
+
+// The id segment of a full entry resource name.
+function idOf(name: string): string {
+  return name.split('/').pop() ?? name;
+}
+
+// Drops undefined-valued keys so the emitted aspect (and its golden) only shows
+// fields the model actually set.
+function compact<T extends Record<string, any>>(obj: T): T {
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as T;
+}

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -54,8 +54,9 @@
 
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
-import {Action, AiContext, CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
+import {Action, AiContext, Constraint, CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
 import {isActionEntry, readAction} from './kc_actions';
+import {isConstraintEntry, readConstraint} from './kc_constraints';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface ReadResult {
@@ -86,8 +87,10 @@ export function modelsFromCatalogResources(
   const metricEntries =
       entries.filter(e => semanticType(e) === 'semantic-metric');
   // Actions have no built-in system type; `kc_actions.ts` owns the custom one
-  // and recognizes an entry carrying it.
+  // and recognizes an entry carrying it. Constraints are the same, through
+  // `kc_constraints.ts`.
   const actionEntries = entries.filter(isActionEntry);
+  const constraintEntries = entries.filter(isConstraintEntry);
 
   if (!anchors.length) {
     warnings.push('no semantic-model entry found; nothing to reconstruct');
@@ -135,6 +138,10 @@ export function modelsFromCatalogResources(
                         .map(e => readAction(e, entityNames, warnings))
                         .filter((a): a is Action => a !== undefined);
     if (actions.length) model.actions = actions;
+    const constraints = childrenOf(anchor.name, constraintEntries)
+                            .map(e => readConstraint(e, warnings))
+                            .filter((c): c is Constraint => c !== undefined);
+    if (constraints.length) model.constraints = constraints;
     // Deployment targets ride back in the same GOOGLE custom_extensions block
     // the author wrote them in (the inverse of the emitter's modelAspectData).
     const targets = readDeploymentTargets(anchor);
@@ -147,8 +154,8 @@ export function modelsFromCatalogResources(
   // Flag children that resolved to no anchor at all (only possible with
   // multiple anchors, where the sole-anchor fallback does not apply).
   if (!soleAnchor) {
-    for (const child of [...entityEntries, ...metricEntries,
-                         ...actionEntries]) {
+    for (const child of [...entityEntries, ...metricEntries, ...actionEntries,
+                         ...constraintEntries]) {
       if (!child.parentEntry || !anchorNames.has(child.parentEntry)) {
         warnings.push(`entry '${
             child.name}' has no resolvable parent semantic-model; omitted`);

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -21,7 +21,8 @@
 // TO ADD A NEW CUSTOM TYPE. Append a record. Provisioning, naming and the init
 // wiring are generic over this list, so no other file in this directory needs
 // to change; what does need writing is the encoding that fills the aspect, the
-// way kc_actions.ts does for `semantic-action`.
+// way kc_actions.ts does for `semantic-action` and kc_constraints.ts for
+// `semantic-constraint`.
 //
 // A CUSTOM TYPE IS ONE ENTRY TYPE PLUS ONE ASPECT TYPE that share an id, the
 // way the built-in `semantic-metric` entry type and aspect type share theirs.
@@ -196,6 +197,64 @@ const ACTION_ASPECT_TYPE: Omit<AspectType, 'name'> = {
   },
 };
 
+
+// The id of the constraint type. A constraint is a named invariant over a
+// semantic model; kc_constraints.ts holds the encoding that fills its aspect.
+export const CONSTRAINT_TYPE_ID = 'semantic-constraint';
+
+// The aspect that carries a constraint's rule.
+//
+// The expression is the whole of the machine-readable content, so it is a
+// required field: a constraint entry without one states no invariant.
+//
+// The other two fields an author can write are the ones every model element
+// carries, and they land in different places. `description` rides the entry
+// source, the way an action's and a metric's do, because a violation quotes it
+// back to the caller as the error, which makes it the entry's human-readable
+// summary rather than part of the rule. `instructions` below is
+// `ai_context.instructions` -- the same blessed field an entity or a metric
+// declares, under the same authoring key -- and it is spelled `instructions`
+// here because that is what the built-in `guidelines` aspect calls it. It rides
+// this aspect instead of that one only because a pull hydrates aspect types
+// from the entry type's own project, where `guidelines` does not exist.
+const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
+  displayName: 'Semantic Constraint',
+  description:
+      'An invariant over a semantic model: a boolean expression that must ' +
+      'hold for every instance of an entity, however that instance was ' +
+      'written.',
+  metadataTemplate: {
+    name: CONSTRAINT_TYPE_ID,
+    type: 'record',
+    recordFields: [
+      {
+        index: 1,
+        name: 'expression',
+        type: 'string',
+        constraints: {required: true},
+        annotations: {
+          displayName: 'Expression',
+          description:
+              'The invariant, as a boolean expression in the model\'s ' +
+              'expression language, for example `Customer.balance >= 0`.',
+        },
+      },
+      {
+        index: 2,
+        name: 'instructions',
+        type: 'string',
+        annotations: {
+          displayName: 'Instructions',
+          description:
+              'The constraint\'s `ai_context.instructions`: guidance for AI ' +
+              'consumers. Its human-readable summary rides the entry\'s own ' +
+              'description rather than this aspect.',
+        },
+      },
+    ],
+  },
+};
+
 // Every type kcmd provisions. This list is the whole of what is custom.
 export const CUSTOM_TYPES: readonly CustomType[] = [
   {
@@ -205,6 +264,14 @@ export const CUSTOM_TYPES: readonly CustomType[] = [
       description: 'A write operation defined on a semantic model.',
     },
     aspectType: ACTION_ASPECT_TYPE,
+  },
+  {
+    id: CONSTRAINT_TYPE_ID,
+    entryType: {
+      displayName: 'Semantic Constraint',
+      description: 'An invariant a semantic model requires to hold.',
+    },
+    aspectType: CONSTRAINT_ASPECT_TYPE,
   },
 ];
 

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -38,6 +38,8 @@
 
 import {AspectType, CatalogClient, EntryType} from '../gcp/dataplex';
 
+import {AiContext} from './ir';
+
 // A type kcmd provisions because no built-in one exists yet.
 export interface CustomType {
   // Shared by the entry type and the aspect type.
@@ -48,6 +50,111 @@ export interface CustomType {
   // The aspect type, including the metadata template that gives the entry its
   // typed, queryable fields.
   aspectType: Omit<AspectType, 'name'>;
+}
+
+
+// ---------------------------------------------------------------------------
+// `ai_context`, shared by every custom aspect.
+// ---------------------------------------------------------------------------
+
+// The whole of a model element's `ai_context`, as one template field.
+//
+// Every element in the format carries the same three-part annotation --
+// instructions, synonyms, examples -- so a custom aspect carries all three. The
+// built-in `guidelines` aspect has a home for `instructions` alone, and an
+// element routed there loses the other two; kcmd owns this template, so there
+// is no reason to inherit that limit. Carrying a chosen part of one would mean
+// a document that loads cleanly comes back from a pull missing fields it
+// declared.
+//
+// A custom aspect carries `ai_context` itself, rather than the entry being
+// given a `guidelines` aspect beside its own, because a pull hydrates aspect
+// types from the project the ENTRY type lives in, and `guidelines` is published
+// under `dataplex-types` instead.
+//
+// `index` is a parameter because template field indexes are positional and
+// append-only (see the header), so each aspect places this field wherever its
+// own template has room. `semantic-action` still carries a flat `instructions`
+// string at index 9: it was provisioned before this existed, and renaming a
+// field is exactly the backwards-incompatible change Dataplex rejects, so it
+// moves over by APPENDING this field and retiring that one.
+export function aiContextField(index: number): Record<string, any> {
+  return {
+    index,
+    name: 'aiContext',
+    type: 'record',
+    recordFields: [
+      {
+        index: 1,
+        name: 'instructions',
+        type: 'string',
+        annotations: {
+          displayName: 'Instructions',
+          description: 'Free-form guidance for AI consumers.',
+        },
+      },
+      {
+        index: 2,
+        name: 'synonyms',
+        type: 'array',
+        arrayItems: {name: 'synonym', type: 'string'},
+        annotations: {
+          displayName: 'Synonyms',
+          description: 'Alternate names for the annotated object.',
+        },
+      },
+      {
+        index: 3,
+        name: 'examples',
+        type: 'array',
+        arrayItems: {name: 'example', type: 'string'},
+        annotations: {
+          displayName: 'Examples',
+          description:
+              'Example questions or usages illustrating the annotated object.',
+        },
+      },
+    ],
+    annotations: {
+      displayName: 'AI Context',
+      description:
+          'The element\'s `ai_context`: guidance, alternate names and ' +
+          'examples for AI consumers.',
+    },
+  };
+}
+
+// The aspect value for an `ai_context`. Undefined when it carries nothing, so
+// an element without one attaches no empty record and its golden stays quiet.
+export function aiContextAspectValue(ai: AiContext|undefined):
+    Record<string, any>|undefined {
+  if (!ai) return undefined;
+  const out: Record<string, any> = {};
+  if (ai.instructions) out.instructions = ai.instructions;
+  if (ai.synonyms?.length) out.synonyms = [...ai.synonyms];
+  if (ai.examples?.length) out.examples = [...ai.examples];
+  return Object.keys(out).length ? out : undefined;
+}
+
+// The inverse: an `ai_context` from an aspect value, or undefined when there is
+// nothing usable in it. Every part is checked rather than trusted, because an
+// aspect can be hand-edited in the catalog into a shape the emitter never
+// writes.
+export function aiContextFromAspect(value: any): AiContext|undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const strings = (v: any): string[]|undefined => {
+    if (!Array.isArray(v)) return undefined;
+    const out = v.filter((s: any) => typeof s === 'string' && s !== '');
+    return out.length ? out : undefined;
+  };
+  const ai: AiContext = {};
+  if (typeof value.instructions === 'string' && value.instructions !== '')
+    ai.instructions = value.instructions;
+  const synonyms = strings(value.synonyms);
+  if (synonyms) ai.synonyms = synonyms;
+  const examples = strings(value.examples);
+  if (examples) ai.examples = examples;
+  return Object.keys(ai).length ? ai : undefined;
 }
 
 // The id of the action type. An action is a write operation defined on a
@@ -207,16 +314,12 @@ export const CONSTRAINT_TYPE_ID = 'semantic-constraint';
 // The expression is the whole of the machine-readable content, so it is a
 // required field: a constraint entry without one states no invariant.
 //
-// The other two fields an author can write are the ones every model element
+// The other two things an author can write are the ones every model element
 // carries, and they land in different places. `description` rides the entry
 // source, the way an action's and a metric's do, because a violation quotes it
 // back to the caller as the error, which makes it the entry's human-readable
-// summary rather than part of the rule. `instructions` below is
-// `ai_context.instructions` -- the same blessed field an entity or a metric
-// declares, under the same authoring key -- and it is spelled `instructions`
-// here because that is what the built-in `guidelines` aspect calls it. It rides
-// this aspect instead of that one only because a pull hydrates aspect types
-// from the entry type's own project, where `guidelines` does not exist.
+// summary rather than part of the rule. `ai_context` rides this aspect whole
+// (see aiContextField).
 const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
   displayName: 'Semantic Constraint',
   description:
@@ -239,18 +342,7 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
               'expression language, for example `Customer.balance >= 0`.',
         },
       },
-      {
-        index: 2,
-        name: 'instructions',
-        type: 'string',
-        annotations: {
-          displayName: 'Instructions',
-          description:
-              'The constraint\'s `ai_context.instructions`: guidance for AI ' +
-              'consumers. Its human-readable summary rides the entry\'s own ' +
-              'description rather than this aspect.',
-        },
-      },
+      aiContextField(2),
     ],
   },
 };

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -59,25 +59,24 @@ export interface CustomType {
 
 // The whole of a model element's `ai_context`, as one template field.
 //
-// Every element in the format carries the same three-part annotation --
-// instructions, synonyms, examples -- so a custom aspect carries all three. The
-// built-in `guidelines` aspect has a home for `instructions` alone, and an
-// element routed there loses the other two; kcmd owns this template, so there
-// is no reason to inherit that limit. Carrying a chosen part of one would mean
-// a document that loads cleanly comes back from a pull missing fields it
-// declared.
+// Every element in the format carries the same three-part annotation:
+// instructions, synonyms, examples. A custom aspect carries all three. Carrying
+// a chosen part instead would mean a document that loads cleanly comes back
+// from a pull missing fields it declared. The built-in `guidelines` aspect does
+// have a home for `instructions` alone, and an element routed there loses the
+// other two, but kcmd owns this template and has no reason to inherit that
+// limit.
 //
-// A custom aspect carries `ai_context` itself, rather than the entry being
-// given a `guidelines` aspect beside its own, because a pull hydrates aspect
-// types from the project the ENTRY type lives in, and `guidelines` is published
-// under `dataplex-types` instead.
+// The annotation goes on the custom aspect rather than on a `guidelines` aspect
+// beside it, because a pull hydrates aspect types from the project the ENTRY
+// type lives in, and `guidelines` is published under `dataplex-types`.
 //
 // `index` is a parameter because template field indexes are positional and
 // append-only (see the header), so each aspect places this field wherever its
 // own template has room. `semantic-action` still carries a flat `instructions`
-// string at index 9: it was provisioned before this existed, and renaming a
-// field is exactly the backwards-incompatible change Dataplex rejects, so it
-// moves over by APPENDING this field and retiring that one.
+// string at index 9. That type was provisioned before this field existed, and
+// renaming a template field is the backwards-incompatible change Dataplex
+// rejects, so it moves over by APPENDING this field and retiring that one.
 export function aiContextField(index: number): Record<string, any> {
   return {
     index,
@@ -314,11 +313,11 @@ export const CONSTRAINT_TYPE_ID = 'semantic-constraint';
 // The expression is the whole of the machine-readable content, so it is a
 // required field: a constraint entry without one states no invariant.
 //
-// The other two things an author can write are the ones every model element
-// carries, and they land in different places. `description` rides the entry
-// source, the way an action's and a metric's do, because a violation quotes it
-// back to the caller as the error, which makes it the entry's human-readable
-// summary rather than part of the rule. `ai_context` rides this aspect whole
+// The other two authored fields are the ones every model element carries, and
+// they land in different places. `description` rides the entry source, the way
+// an action's and a metric's do: a violation quotes it back to the caller as
+// the error, which makes it the entry's summary rather than part of the rule.
+// `ai_context` rides this aspect whole
 // (see aiContextField).
 const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
   displayName: 'Semantic Constraint',
@@ -428,18 +427,28 @@ export interface ProvisionResult {
  * template lacks fails with an opaque parsing error. Dataplex rejects a
  * backwards-incompatible change, so the patch only ever adds appended fields.
  *
- * Stops at the first hard failure, and returns as soon as one type is refused
- * for lack of permission, since the same caller will be refused the next one.
+ * Stops at the first hard failure. A permission refusal does NOT stop it: the
+ * refusals differ per type and per operation -- patching a type that already
+ * exists needs `update`, creating one that does not needs `create` -- so a
+ * caller refused one type may well be allowed the next, and giving up early
+ * would leave a type uncreated that nothing was stopping. Every type is
+ * attempted and the first refusal is reported once they have been.
  */
 export async function provisionCustomTypes(
     cat: CatalogClient, dest: {project: string}): Promise<ProvisionResult> {
   const warnings: string[] = [];
+  let denied: ProvisionResult|undefined;
   for (const type of CUSTOM_TYPES) {
     const result = await provisionOne(cat, dest, type);
     if (result.warnings) warnings.push(...result.warnings);
-    if (result.error || result.denied)
+    // A hard failure is infrastructure-level and says nothing about the next
+    // type, so it still stops everything.
+    if (result.error)
       return {...result, warnings: warnings.length ? warnings : undefined};
+    if (result.denied && !denied) denied = result;
   }
+  if (denied)
+    return {...denied, warnings: warnings.length ? warnings : undefined};
   return warnings.length ? {warnings} : {};
 }
 

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -19,12 +19,13 @@
 //   * semantic-entity entry -> { semantic-entity, schema, guidelines? }
 //   * semantic-metric entry -> { semantic-metric, guidelines? }
 //
-// An action (the model's write operations) is published the same way, one entry
-// per action parented to the anchor, but its entry and aspect types are CUSTOM:
-// there is no built-in type for an action yet, so `kcmd init` provisions the
-// pair in the destination project. `kc_custom_types.ts` declares those types
-// and `kc_actions.ts` encodes the aspect an action carries; this module only
-// appends the entries the latter returns.
+// An action (the model's write operations) and a constraint (an invariant the
+// model requires to hold) are published the same way, one entry each parented
+// to the anchor, but their entry and aspect types are CUSTOM: there is no
+// built-in type for either yet, so `kcmd init` provisions the pairs in the
+// destination project. `kc_custom_types.ts` declares those types, and
+// `kc_actions.ts` and `kc_constraints.ts` encode the aspects they carry; this
+// module only appends the entries those two return.
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):
@@ -58,6 +59,7 @@ import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 import {googleDeploymentTargets} from './deployment_target';
 import {AiContext, DataType, Entity, Metric, Relationship, SemanticModel} from './ir';
 import {actionEntries, actionOwnedPrefix} from './kc_actions';
+import {constraintEntries, constraintOwnedPrefix} from './kc_constraints';
 
 // Where the `semantic-*` and `schema` system types live: built-in types in
 // project `dataplex-types`, location `global`. Callers may override to reference
@@ -216,6 +218,17 @@ export function generateCatalogResources(
     publishedEntities: new Set(entityEntryName.keys()),
   }, warnings));
 
+  // One entry per constraint, on the same footing as an action: no built-in
+  // system type, so the custom pair declared in `kc_custom_types.ts`, filled by
+  // `kc_constraints.ts`. Nothing when the model declares no constraints.
+  entries.push(...constraintEntries(model, modelId, {
+    project: opts.project,
+    entry: (id: string) => names.entry(id),
+    anchor: modelEntryName,
+    claim: (id: string, label: string) =>
+        claim(seen, id, 'entry', label, warnings),
+  }, warnings));
+
   // Relationships map to schema-join entry links between their endpoint entries.
   const entryLinks: EntryLink[] = [];
   const seenLinks = new Set<string>();
@@ -230,11 +243,12 @@ export function generateCatalogResources(
     entryLinks,
     warnings: [...new Set(warnings)],
     // Ossie ids are dotted: `<model>.entities.<name>` / `<model>.metrics.<name>`
-    // / `<model>.actions.<name>`.
+    // / `<model>.actions.<name>` / `<model>.constraints.<name>`.
     ownedPrefixes: [
       `${modelId}.entities.`,
       `${modelId}.metrics.`,
       actionOwnedPrefix(modelId),
+      constraintOwnedPrefix(modelId),
     ],
   };
 }

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -19,13 +19,13 @@
 //   * semantic-entity entry -> { semantic-entity, schema, guidelines? }
 //   * semantic-metric entry -> { semantic-metric, guidelines? }
 //
-// An action (the model's write operations) and a constraint (an invariant the
-// model requires to hold) are published the same way, one entry each parented
-// to the anchor, but their entry and aspect types are CUSTOM: there is no
-// built-in type for either yet, so `kcmd init` provisions the pairs in the
-// destination project. `kc_custom_types.ts` declares those types, and
-// `kc_actions.ts` and `kc_constraints.ts` encode the aspects they carry; this
-// module only appends the entries those two return.
+// An action (a write operation the model defines) and a constraint (an
+// invariant the model states) are published the same way: one entry each,
+// parented to the anchor. Their entry and aspect types are CUSTOM, because
+// Dataplex has no built-in type for either yet, so `kcmd init` provisions the
+// pairs in the destination project. `kc_custom_types.ts` declares those types
+// and `kc_actions.ts` and `kc_constraints.ts` encode the aspects they carry.
+// This module only appends the entries those two return.
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -12,7 +12,7 @@
 import * as yaml from 'yaml';
 import * as z from 'zod';
 
-import {Action, ActionParameter, AiContext, CustomExtension, DATA_TYPES, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, ActionParameter, AiContext, Constraint, CustomExtension, DATA_TYPES, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface LoadOptions {
@@ -236,6 +236,18 @@ const actionSchema = z.object({
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
 
+// A constraint: a named boolean invariant over the ontology. `expression` is a
+// logical expression in the model's own language (`Customer.accountBalance >=
+// 0`), not a physical binding, so it stays a plain string -- it is resolved
+// against the ontology by the consumer that evaluates it, not here.
+const constraintSchema = z.object({
+  name: z.string(),
+  expression: z.string(),
+  description: z.string().optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+});
+
 const modelBase = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -249,6 +261,7 @@ const modelBase = z.object({
   deployment_target: z.string().optional(),
   // Model-level write operations, also GOOGLE_VERSION only (see actionSchema).
   actions: z.array(actionSchema).optional(),
+  constraints: z.array(constraintSchema).optional(),
 });
 
 
@@ -399,6 +412,14 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
                     ...ce,
                   }).strict();
 
+  const constraint = z.object({
+                        name: z.string(),
+                        expression: z.string(),
+                        description: z.string().optional(),
+                        ai_context: aiContextSchema.optional(),
+                        ...ce,
+                      }).strict();
+
   const model =
       z.object({
          name: z.string(),
@@ -408,13 +429,15 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
          relationships: z.array(relationship).optional(),
          metrics: z.array(metric).optional(),
          ...ce,
-         // Native extension keys: extended profile only. `actions` is one of
-         // them because vanilla Ossie has no action construct and no
-         // `custom_extensions` encoding for one, so under OSSIE_VERSION an
-         // `actions` key is rejected as unknown rather than silently dropped.
+         // Native extension keys: extended profile only. `actions` and
+         // `constraints` are among them because vanilla Ossie has neither
+         // construct and no `custom_extensions` encoding for either, so under
+         // OSSIE_VERSION such a key is rejected as unknown rather than
+         // silently dropped.
          ...(extended ? {
            deployment_target: z.string().optional(),
            actions: z.array(action).optional(),
+           constraints: z.array(constraint).optional(),
          } :
                         {}),
        }).strict();
@@ -452,6 +475,7 @@ type RelationshipDoc = z.infer<typeof relationshipSchema>;
 type MetricDoc = z.infer<typeof metricSchema>;
 type ModelDoc = z.infer<typeof modelBase>;
 type ActionDoc = z.infer<typeof actionSchema>;
+type ConstraintDoc = z.infer<typeof constraintSchema>;
 type ParameterDoc = z.infer<typeof parameterSchema>;
 type ExecutorDoc = z.infer<typeof executorSchema>;
 type CustomExtensionDoc = z.infer<typeof customExtensionSchema>;
@@ -679,10 +703,15 @@ function convertModel(
   rejectDuplicateNames(
       actions.map(a => a.name), 'action name', `model '${m.name}'`);
 
+  const constraints = (m.constraints ?? []).map(convertConstraint);
+  rejectDuplicateNames(
+      constraints.map(c => c.name), 'constraint name', `model '${m.name}'`);
+
   const description = composeDescription(m.description);
 
   const model: SemanticModel = {name: m.name, entities, relationships, metrics};
   if (actions.length) model.actions = actions;
+  if (constraints.length) model.constraints = constraints;
   if (description) model.description = description;
   const ai = aiContextOrUndefined(m.ai_context);
   if (ai) model.aiContext = ai;
@@ -850,6 +879,20 @@ function convertMetric(
   const ce = toCustomExtensions(mt.custom_extensions);
   if (ce) metric.customExtensions = ce;
   return metric;
+}
+
+// Converts a constraint document to the IR. The `expression` is kept verbatim
+// (a logical invariant resolved by the evaluator, not the loader); description
+// and AI context round-trip like everywhere else.
+function convertConstraint(c: ConstraintDoc): Constraint {
+  const constraint: Constraint = { name: c.name, expression: c.expression };
+  const description = composeDescription(c.description);
+  if (description) constraint.description = description;
+  const ai = aiContextOrUndefined(c.ai_context);
+  if (ai) constraint.aiContext = ai;
+  const ce = toCustomExtensions(c.custom_extensions);
+  if (ce) constraint.customExtensions = ce;
+  return constraint;
 }
 
 // Maps an authored action onto the IR. Parameter types are resolved against the

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -238,14 +238,16 @@ const actionSchema = z.object({
 
 // A constraint: a named boolean invariant over the ontology. `expression` is a
 // logical expression in the model's own language (`Customer.accountBalance >=
-// 0`), not a physical binding, so it stays a plain string -- it is resolved
-// against the ontology by the consumer that evaluates it, not here.
+// 0`) rather than a physical binding, so it stays a plain string. Whatever
+// evaluates the constraint resolves it against the ontology; the loader leaves
+// it alone.
 const constraintSchema = z.object({
   name: z.string(),
   expression: z.string(),
   description: z.string().optional(),
   ai_context: aiContextSchema.optional(),
-  custom_extensions: z.array(customExtensionSchema).optional(),
+  // No `custom_extensions`: it is a vanilla-Ossie surface, and `constraints` is
+  // an extended-profile-only key, so the two never co-occur. See Constraint.
 });
 
 const modelBase = z.object({
@@ -881,17 +883,15 @@ function convertMetric(
   return metric;
 }
 
-// Converts a constraint document to the IR. The `expression` is kept verbatim
-// (a logical invariant resolved by the evaluator, not the loader); description
-// and AI context round-trip like everywhere else.
+// Converts a constraint document to the IR. The `expression` is kept verbatim:
+// it is a logical invariant, resolved against the ontology by whatever
+// evaluates it. Description and AI context round-trip like everywhere else.
 function convertConstraint(c: ConstraintDoc): Constraint {
   const constraint: Constraint = { name: c.name, expression: c.expression };
   const description = composeDescription(c.description);
   if (description) constraint.description = description;
   const ai = aiContextOrUndefined(c.ai_context);
   if (ai) constraint.aiContext = ai;
-  const ce = toCustomExtensions(c.custom_extensions);
-  if (ce) constraint.customExtensions = ce;
   return constraint;
 }
 

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -199,7 +199,7 @@ function modelDoc(model: SemanticModel, warnings: string[], logical: boolean):
     actions:
         nonEmpty((model.actions ?? []).map(a => actionDoc(a, warnings))),
     constraints: nonEmpty(
-        (model.constraints ?? []).map(c => constraintDoc(c, warnings))),
+        (model.constraints ?? []).map(c => constraintDoc(c))),
   });
 }
 
@@ -296,12 +296,10 @@ function actionDoc(action: Action, warnings: string[]): Record<string, any> {
   });
 }
 
-// Inverts loader.convertConstraint. The expression is a logical invariant, so
-// it round-trips verbatim -- there is nothing derived to drop.
-function constraintDoc(
-    constraint: Constraint, warnings: string[]): Record<string, any> {
-  dropExtensions(
-      constraint.customExtensions, `constraint '${constraint.name}'`, warnings);
+// Inverts loader.convertConstraint. The expression is a logical invariant and
+// round-trips verbatim, since nothing about it is derived.
+function constraintDoc(constraint: Constraint): Record<string, any> {
+  // No dropExtensions call: a constraint carries no custom extensions to drop.
   return compact({
     name: constraint.name,
     expression: constraint.expression,

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -42,7 +42,7 @@
 
 import * as yaml from 'yaml';
 
-import {Action, AiContext, CustomExtension, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, AiContext, Constraint, CustomExtension, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
 
 // The version stamped on every serialized document. Pull emits kcmd's extended
 // profile: it uses native extension keys (`entities`, `deployment_target`)
@@ -198,6 +198,8 @@ function modelDoc(model: SemanticModel, warnings: string[], logical: boolean):
     metrics: nonEmpty((model.metrics ?? []).map(m => metricDoc(m, warnings))),
     actions:
         nonEmpty((model.actions ?? []).map(a => actionDoc(a, warnings))),
+    constraints: nonEmpty(
+        (model.constraints ?? []).map(c => constraintDoc(c, warnings))),
   });
 }
 
@@ -291,6 +293,20 @@ function actionDoc(action: Action, warnings: string[]): Record<string, any> {
     parameters: nonEmpty(
         (action.parameters ?? []).map(p => ({name: p.name, type: p.type}))),
     ai_context: aiContextDoc(action.aiContext),
+  });
+}
+
+// Inverts loader.convertConstraint. The expression is a logical invariant, so
+// it round-trips verbatim -- there is nothing derived to drop.
+function constraintDoc(
+    constraint: Constraint, warnings: string[]): Record<string, any> {
+  dropExtensions(
+      constraint.customExtensions, `constraint '${constraint.name}'`, warnings);
+  return compact({
+    name: constraint.name,
+    expression: constraint.expression,
+    description: constraint.description,
+    ai_context: aiContextDoc(constraint.aiContext),
   });
 }
 

--- a/toolbox/mdcode/src/libts/semantic/pull_kc.ts
+++ b/toolbox/mdcode/src/libts/semantic/pull_kc.ts
@@ -20,7 +20,8 @@ import {CatalogClient, Entry, EntryLink} from '../gcp/dataplex';
 
 import {SemanticModel} from './ir';
 import {actionAspectTypes} from './kc_actions';
-import {ACTION_TYPE_ID} from './kc_custom_types';
+import {constraintAspectTypes} from './kc_constraints';
+import {ACTION_TYPE_ID, CONSTRAINT_TYPE_ID} from './kc_custom_types';
 import {idOf, linkDedupKey, modelsFromCatalogResources} from './kc_converter';
 
 export interface KcPullOptions {
@@ -165,6 +166,9 @@ function semanticAspectTypes(entryType: string): string[]|undefined {
       // `typeBase` already points there, and kc_actions.ts names the aspects
       // to fetch beneath it.
       return actionAspectTypes(typeBase);
+    case CONSTRAINT_TYPE_ID:
+      // Custom for the same reason, and named through the same `typeBase`.
+      return constraintAspectTypes(typeBase);
     default:
       return undefined;
   }

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -63,6 +63,22 @@ export function generateSpannerPropertyGraph(
   const relationships = resolved.model.relationships ?? [];
   const metrics = resolved.model.metrics ?? [];
 
+  // Knowledge Catalog is the only system an action or a constraint reaches, so
+  // this leg emits nothing for either. Warn once each, as the BigQuery leg
+  // does, so an author who declared them learns where they go.
+  const actions = resolved.model.actions ?? [];
+  if (actions.length) {
+    warnings.push(
+        `${actions.length} action(s) reach Knowledge Catalog only; the ` +
+        `Spanner push deploys none of them.`);
+  }
+  const constraints = resolved.model.constraints ?? [];
+  if (constraints.length) {
+    warnings.push(
+        `${constraints.length} constraint(s) reach Knowledge Catalog only; ` +
+        `the Spanner push deploys none of them.`);
+  }
+
   // Spanner Graph has no MEASURE, so a model-level metric cannot be expressed
   // in the graph. Drop each with a warning rather than silently omit it, so an
   // author who expects a metric in the graph learns it lives elsewhere (a

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -116,6 +116,9 @@ export function validatePushRequirements(
     // to dispatch it. (The "exactly one executor kind" rule is already
     // guaranteed by the loader schema, so it cannot reach here.)
     errors.push(...validateActions(model, document));
+
+    // Constraints are logical invariants, target-independent like actions.
+    errors.push(...validateConstraints(model, document));
   }
   return errors;
 }
@@ -147,6 +150,44 @@ function validateActions(model: SemanticModel, document: string): string[] {
   return errors;
 }
 
+
+// Static, target-independent checks for a model's constraints. A constraint's
+// `expression` is a logical boolean invariant, resolved against the ontology by
+// the evaluator at action time, so validation here is deliberately light:
+//   - the expression must be non-empty;
+//   - when it opens with a `<Entity>.<field>` qualifier that names a KNOWN
+//     entity, that entity must actually declare the field -- this catches a typo
+//     that would otherwise surface only inside an agent's rejected action.
+// A leading qualifier that is not a known entity (a relationship-qualified name
+// like `OrderedAs.quantity`, a metric reference, or compound logic) is left to
+// the evaluator rather than guessed at here, so a valid constraint is never
+// falsely rejected.
+function validateConstraints(model: SemanticModel, document: string): string[] {
+  const errors: string[] = [];
+  for (const c of model.constraints ?? []) {
+    const where =
+        `constraint '${c.name}' in model '${model.name}' (${document})`;
+    if (!c.expression.trim()) {
+      errors.push(`${where} has an empty expression.`);
+      continue;
+    }
+    const ref = leadingFieldRef(c.expression);
+    if (!ref) continue;
+    const entity = (model.entities ?? []).find(e => e.name === ref.entity);
+    if (entity && !entity.fields.some(f => f.name === ref.field)) {
+      errors.push(`${where} references '${ref.entity}.${ref.field}', but ` +
+          `entity '${ref.entity}' declares no field '${ref.field}'.`);
+    }
+  }
+  return errors;
+}
+
+// The leading `<name>.<field>` qualifier of a constraint expression, or null
+// when it does not open with one.
+function leadingFieldRef(expr: string): {entity: string; field: string}|null {
+  const m = expr.trim().match(/^([A-Za-z_]\w*)\.([A-Za-z_]\w*)/);
+  return m ? {entity: m[1], field: m[2]} : null;
+}
 
 // The executor coordinate fields that are absent or blank. An executor with no
 // gaps yields an empty list.

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -13,6 +13,7 @@ import {BigQueryClient} from '../gcp/bigquery';
 import {googleDeploymentTargets} from './deploy_bigquery';
 import {Executor, SemanticModel} from './ir';
 import {LoadedModel} from './loader';
+import {resolveInheritance} from './resolve_inheritance';
 
 // Checks every model against the push requirements and returns the collected
 // error messages (empty when all models pass), each tagged with the model's
@@ -23,8 +24,14 @@ import {LoadedModel} from './loader';
 // graph. A graph leg never sets it, so a bq/spanner/all push still requires
 // exactly one target. A KC-only push ignores its deployment target entirely --
 // it deploys no graph.
+//
+// `fieldsPruned` says the caller has already dropped every field the selected
+// binding profile leaves unbound, so `entity.fields` is a subset of what the
+// author declared. Checks that read a field list have to stand down for such a
+// model (see validateConstraints).
 export function validatePushRequirements(
-    models: LoadedModel[], opts: {targetOptional?: boolean} = {}): string[] {
+    models: LoadedModel[],
+    opts: {targetOptional?: boolean; fieldsPruned?: boolean} = {}): string[] {
   const errors: string[] = [];
   for (const {document, model} of models) {
     let deployInfo: ReturnType<typeof googleDeploymentTargets>;
@@ -118,7 +125,8 @@ export function validatePushRequirements(
     errors.push(...validateActions(model, document));
 
     // Constraints are logical invariants, target-independent like actions.
-    errors.push(...validateConstraints(model, document));
+    errors.push(
+        ...validateConstraints(model, document, !!opts.fieldsPruned));
   }
   return errors;
 }
@@ -151,35 +159,63 @@ function validateActions(model: SemanticModel, document: string): string[] {
 }
 
 
-// Static, target-independent checks for a model's constraints. A constraint's
-// `expression` is a logical boolean invariant, resolved against the ontology by
-// the evaluator at action time, so validation here is deliberately light:
+// Static, target-independent checks for a model's constraints. Two checks:
 //   - the expression must be non-empty;
-//   - when it opens with a `<Entity>.<field>` qualifier that names a KNOWN
-//     entity, that entity must actually declare the field -- this catches a typo
-//     that would otherwise surface only inside an agent's rejected action.
-// A leading qualifier that is not a known entity (a relationship-qualified name
-// like `OrderedAs.quantity`, a metric reference, or compound logic) is left to
-// the evaluator rather than guessed at here, so a valid constraint is never
-// falsely rejected.
-function validateConstraints(model: SemanticModel, document: string): string[] {
+//   - when it opens with a `<Entity>.<field>` qualifier naming a KNOWN entity,
+//     that entity must declare the field. This catches a typo that would
+//     otherwise surface only inside an agent's rejected action.
+// Everything else is left alone. The expression is a logical invariant, and
+// whatever evaluates it resolves it against the ontology. So a leading
+// qualifier that is not a known entity is not guessed at here: a
+// relationship-qualified name like `OrderedAs.quantity`, a metric reference,
+// compound logic. A valid constraint must never be falsely rejected.
+//
+// Keeping that promise takes care, because the model reaching this function is
+// not the document the author wrote. Its field lists have moved twice:
+//   - Inheritance is still AS DECLARED. `extends` is flattened by the graph
+//     legs, which run after this gate, so a subtype's `fields` here omit every
+//     field it inherits. Looking the field up on the resolved model fixes that.
+//   - A profile push has already pruned unbound fields (`fieldsPruned`). The
+//     author's field is gone from the model, and resolving does not bring it
+//     back, so the field check stands down. A constraint reaches no graph in
+//     any case, and failing a push over a field this profile does not bind
+//     would refuse a deploy for no reason.
+function validateConstraints(
+    model: SemanticModel, document: string, fieldsPruned: boolean): string[] {
   const errors: string[] = [];
-  for (const c of model.constraints ?? []) {
+  const constraints = model.constraints ?? [];
+  if (!constraints.length) return errors;
+  const fieldsByEntity = fieldsPruned ? undefined : declaredFields(model);
+
+  for (const c of constraints) {
     const where =
         `constraint '${c.name}' in model '${model.name}' (${document})`;
     if (!c.expression.trim()) {
       errors.push(`${where} has an empty expression.`);
       continue;
     }
+    if (!fieldsByEntity) continue;
     const ref = leadingFieldRef(c.expression);
     if (!ref) continue;
-    const entity = (model.entities ?? []).find(e => e.name === ref.entity);
-    if (entity && !entity.fields.some(f => f.name === ref.field)) {
+    const fields = fieldsByEntity.get(ref.entity);
+    if (fields && !fields.has(ref.field)) {
       errors.push(`${where} references '${ref.entity}.${ref.field}', but ` +
           `entity '${ref.entity}' declares no field '${ref.field}'.`);
     }
   }
   return errors;
+}
+
+// Every field each entity has, inherited ones included. Inheritance is resolved
+// through the same pass the graph legs use rather than by walking `extends`
+// here, so the two can never disagree about what a subtype has. The pass
+// clones, so it is skipped for a model that declares no inheritance.
+function declaredFields(model: SemanticModel): Map<string, Set<string>> {
+  const inherits = (model.entities ?? []).some(e => e.extends?.length);
+  const entities =
+      (inherits ? resolveInheritance(model).model : model).entities ?? [];
+  return new Map(
+      entities.map(e => [e.name, new Set((e.fields ?? []).map(f => f.name))]));
 }
 
 // The leading `<name>.<field>` qualifier of a constraint expression, or null

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -621,10 +621,10 @@ export async function push(options: PushOptions): Promise<number> {
           '.');
     }
 
-    // Actions have no BigQuery/Spanner Graph construct -- their only destination
-    // is Knowledge Catalog. A push that omits the KC leg (--no-kc) would
-    // validate a model's actions and then deploy them nowhere, so warn rather
-    // than drop them silently.
+    // Actions and constraints have no BigQuery/Spanner Graph construct -- their
+    // only destination is Knowledge Catalog. A push that omits the KC leg
+    // (--no-kc) would validate them and then deploy them nowhere, so warn
+    // rather than drop them silently.
     if (!kcEnabled) {
       // The loop above already loaded every document that contributes a graph.
       // Only the rest need loading, which is usually none, and a model that

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -464,8 +464,8 @@ export async function push(options: PushOptions): Promise<number> {
               }
             }
           }
-          const validationErrors =
-              validatePushRequirements(models, {targetOptional: !prune});
+          const validationErrors = validatePushRequirements(
+              models, {targetOptional: !prune, fieldsPruned: prune});
           if (validationErrors.length) {
             for (const e of validationErrors) console.error(`Error: ${e}`);
             return null;
@@ -553,7 +553,18 @@ export async function push(options: PushOptions): Promise<number> {
     let deployedGraphs = 0;
     // Model name -> action count, and the documents already loaded below, so
     // the --no-kc actions warning can reuse this pass instead of repeating it.
-    const actionCounts = new Map<string, number>();
+    // Per model, what deploys through the Knowledge Catalog leg ALONE:
+    // actions and constraints both have a catalog home and no graph one, so a
+    // push that omits that leg has to account for either.
+    const catalogOnly = new Map<string, {actions: number; constraints: number}>();
+    const noteCatalogOnly = (loaded: LoadedModel[]) => {
+      for (const {model} of loaded) {
+        const actions = model.actions?.length ?? 0;
+        const constraints = model.constraints?.length ?? 0;
+        if (actions || constraints)
+          catalogOnly.set(model.name, {actions, constraints});
+      }
+    };
     const loadedDocs = new Set<string>();
     for (const profileName of graphProfileNames) {
       // --all-profiles fans out over every model's profiles, so a model that
@@ -569,9 +580,7 @@ export async function push(options: PushOptions): Promise<number> {
       const prepared = await prepareOnce(docs, profileName, true);
       if (!prepared) return 1;
       for (const d of docs) loadedDocs.add(d.name);
-      for (const {model} of prepared.models) {
-        if (model.actions?.length) actionCounts.set(model.name, model.actions.length);
-      }
+      noteCatalogOnly(prepared.models);
       // Fail before any deploy if this profile's targets collide with a graph an
       // earlier profile already claimed this run.
       for (const m of prepared.models) {
@@ -621,10 +630,10 @@ export async function push(options: PushOptions): Promise<number> {
           '.');
     }
 
-    // Actions and constraints have no BigQuery/Spanner Graph construct -- their
-    // only destination is Knowledge Catalog. A push that omits the KC leg
-    // (--no-kc) would validate them and then deploy them nowhere, so warn
-    // rather than drop them silently.
+    // Neither a BigQuery nor a Spanner property graph has a construct for an
+    // action or a constraint, so Knowledge Catalog is their only destination. A
+    // push that omits the KC leg (--no-kc) would validate them and then deploy
+    // them nowhere. Warn instead of dropping them silently.
     if (!kcEnabled) {
       // The loop above already loaded every document that contributes a graph.
       // Only the rest need loading, which is usually none, and a model that
@@ -640,16 +649,10 @@ export async function push(options: PushOptions): Promise<number> {
         // same document fails the default push through the Knowledge Catalog
         // leg, so --no-kc fails on it too.
         if (!prepared) return 1;
-        for (const {model} of prepared.models) {
-          if (model.actions?.length)
-            actionCounts.set(model.name, model.actions.length);
-        }
+        noteCatalogOnly(prepared.models);
       }
-      for (const [name, n] of actionCounts) {
-        console.warn(
-            `Warning: model '${name}' declares ${n} action(s), which ` +
-            `deploy only to Knowledge Catalog; --no-kc excludes that leg, so ` +
-            `they will not be deployed. Drop --no-kc to deploy them.`);
+      for (const [name, n] of catalogOnly) {
+        console.warn(`Warning: ${catalogOnlyWarning(name, n)}`);
       }
     }
 
@@ -1150,4 +1153,21 @@ export async function owl(
 // Selects the singular or plural form based on `n` (English count agreement).
 function plural(n: number, one: string, many: string): string {
   return n === 1 ? one : many;
+}
+
+
+// What `--no-kc` costs a model that declares catalog-only constructs. Both
+// actions and constraints deploy through the Knowledge Catalog leg alone, so
+// either one on its own is worth a warning, and a model with both gets one
+// sentence naming both. Exported for the same reason checkPushSelection is: it
+// is a pure decision about what a flag combination means.
+export function catalogOnlyWarning(
+    model: string, n: {actions: number; constraints: number}): string {
+  const declared = [
+    n.actions ? `${n.actions} action(s)` : '',
+    n.constraints ? `${n.constraints} constraint(s)` : '',
+  ].filter(part => part).join(' and ');
+  return `model '${model}' declares ${declared}, which deploy only to ` +
+      `Knowledge Catalog; --no-kc excludes that leg, so they will not be ` +
+      `deployed. Drop --no-kc to deploy them.`;
 }

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -1,0 +1,340 @@
+// Behavior specification for model-level CONSTRAINTS -- the named invariants
+// that gate an action -- across the pipeline: loader parsing, the push-time
+// validation gate, the OSI round trip, and the Knowledge Catalog publish/pull
+// round trip. Constraints have no built-in system type, so they publish as one
+// entry each under the custom `semantic-constraint` type, exactly as actions
+// publish under `semantic-action`.
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
+import {generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
+import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
+import {serializeModel} from '../../../src/libts/semantic/osi_converter';
+import {validatePushRequirements} from '../../../src/libts/semantic/validate';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const OPTS = {
+  project: 'dest',
+  location: 'us',
+  entryGroup: 'eg'
+};
+
+function loadFixtureModel(name: string): SemanticModel {
+  const text = fs.readFileSync(path.join(FIXTURES, name), 'utf8');
+  return loadModels(text).models[0];
+}
+
+// A one-entity document with a constraints array, for focused loader tests.
+function withConstraints(constraints: any[], over: any = {}) {
+  return fromDocument({
+    version: '0.2.0.dev0/google',
+    semantic_model: [{
+      name: 'm',
+      datasets: [{
+        name: 'customer',
+        source: 'p.d.c',
+        primary_key: ['id'],
+        fields: [{
+          name: 'balance',
+          expression: {dialects: [{dialect: 'ANSI_SQL', expression: 'balance'}]},
+        }],
+      }],
+      constraints,
+      ...over,
+    }],
+  });
+}
+
+
+describe('loader parses constraints', () => {
+  test('reads name, expression, and description', () => {
+    const {models, warnings} = withConstraints([{
+      name: 'NonNegativeBalance',
+      expression: 'customer.balance >= 0',
+      description: 'A balance cannot go negative.',
+    }]);
+    // Scoped to constraints: the fixture's field expression emits an unrelated
+    // dialect note.
+    expect(warnings.filter(w => w.includes('constraint'))).toEqual([]);
+    expect(models[0].constraints).toEqual([{
+      name: 'NonNegativeBalance',
+      expression: 'customer.balance >= 0',
+      description: 'A balance cannot go negative.',
+    }]);
+  });
+
+  test('a model without constraints leaves model.constraints unset', () => {
+    const {models} = fromDocument({
+      version: '0.2.0.dev0/google',
+      semantic_model: [{
+        name: 'm',
+        datasets:
+            [{name: 'customer', source: 'p.d.c', primary_key: ['id'], fields: []}],
+      }],
+    });
+    expect(models[0].constraints).toBeUndefined();
+  });
+
+  test('description is optional', () => {
+    const {models} =
+        withConstraints([{name: 'C', expression: 'customer.balance >= 0'}]);
+    expect(models[0].constraints).toEqual([
+      {name: 'C', expression: 'customer.balance >= 0'}
+    ]);
+  });
+
+  test('the expression is kept verbatim, not parsed', () => {
+    // A compound expression the loader has no business interpreting: it belongs
+    // to the evaluator, so it must survive character for character.
+    const expr = 'customer.balance >= 0 AND (total_revenue > 100 OR NOT flagged)';
+    const {models} = withConstraints([{name: 'C', expression: expr}]);
+    expect(models[0].constraints![0].expression).toBe(expr);
+  });
+
+  test('a constraint with no expression is rejected at parse', () => {
+    expect(() => withConstraints([{name: 'C'}])).toThrow();
+  });
+
+  test('duplicate constraint names are rejected', () => {
+    // A duplicate name is a hard load error in every other scope, and for the
+    // same reason: an action naming a constraint would not say which it meant.
+    expect(() => withConstraints([
+             {name: 'C', expression: 'customer.balance >= 0'},
+             {name: 'C', expression: 'customer.balance < 100'},
+           ])).toThrow(/duplicate constraint name 'C'/);
+  });
+
+  test('ai_context rides the constraint onto the IR', () => {
+    const {models} = withConstraints([{
+      name: 'C',
+      expression: 'customer.balance >= 0',
+      ai_context: {instructions: 'Explain the shortfall in currency terms.'},
+    }]);
+    expect(models[0].constraints![0].aiContext)
+        .toEqual({instructions: 'Explain the shortfall in currency terms.'});
+  });
+
+  test('custom_extensions on a constraint is rejected', () => {
+    // A constraint is a native key of the extended profile, and that profile
+    // has no `custom_extensions` surface at all -- the native keys replace it.
+    expect(() => withConstraints([{
+             name: 'C',
+             expression: 'customer.balance >= 0',
+             custom_extensions: [{vendor_name: 'ACME', data: '{}'}],
+           }])).toThrow(/custom_extensions/);
+  });
+});
+
+
+describe('validatePushRequirements gates constraints', () => {
+  const target =
+      '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
+  const googleExt = {
+    vendorName: 'GOOGLE',
+    data: JSON.stringify({deploymentTargets: [target]})
+  };
+
+  function loaded(constraints: any[]): LoadedModel {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{
+        name: 'customer',
+        dataSource: 'p.d.c',
+        keys: ['id'],
+        fields: [{name: 'balance'}],
+      }],
+      relationships: [],
+      metrics: [],
+      constraints,
+      customExtensions: [googleExt],
+    };
+    return {document: 'doc', model};
+  }
+
+  test('a well-formed constraint passes', () => {
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'customer.balance >= 0'}])]);
+    expect(errs).toEqual([]);
+  });
+
+  test('an empty expression is a hard error', () => {
+    const errs =
+        validatePushRequirements([loaded([{name: 'C', expression: '   '}])]);
+    expect(errs.some(e => e.includes("constraint 'C'") &&
+                      e.includes('empty expression')))
+        .toBe(true);
+  });
+
+  test('an unknown field on a KNOWN entity is a hard error', () => {
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'customer.blance >= 0'}])]);
+    expect(errs.some(e => e.includes('customer.blance'))).toBe(true);
+  });
+
+  test('a leading qualifier that is not an entity is left to the evaluator',
+       () => {
+         // `OrderedAs` is a relationship, not an entity -- guessing here would
+         // falsely reject a valid constraint, so validation stays out of it.
+         const errs = validatePushRequirements(
+             [loaded([{name: 'C', expression: 'OrderedAs.quantity > 0'}])]);
+         expect(errs).toEqual([]);
+       });
+
+  test('an expression that does not open with a field ref passes', () => {
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'COUNT(*) > 0'}])]);
+    expect(errs).toEqual([]);
+  });
+});
+
+
+describe('OSI round trip', () => {
+  test('constraints survive serialize -> reload', () => {
+    const model = loadFixtureModel('actions_place_order.yaml');
+    expect(model.constraints).toHaveLength(2);
+    const {yaml} = serializeModel(model);
+    expect(yaml).toContain('constraints:');
+    const reloaded = loadModels(yaml).models[0];
+    expect(reloaded.constraints).toEqual(model.constraints);
+  });
+
+  test('a model with no constraints emits no constraints key', () => {
+    const model = loadFixtureModel('actions_place_order.yaml');
+    const {yaml} = serializeModel({...model, constraints: undefined});
+    expect(yaml).not.toContain('constraints:');
+  });
+});
+
+
+describe('Knowledge Catalog publish/pull round trip', () => {
+  const model = loadFixtureModel('actions_place_order.yaml');
+  const CONSTRAINT_ENTRY_TYPE = '/entryTypes/semantic-constraint';
+  const CONSTRAINT_ASPECT = 'dest.global.semantic-constraint';
+
+  function constraintEntriesOf(m: SemanticModel) {
+    return generateCatalogResources(m, OPTS)
+        .entries.filter(e => e.entryType.endsWith(CONSTRAINT_ENTRY_TYPE));
+  }
+
+  test('every constraint becomes one entry, parented to the model anchor',
+       () => {
+         const {entries, warnings} = generateCatalogResources(model, OPTS);
+         const constraints =
+             entries.filter(e => e.entryType.endsWith(CONSTRAINT_ENTRY_TYPE));
+         expect(constraints.map(e => e.name.split('/entries/')[1])).toEqual([
+           'sales.constraints.NonNegativeOrderTotal',
+           'sales.constraints.PositiveQuantity',
+         ]);
+         for (const e of constraints) expect(e.parentEntry).toBe(entries[0].name);
+         // Author is warned constraints are catalog-only.
+         expect(warnings.some(w => w.includes('constraint(s) published')))
+             .toBe(true);
+       });
+
+  test('the entry type is custom, so it lives in the destination project',
+       () => {
+         // Every built-in type is referenced from `dataplex-types`; this one is
+         // provisioned by `kcmd init` in the project being pushed to.
+         const [first] = constraintEntriesOf(model);
+         expect(first.entryType)
+             .toBe('projects/dest/locations/global/entryTypes/' +
+                   'semantic-constraint');
+         expect(first.aspects![CONSTRAINT_ASPECT].aspectType)
+             .toBe('projects/dest/locations/global/aspectTypes/' +
+                   'semantic-constraint');
+       });
+
+  test('the aspect carries the expression and the entry source the description',
+       () => {
+         const [nonNegative] = constraintEntriesOf(model);
+         expect(nonNegative.aspects![CONSTRAINT_ASPECT].data)
+             .toEqual({expression: 'orders.o_totalprice >= 0'});
+         // The description is the message a violation quotes back, so it is the
+         // entry's human-readable summary rather than an aspect field.
+         expect(nonNegative.entrySource!.displayName)
+             .toBe('NonNegativeOrderTotal');
+         expect(nonNegative.entrySource!.description)
+             .toContain('cannot be negative');
+       });
+
+  test('ai_context instructions ride the constraint\'s own aspect', () => {
+    const withAi: SemanticModel = {
+      ...model,
+      constraints: [{
+        name: 'C',
+        expression: 'orders.o_totalprice >= 0',
+        aiContext: {instructions: 'Explain the shortfall in currency terms.'},
+      }],
+    };
+    expect(constraintEntriesOf(withAi)[0].aspects![CONSTRAINT_ASPECT].data)
+        .toEqual({
+          expression: 'orders.o_totalprice >= 0',
+          instructions: 'Explain the shortfall in currency terms.',
+        });
+  });
+
+  test('a model with no constraints publishes no constraint entry', () => {
+    const none: SemanticModel = {...model, constraints: undefined};
+    expect(constraintEntriesOf(none)).toEqual([]);
+  });
+
+  test('the constraint prefix is owned, so a dropped constraint is deleted',
+       () => {
+         // Delete reconciliation removes server entries under an owned prefix
+         // that this push did not re-emit; without the prefix a constraint
+         // dropped from the model would linger in the catalog.
+         const {ownedPrefixes} = generateCatalogResources(model, OPTS);
+         expect(ownedPrefixes).toContain('sales.constraints.');
+       });
+
+  test('a pull recovers the constraints', () => {
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    expect(models[0].constraints).toEqual(model.constraints);
+  });
+
+  test('a pull recovers actions and constraints together', () => {
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    expect(models[0].actions).toEqual(model.actions);
+    expect(models[0].constraints).toEqual(model.constraints);
+  });
+
+  test('a second push of the pulled model produces the same entries', () => {
+    // Push -> pull -> push has to be a fixed point: if it were not, a pull
+    // followed by a push would rewrite entries that nobody edited.
+    const first = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(first.entries, first.entryLinks);
+    const second = generateCatalogResources(models[0], OPTS);
+
+    const constraintsOf = (entries: typeof first.entries) =>
+        entries.filter(e => e.entryType.endsWith(CONSTRAINT_ENTRY_TYPE))
+            .map(e => [e.name, e.aspects![CONSTRAINT_ASPECT].data])
+            .sort();
+    expect(constraintsOf(second.entries))
+        .toEqual(constraintsOf(first.entries));
+  });
+
+  test('an entry whose expression is blank is skipped and warned', () => {
+    // A hand-edited aspect can carry a blank expression. Such a constraint
+    // states no invariant, so it degrades itself rather than the pull.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const broken = entries.find(
+        e => e.entrySource?.displayName === 'PositiveQuantity')!;
+    broken.aspects![CONSTRAINT_ASPECT].data!.expression = '  ';
+    const {models, warnings} = modelsFromCatalogResources(entries);
+    expect(models[0].constraints!.map(c => c.name)).toEqual([
+      'NonNegativeOrderTotal'
+    ]);
+    expect(warnings.some(
+               w => w.includes("constraint 'PositiveQuantity'") &&
+                   w.includes('no expression')))
+        .toBe(true);
+    // The actions, published under their own type, are unaffected.
+    expect(models[0].actions).toHaveLength(1);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -1,19 +1,21 @@
-// Behavior specification for model-level CONSTRAINTS -- the named invariants
-// that gate an action -- across the pipeline: loader parsing, the push-time
-// validation gate, the OSI round trip, and the Knowledge Catalog publish/pull
-// round trip. Constraints have no built-in system type, so they publish as one
-// entry each under the custom `semantic-constraint` type, exactly as actions
-// publish under `semantic-action`.
+// Behavior specification for model-level CONSTRAINTS: the named invariants a
+// model states over its ontology. Covers the whole pipeline -- loader parsing,
+// the push-time validation gate, the OSI round trip, and the Knowledge Catalog
+// publish/pull round trip. Dataplex has no built-in constraint type, so a
+// constraint publishes as one entry under the custom `semantic-constraint`
+// type, the way an action publishes under `semantic-action`.
 
 import {describe, expect, test} from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import {generatePropertyGraph} from '../../../src/libts/semantic/bigquery';
 import {SemanticModel} from '../../../src/libts/semantic/ir';
 import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
 import {generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
 import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
 import {serializeModel} from '../../../src/libts/semantic/osi_converter';
+import {generateSpannerPropertyGraph} from '../../../src/libts/semantic/spanner';
 import {validatePushRequirements} from '../../../src/libts/semantic/validate';
 
 const FIXTURES = path.join(__dirname, 'fixtures');
@@ -177,8 +179,9 @@ describe('validatePushRequirements gates constraints', () => {
 
   test('a leading qualifier that is not an entity is left to the evaluator',
        () => {
-         // `OrderedAs` is a relationship, not an entity -- guessing here would
-         // falsely reject a valid constraint, so validation stays out of it.
+         // `OrderedAs` names a relationship rather than an entity. Guessing
+         // here would falsely reject a valid constraint, so validation stays
+         // out of it.
          const errs = validatePushRequirements(
              [loaded([{name: 'C', expression: 'OrderedAs.quantity > 0'}])]);
          expect(errs).toEqual([]);
@@ -188,6 +191,69 @@ describe('validatePushRequirements gates constraints', () => {
     const errs = validatePushRequirements(
         [loaded([{name: 'C', expression: 'COUNT(*) > 0'}])]);
     expect(errs).toEqual([]);
+  });
+
+  // The field check reads a field list, and by the time this gate runs the
+  // model's field lists are no longer what the author wrote. Both directions
+  // of that gap rejected a valid constraint.
+
+  // `extends` is flattened by the graph legs, which run AFTER this gate, so a
+  // subtype's own `fields` omit everything it inherits.
+  function withInheritance(expression: string): LoadedModel {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [
+        {
+          name: 'account',
+          dataSource: 'p.d.a',
+          keys: ['id'],
+          fields: [{name: 'balance'}],
+        },
+        {
+          name: 'savings',
+          dataSource: 'p.d.s',
+          keys: ['id'],
+          fields: [],
+          extends: ['account'],
+        },
+      ],
+      relationships: [],
+      metrics: [],
+      constraints: [{name: 'C', expression}],
+      customExtensions: [googleExt],
+    };
+    return {document: 'doc', model};
+  }
+
+  test('a constraint over an INHERITED field passes', () => {
+    const errs = validatePushRequirements([withInheritance('savings.balance >= 0')]);
+    expect(errs).toEqual([]);
+  });
+
+  test('a typo is still caught on an entity that inherits', () => {
+    const errs = validatePushRequirements([withInheritance('savings.blance >= 0')]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain(`declares no field 'blance'`);
+  });
+
+  test('the field check stands down once the profile has pruned fields', () => {
+    // A profile push drops every field the profile leaves unbound before this
+    // gate sees the model, so the author's field is gone rather than misspelt.
+    // A constraint reaches no graph in any case, so failing the push here would
+    // refuse a deploy for no reason.
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'customer.unbound >= 0'}])],
+        {fieldsPruned: true});
+    expect(errs).toEqual([]);
+  });
+
+  test('an empty expression is rejected even on a pruned model', () => {
+    // Standing down applies to the field check alone; the expression itself is
+    // still the constraint's whole content.
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: '   '}])], {fieldsPruned: true});
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain('empty expression');
   });
 });
 
@@ -355,5 +421,40 @@ describe('Knowledge Catalog publish/pull round trip', () => {
         .toBe(true);
     // The actions, published under their own type, are unaffected.
     expect(models[0].actions).toHaveLength(1);
+  });
+});
+
+
+// Knowledge Catalog is the only system an action or a constraint reaches, so a
+// push to any other target deploys neither. Dropping them silently is the
+// failure mode worth guarding: an author who declared a rule and sees a clean
+// push has no way to learn it went nowhere.
+describe('a graph leg says what it dropped', () => {
+  const model = () => loadFixtureModel('actions_place_order.yaml');
+
+  for (const [backend, generate] of [
+           ['BigQuery', generatePropertyGraph],
+           ['Spanner', generateSpannerPropertyGraph],
+  ] as const) {
+    test(`the ${backend} leg warns about actions and constraints`, () => {
+      const {warnings} = generate(model());
+      // The fixture declares one action and two constraints.
+      expect(warnings.some(
+                 w => /1 action\(s\) reach Knowledge Catalog only/.test(w)))
+          .toBe(true);
+      expect(warnings.some(
+                 w => /2 constraint\(s\) reach Knowledge Catalog only/.test(w)))
+          .toBe(true);
+      // Named the system it does reach, and the one that drops it.
+      expect(warnings.some(w => w.includes(`the ${backend} push deploys none`)))
+          .toBe(true);
+    });
+  }
+
+  test('a model with neither is quiet about both', () => {
+    const {warnings} = generatePropertyGraph(
+        loadFixtureModel('star_orders_customer.yaml'));
+    expect(warnings.some(w => /reach Knowledge Catalog only/.test(w)))
+        .toBe(false);
   });
 });

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -250,31 +250,50 @@ describe('Knowledge Catalog publish/pull round trip', () => {
 
   test('the aspect carries the expression and the entry source the description',
        () => {
-         const [nonNegative] = constraintEntriesOf(model);
-         expect(nonNegative.aspects![CONSTRAINT_ASPECT].data)
-             .toEqual({expression: 'orders.o_totalprice >= 0'});
+         // PositiveQuantity is the fixture's constraint with no `ai_context`,
+         // so its aspect is the expression alone.
+         const positive = constraintEntriesOf(model).find(
+             e => e.entrySource!.displayName === 'PositiveQuantity')!;
+         expect(positive.aspects![CONSTRAINT_ASPECT].data)
+             .toEqual({expression: 'OrderedAs.quantity > 0'});
          // The description is the message a violation quotes back, so it is the
          // entry's human-readable summary rather than an aspect field.
-         expect(nonNegative.entrySource!.displayName)
-             .toBe('NonNegativeOrderTotal');
-         expect(nonNegative.entrySource!.description)
-             .toContain('cannot be negative');
+         expect(positive.entrySource!.description)
+             .toBe('An order line must be for at least one unit.');
        });
 
-  test('ai_context instructions ride the constraint\'s own aspect', () => {
-    const withAi: SemanticModel = {
-      ...model,
-      constraints: [{
-        name: 'C',
-        expression: 'orders.o_totalprice >= 0',
-        aiContext: {instructions: 'Explain the shortfall in currency terms.'},
-      }],
-    };
-    expect(constraintEntriesOf(withAi)[0].aspects![CONSTRAINT_ASPECT].data)
-        .toEqual({
-          expression: 'orders.o_totalprice >= 0',
-          instructions: 'Explain the shortfall in currency terms.',
-        });
+  test('the whole ai_context rides the constraint\'s own aspect', () => {
+    // Not `instructions` alone: the built-in guidelines aspect has a home for
+    // that part only, and a custom aspect kcmd defines has no reason to lose
+    // the other two. The fixture declares all three so this is browsable.
+    const [nonNegative] = constraintEntriesOf(model);
+    expect(nonNegative.entrySource!.displayName).toBe('NonNegativeOrderTotal');
+    expect(nonNegative.aspects![CONSTRAINT_ASPECT].data).toEqual({
+      expression: 'orders.o_totalprice >= 0',
+      aiContext: {
+        instructions:
+            'Quote the shortfall in the customer\'s own currency when refusing.',
+        synonyms: ['NoNegativeTotals', 'NonNegativeTotal'],
+        examples: ['Why was my order rejected?'],
+      },
+    });
+  });
+
+  test('a pull recovers every part of the ai_context', () => {
+    // The emit side above and this read side are what make the annotation
+    // survive a round trip; dropping either would lose a declared field
+    // silently, since the pull rewrites the document it read.
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    expect(models[0].constraints![0].aiContext).toEqual({
+      instructions:
+          'Quote the shortfall in the customer\'s own currency when refusing.',
+      synonyms: ['NoNegativeTotals', 'NonNegativeTotal'],
+      examples: ['Why was my order rejected?'],
+    });
+    // The constraint that declares none stays clean rather than gaining an
+    // empty record.
+    expect(models[0].constraints![1].aiContext).toBeUndefined();
   });
 
   test('a model with no constraints publishes no constraint entry', () => {

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
@@ -1,0 +1,252 @@
+{
+  "entries": [
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entryType": "projects/dataplex-types/locations/global/entryTypes/semantic-model",
+      "entrySource": {
+        "displayName": "sales",
+        "description": "Sales orders with customer attributes"
+      },
+      "aspects": {
+        "dataplex-types.global.semantic-model": {
+          "aspectType": "projects/dataplex-types/locations/global/aspectTypes/semantic-model",
+          "data": {
+            "deploymentTargets": [
+              "//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.entities.orders",
+      "entryType": "projects/dataplex-types/locations/global/entryTypes/semantic-entity",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "orders"
+      },
+      "aspects": {
+        "dataplex-types.global.semantic-entity": {
+          "aspectType": "projects/dataplex-types/locations/global/aspectTypes/semantic-entity",
+          "data": {
+            "source": {
+              "resources": [
+                "//bigquery.googleapis.com/projects/samples/datasets/tpch/tables/orders"
+              ]
+            }
+          }
+        },
+        "dataplex-types.global.schema": {
+          "aspectType": "projects/dataplex-types/locations/global/aspectTypes/schema",
+          "data": {
+            "fields": [
+              {
+                "name": "o_orderkey",
+                "dataType": "STRING",
+                "metadataType": "OTHER"
+              },
+              {
+                "name": "o_custkey",
+                "dataType": "STRING",
+                "metadataType": "OTHER"
+              },
+              {
+                "name": "o_totalprice",
+                "dataType": "STRING",
+                "metadataType": "OTHER"
+              }
+            ],
+            "primaryKey": {
+              "fields": [
+                "o_orderkey"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.entities.customer",
+      "entryType": "projects/dataplex-types/locations/global/entryTypes/semantic-entity",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "customer"
+      },
+      "aspects": {
+        "dataplex-types.global.semantic-entity": {
+          "aspectType": "projects/dataplex-types/locations/global/aspectTypes/semantic-entity",
+          "data": {
+            "source": {
+              "resources": [
+                "//bigquery.googleapis.com/projects/samples/datasets/tpch/tables/customer"
+              ]
+            }
+          }
+        },
+        "dataplex-types.global.schema": {
+          "aspectType": "projects/dataplex-types/locations/global/aspectTypes/schema",
+          "data": {
+            "fields": [
+              {
+                "name": "c_custkey",
+                "dataType": "STRING",
+                "metadataType": "OTHER"
+              },
+              {
+                "name": "c_name",
+                "dataType": "STRING",
+                "metadataType": "OTHER"
+              }
+            ],
+            "primaryKey": {
+              "fields": [
+                "c_custkey"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.metrics.total_revenue",
+      "entryType": "projects/dataplex-types/locations/global/entryTypes/semantic-metric",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "total_revenue",
+        "description": "Total order revenue"
+      },
+      "aspects": {
+        "dataplex-types.global.semantic-metric": {
+          "aspectType": "projects/dataplex-types/locations/global/aspectTypes/semantic-metric",
+          "data": {
+            "entity": "orders",
+            "dataType": "STRING"
+          }
+        }
+      }
+    },
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.actions.PlaceOrder",
+      "entryType": "projects/sqlgen-testing/locations/global/entryTypes/semantic-action",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "PlaceOrder",
+        "description": "Create an order for a customer"
+      },
+      "aspects": {
+        "sqlgen-testing.global.semantic-action": {
+          "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-action",
+          "data": {
+            "executorKind": "mcp",
+            "mcpServer": "//agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/commerce",
+            "mcpTool": "place_order",
+            "parameters": [
+              {
+                "name": "customer",
+                "type": "customer",
+                "isEntityRef": true
+              },
+              {
+                "name": "quantity",
+                "type": "Integer",
+                "isEntityRef": false
+              }
+            ],
+            "instructions": "Resolve the buyer to a customer before calling."
+          }
+        }
+      }
+    },
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.constraints.NonNegativeOrderTotal",
+      "entryType": "projects/sqlgen-testing/locations/global/entryTypes/semantic-constraint",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "NonNegativeOrderTotal",
+        "description": "An order's total cannot be negative. Reduce the quantity or check the unit price before retrying."
+      },
+      "aspects": {
+        "sqlgen-testing.global.semantic-constraint": {
+          "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
+          "data": {
+            "expression": "orders.o_totalprice >= 0",
+            "aiContext": {
+              "instructions": "Quote the shortfall in the customer's own currency when refusing.",
+              "synonyms": [
+                "NoNegativeTotals",
+                "NonNegativeTotal"
+              ],
+              "examples": [
+                "Why was my order rejected?"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.constraints.PositiveQuantity",
+      "entryType": "projects/sqlgen-testing/locations/global/entryTypes/semantic-constraint",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "PositiveQuantity",
+        "description": "An order line must be for at least one unit."
+      },
+      "aspects": {
+        "sqlgen-testing.global.semantic-constraint": {
+          "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
+          "data": {
+            "expression": "OrderedAs.quantity > 0"
+          }
+        }
+      }
+    }
+  ],
+  "entryLinks": [
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entryLinks/sales-orders-to-customer",
+      "entryLinkType": "projects/dataplex-types/locations/global/entryLinkTypes/schema-join",
+      "entryReferences": [
+        {
+          "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.entities.orders",
+          "type": "UNSPECIFIED"
+        },
+        {
+          "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.entities.customer",
+          "type": "UNSPECIFIED"
+        }
+      ],
+      "aspects": {
+        "dataplex-types.global.schema-join": {
+          "aspectType": "projects/dataplex-types/locations/global/aspectTypes/schema-join",
+          "data": {
+            "joins": [
+              {
+                "source": {
+                  "name": "samples.tpch.orders",
+                  "fields": [
+                    "o_custkey"
+                  ]
+                },
+                "target": {
+                  "name": "samples.tpch.customer",
+                  "fields": [
+                    "c_custkey"
+                  ]
+                },
+                "type": "FOREIGN_KEY",
+                "inferenceSource": "USER"
+              }
+            ],
+            "userManaged": true
+          }
+        }
+      }
+    }
+  ],
+  "warnings": [
+    "model 'sales': 1 action(s) published as semantic-action entries (actions have no BigQuery Graph representation).",
+    "model 'sales': 2 constraint(s) published as semantic-constraint entries (constraints have no BigQuery Graph representation).",
+    "relationship 'orders_to_customer': Knowledge Catalog stores the name only in the normalized link id, so a pull returns it lowercased/hyphenated (e.g. 'orders-to-customer'), not 'orders_to_customer'."
+  ]
+}

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
@@ -1,0 +1,85 @@
+version: 0.2.0.dev0/google
+semantic_model:
+  - name: sales
+    description: Sales orders with customer attributes
+    deployment_target: //bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales
+    entities:
+      - name: orders
+        source: samples.tpch.orders
+        primary_key:
+          - o_orderkey
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: o_orderkey
+          - name: o_custkey
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: o_custkey
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: o_totalprice
+      - name: customer
+        source: samples.tpch.customer
+        primary_key:
+          - c_custkey
+        fields:
+          - name: c_custkey
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: c_custkey
+          - name: c_name
+            expression:
+              dialects:
+                - dialect: BIGQUERY
+                  expression: c_name
+    relationships:
+      - name: orders_to_customer
+        from: orders
+        to: customer
+        from_columns:
+          - o_custkey
+        to_columns:
+          - c_custkey
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: BIGQUERY
+              expression: SUM(orders.o_totalprice)
+        description: Total order revenue
+    actions:
+      - name: PlaceOrder
+        description: Create an order for a customer
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/commerce
+            tool: place_order
+        parameters:
+          - name: customer
+            type: customer
+          - name: quantity
+            type: Integer
+        ai_context:
+          instructions: Resolve the buyer to a customer before calling.
+    constraints:
+      - name: NonNegativeOrderTotal
+        expression: orders.o_totalprice >= 0
+        description: An order's total cannot be negative. Reduce the quantity or check
+          the unit price before retrying.
+        ai_context:
+          instructions: Quote the shortfall in the customer's own currency when refusing.
+          synonyms:
+            - NoNegativeTotals
+            - NonNegativeTotal
+          examples:
+            - Why was my order rejected?
+      - name: PositiveQuantity
+        expression: OrderedAs.quantity > 0
+        description: An order line must be for at least one unit.

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
@@ -1,0 +1,67 @@
+# (no warnings)
+version: 0.2.0.dev0/google
+semantic_model:
+  - name: sales
+    description: Sales orders with customer attributes
+    deployment_target: //bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales
+    entities:
+      - name: orders
+        source: samples.tpch.orders
+        primary_key:
+          - o_orderkey
+        fields:
+          - name: o_orderkey
+            datatype: Opaque
+          - name: o_custkey
+            datatype: Opaque
+          - name: o_totalprice
+            datatype: Opaque
+      - name: customer
+        source: samples.tpch.customer
+        primary_key:
+          - c_custkey
+        fields:
+          - name: c_custkey
+            datatype: Opaque
+          - name: c_name
+            datatype: Opaque
+    relationships:
+      - name: orders-to-customer
+        from: orders
+        to: customer
+        from_columns:
+          - o_custkey
+        to_columns:
+          - c_custkey
+    metrics:
+      - name: total_revenue
+        description: Total order revenue
+    actions:
+      - name: PlaceOrder
+        description: Create an order for a customer
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/commerce
+            tool: place_order
+        parameters:
+          - name: customer
+            type: customer
+          - name: quantity
+            type: Integer
+        ai_context:
+          instructions: Resolve the buyer to a customer before calling.
+    constraints:
+      - name: NonNegativeOrderTotal
+        expression: orders.o_totalprice >= 0
+        description: An order's total cannot be negative. Reduce the quantity or check
+          the unit price before retrying.
+        ai_context:
+          instructions: Quote the shortfall in the customer's own currency when refusing.
+          synonyms:
+            - NoNegativeTotals
+            - NonNegativeTotal
+          examples:
+            - Why was my order rejected?
+      - name: PositiveQuantity
+        expression: OrderedAs.quantity > 0
+        description: An order line must be for at least one unit.

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -13,6 +13,12 @@
 # NonNegativeOrderTotal opens with a KNOWN entity, so its field is checked;
 # PositiveQuantity opens with `OrderedAs`, which is not an entity, so it is left
 # to the evaluator rather than falsely rejected.
+#
+# They also cover both annotation shapes, which land in different places:
+# NonNegativeOrderTotal declares a full `ai_context` -- instructions, synonyms
+# and examples -- beside its description, so the catalog golden shows the
+# description on the entry source and the whole `ai_context` on the aspect;
+# PositiveQuantity declares a description alone.
 
 version: "0.2.0.dev0/google"
 
@@ -85,6 +91,11 @@ semantic_model:
         description: >-
           An order's total cannot be negative. Reduce the quantity or check the
           unit price before retrying.
+        ai_context:
+          instructions: >-
+            Quote the shortfall in the customer's own currency when refusing.
+          synonyms: [NoNegativeTotals, NonNegativeTotal]
+          examples: ["Why was my order rejected?"]
       - name: PositiveQuantity
         expression: OrderedAs.quantity > 0
         description: An order line must be for at least one unit.

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -4,20 +4,20 @@
 # counterpart to a metric, and the CONSTRAINTS that gate it. PlaceOrder carries
 # an MCP executor (a tool in Agent Registry) and ontology-typed parameters: an
 # entity-typed one (`customer`, an object reference to the customer entity) and
-# scalar ones. Per-action preconditions and affects are intentionally out of
-# scope for this prototype; the gate here is model-level. A GOOGLE BigQuery
-# Graph target keeps the model executable (neither actions nor constraints
-# produce a graph element).
+# scalar ones. Per-action preconditions and affects are out of scope for this
+# prototype; the gate here is model-level. The model also names a BigQuery
+# deployment target, so a push exercises the leg that deploys neither an action
+# nor a constraint.
 #
-# The two constraints deliberately exercise both validation paths:
-# NonNegativeOrderTotal opens with a KNOWN entity, so its field is checked;
-# PositiveQuantity opens with `OrderedAs`, which is not an entity, so it is left
-# to the evaluator rather than falsely rejected.
+# The two constraints cover both validation paths. NonNegativeOrderTotal opens
+# with a KNOWN entity, so its field is checked. PositiveQuantity opens with
+# `OrderedAs`, which is no entity, so it is left to the evaluator rather than
+# falsely rejected.
 #
-# They also cover both annotation shapes, which land in different places:
-# NonNegativeOrderTotal declares a full `ai_context` -- instructions, synonyms
-# and examples -- beside its description, so the catalog golden shows the
-# description on the entry source and the whole `ai_context` on the aspect;
+# They also cover both annotation shapes, which land in different places.
+# NonNegativeOrderTotal declares a full `ai_context` beside its description --
+# instructions, synonyms and examples -- so the catalog golden shows the
+# description on the entry source and the whole `ai_context` on the aspect.
 # PositiveQuantity declares a description alone.
 
 version: "0.2.0.dev0/google"

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -1,13 +1,18 @@
 # Test fixture -- AI-first semantics format (v0.2.0.dev0/google).
 #
 # A minimal star (orders -> customer) plus a model-level ACTION, the write-side
-# counterpart to a metric. PlaceOrder carries an MCP executor (a tool in Agent
-# Registry) and ontology-typed parameters: an entity-typed one (`customer`, an
-# object reference to the customer entity) and scalar ones. Preconditions and
-# affects are intentionally out of scope for this prototype. A BigQuery Graph
-# deployment target keeps the model executable (actions produce no graph
-# element). `actions` is a native extension key, so this document declares the
-# extended profile.
+# counterpart to a metric, and the CONSTRAINTS that gate it. PlaceOrder carries
+# an MCP executor (a tool in Agent Registry) and ontology-typed parameters: an
+# entity-typed one (`customer`, an object reference to the customer entity) and
+# scalar ones. Per-action preconditions and affects are intentionally out of
+# scope for this prototype; the gate here is model-level. A GOOGLE BigQuery
+# Graph target keeps the model executable (neither actions nor constraints
+# produce a graph element).
+#
+# The two constraints deliberately exercise both validation paths:
+# NonNegativeOrderTotal opens with a KNOWN entity, so its field is checked;
+# PositiveQuantity opens with `OrderedAs`, which is not an entity, so it is left
+# to the evaluator rather than falsely rejected.
 
 version: "0.2.0.dev0/google"
 
@@ -74,3 +79,12 @@ semantic_model:
           - {name: quantity, type: Integer}
         ai_context:
           instructions: "Resolve the buyer to a customer before calling."
+    constraints:
+      - name: NonNegativeOrderTotal
+        expression: orders.o_totalprice >= 0
+        description: >-
+          An order's total cannot be negative. Reduce the quantity or check the
+          unit price before retrying.
+      - name: PositiveQuantity
+        expression: OrderedAs.quantity > 0
+        description: An order line must be for at least one unit.

--- a/toolbox/mdcode/tests/libts/semantic/kc_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/kc_converter.test.ts
@@ -753,6 +753,9 @@ describe(
         'sales_bq_graph_target.yaml',
         'star_orders_customer.yaml',
         'tpcds_date_edge.yaml',
+        // Actions and constraints publish under custom types, so this is the
+        // fixture whose pull golden shows them recovered.
+        'actions_place_order.yaml',
       ];
       const kcGoldenPath = (fixture: string) => path.join(
           FIXTURES,

--- a/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.e2e.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/knowledge_catalog.e2e.test.ts
@@ -31,11 +31,14 @@ const FIXTURES = path.join(__dirname, 'fixtures');
 //   sales_bq_graph_target -> model aspect deploymentTargets + un-typed metric
 //     (dataType fallback); star_orders_customer -> a direct-FK relationship
 //     (schema-join link) + multiple entities/metrics; tpcds_date_edge ->
-//     temporal field types.
+//     temporal field types; actions_place_order -> the custom
+//     `semantic-action` and `semantic-constraint` types, the only fixture that
+//     declares either.
 const CORPUS = [
   'sales_bq_graph_target.yaml',
   'star_orders_customer.yaml',
   'tpcds_date_edge.yaml',
+  'actions_place_order.yaml',
 ];
 
 // A fixed destination + default (dataplex-types/global) system types, so the

--- a/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
@@ -350,6 +350,10 @@ describe('golden OSI document: each corpus fixture serializes to its exact YAML'
              'sales_bq_graph_target.yaml',
              'star_orders_customer.yaml',
              'tpcds_date_edge.yaml',
+             // The only corpus fixture with actions and constraints, so it is
+             // the only golden showing the custom `semantic-action` and
+             // `semantic-constraint` types.
+             'actions_place_order.yaml',
            ];
            // Same load defaults as the KC e2e/pull goldens, so the OSI golden
            // and the pull golden are directly comparable.

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -165,10 +165,11 @@ function onlyExtendedModelBlocks(errors: typeof validate.errors): boolean {
 }
 
 // A `.pull.golden.yaml` of a fixture that declares actions or constraints trips
-// BOTH tolerated classes at once: the #290 missing-`expression` gap and the
+// two tolerated classes at once: the #290 missing-`expression` gap and the
 // extended model blocks. Each predicate above is all-or-nothing, so a document
-// hitting two of them passes neither. Tolerate the union for exactly that
-// combination rather than loosening either predicate for every other fixture.
+// hitting both passes neither. This one tolerates their union, and is applied
+// only to that combination, so neither predicate has to loosen for every other
+// fixture.
 function onlyExpressionGapAndExtendedBlocks(
   errors: typeof validate.errors): boolean {
   return !!errors && errors.length > 0 &&
@@ -217,11 +218,11 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
             onlyExtendsExtension(validate.errors)) {
           return;
         }
-        // The model-level `actions` and `constraints` blocks are a deliberate
-        // superset of released OSI (the Extended-spec proposal); tolerate
-        // exactly those extra properties and nothing else, and only on the
-        // fixtures that legitimately carry them -- so a stray `actions` or
-        // `constraints` slipping into any other fixture still fails.
+        // The model-level `actions` and `constraints` blocks are a superset
+        // of released OSI, proposed in the Extended spec. Tolerate those two
+        // extra properties and nothing else, and only on the fixtures that
+        // carry them, so a stray `actions` or `constraints` slipping into any
+        // other fixture still fails.
         if (rel.startsWith('actions_') &&
             (rel.endsWith('.pull.golden.yaml') ?
                  onlyExpressionGapAndExtendedBlocks(validate.errors) :

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -164,6 +164,26 @@ function onlyExtendedModelBlocks(errors: typeof validate.errors): boolean {
         /\/semantic_model\/\d+$/.test(e.instancePath));
 }
 
+// A `.pull.golden.yaml` of a fixture that declares actions or constraints trips
+// BOTH tolerated classes at once: the #290 missing-`expression` gap and the
+// extended model blocks. Each predicate above is all-or-nothing, so a document
+// hitting two of them passes neither. Tolerate the union for exactly that
+// combination rather than loosening either predicate for every other fixture.
+function onlyExpressionGapAndExtendedBlocks(
+  errors: typeof validate.errors): boolean {
+  return !!errors && errors.length > 0 &&
+    errors.every(
+      e =>
+        (e.keyword === 'required' &&
+          (e.params as {missingProperty?: string}).missingProperty ===
+            'expression') ||
+        (e.keyword === 'additionalProperties' &&
+          EXTENDED_MODEL_BLOCKS.has(
+            (e.params as {additionalProperty?: string}).additionalProperty ??
+            '') &&
+          /\/semantic_model\/\d+$/.test(e.instancePath)));
+}
+
 describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () => {
   test('at least one fixture is discovered', () => {
     expect(fixtures.length).toBeGreaterThan(0);
@@ -203,7 +223,9 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
         // fixtures that legitimately carry them -- so a stray `actions` or
         // `constraints` slipping into any other fixture still fails.
         if (rel.startsWith('actions_') &&
-            onlyExtendedModelBlocks(validate.errors)) {
+            (rel.endsWith('.pull.golden.yaml') ?
+                 onlyExpressionGapAndExtendedBlocks(validate.errors) :
+                 onlyExtendedModelBlocks(validate.errors))) {
           return;
         }
         const details = (validate.errors ?? [])

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -150,12 +150,17 @@ function toSchemaShape(doc: any): any {
 // fixture validates while every other drift from the spec still fails. When
 // upstream OSI adopts actions, re-vendoring the schema makes this pass with no
 // special-casing and this tolerance can be removed.
-function onlyActionsExtension(errors: typeof validate.errors): boolean {
+// The model-level write-side blocks that are a deliberate superset of released
+// OSI (the Extended-spec proposal): `actions` and the `constraints` that gate
+// them.
+const EXTENDED_MODEL_BLOCKS = new Set(['actions', 'constraints']);
+
+function onlyExtendedModelBlocks(errors: typeof validate.errors): boolean {
   return !!errors && errors.length > 0 &&
     errors.every(
       e => e.keyword === 'additionalProperties' &&
-        (e.params as {additionalProperty?: string}).additionalProperty ===
-          'actions' &&
+        EXTENDED_MODEL_BLOCKS.has(
+          (e.params as {additionalProperty?: string}).additionalProperty ?? '') &&
         /\/semantic_model\/\d+$/.test(e.instancePath));
 }
 
@@ -192,13 +197,13 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
             onlyExtendsExtension(validate.errors)) {
           return;
         }
-        // A model-level `actions` block is a deliberate superset of released
-        // OSI (the Extended-spec proposal); tolerate exactly that extra property
-        // and nothing else, and only on the actions fixtures that legitimately
-        // carry it -- so a stray `actions` slipping into any other fixture still
-        // fails.
+        // The model-level `actions` and `constraints` blocks are a deliberate
+        // superset of released OSI (the Extended-spec proposal); tolerate
+        // exactly those extra properties and nothing else, and only on the
+        // fixtures that legitimately carry them -- so a stray `actions` or
+        // `constraints` slipping into any other fixture still fails.
         if (rel.startsWith('actions_') &&
-            onlyActionsExtension(validate.errors)) {
+            onlyExtendedModelBlocks(validate.errors)) {
           return;
         }
         const details = (validate.errors ?? [])

--- a/toolbox/mdcode/tests/libts/semantic/push_plan.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/push_plan.test.ts
@@ -12,7 +12,7 @@
 
 import {describe, expect, test} from 'bun:test';
 
-import {checkPushSelection, declaresGraphTarget} from '../../../src/tool/commands';
+import {catalogOnlyWarning, checkPushSelection, declaresGraphTarget} from '../../../src/tool/commands';
 
 describe('checkPushSelection', () => {
   // Both legs on, no binding-profile selection: the default `kcmd push`. Each
@@ -144,4 +144,28 @@ semantic_model:
         data: 'not json'
 `)).toBe(true);
        });
+});
+
+
+// --no-kc drops the only leg an action or a constraint deploys through. The
+// warning counted actions alone, so a model whose catalog-only content was all
+// constraints was dropped without a word.
+describe('catalogOnlyWarning', () => {
+  test('names constraints when the model declares only constraints', () => {
+    const msg = catalogOnlyWarning('sales', {actions: 0, constraints: 2});
+    expect(msg).toContain('2 constraint(s)');
+    expect(msg).not.toContain('action(s)');
+    expect(msg).toContain('--no-kc');
+  });
+
+  test('names actions when the model declares only actions', () => {
+    const msg = catalogOnlyWarning('sales', {actions: 1, constraints: 0});
+    expect(msg).toContain('1 action(s)');
+    expect(msg).not.toContain('constraint(s)');
+  });
+
+  test('names both, in one sentence, when the model declares both', () => {
+    expect(catalogOnlyWarning('sales', {actions: 1, constraints: 2}))
+        .toContain('1 action(s) and 2 constraint(s)');
+  });
 });

--- a/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
+++ b/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
@@ -4,11 +4,10 @@
 // Both are created at init -- not on push -- so a semantic-model push writes
 // only entries, matching how the standard layout operates (its push creates
 // entries, never the entry group). The types kcmd creates rather than
-// references are declared in kc_custom_types.ts, which today holds the one
-// action pair. These tests spy on the catalog client so no network call is
-// made and run init
-// inside a temp working directory (it writes catalog.yaml + the layout dirs
-// relative to cwd).
+// references are declared in kc_custom_types.ts, which today holds the action
+// and constraint pairs. These tests spy on the catalog client so no network
+// call is made, and run init inside a temp working directory (it writes
+// catalog.yaml + the layout dirs relative to cwd).
 
 import {afterEach, beforeEach, describe, expect, mock, spyOn, test} from 'bun:test';
 import * as fs from 'node:fs';
@@ -112,9 +111,9 @@ describe('init --semantic-model: entry-group provisioning', () => {
 
     expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
 
-    // Every registered type gets both halves, and both are custom, so they
-    // live in the destination project at `global` -- not beside the built-in
-    // types, and not in the entry group's region.
+    // Every registered type gets both halves. Both are custom, so both live in
+    // the destination project at `global`, rather than beside the built-in
+    // types or in the entry group's region.
     const ids = CUSTOM_TYPES.map(t => t.id);
     expect(ids).toContain('semantic-action');
     for (const spy of [aspectType, entryType]) {
@@ -224,6 +223,27 @@ describe('init --semantic-model: entry-group provisioning', () => {
     expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
     expect(fs.existsSync(path.join('catalog', 'EntryGroups', 'sales-group')))
         .toBe(true);
+  });
+
+  test('a type refused for lack of permission does not skip the next one',
+       async () => {
+    // The refusals differ per type and per operation, so a caller refused one
+    // may well be allowed the next. Giving up at the first one left a type
+    // uncreated that nothing was stopping.
+    spyOn(CatalogClient.prototype, 'createEntryGroup')
+        .mockImplementation(async () => ok({name: 'sales-group'}));
+    const first = CUSTOM_TYPES[0].id;
+    const aspectType =
+        spyOn(CatalogClient.prototype, 'createAspectType')
+            .mockImplementation(async (_p: any, _l: any, id: string) =>
+                id === first ? err(403, 'permission denied') :
+                               ok({name: id}));
+
+    expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
+
+    // Every type is attempted, including the ones after the refusal.
+    expect(aspectType.mock.calls.map(c => c[2])).toEqual(
+        CUSTOM_TYPES.map(t => t.id));
   });
 
   test('a fatal action-type error fails init', async () => {

--- a/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
+++ b/toolbox/mdcode/tests/tool/init_semantic_model.test.ts
@@ -18,6 +18,7 @@ import * as path from 'node:path';
 import {ApiResult} from '../../src/libts/gcp/api';
 import {ApiContext} from '../../src/libts/gcp/context';
 import {CatalogClient} from '../../src/libts/gcp/dataplex';
+import {CUSTOM_TYPES} from '../../src/libts/semantic/kc_custom_types';
 import {init} from '../../src/tool/commands';
 
 const CTX = new ApiContext('test-project', 'us', 'test-token');
@@ -45,7 +46,7 @@ beforeEach(() => {
   spyOn(console, 'log').mockImplementation(() => {});
   spyOn(console, 'error').mockImplementation(() => {});
   spyOn(console, 'warn').mockImplementation(() => {});
-  // Provisioning the custom action types succeeds by default; the tests that
+  // Provisioning the custom types succeeds by default; the tests that
   // care about it re-stub these. Each create returns a long-running operation,
   // so `getOperation` has to answer too.
   spyOn(CatalogClient.prototype, 'createAspectType')
@@ -100,7 +101,7 @@ describe('init --semantic-model: entry-group provisioning', () => {
         .toBe(true);
   });
 
-  test('provisions the custom action types in the destination project',
+  test('provisions every registered custom type in the destination project',
        async () => {
     spyOn(CatalogClient.prototype, 'createEntryGroup')
         .mockImplementation(async () => ok({name: 'sales-group'}));
@@ -111,44 +112,55 @@ describe('init --semantic-model: entry-group provisioning', () => {
 
     expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
 
-    // Both types are custom, so they live in the destination project at
-    // `global` -- not beside the built-in types, and not in the entry group's
-    // region.
+    // Every registered type gets both halves, and both are custom, so they
+    // live in the destination project at `global` -- not beside the built-in
+    // types, and not in the entry group's region.
+    const ids = CUSTOM_TYPES.map(t => t.id);
+    expect(ids).toContain('semantic-action');
     for (const spy of [aspectType, entryType]) {
-      expect(spy).toHaveBeenCalledTimes(1);
-      const [project, location, typeId] = spy.mock.calls[0];
-      expect(project).toBe('proj');
-      expect(location).toBe('global');
-      expect(typeId).toBe('semantic-action');
+      expect(spy).toHaveBeenCalledTimes(ids.length);
+      expect(spy.mock.calls.map(c => c[2])).toEqual(ids);
+      for (const [project, location] of spy.mock.calls) {
+        expect(project).toBe('proj');
+        expect(location).toBe('global');
+      }
     }
     // The entry type requires the aspect type, so the server rejects it while
     // the aspect type's create is still running.
-    expect(aspectType.mock.invocationCallOrder[0])
-        .toBeLessThan(entryType.mock.invocationCallOrder[0]);
+    for (let i = 0; i < ids.length; i++) {
+      expect(aspectType.mock.invocationCallOrder[i])
+          .toBeLessThan(entryType.mock.invocationCallOrder[i]);
+    }
   });
 
   test('waits for each type-creation operation to finish', async () => {
     spyOn(CatalogClient.prototype, 'createEntryGroup')
         .mockImplementation(async () => ok({name: 'sales-group'}));
-    // The aspect type is still being created when the call returns.
+    // Each aspect type is still being created when the call returns, under
+    // an operation of its own, and reports done on its second poll.
+    let created = 0;
     spyOn(CatalogClient.prototype, 'createAspectType')
-        .mockImplementation(async () => ok({name: OP, done: false}));
-    let polls = 0;
+        .mockImplementation(async () => ok({name: `op-${++created}`, done: false}));
+    const polls = new Map<string, number>();
     spyOn(CatalogClient.prototype, 'getOperation')
-        .mockImplementation(async () => ok({name: OP, done: ++polls > 1}));
-    // How many times the operation had been polled when the entry type was
-    // created. The aspect type reports done on the second poll, so anything
-    // less than two means the entry type was created while its required
-    // aspect type was still being created, which the server rejects.
-    let polledBeforeEntryType = -1;
+        .mockImplementation(async (name: string) => {
+          const n = (polls.get(name) ?? 0) + 1;
+          polls.set(name, n);
+          return ok({name, done: n > 1});
+        });
+    // Types whose entry type was created while the aspect type it requires was
+    // still being created, which the server rejects.
+    const premature: string[] = [];
     spyOn(CatalogClient.prototype, 'createEntryType')
-        .mockImplementation(async () => {
-          polledBeforeEntryType = polls;
-          return ok({name: OP});
+        .mockImplementation(async (_p: string, _l: string, typeId: string) => {
+          if ((polls.get(`op-${created}`) ?? 0) < 2) premature.push(typeId);
+          // Already finished, so the next type starts without a poll delay.
+          return ok({name: OP, done: true});
         });
 
     expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
-    expect(polledBeforeEntryType).toBe(2);
+    expect(premature).toEqual([]);
+    expect(created).toBe(CUSTOM_TYPES.length);
   });
 
   test('an already-existing aspect type is patched with the current template',
@@ -167,7 +179,7 @@ describe('init --semantic-model: entry-group provisioning', () => {
 
     // A project provisioned by an earlier kcmd holds an older template, so the
     // patch names the template field to bring it up to date.
-    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(CUSTOM_TYPES.length);
     expect(update.mock.calls[0][4]).toContain('metadata_template');
   });
 
@@ -194,7 +206,7 @@ describe('init --semantic-model: entry-group provisioning', () => {
     // reports the refusal and carries on rather than abandoning a workspace
     // whose entry group it has already created.
     expect(await init({semanticModel: 'proj.us.sales-group'})).toBe(0);
-    expect(entryType).toHaveBeenCalledTimes(1);
+    expect(entryType).toHaveBeenCalledTimes(CUSTOM_TYPES.length);
     expect(fs.existsSync(path.join('catalog', 'EntryGroups', 'sales-group')))
         .toBe(true);
     expect(warned.some(m => m.includes('unchanged'))).toBe(true);


### PR DESCRIPTION
A **constraint** is a named boolean invariant over the ontology: something the model asserts about every instance of an entity, written in the same expression language as a metric. `Account.balance >= 0` is part of what the model means by an account, and it holds however the row got there.

This PR adds the construct and nothing else. A constraint is parsed, validated, published to Knowledge Catalog under its own custom type, and recovered by `pull` unchanged. Checking one against live data is deliberately out of scope here — see **Follow-ups** below.

## What is in it

- **Model and loader.** `constraints:` at model level, beside `actions` and `metrics`. It is a native key of the extended profile (`0.2.0.dev0/google`), so a vanilla-profile document is told the key is unknown rather than having it silently dropped.
- **Validation.** A constraint's `expression` must be non-empty, and when it opens with an `<Entity>.<field>` qualifier naming a *known* entity, that entity must declare the field. A relationship-qualified name, a metric reference, or compound logic is left alone rather than guessed at, so a valid constraint is never falsely rejected.
- **Knowledge Catalog.** Each constraint publishes as one entry under the model anchor, carrying its expression in a `semantic-constraint` aspect and its `description` as the entry's own summary. `pull` reads them back losslessly.
- **A custom type, registered the same way as actions.** `semantic-constraint` is an entry + aspect type pair added as one record to the `CUSTOM_TYPES` registry in `kc_custom_types.ts`, beside `semantic-action`, and provisioned by `kcmd init --semantic-model`. The encoding is isolated in `kc_constraints.ts`, mirroring `kc_actions.ts`, so the registry stays the one place a type owner has to look.
- **No graph construct.** A constraint reaches neither BigQuery nor Spanner Graph. The graph leg emits nothing and warns once; a `--no-kc` push warns the constraints will not be deployed.
- **Docs.** Reference and fidelity gain their constraint rows: the catalog mapping, the aspect shape, the init and push permissions, and the round-trip matrix. The README overview says outright that nothing checks a constraint against live data.

## Testing

`bun test` — 642 pass, 0 fail. `tsc --noEmit` clean, and each of the two commits typechecks on its own.

The catalog round trip is covered hermetically (`tests/libts/semantic/constraints.test.ts`): the emitter's output is handed back to the reader and every field survives. What that cannot ask is whether a real Dataplex accepts an entry of a type this code created, holding an aspect shaped by a template this code wrote. A live test for exactly that question exists and travels with the follow-up, because it shares its scaffolding with the runtime's live suite; it has not been run against a server yet, and the aspect template remains an unverified claim until it is.

## Follow-ups

Both are written and pushed, waiting on this PR to land:

1. **`constraints-runtime`** — the semantic runtime that enforces a constraint on a write: resolve entity-typed arguments, apply the write in a transaction, probe every constraint in that same transaction, commit or roll back with the violated constraint's `description`. Includes the expression evaluator, the live test suite, and the user guide.
2. **`constraints-demo`** — the payments demo over live Spanner and MCP, showing an agent read a refusal and correct itself.
