### PR TITLE
docs(mdcode): a user guide for modeling write operations

### DIFF
--- a/toolbox/mdcode/demo/README.md
+++ b/toolbox/mdcode/demo/README.md
@@ -256,3 +256,26 @@ bun pull.ts --bundle /tmp/acme_pulled
 ```bash
 bun cleanup.ts
 ```
+
+
+## Actions and Constraints
+
+This demo shows the write side of a semantic model: an action that moves money
+between accounts, four constraints that say what has to stay true, and a runtime
+that applies the write in a Spanner transaction and rolls it back if any
+constraint would be broken. It also exposes the action over MCP, so an agent can
+call it and correct itself from the rejection message.
+
+It creates its own Spanner database (`semantic_action_demo`) and leaves
+everything else in the instance alone.
+
+```bash
+cd action
+bun setup.ts
+bun transfer.ts --list
+bun transfer.ts "Alice Checking" "Bob Checking" 500     # commits
+bun transfer.ts "Alice Checking" "Bob Checking" 5000    # rejected, rolled back
+bun cleanup.ts
+```
+
+See `action/README.md` for the full runbook.

--- a/toolbox/mdcode/demo/action/README.md
+++ b/toolbox/mdcode/demo/action/README.md
@@ -1,0 +1,235 @@
+# Actions and constraints: a model that can be acted on
+
+A semantic model usually describes what data means. This one also describes what
+can be *done* to it, and what has to stay true while it is being done.
+
+The model is `payments.yaml`: accounts, their owners, transfers between them, one
+action called `TransferFunds`, and four constraints. The demo runs that action
+against a real Spanner database and shows what happens when a transfer would
+break one of the rules.
+
+## What the pieces are
+
+**The action** says a transfer takes two accounts and an amount. Both accounts
+are typed `Account`, which makes them object references rather than values: the
+caller says `"Alice Checking"` or `1` and the runtime works out which row that
+is.
+
+**The constraints** are named invariants written in the model:
+
+| Constraint | Expression |
+| --- | --- |
+| `NonNegativeBalance` | `Account.balance >= 0` |
+| `AboveMinimumBalance` | `Account.balance >= Account.minimumBalance` |
+| `PositiveAmount` | `Transfer.amount > 0` |
+| `OpenAccountsOnly` | `Account.status != 'FROZEN'` |
+
+Each one carries a description, and the description is written as an
+instruction -- "transfer a smaller amount, or move money from an account that
+holds enough" -- because that text is what comes back when the rule is broken.
+
+**The runtime** puts them together. It resolves the account references, opens a
+read-write transaction, applies the debit and credit, and then checks every
+constraint against the result *before committing*. The checks run inside the
+same transaction, so they see the new balances even though nobody else can yet.
+If any check fails, the transaction is rolled back and the constraint's
+description is returned. If they all pass, it commits.
+
+Two things about that are worth stating plainly.
+
+The runtime does not invent the write. An action names an executor, not SQL, so
+the DML lives in `action.ts` and the runtime calls it. The model contributes the
+typed resolution and the gate.
+
+The gate fails closed. If a constraint cannot be turned into a check -- an
+aggregate, a function call, anything outside the small expression grammar -- the
+action is refused before the transaction is even opened. A gate that quietly
+lets writes through is worse than no gate, because it is believed.
+
+## Configuration
+
+You need a project with Spanner, and an instance to create a database in.
+
+```bash
+export DEMO_CLOUD_PROJECT=<GCP_PROJECT_ID>
+export DEMO_SPANNER_INSTANCE=<SPANNER_INSTANCE>
+gcloud auth application-default login
+gcloud config set project $DEMO_CLOUD_PROJECT
+```
+
+The demo defaults to `sqlgen-testing` / `graph-unified-solution-demo` and always
+creates its own database, `semantic_action_demo`, so nothing that was already in
+the instance is touched.
+
+## Set up
+
+Creates the database, the three tables, a property graph over them, and four
+seeded accounts.
+
+```bash
+bun setup.ts
+bun transfer.ts --list
+```
+
+```
+id  account          balance     floor    status
+1   Alice Checking        2500      100  OPEN
+2   Alice Savings        18000     5000  OPEN
+3   Bob Checking           400        0  OPEN
+4   Carol Savings          900        0  FROZEN
+```
+
+## A transfer that is allowed
+
+```bash
+bun transfer.ts "Alice Checking" "Bob Checking" 500
+```
+
+```
+Committed. Checked NonNegativeBalance, AboveMinimumBalance, PositiveAmount,
+OpenAccountsOnly. Resolved Alice Checking -> 1, Bob Checking -> 3.
+```
+
+Both names resolved to account ids, all four constraints held against the
+post-transfer balances, and the transaction committed.
+
+## Four transfers that are refused
+
+Each of these leaves the database exactly as it was. Run `bun transfer.ts --list`
+after any of them to confirm.
+
+**Overdrawing an account.** Alice Checking holds 2500.
+
+```bash
+bun transfer.ts "Alice Checking" "Bob Checking" 5000
+```
+
+```
+REJECTED (rolled back): An account cannot be overdrawn. Transfer a smaller
+amount, or move money from an account that holds enough. Rejected by constraint
+'NonNegativeBalance' (Account.balance >= 0). Violating Account: 1. ...
+```
+
+Two constraints fail here, and both are reported: the balance goes below zero
+*and* below the account's own floor.
+
+**Breaking an account's minimum balance.** Alice Savings holds 18000 and has to
+keep 5000.
+
+```bash
+bun transfer.ts "Alice Savings" "Bob Checking" 14000
+```
+
+```
+REJECTED (rolled back): This account has to keep a minimum balance. Move less,
+or draw from an account with more room above its floor. Rejected by constraint
+'AboveMinimumBalance' (Account.balance >= Account.minimumBalance). Violating
+Account: 2.
+```
+
+There is enough money for the transfer. It is still refused, because "enough
+money" is not the rule the model states.
+
+**Touching a frozen account.**
+
+```bash
+bun transfer.ts "Alice Checking" "Carol Savings" 100
+```
+
+```
+REJECTED (rolled back): A frozen account cannot send or receive money. Choose a
+different account, or have this one unfrozen first. Rejected by constraint
+'OpenAccountsOnly' (Account.status != 'FROZEN'). Violating Account: 4.
+```
+
+Carol's account was never going to go wrong -- the transfer only adds to it --
+but the action touched it, and a touched row has to satisfy every constraint.
+
+**A negative amount.**
+
+```bash
+bun transfer.ts "Alice Checking" "Bob Checking" -50
+```
+
+```
+REJECTED (rolled back): A transfer has to move a positive amount. To reverse a
+payment, make a transfer in the other direction. Rejected by constraint
+'PositiveAmount' (Transfer.amount > 0). ...
+```
+
+Nothing in the handler checks the sign of the amount. The model does.
+
+## A reference that does not resolve
+
+```bash
+bun transfer.ts "Dave Checking" "Bob Checking" 10
+```
+
+```
+ERROR: No Account matches 'Dave Checking'.
+```
+
+An ambiguous reference is reported the same way, with the candidates listed, so
+the caller can pick one.
+
+## What the constraints are checked against
+
+The probes are scoped to the rows the action touched. An account that was
+already below its floor before the demo started is not the transfer's fault and
+does not block it; an account the transfer *changed* has to come out satisfying
+every rule.
+
+That is the enforcement contract: an action must not introduce a violation among
+the rows it changes. It is also the only version that scales -- re-reading a
+whole table on every write would make each transfer cost more as the bank grows.
+
+## The same model, as a graph
+
+`setup.ts` also creates a Spanner property graph over the same tables, so the
+transfers the runtime committed are queryable as edges:
+
+```bash
+gcloud spanner databases execute-sql semantic_action_demo \
+  --instance=$DEMO_SPANNER_INSTANCE --project=$DEMO_CLOUD_PROJECT \
+  --sql="GRAPH payments
+         MATCH (src:Account)-[t:Transfers]->(dst:Account)
+         RETURN src.name AS source, dst.name AS target, t.amount AS amount"
+```
+
+```
+source          target          amount
+Alice Checking  Bob Checking    500
+```
+
+Only the committed transfer is there. The four refused ones left no trace.
+
+## Letting an agent act
+
+`mcp.ts` is an MCP server over stdio exposing three tools: `describe_model`,
+`list_accounts`, and `transfer_funds`.
+
+```bash
+bun mcp.ts
+```
+
+To use it from Claude Code, register it and then ask for a transfer in plain
+language:
+
+```bash
+claude mcp add payments -- bun /absolute/path/to/demo/action/mcp.ts
+```
+
+The loop closes because a refusal is useful. Ask for a transfer that overdraws
+an account and the tool returns the constraint's description; the agent reads
+"transfer a smaller amount, or move money from an account that holds enough",
+checks the balances, and tries again with a workable figure -- without the rule
+having been written into its prompt. The rule lives in the model, and the model
+is what the agent was handed.
+
+## Clean up
+
+```bash
+bun cleanup.ts
+```
+
+Deletes the `semantic_action_demo` database and nothing else.

--- a/toolbox/mdcode/demo/action/action.ts
+++ b/toolbox/mdcode/demo/action/action.ts
@@ -1,0 +1,132 @@
+// The TransferFunds action: the model it comes from, the write it performs, and
+// a one-call entry point the CLI and the MCP server both use.
+//
+// The division of labour is the interesting part. The model supplies the
+// action's shape (two object references and an amount) and the constraints. The
+// runtime supplies resolution, the transaction, the gate, and the decision. What
+// is left -- the actual SQL that moves the money -- is here, in the handler,
+// because an action declares an executor rather than a statement. In a
+// production system the handler is whatever the executor points at; in this
+// demo it is fifteen lines of DML, so the gate has something real to gate.
+//
+
+import {readFileSync} from 'node:fs';
+
+import {loadModels} from '../../src/libts/semantic/loader';
+import {SemanticModel} from '../../src/libts/semantic/ir';
+import {
+  ActionContext,
+  ActionOutcome,
+  ActionPlan,
+  runAction,
+} from '../../src/libts/semantic/runtime';
+
+import {dataClient, modelPath} from './config';
+
+
+export const ACTION_NAME = 'TransferFunds';
+
+
+// Parsed once per process: the MCP server calls this on every tool invocation,
+// and re-reading the file each time would repeat any load warning on every call.
+let cached: SemanticModel|undefined;
+
+export function loadModel(): SemanticModel {
+  if (cached) return cached;
+  // The model's expressions are written in the portable ANSI_SQL dialect, which
+  // Spanner accepts; saying so keeps the loader from noting that it fell back
+  // from its BigQuery default.
+  const {models, warnings} =
+      loadModels(readFileSync(modelPath, 'utf8'), {dialect: 'ANSI_SQL'});
+  for (const w of warnings) console.warn(`Model warning: ${w}`);
+  if (!models.length) throw new Error(`No semantic model in ${modelPath}`);
+  cached = models[0];
+  return cached;
+}
+
+
+// Debit, credit, and record. `touched` names the rows the statements changed so
+// the constraint probes only look at those -- the accounts on either end of the
+// transfer and the transfer row itself.
+async function transferHandler(ctx: ActionContext): Promise<ActionPlan> {
+  const source = ctx.refs.source.keys[0];
+  const target = ctx.refs.target.keys[0];
+  const amount = Number(ctx.args.amount);
+  if (!Number.isFinite(amount)) {
+    throw new Error(`'${ctx.args.amount}' is not an amount.`);
+  }
+  if (source === target) {
+    throw new Error('The source and target accounts are the same.');
+  }
+  const transferId = `${Date.now()}`;
+
+  const money = {
+    params: {amount, source, target},
+    paramTypes: {
+      amount: {code: 'FLOAT64'},
+      source: {code: 'STRING'},
+      target: {code: 'STRING'},
+    },
+  };
+
+  return {
+    statements: [
+      {
+        sql: 'UPDATE Account SET balance = balance - @amount ' +
+            'WHERE CAST(account_id AS STRING) = @source',
+        ...money,
+      },
+      {
+        sql: 'UPDATE Account SET balance = balance + @amount ' +
+            'WHERE CAST(account_id AS STRING) = @target',
+        ...money,
+      },
+      {
+        sql: 'INSERT INTO Transfer ' +
+            '(transfer_id, source_account_id, target_account_id, amount) ' +
+            'VALUES (@transferId, CAST(@source AS INT64), ' +
+            'CAST(@target AS INT64), @amount)',
+        params: {...money.params, transferId},
+        paramTypes: {...money.paramTypes, transferId: {code: 'INT64'}},
+      },
+    ],
+    touched: {Account: [source, target], Transfer: [transferId]},
+  };
+}
+
+
+// Runs one transfer. `source` and `target` are whatever the caller has -- an
+// account id or a display name; the runtime resolves either to the same row.
+export async function transferFunds(
+    source: string, target: string, amount: number): Promise<ActionOutcome> {
+  return await runAction({
+    model: loadModel(),
+    actionName: ACTION_NAME,
+    args: {source, target, amount},
+    client: dataClient(),
+    handler: transferHandler,
+  });
+}
+
+
+// The accounts as they stand, for orienting a caller before it acts. Read-only
+// and outside any action, so it uses a throwaway transaction it never commits.
+export async function listAccounts(): Promise<
+    Array<{id: string; name: string; balance: string; floor: string; status: string}>> {
+  const client = dataClient();
+  return await client.withSession(async sessionName => {
+    const begun = await client.beginReadWrite(sessionName);
+    const transactionId = begun.result?.id;
+    if (!transactionId) throw new Error(`Could not read accounts: ${begun.message}`);
+    const res = await client.executeSql(sessionName, transactionId, {
+      sql: 'SELECT CAST(account_id AS STRING), name, CAST(balance AS STRING), ' +
+          'CAST(minimum_balance AS STRING), status FROM Account ORDER BY account_id',
+    });
+    await client.rollback(sessionName, transactionId);
+    if (res.status < 200 || res.status >= 300) {
+      throw new Error(`Could not read accounts: ${res.message}`);
+    }
+    return (res.result?.rows ?? []).map(
+        r => ({id: r[0], name: r[1], balance: r[2], floor: r[3], status: r[4]}));
+  });
+}

--- a/toolbox/mdcode/demo/action/cleanup.ts
+++ b/toolbox/mdcode/demo/action/cleanup.ts
@@ -1,0 +1,12 @@
+// Drops the database the demo created. Nothing else in the instance is touched.
+//
+
+import * as cp from 'child_process';
+
+import {database, instance, project} from './config';
+
+cp.execSync(
+    `gcloud spanner databases delete ${database} --instance=${instance} ` +
+        `--project=${project} --quiet`,
+    {stdio: 'inherit'});
+console.log(`Deleted Spanner database ${database}.`);

--- a/toolbox/mdcode/demo/action/config.ts
+++ b/toolbox/mdcode/demo/action/config.ts
@@ -1,0 +1,26 @@
+// Where the demo runs, and how its pieces find each other.
+//
+// Everything is overridable by environment variable so the demo can be pointed
+// at a project the reader actually owns; the defaults are the instance it was
+// developed against.
+//
+
+import * as path from 'node:path';
+
+import * as gcp from '../../src/libts/gcp/context';
+import * as spanner from '../../src/libts/gcp/spanner';
+
+export const project =
+    process.env.DEMO_CLOUD_PROJECT ?? 'sqlgen-testing';
+export const instance =
+    process.env.DEMO_SPANNER_INSTANCE ?? 'graph-unified-solution-demo';
+export const database =
+    process.env.DEMO_SPANNER_DATABASE ?? 'semantic_action_demo';
+
+export const modelPath = path.join(import.meta.dir, 'payments.yaml');
+
+
+export function dataClient(): spanner.SpannerDataClient {
+  return new spanner.SpannerDataClient(
+      gcp.ApiContext.default(), project, instance, database);
+}

--- a/toolbox/mdcode/demo/action/mcp.ts
+++ b/toolbox/mdcode/demo/action/mcp.ts
@@ -1,0 +1,98 @@
+// An MCP server exposing the model's action, so an agent can act through it.
+//
+// This is the last link: the model already says what a transfer is and what
+// must stay true; the runtime already enforces that; this makes both reachable
+// by a language model over stdio. Three tools, in the order an agent uses them:
+// read the rules, read the state, act.
+//
+// The rejection path is what makes an agent loop out of a tool call. A refused
+// transfer comes back as the constraint's description -- "an account cannot be
+// overdrawn, transfer a smaller amount or move money from an account that holds
+// enough" -- so the agent has what it needs to fix its own next call without
+// anyone hard-coding the rule into its prompt.
+//
+
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
+import {z} from 'zod';
+
+import {listAccounts, loadModel, transferFunds} from './action';
+
+const server = new McpServer({name: 'payments-actions', version: '0.1.0'});
+
+server.registerTool(
+    'describe_model',
+    {
+      description:
+          'The payments semantic model: its entities, the actions that can be ' +
+          'taken, and the constraints every action is checked against. Read ' +
+          'this first -- the constraints are the rules a transfer has to obey.',
+    },
+    async () => {
+      const model = loadModel();
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify(
+              {
+                name: model.name,
+                description: model.description,
+                entities: model.entities.map(
+                    e => ({name: e.name, fields: e.fields.map(f => f.name)})),
+                actions: (model.actions ?? []).map(a => ({
+                                                     name: a.name,
+                                                     description: a.description,
+                                                     parameters: a.parameters,
+                                                   })),
+                constraints: model.constraints ?? [],
+              },
+              null, 2),
+        }],
+      };
+    });
+
+server.registerTool(
+    'list_accounts',
+    {description: 'Every account with its balance, its minimum balance, and whether it is open or frozen.'},
+    async () => ({
+      content: [{
+        type: 'text',
+        text: JSON.stringify(await listAccounts(), null, 2),
+      }],
+    }));
+
+server.registerTool(
+    'transfer_funds',
+    {
+      description:
+          'Move money between two accounts. Either account may be given as an ' +
+          'account id or as its display name. The transfer is applied and then ' +
+          'checked against the model\'s constraints before it commits: if any ' +
+          'constraint would be broken the whole transfer is rolled back and the ' +
+          'reason explains what to change.',
+      inputSchema: {
+        source: z.string().describe('The account to debit -- an id or a display name.'),
+        target: z.string().describe('The account to credit -- an id or a display name.'),
+        amount: z.number().describe('How much to move, in dollars.'),
+      },
+    },
+    async ({source, target, amount}) => {
+      const outcome = await transferFunds(source, target, amount);
+      if (outcome.status === 'committed') {
+        return {
+          content: [{
+            type: 'text',
+            text: `Transferred ${amount} from ${source} to ${target}. ` +
+                `Checked: ${outcome.checked.join(', ')}.`,
+          }],
+        };
+      }
+      // A rejection is reported as an error so the agent notices it, with the
+      // constraint's own words as the message -- that text is the instruction.
+      return {
+        isError: true,
+        content: [{type: 'text', text: outcome.message}],
+      };
+    });
+
+await server.connect(new StdioServerTransport());

--- a/toolbox/mdcode/demo/action/payments.yaml
+++ b/toolbox/mdcode/demo/action/payments.yaml
@@ -1,0 +1,144 @@
+# A semantic model with a write side, for the action demo.
+#
+# Three entities over a Spanner payments database, one action that moves money
+# between accounts, and the constraints that decide whether a given move is
+# allowed. Every name here is logical: `Account.balance` is a concept, and the
+# column it happens to live in is a binding detail underneath it.
+#
+# The constraints are the point. `NonNegativeBalance` is not documentation and
+# not a database CHECK -- it is part of the model, so anything that reads the
+# model knows the rule, and the runtime enforces it against the uncommitted
+# result of the action before deciding to commit. Each description is written as
+# an instruction to whoever tripped it, because that text is what comes back on
+# a rejection.
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: payments
+    description: Accounts, their owners, and the transfers between them
+    datasets:
+      - name: Person
+        source: Person
+        primary_key: [personId]
+        fields:
+          - name: personId
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: person_id}]
+          - name: name
+            datatype: String
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: name}]
+          - name: city
+            datatype: String
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: city}]
+      - name: Account
+        source: Account
+        primary_key: [accountId]
+        fields:
+          - name: accountId
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: account_id}]
+          - name: ownerId
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: owner_id}]
+          - name: name
+            datatype: String
+            description: The account's display name, e.g. "Alice Checking".
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: name}]
+          - name: balance
+            datatype: Float
+            description: Current cleared balance, in dollars.
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: balance}]
+          - name: minimumBalance
+            datatype: Float
+            description: >-
+              The floor this particular account must stay above, separate from
+              the hard zero that applies to every account.
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: minimum_balance}]
+          - name: status
+            datatype: String
+            description: OPEN or FROZEN.
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: status}]
+      - name: Transfer
+        source: Transfer
+        primary_key: [transferId]
+        fields:
+          - name: transferId
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: transfer_id}]
+          - name: sourceAccountId
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: source_account_id}]
+          - name: targetAccountId
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: target_account_id}]
+          - name: amount
+            datatype: Float
+            expression:
+              dialects: [{dialect: ANSI_SQL, expression: amount}]
+    relationships:
+      - name: account_owner
+        from: Account
+        to: Person
+        from_columns: [owner_id]
+        to_columns: [person_id]
+      - name: transfer_source
+        from: Transfer
+        to: Account
+        from_columns: [source_account_id]
+        to_columns: [account_id]
+      - name: transfer_target
+        from: Transfer
+        to: Account
+        from_columns: [target_account_id]
+        to_columns: [account_id]
+    metrics:
+      - name: total_transferred
+        description: Total value moved by the transfers in scope.
+        expression:
+          dialects: [{dialect: ANSI_SQL, expression: SUM(Transfer.amount)}]
+    actions:
+      - name: TransferFunds
+        description: >-
+          Move money from one account to another. Both accounts are object
+          references: give an account id or its display name and the runtime
+          resolves it.
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/projects/sqlgen-testing/locations/us-central1/mcpServers/payments
+            tool: transfer_funds
+        parameters:
+          - {name: source, type: Account}
+          - {name: target, type: Account}
+          - {name: amount, type: Float}
+        ai_context:
+          instructions: >-
+            Resolve both accounts before calling. If the call is rejected, read
+            the reason: it names the rule that was broken and what to change.
+    constraints:
+      - name: NonNegativeBalance
+        expression: Account.balance >= 0
+        description: >-
+          An account cannot be overdrawn. Transfer a smaller amount, or move
+          money from an account that holds enough.
+      - name: AboveMinimumBalance
+        expression: Account.balance >= Account.minimumBalance
+        description: >-
+          This account has to keep a minimum balance. Move less, or draw from an
+          account with more room above its floor.
+      - name: PositiveAmount
+        expression: Transfer.amount > 0
+        description: >-
+          A transfer has to move a positive amount. To reverse a payment, make a
+          transfer in the other direction.
+      - name: OpenAccountsOnly
+        expression: Account.status != 'FROZEN'
+        description: >-
+          A frozen account cannot send or receive money. Choose a different
+          account, or have this one unfrozen first.

--- a/toolbox/mdcode/demo/action/setup.ts
+++ b/toolbox/mdcode/demo/action/setup.ts
@@ -1,0 +1,132 @@
+// Creates the payments database the action demo runs against.
+//
+// A NEW database, not one of the existing demo databases: the demo writes and
+// rolls back real transactions, and it should not be able to disturb anything
+// that was already there. Re-running this is safe -- the schema statements are
+// IF NOT EXISTS and the seed replaces the rows it owns.
+//
+
+import * as cp from 'child_process';
+
+import {database, dataClient, instance, project} from './config';
+
+
+// Tables plus the property graph over them. The graph makes the same model
+// queryable with GQL after the runtime has written through it (see the
+// runbook's last step), which is the point of putting an action and a graph on
+// one model.
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS Person (
+  person_id INT64 NOT NULL,
+  name STRING(128),
+  city STRING(128),
+) PRIMARY KEY (person_id);
+
+CREATE TABLE IF NOT EXISTS Account (
+  account_id INT64 NOT NULL,
+  owner_id INT64,
+  name STRING(128),
+  balance FLOAT64,
+  minimum_balance FLOAT64,
+  status STRING(16),
+) PRIMARY KEY (account_id);
+
+CREATE TABLE IF NOT EXISTS Transfer (
+  transfer_id INT64 NOT NULL,
+  source_account_id INT64,
+  target_account_id INT64,
+  amount FLOAT64,
+) PRIMARY KEY (transfer_id);
+
+CREATE OR REPLACE PROPERTY GRAPH payments
+  NODE TABLES (
+    Account KEY (account_id) LABEL Account
+  )
+  EDGE TABLES (
+    Transfer
+      KEY (transfer_id)
+      SOURCE KEY (source_account_id) REFERENCES Account (account_id)
+      DESTINATION KEY (target_account_id) REFERENCES Account (account_id)
+      LABEL Transfers
+  );
+`;
+
+// Four accounts across three people, chosen so each constraint has a case that
+// trips it and a case that does not:
+//
+//   Alice Checking  2500, floor    100  -- a small transfer out is fine, a big
+//                                          one overdraws it
+//   Alice Savings  18000, floor   5000  -- has money, but not 14000 of headroom
+//   Bob Checking     400, floor      0  -- the ordinary destination
+//   Carol Savings    900, FROZEN       -- cannot be touched at all
+const SEED = [
+  `DELETE FROM Transfer WHERE TRUE`,
+  `DELETE FROM Account WHERE TRUE`,
+  `DELETE FROM Person WHERE TRUE`,
+  `INSERT INTO Person (person_id, name, city) VALUES
+     (1, 'Alice', 'Seattle'), (2, 'Bob', 'Austin'), (3, 'Carol', 'Denver')`,
+  `INSERT INTO Account
+     (account_id, owner_id, name, balance, minimum_balance, status) VALUES
+     (1, 1, 'Alice Checking', 2500.0,  100.0, 'OPEN'),
+     (2, 1, 'Alice Savings', 18000.0, 5000.0, 'OPEN'),
+     (3, 2, 'Bob Checking',    400.0,    0.0, 'OPEN'),
+     (4, 3, 'Carol Savings',   900.0,    0.0, 'FROZEN')`,
+];
+
+
+function databaseExists(): boolean {
+  const listed = cp.execSync(
+      `gcloud spanner databases list --instance=${instance} ` +
+          `--project=${project} --format='value(name)'`,
+      {encoding: 'utf8'});
+  // gcloud prints the bare database id here, but has printed the full resource
+  // path in other versions, so accept either rather than silently deciding the
+  // database is missing and failing on a create that cannot succeed.
+  return listed.split('\n').some(line => {
+    const name = line.trim();
+    return name === database || name.endsWith(`/${database}`);
+  });
+}
+
+
+if (!databaseExists()) {
+  console.log(`Creating Spanner database ${database} ...`);
+  cp.execSync(
+      `gcloud spanner databases create ${database} --instance=${instance} ` +
+          `--project=${project} --database-dialect=GOOGLE_STANDARD_SQL`,
+      {stdio: 'inherit'});
+} else {
+  console.log(`Spanner database ${database} already exists.`);
+}
+
+console.log('Applying the schema and the property graph ...');
+cp.execSync(
+    `gcloud spanner databases ddl update ${database} --instance=${instance} ` +
+        `--project=${project} --ddl-file=/dev/stdin`,
+    {input: SCHEMA, stdio: ['pipe', 'inherit', 'inherit']});
+
+console.log('Seeding accounts ...');
+const client = dataClient();
+await client.withSession(async sessionName => {
+  const begun = await client.beginReadWrite(sessionName);
+  const transactionId = begun.result?.id;
+  if (!transactionId) {
+    throw new Error(`Could not begin a transaction: ${begun.message}`);
+  }
+  for (const sql of SEED) {
+    const res = await client.executeSql(sessionName, transactionId, {sql});
+    if (res.status < 200 || res.status >= 300) {
+      await client.rollback(sessionName, transactionId);
+      throw new Error(`Seed failed on "${sql}": ${res.message}`);
+    }
+  }
+  const committed = await client.commit(sessionName, transactionId);
+  if (committed.status < 200 || committed.status >= 300) {
+    throw new Error(`Seed commit failed: ${committed.message}`);
+  }
+});
+
+console.log();
+console.log(`Ready: projects/${project}/instances/${instance}/databases/${
+    database}`);
+console.log('Next: bun transfer.ts --list');

--- a/toolbox/mdcode/demo/action/transfer.ts
+++ b/toolbox/mdcode/demo/action/transfer.ts
@@ -1,0 +1,49 @@
+// Command-line driver for the TransferFunds action.
+//
+//   bun transfer.ts --list
+//   bun transfer.ts "Alice Checking" "Bob Checking" 500
+//
+// The interesting output is a rejection: it is the constraint's own description,
+// which is the same text an agent gets back and acts on.
+//
+
+import {listAccounts, transferFunds} from './action';
+
+const args = process.argv.slice(2);
+
+if (args[0] === '--list' || args.length === 0) {
+  const accounts = await listAccounts();
+  console.log('id  account          balance     floor    status');
+  for (const a of accounts) {
+    console.log(
+        `${a.id.padEnd(3)} ${a.name.padEnd(16)} ${a.balance.padStart(9)} ${
+            a.floor.padStart(8)}  ${a.status}`);
+  }
+  process.exit(0);
+}
+
+if (args.length !== 3) {
+  console.error('usage: bun transfer.ts <source> <target> <amount>');
+  console.error('       bun transfer.ts --list');
+  process.exit(2);
+}
+
+const [source, target, amountText] = args;
+const outcome = await transferFunds(source, target, Number(amountText));
+
+switch (outcome.status) {
+  case 'committed':
+    console.log(
+        `Committed. Checked ${outcome.checked.join(', ')}. ` +
+        `Resolved ${source} -> ${outcome.refs.source.keys.join('/')}, ` +
+        `${target} -> ${outcome.refs.target.keys.join('/')}.`);
+    break;
+  case 'rejected':
+    console.log(`REJECTED (rolled back): ${outcome.message}`);
+    process.exitCode = 1;
+    break;
+  case 'error':
+    console.log(`ERROR: ${outcome.message}`);
+    process.exitCode = 1;
+    break;
+}

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -88,6 +88,10 @@ supertype's fields down and expresses the hierarchy as BigQuery labels. See
 [Class hierarchies](reference.md#class-hierarchies-extends--labels) for the
 rules.
 
+A model can also declare **actions** — named write operations over the ontology,
+the write-side counterpart to metrics. See [Actions](#actions-write-operations)
+below.
+
 ### Deployment targets (required)
 
 Every model must declare exactly one **deployment target** — the property graph
@@ -128,6 +132,41 @@ database the target names, so a `source` is reduced to its **final segment** —
 the table name in that database (`demo.sales.Orders` → `Orders`). That lets one
 authored `source` serve both backends; a Spanner-native `source` form is a
 planned [profiles](profiles.md) feature.
+
+### Actions (write operations)
+
+Where a metric reads a value over the ontology, an **action** *changes state*.
+Both are model-level and defined over the concepts, not bound to a single entity;
+the difference is direction. An action names a business operation and leaves the
+mechanics to an **executor**; the model contributes only what the ontology can
+say that a plain tool schema cannot — **parameters typed by the ontology**, where
+a scalar type is an ordinary value and an **entity type is an object reference**.
+
+```yaml
+    actions:
+      - name: PlaceOrder
+        description: Create an order for a customer   # informational; does not affect runtime
+        executor:                                     # exactly one kind: mcp / rest / grpc
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/commerce
+            tool: place_order                         # the tool's name within that server
+        parameters:                                   # each input an entity (object reference) or a scalar
+          - {name: customer, type: customer}          # `customer` is an entity -> an object reference
+          - {name: quantity, type: Integer}           # a scalar value
+```
+
+The `mcp` executor **references** a tool already registered in Agent Registry, by
+the server's resource name plus the tool's name; `rest` (`{endpoint, method}`)
+and `grpc` (`{service, method}`) are the other kinds. Exactly one kind is
+required.
+
+Actions are **write-side, so they have no BigQuery Graph representation** — the
+push emits no node/edge/measure for them and warns once that they were not placed
+in the graph. They are published to **Knowledge Catalog** instead, on the model's
+anchor entry (see
+[What gets created in Knowledge Catalog](reference.md#what-gets-created-in-knowledge-catalog)),
+and a `pull` recovers them. This is a prototype: an action's `precondition` and
+`affects` (its gate and blast radius) are **not** modeled yet.
 
 ## 2. Push
 

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -89,8 +89,9 @@ supertype's fields down and expresses the hierarchy as BigQuery labels. See
 rules.
 
 A model can also declare **actions** — named write operations over the ontology,
-the write-side counterpart to metrics. See [Actions](#actions-write-operations)
-below.
+the write-side counterpart to metrics — and **constraints**, the invariants an
+action must not break. See [Actions](#actions-write-operations) and
+[Constraints](#constraints-invariants) below.
 
 ### Deployment targets (required)
 
@@ -165,8 +166,42 @@ push emits no node/edge/measure for them and warns once that they were not place
 in the graph. They are published to **Knowledge Catalog** instead, on the model's
 anchor entry (see
 [What gets created in Knowledge Catalog](reference.md#what-gets-created-in-knowledge-catalog)),
-and a `pull` recovers them. This is a prototype: an action's `precondition` and
-`affects` (its gate and blast radius) are **not** modeled yet.
+and a `pull` recovers them. This is a prototype: an action's own `precondition`
+and `affects` (its per-action gate and blast radius) are **not** modeled yet —
+the gate today is model-level, expressed as [constraints](#constraints-invariants).
+
+### Constraints (invariants)
+
+A **constraint** is a named boolean invariant over the ontology — something that
+must hold for every instance, whatever writes to the model. Constraints are
+model-level like metrics and actions, and written in the same expression
+language:
+
+```yaml
+    constraints:
+      - name: NonNegativeBalance
+        expression: Customer.accountBalance >= 0
+        description: >-
+          A customer's account balance cannot go negative. Reduce the order
+          quantity or choose a customer with more available balance.
+      - name: PositiveQuantity
+        expression: OrderedAs.quantity > 0
+        description: An order line must be for at least one unit.
+```
+
+Constraints exist because actions change state: an agent running an action
+writes to a live store, and a bad write corrupts data. A constraint is checked
+**before the action commits** — if the write would leave any instance violating
+it, the action is rejected and nothing changes.
+
+Write the `description` as the message you want the caller to act on. It is
+surfaced verbatim as the violation error, so an agent that gets rejected can
+read it and choose a different move ("reduce the order quantity") instead of
+retrying the same call.
+
+Like actions, constraints are **not** part of the graph — the push emits nothing
+for them and warns once, then publishes them to **Knowledge Catalog** on the
+model's anchor entry, where a `pull` recovers them.
 
 ## 2. Push
 

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -26,6 +26,7 @@ back. For the Ossie document format itself, see
 |---|---|
 | **This page** | author a model and deploy it |
 | [Codelab: one semantic ontology, one data journey](codelab.md) | see the whole lifecycle: author, govern, hydrate, query |
+| [Modeling write operations](actions.md) | let an agent change data, gated by the model's constraints |
 | [Reference](reference.md) | look up a flag, what push creates, validation, or permissions |
 | [What push and pull preserve](fidelity.md) | understand why something changed or wasn't recovered |
 | [Importing an OWL ontology](owl-import.md) | start from an OWL ontology instead of hand-authoring |
@@ -169,6 +170,8 @@ anchor entry (see
 and a `pull` recovers them. This is a prototype: an action's own `precondition`
 and `affects` (its per-action gate and blast radius) are **not** modeled yet —
 the gate today is model-level, expressed as [constraints](#constraints-invariants).
+[Modeling write operations](actions.md) walks the whole path, from declaring an
+action to running one against a live store.
 
 ### Constraints (invariants)
 

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -203,6 +203,13 @@ Like actions, constraints are **not** part of the graph — the push emits nothi
 for them and warns once, then publishes them to **Knowledge Catalog** on the
 model's anchor entry, where a `pull` recovers them.
 
+Enforcing a constraint is a separate job from publishing it, and `demo/action/`
+shows what that looks like: a runtime resolves an action's entity-typed
+arguments, applies the write in a transaction, checks every constraint against
+the uncommitted result, and either commits or rolls back with the violated
+constraint's `description`. That demo also exposes the action over MCP, so an
+agent that gets rejected reads the description and corrects its next call.
+
 ## 2. Push
 
 ```bash

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -1,0 +1,284 @@
+# Modeling write operations
+
+A semantic model says what the data means. An **action** says what can be done to
+it, and a **constraint** says what has to stay true while it is done. A model
+with both is something an agent can act through rather than only read from.
+
+An action names a business operation and leaves the mechanics to an
+**executor**. The model adds two things on top of a plain tool schema. The first
+is parameters typed by the ontology, so an entity-typed argument is an object
+reference rather than a value. The second is a gate: the model's constraints are
+checked against the result of the write before that write is allowed to stand.
+
+Actions and constraints are write-side, so they have no representation in the
+graph. `kcmd push` publishes both to Knowledge Catalog on the model's anchor
+entry and warns once that nothing was placed in the graph. Enforcing them is a
+separate job from publishing them, done by the runtime in
+[`src/libts/semantic/runtime.ts`](../../src/libts/semantic/runtime.ts); the
+runnable version of everything below is in
+[`demo/action/`](../../demo/action/README.md).
+
+## When to use it
+
+Declare an action when an agent has to change data and you want the rules that
+keep that data correct to live in the model. The rules then hold for every
+caller, and a caller that is refused is told what to do differently in the words
+you wrote.
+
+Do not declare an action for a question about the data; that is a
+[metric](README.md#1-author-a-model). Do not write a constraint to say who is
+allowed to see what. A constraint explains itself to the caller so the caller
+can correct its next move, and an explanation of an access rule describes the
+data the rule protects.
+
+## The one rule
+
+Every constraint in the model is checked on every action, and the check looks at
+the rows the action touched:
+
+> **An action must not introduce a violation among the rows it changes.**
+
+An account that was already below its floor before the call was not put there by
+this action, and it does not block the call. An account the action *changed* has
+to come out satisfying every constraint. Scoping the check this way also keeps
+the cost of a write independent of table size; probing whole tables on every
+write would make each call cost more as the data grows.
+
+## 1. Declare the action
+
+An action is model-level, beside metrics. It carries a name, an executor, and
+its parameters:
+
+```yaml
+version: "0.2.0.dev0"
+semantic_model:
+  - name: payments
+    entities:
+      - name: Account
+        primary_key: [accountId]
+        source: my-project.bank.account
+        fields:
+          - { name: accountId,      datatype: Integer, expression: account_id }
+          - { name: name,           datatype: String,  expression: name }
+          - { name: balance,        datatype: Float,   expression: balance }
+          - { name: minimumBalance, datatype: Float,   expression: minimum_balance }
+          - { name: status,         datatype: String,  expression: status }
+      - name: Transfer
+        primary_key: [transferId]
+        source: my-project.bank.transfer
+        fields:
+          - { name: transferId, datatype: Integer, expression: transfer_id }
+          - { name: amount,     datatype: Float,   expression: amount }
+    actions:
+      - name: TransferFunds
+        description: Move money from one account to another.
+        executor:                                  # exactly one kind: mcp / rest / grpc
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/payments
+            tool: transfer_funds
+        parameters:
+          - { name: source, type: Account }        # an entity type: an object reference
+          - { name: target, type: Account }
+          - { name: amount, type: Float }
+        ai_context:
+          instructions: >-
+            Resolve both accounts before calling. If the call is rejected, read
+            the reason: it names the rule that was broken and what to change.
+```
+
+`source` and `target` are typed `Account`, which is an entity in this model, so
+they are object references. A caller supplies something human — an account id or
+a display name — and the runtime works out which row that denotes, failing when
+nothing matches and when more than one thing does. `amount` is typed `Float`,
+one of the scalar datatypes, so it is an ordinary value and is passed through.
+
+The executor says where the operation lives. `mcp` (`{server, tool}`) references
+a tool already registered in Agent Registry; `rest` (`{endpoint, method}`) and
+`grpc` (`{service, method}`) are the other kinds, and exactly one kind is
+required. An executor names no statement, which is why the runtime does not
+produce the write itself — see
+[What is not modeled yet](#what-is-not-modeled-yet).
+
+## 2. State the rules as constraints
+
+A constraint is a named boolean invariant over the ontology, written in the same
+expression language as a metric:
+
+```yaml
+    constraints:
+      - name: NonNegativeBalance
+        expression: Account.balance >= 0
+        description: >-
+          An account cannot be overdrawn. Transfer a smaller amount, or move
+          money from an account that holds enough.
+      - name: AboveMinimumBalance
+        expression: Account.balance >= Account.minimumBalance
+        description: >-
+          This account has to keep a minimum balance. Move less, or draw from an
+          account with more room above its floor.
+      - name: PositiveAmount
+        expression: Transfer.amount > 0
+        description: >-
+          A transfer has to move a positive amount. To reverse a payment, make a
+          transfer in the other direction.
+      - name: OpenAccountsOnly
+        expression: Account.status != 'FROZEN'
+        description: >-
+          A frozen account cannot send or receive money. Choose a different
+          account, or have this one unfrozen first.
+```
+
+Two things decide whether this block does its job.
+
+**A constraint belongs to the model rather than to an action.** No action lists
+the constraints it cares about; every constraint is checked on every action. A
+rule you write once holds for `TransferFunds` and for the next action you add.
+
+**The description is the error message.** It comes back verbatim when the rule
+is broken, so write it as an instruction to whoever tripped it. "Transfer a
+smaller amount, or move money from an account that holds enough" tells an agent
+what to try next. "Invalid balance" sends it back to retry the same call.
+
+## 3. Push the model
+
+```bash
+kcmd push
+```
+
+Push emits no node, edge, or measure for an action or a constraint, and warns
+once for each kind that they were not placed in the graph. Both are published to
+Knowledge Catalog instead, on the model's anchor entry, where `kcmd pull`
+recovers them. What that entry holds is in
+[Reference → What gets created in Knowledge Catalog](reference.md#what-gets-created-in-knowledge-catalog).
+
+Publishing puts the rules where anything reading the model can see them. It does
+not enforce them. Enforcement is step 4.
+
+## 4. Run the action
+
+The runtime takes the model, the action's name, the caller's arguments, a
+Spanner client, and a handler that produces the write:
+
+```ts
+const outcome = await runAction({
+  model,
+  actionName: 'TransferFunds',
+  args: {source: 'Alice Checking', target: 'Bob Checking', amount: 500},
+  client,
+  handler: transferHandler,
+});
+```
+
+It then runs four steps:
+
+1. **Resolve.** Each entity-typed argument becomes the row it denotes. `"Alice
+   Checking"` becomes account 1.
+2. **Apply.** A read-write transaction opens and the handler's statements run
+   inside it. Nothing is visible to anyone else yet.
+3. **Gate.** Every constraint is lowered to a query that returns violating rows,
+   and each one runs in that same transaction, so it observes the uncommitted
+   write.
+4. **Decide.** Any violation rolls the transaction back and returns the violated
+   constraint's `description`. No violation commits.
+
+A transfer that satisfies every rule commits, and the outcome names what was
+checked and what was resolved:
+
+```
+Committed. Checked NonNegativeBalance, AboveMinimumBalance, PositiveAmount,
+OpenAccountsOnly. Resolved Alice Checking -> 1, Bob Checking -> 3.
+```
+
+A transfer of 5000 out of an account holding 2500 is refused, and the message is
+the one the model author wrote:
+
+```
+REJECTED (rolled back): An account cannot be overdrawn. Transfer a smaller
+amount, or move money from an account that holds enough. Rejected by constraint
+'NonNegativeBalance' (Account.balance >= 0). Violating Account: 1. ...
+```
+
+Two constraints fail in that example and both are reported: the balance goes
+below zero and below the account's own floor. The database is left as it was.
+
+An argument that names nothing fails before any transaction opens:
+
+```
+ERROR: No Account matches 'Dave Checking'.
+```
+
+An ambiguous reference is reported the same way, with the candidates listed, so
+the caller can pick one.
+
+## 5. Let an agent act
+
+Expose the action as a tool and the rejection becomes the useful part of the
+loop. An agent asks for a transfer that overdraws an account, reads back
+"transfer a smaller amount, or move money from an account that holds enough",
+checks the balances, and tries again with a workable figure. The rule was never
+written into its prompt. It lives in the model, and the model is what the agent
+was handed.
+
+[`demo/action/mcp.ts`](../../demo/action/mcp.ts) is a worked example: an MCP
+server over stdio exposing `describe_model`, `list_accounts`, and
+`transfer_funds`.
+
+## What the gate can check
+
+The expression grammar is small on purpose: comparisons between a field and
+either a literal or another field of the same entity, joined by `AND` and `OR`.
+The operators are `>=`, `<=`, `!=`, `<>`, `=`, `>`, and `<`. A single constraint
+ranges over one entity, so `Account.balance >= Account.minimumBalance` is inside
+the grammar and a comparison across two entities is outside it. Aggregates and
+function calls are outside it as well, and parentheses are not parsed at all. A
+chain that mixes `AND` and `OR` is accepted and grouped by SQL precedence, so
+`AND` binds tighter than `OR`.
+
+A NULL counts as a violation. `Account.balance >= 0` is unknown when the balance
+is NULL, and the gate reads unknown as unsatisfied, so a row with a NULL in a
+constrained field is refused. To ask whether a field is populated, write
+`= NULL` or `!= NULL`; those two lower to `IS NULL` and `IS NOT NULL`, and NULL
+with an ordering operator is refused as meaningless.
+
+An expression the runtime cannot lower does not quietly pass. The action is
+refused before the transaction opens, because the runtime cannot tell an
+unevaluated invariant from a satisfied one, and resolving that doubt in favor of
+the write is how data gets corrupted.
+
+## What is not modeled yet
+
+This is a prototype, and four gaps are worth knowing before you build on it.
+
+- **An action has no `precondition` and no `affects`.** The gate is model-level:
+  every constraint is checked on every action. The rows an action touched are
+  used to keep each probe cheap, and they never narrow which rules apply.
+- **The runtime does not call the executor.** An action names where an operation
+  lives rather than what statement it runs, so the caller supplies a handler
+  that produces the statements. Executor dispatch is the seam where MCP, REST,
+  and gRPC would later slot in.
+- **The write path is Spanner.** `runAction` takes a Spanner client, and the
+  gate depends on running the probes inside the same transaction as the write.
+- **No `kcmd` command runs an action.** Push publishes the action and its
+  constraints; running one means calling the runtime, as `demo/action/` does.
+
+## When an action is refused and you did not expect it
+
+- **A row that only gains value is still checked.** A transfer into a frozen
+  account is refused by `OpenAccountsOnly` even though the transfer only adds
+  money, because the action touched that row and a touched row has to satisfy
+  every constraint.
+- **Enough money is not the rule the model states.** An account holding 18000
+  with a 5000 floor refuses a transfer of 14000, and the constraint that
+  refuses it is `AboveMinimumBalance`. If that is wrong, the expression is what
+  to change.
+- **A constraint outside the grammar refuses everything.** The action aborts
+  before it writes, and the message names the constraint that could not be
+  lowered. Rewrite it inside the grammar, or take it out of the model and check
+  it elsewhere.
+- **A pre-existing violation is not the cause.** Probes are scoped to the rows
+  the action touched, so an account that was already below its floor before the
+  call does not block an unrelated transfer.
+
+Actions and constraints reach Knowledge Catalog the same way for a BigQuery
+model and a Spanner model, and neither backend's graph carries them. Enforcement
+today runs against Spanner.

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -27,6 +27,7 @@ measures and no `OPTIONS` metadata — see [To Spanner Graph](#to-spanner-graph)
 | Relationship (1:1 / 1:N) | `EDGE TABLE` | `schema-join` link | ✓ (name normalized⁶) |
 | Relationship (M:N / `association`) | `EDGE TABLE` (via junction table) | — not stored | — |
 | Entity `extends` | `LABEL` clauses + flattened fields | — not modelled | — |
+| Action | — not represented (write-side)¹⁰ | `overview` aspect on the model anchor | ✓¹⁰ |
 | `description` (entity / metric / field / relationship) | `OPTIONS(description)` | entry description / aspect | ✓ |
 | `ai_context.synonyms` | `OPTIONS(synonyms=[...])` | — not stored | — |
 | `ai_context.instructions` | into `OPTIONS(description)` | `guidelines` aspect⁷ | ✓⁷ |
@@ -45,6 +46,8 @@ measures and no `OPTIONS` metadata — see [To Spanner Graph](#to-spanner-graph)
 ⁶ Relationship names come back lowercased/hyphenated (`Places Order` → `places-order`) — the catalog stores the name only in the link id. See [Writer-side follow-up](#writer-side-follow-up).
 ⁷ The `guidelines` aspect exists only for the model, entities, and metrics — not fields or relationships, so field- and relationship-level `ai_context.instructions` has no Knowledge Catalog home (a relationship's instructions still reach BigQuery, folded into the edge's `OPTIONS(description)`).
 ⁸ BigQuery silently drops statement-level graph `OPTIONS`, so model-level metadata has no home in the graph; the model's `description` and `ai_context.instructions` are carried into Knowledge Catalog instead.
+¹⁰ Actions are write-side, so they produce no graph construct — the push warns once and emits nothing to BigQuery. They are published to Knowledge Catalog on the model anchor's `overview` aspect (Markdown plus an embedded JSON block) and `pull` recovers them from that JSON. Prototype scope: an action's `precondition` and `affects` are not modelled, so nothing about them is stored either way.
+
 ⁹ Every other `custom_extensions` block — most notably the OWL constructs the importer carries with no native home yet (`owl:inverseOf`, `rdfs:subPropertyOf`, the equivalences and disjointness pairs, property characteristics, `owl:deprecated`/`owl:versionInfo`, …) — is inert on push and not persisted to Knowledge Catalog, so `pull` never recovers it. It does survive the OSI *document* round-trip verbatim, so it stays intact in your authored file. See [Constructs carried as custom extensions](owl-import.md#constructs-carried-as-custom-extensions-not-yet-native) for the full list and shape.
 
 ## To BigQuery
@@ -111,6 +114,13 @@ the `guidelines` aspect), or the original vendor SQL (`importedExpression` — e
 the MAQL or Snowflake form a metric was imported from). Those stay in your
 authored document; the vendor SQL and expressions are still used when generating
 BigQuery SQL.
+
+**Actions** are the exception to "one entry per element": they have no
+`semantic-*` type, so they are stored on the model anchor's built-in `overview`
+aspect — Markdown for humans plus an embedded JSON block. That JSON is the
+canonical copy, so actions round-trip losslessly through `pull` (name,
+description, executor, and typed parameters). Their `precondition`/`affects` are
+out of scope for this prototype and are not stored.
 
 ## What pull recovers
 

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -115,12 +115,13 @@ the MAQL or Snowflake form a metric was imported from). Those stay in your
 authored document; the vendor SQL and expressions are still used when generating
 BigQuery SQL.
 
-**Actions** are the exception to "one entry per element": they have no
-`semantic-*` type, so they are stored on the model anchor's built-in `overview`
-aspect — Markdown for humans plus an embedded JSON block. That JSON is the
-canonical copy, so actions round-trip losslessly through `pull` (name,
-description, executor, and typed parameters). Their `precondition`/`affects` are
-out of scope for this prototype and are not stored.
+**Actions and constraints** are the exception to "one entry per element": they
+have no `semantic-*` type, so they are stored on the model anchor's built-in
+`overview` aspect — Markdown for humans plus an embedded JSON block, one block
+each under its own marker. That JSON is the canonical copy, so both round-trip
+losslessly through `pull`: an action's name, description, executor, and typed
+parameters; a constraint's name, expression, and description. An action's own
+`precondition`/`affects` are out of scope for this prototype and are not stored.
 
 ## What pull recovers
 

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -76,6 +76,7 @@ becomes one part of that graph:
 | Relationship | `EDGE TABLE` | connects the two entities' node tables |
 | Metric | `MEASURE` on a node table | must resolve to a single entity (otherwise the push is rejected — see [Validation](#validation)) and reduce to one supported aggregate over one operand (otherwise that metric is skipped with a warning) |
 | Entity `extends` | extra `LABEL` clauses on the subclass node table | the subclass also matches its supertypes; the supertypes' fields flatten down (see [Class hierarchies](#class-hierarchies-extends--labels)) |
+| Action | *nothing* | actions are write-side and have no graph construct; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
 
 `push` reads the target dataset's location (`bigquery.datasets.get`) so the
 statement runs in the right region; without that permission it falls back to
@@ -225,6 +226,7 @@ them, it never creates them.
 | Entity | `semantic-entity` (+ built-in `schema` aspect) | entry | `<model>.entities.<entity>` |
 | Metric | `semantic-metric` | entry | `<model>.metrics.<metric>` |
 | Relationship | `schema-join` | entry link between the two entity entries | derived from the model and relationship names |
+| Actions | built-in `overview` aspect on the model anchor | aspect (not its own entry) | — |
 
 An entity entry carries its columns in the `schema` aspect (name, data type,
 description, and any `label` per field), plus the entity's keys and unique keys
@@ -232,6 +234,13 @@ description, and any `label` per field), plus the entity's keys and unique keys
 relationship detail — the paired columns and foreign-key direction — in its
 aspect. Any element with `ai_context.instructions` (the model, an entity, or a
 metric) also gets a built-in `guidelines` aspect holding that text.
+
+A model's **actions** have no `semantic-*` system type of their own, so they ride
+the model anchor's built-in `overview` aspect: human-readable Markdown for each
+action (name, description, executor, typed parameters) followed by an embedded
+JSON block that a `pull` recovers them from losslessly. The overview is attached
+only when the model declares actions. (This is the prototype scope — an action's
+`precondition` and `affects` are not modeled yet.)
 
 Push to Knowledge Catalog is lossy — the catalog holds metadata, not a full copy
 of your model. For exactly what is stored, what is gated behind
@@ -261,6 +270,15 @@ touched**, so a model that cannot deploy fails fast instead of half-deploying:
   entity, or scope its expression to a single entity. This rule is
   BigQuery-only: Spanner Graph has no `MEASURE`, so a Spanner target drops its
   metrics by design and imposes no such requirement. *(static)*
+* **Every action is well-formed.** Each action parameter's `type` must resolve to
+  a known entity (an object reference) or a scalar datatype, and each executor
+  must carry its coordinates (an `mcp` server + tool, a `rest` endpoint + method,
+  or a `grpc` service + method) with no blank field. (The "exactly one executor
+  kind" rule is enforced when the model is parsed.) These checks are static, so
+  they run on every push, regardless of destination. Note that actions themselves
+  deploy **only** through the Knowledge Catalog leg — a graph-only `--no-kc` push
+  validates them but has nowhere to put them, and warns that they will not be
+  deployed. *(static)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it
   exactly as the deploy will — a three-part `project.dataset.table`, a four-part
@@ -311,6 +329,8 @@ and each aspect type attached, so a push needs, on the destination entry group:
   `schema` aspect (its fields, keys, unique keys, and labels)
 * `dataplex.entryGroups.useGuidelinesAspect` — when the model, an entity, or a
   metric carries `ai_context.instructions`
+* `dataplex.entryGroups.useOverviewAspect` — when the model declares actions
+  (they ride the anchor's built-in `overview` aspect)
 * `dataplex.entryGroups.useSchemaJoinAspect` and
   `dataplex.entryGroups.useSchemaJoinEntryLink` — when the model has relationships
 * the `use<AspectType>Aspect` permission for the `semantic-model`,

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -77,6 +77,7 @@ becomes one part of that graph:
 | Metric | `MEASURE` on a node table | must resolve to a single entity (otherwise the push is rejected — see [Validation](#validation)) and reduce to one supported aggregate over one operand (otherwise that metric is skipped with a warning) |
 | Entity `extends` | extra `LABEL` clauses on the subclass node table | the subclass also matches its supertypes; the supertypes' fields flatten down (see [Class hierarchies](#class-hierarchies-extends--labels)) |
 | Action | *nothing* | actions are write-side and have no graph construct; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
+| Constraint | *nothing* | constraints are checked when an action runs, not read-side structure; the push emits nothing and warns once, then publishes them to Knowledge Catalog (see below) |
 
 `push` reads the target dataset's location (`bigquery.datasets.get`) so the
 statement runs in the right region; without that permission it falls back to
@@ -240,7 +241,13 @@ the model anchor's built-in `overview` aspect: human-readable Markdown for each
 action (name, description, executor, typed parameters) followed by an embedded
 JSON block that a `pull` recovers them from losslessly. The overview is attached
 only when the model declares actions. (This is the prototype scope — an action's
-`precondition` and `affects` are not modeled yet.)
+own `precondition` and `affects` are not modeled yet.)
+
+A model's **constraints** ride that same `overview` aspect, under their own
+marker: a Markdown section for each constraint (name, description, expression)
+followed by its own embedded JSON block. Actions and constraints therefore share
+one aspect without overwriting each other, and the overview is attached when the
+model declares **either**.
 
 Push to Knowledge Catalog is lossy — the catalog holds metadata, not a full copy
 of your model. For exactly what is stored, what is gated behind
@@ -279,6 +286,16 @@ touched**, so a model that cannot deploy fails fast instead of half-deploying:
   deploy **only** through the Knowledge Catalog leg — a graph-only `--no-kc` push
   validates them but has nowhere to put them, and warns that they will not be
   deployed. *(static)*
+* **Every constraint is checkable.** A constraint's `expression` must be
+  non-empty, and when it opens with an `<Entity>.<field>` qualifier naming a
+  **known** entity, that entity must actually declare the field — this catches a
+  typo that would otherwise surface only inside an agent's rejected action. A
+  leading qualifier that is not a known entity (a relationship-qualified name
+  like `OrderedAs.quantity`, a metric reference, or compound logic) is left to
+  the evaluator rather than guessed at, so a valid constraint is never falsely
+  rejected. Like actions, constraints deploy **only** through the Knowledge
+  Catalog leg, and a `--no-kc` push warns that they will not be deployed.
+  *(static)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it
   exactly as the deploy will — a three-part `project.dataset.table`, a four-part
@@ -329,8 +346,8 @@ and each aspect type attached, so a push needs, on the destination entry group:
   `schema` aspect (its fields, keys, unique keys, and labels)
 * `dataplex.entryGroups.useGuidelinesAspect` — when the model, an entity, or a
   metric carries `ai_context.instructions`
-* `dataplex.entryGroups.useOverviewAspect` — when the model declares actions
-  (they ride the anchor's built-in `overview` aspect)
+* `dataplex.entryGroups.useOverviewAspect` — when the model declares actions or
+  constraints (both ride the anchor's built-in `overview` aspect)
 * `dataplex.entryGroups.useSchemaJoinAspect` and
   `dataplex.entryGroups.useSchemaJoinEntryLink` — when the model has relationships
 * the `use<AspectType>Aspect` permission for the `semantic-model`,

--- a/toolbox/mdcode/package.json
+++ b/toolbox/mdcode/package.json
@@ -18,6 +18,7 @@
     "test:libts": "npx bun test ./tests/libts/scenarios.ts && npx bun test ./tests/libts/layouts/",
     "test:semantic": "npx bun test ./tests/libts/semantic/",
     "test": "npm run test:libts && npm run test:semantic",
+    "test:live": "npx bun test ./tests/live/",
     "x:mcp": "npx @modelcontextprotocol/inspector dist/kcmd mcp"
   },
   "keywords": [],

--- a/toolbox/mdcode/src/libts/gcp/spanner.ts
+++ b/toolbox/mdcode/src/libts/gcp/spanner.ts
@@ -110,6 +110,15 @@ export interface Statement {
 // semantic runtime, whose gate runs between the write and the commit.
 export class SpannerDataClient extends api.ApiClient {
   private readonly _database: string;
+  // Per-transaction statement counter. Spanner REQUIRES a monotonically
+  // increasing `seqno` on every DML statement in a read-write transaction --
+  // it is how the server recognizes a retry of a statement it has already
+  // applied, so that a retried DML is not applied twice. Sending the same seqno
+  // with a DIFFERENT statement fails with "Previously received a different
+  // request with this seqno", which is what makes a hand-rolled client fail on
+  // its second statement. Tracking it here means a caller running several
+  // statements in one transaction does not have to know about it at all.
+  private readonly _seqno = new Map<string, number>();
 
   constructor(
       ctx: context.ApiContext, project: string, instance: string,
@@ -146,22 +155,29 @@ export class SpannerDataClient extends api.ApiClient {
   async executeSql(
       sessionName: string, transactionId: string,
       stmt: Statement): Promise<api.ApiResult<ResultSet>> {
+    const seqno = (this._seqno.get(transactionId) ?? 0) + 1;
+    this._seqno.set(transactionId, seqno);
     return await this._post<ResultSet>(`${sessionName}:executeSql`, {
       transaction: {id: transactionId},
       sql: stmt.sql,
       params: stmt.params,
       paramTypes: stmt.paramTypes,
+      // Ignored for queries, required for DML; sent unconditionally so the
+      // counter stays in step with the statements actually issued.
+      seqno: `${seqno}`,
     });
   }
 
   async commit(sessionName: string, transactionId: string):
       Promise<api.ApiResult<{commitTimestamp?: string}>> {
+    this._seqno.delete(transactionId);
     return await this._post<{commitTimestamp?: string}>(
         `${sessionName}:commit`, {transactionId});
   }
 
   async rollback(sessionName: string, transactionId: string):
       Promise<api.ApiResult<{}>> {
+    this._seqno.delete(transactionId);
     return await this._post<{}>(`${sessionName}:rollback`, {transactionId});
   }
 

--- a/toolbox/mdcode/src/libts/gcp/spanner.ts
+++ b/toolbox/mdcode/src/libts/gcp/spanner.ts
@@ -1,9 +1,15 @@
-// API client for Cloud Spanner (Database Admin surface).
+// API client for Cloud Spanner.
 //
-// The semantic-model Spanner leg only needs to run DDL and a table existence
-// probe, so this exposes just those: updateDatabaseDdl (which returns a
-// long-running operation), getOperation (to poll it), and getTable (a cheap
-// pre-flight over information schema is out of scope here; see the deploy leg).
+// Two surfaces, on two hosts:
+//
+//   * Database Admin -- updateDatabaseDdl (which returns a long-running
+//     operation) and getOperation (to poll it). This is what the semantic-model
+//     push leg needs to create a property graph.
+//   * Data (SpannerDataClient) -- sessions and read-write transactions, so a
+//     caller can run DML and queries and decide whether to commit. This is what
+//     the semantic runtime needs: it applies an action's writes, evaluates the
+//     model's constraints against the UNCOMMITTED state in the same
+//     transaction, and then commits or rolls back.
 //
 
 import * as api from './api';
@@ -46,5 +52,133 @@ export class SpannerClient extends api.ApiClient {
   // `projects/.../instances/.../databases/.../operations/...`).
   async getOperation(operationName: string): Promise<api.ApiResult<Operation>> {
     return await this._get<Operation>(operationName);
+  }
+}
+
+
+// A Spanner session, the handle every data-API call is scoped to. Sessions are
+// server resources with a finite lifetime, so a caller creates one, uses it,
+// and deletes it (see SpannerDataClient.withSession).
+export interface Session {
+  name?: string;
+  [key: string]: any;
+}
+
+
+// A transaction handle returned by beginTransaction. `id` is the opaque token
+// that subsequent executeSql / commit / rollback calls quote.
+export interface Transaction {
+  id?: string;
+  [key: string]: any;
+}
+
+
+// One row of a query result. The Spanner REST surface returns values
+// positionally in `rows` with the column layout in `metadata.rowType.fields`,
+// and encodes every scalar as a STRING (an INT64 comes back as "42"), so a
+// caller converts as needed.
+export interface ResultSet {
+  metadata?: {rowType?: {fields?: Array<{name?: string; type?: any}>}};
+  rows?: string[][];
+  stats?: {rowCountExact?: string; [key: string]: any};
+  [key: string]: any;
+}
+
+
+// The parameter types accompanying a parameterized statement. Spanner infers
+// most types from the JSON value, but cannot infer one for a NULL or for an
+// empty array, so those must be declared. Codes are Spanner TypeCode names
+// (e.g. 'INT64', 'STRING', 'FLOAT64', 'TIMESTAMP').
+export type ParamTypes = Record<string, {code: string; arrayElementType?: {code: string}}>;
+
+
+// A statement to run inside a transaction: SQL plus its named parameters
+// (referenced as @name in the SQL).
+export interface Statement {
+  sql: string;
+  params?: Record<string, any>;
+  paramTypes?: ParamTypes;
+}
+
+
+// The Spanner DATA surface (spanner.googleapis.com/v1), a separate client from
+// the Database Admin one above because the two share a host but nothing else:
+// this one is scoped to a single database and speaks sessions, not operations.
+//
+// Read-write transactions here are explicit rather than a callback wrapper, so
+// the caller keeps the decision to commit -- which is the whole point for the
+// semantic runtime, whose gate runs between the write and the commit.
+export class SpannerDataClient extends api.ApiClient {
+  private readonly _database: string;
+
+  constructor(
+      ctx: context.ApiContext, project: string, instance: string,
+      database: string) {
+    super('https://spanner.googleapis.com', 'v1', ctx);
+    this._database =
+        `projects/${project}/instances/${instance}/databases/${database}`;
+  }
+
+  get database(): string {
+    return this._database;
+  }
+
+  async createSession(): Promise<api.ApiResult<Session>> {
+    return await this._post<Session>(`${this._database}/sessions`, {});
+  }
+
+  async deleteSession(sessionName: string): Promise<api.ApiResult<{}>> {
+    return await this._delete<{}>(sessionName);
+  }
+
+  // Starts a read-write transaction. Spanner also allows a single-use
+  // transaction inlined on executeSql, but the runtime needs a durable id it
+  // can hold across the write, the constraint probes, and the commit.
+  async beginReadWrite(sessionName: string): Promise<api.ApiResult<Transaction>> {
+    return await this._post<Transaction>(
+        `${sessionName}:beginTransaction`, {options: {readWrite: {}}});
+  }
+
+  // Runs one statement inside `transactionId`. Used for both the action's DML
+  // and the constraint probes, so the probes observe the transaction's own
+  // uncommitted writes (read-your-writes) -- the property that makes the gate
+  // meaningful.
+  async executeSql(
+      sessionName: string, transactionId: string,
+      stmt: Statement): Promise<api.ApiResult<ResultSet>> {
+    return await this._post<ResultSet>(`${sessionName}:executeSql`, {
+      transaction: {id: transactionId},
+      sql: stmt.sql,
+      params: stmt.params,
+      paramTypes: stmt.paramTypes,
+    });
+  }
+
+  async commit(sessionName: string, transactionId: string):
+      Promise<api.ApiResult<{commitTimestamp?: string}>> {
+    return await this._post<{commitTimestamp?: string}>(
+        `${sessionName}:commit`, {transactionId});
+  }
+
+  async rollback(sessionName: string, transactionId: string):
+      Promise<api.ApiResult<{}>> {
+    return await this._post<{}>(`${sessionName}:rollback`, {transactionId});
+  }
+
+  // Runs `fn` with a fresh session and deletes it afterwards, including when
+  // `fn` throws -- a leaked session holds server resources until it ages out.
+  async withSession<T>(fn: (sessionName: string) => Promise<T>): Promise<T> {
+    const created = await this.createSession();
+    const sessionName = created.result?.name;
+    if (!sessionName) {
+      throw new Error(
+          `Spanner: could not create a session on ${this._database} (${
+              created.status}${created.message ? `: ${created.message}` : ''})`);
+    }
+    try {
+      return await fn(sessionName);
+    } finally {
+      await this.deleteSession(sessionName);
+    }
   }
 }

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -76,6 +76,21 @@ export function generatePropertyGraph(
   const relationships = resolved.model.relationships ?? [];
   const metrics = resolved.model.metrics ?? [];
 
+  // Actions are write-side operations with no read-side graph construct (no
+  // NODE TABLE / EDGE TABLE / MEASURE), so the BigQuery leg emits nothing for
+  // them. Warn once so an author who declared actions is not surprised they are
+  // absent from the graph. Their only destination is Knowledge Catalog (see
+  // knowledge_catalog.actionsOverviewAspectData) -- but that leg runs only when
+  // the KC destination is in the push, so the message stays conditional (a
+  // bq-only push warns separately that actions go nowhere; see commands.ts).
+  const actions = resolved.model.actions ?? [];
+  if (actions.length) {
+    warnings.push(
+        `${actions.length} action(s) are not represented in the BigQuery ` +
+        `property graph (actions are write-side); they are published to ` +
+        `Knowledge Catalog when that destination is included in the push.`);
+  }
+
   // An abstract entity is conceptual: it has no physical table and produces no
   // NODE TABLE, surviving only as a LABEL on its concrete descendants (whose
   // node tables carry its flattened fields). Collect the abstract names so the

--- a/toolbox/mdcode/src/libts/semantic/bigquery.ts
+++ b/toolbox/mdcode/src/libts/semantic/bigquery.ts
@@ -80,7 +80,7 @@ export function generatePropertyGraph(
   // NODE TABLE / EDGE TABLE / MEASURE), so the BigQuery leg emits nothing for
   // them. Warn once so an author who declared actions is not surprised they are
   // absent from the graph. Their only destination is Knowledge Catalog (see
-  // knowledge_catalog.actionsOverviewAspectData) -- but that leg runs only when
+  // knowledge_catalog.overviewAspectData) -- but that leg runs only when
   // the KC destination is in the push, so the message stays conditional (a
   // bq-only push warns separately that actions go nowhere; see commands.ts).
   const actions = resolved.model.actions ?? [];
@@ -89,6 +89,18 @@ export function generatePropertyGraph(
         `${actions.length} action(s) are not represented in the BigQuery ` +
         `property graph (actions are write-side); they are published to ` +
         `Knowledge Catalog when that destination is included in the push.`);
+  }
+
+  // Constraints are invariants checked at action time, not read-side graph
+  // structure, so the BigQuery leg emits nothing for them either. Same
+  // reasoning and same catalog home as actions above.
+  const constraints = resolved.model.constraints ?? [];
+  if (constraints.length) {
+    warnings.push(
+        `${constraints.length} constraint(s) are not represented in the ` +
+        `BigQuery property graph (constraints are checked when an action ` +
+        `runs); they are published to Knowledge Catalog when that destination ` +
+        `is included in the push.`);
   }
 
   // An abstract entity is conceptual: it has no physical table and produces no

--- a/toolbox/mdcode/src/libts/semantic/constraint_eval.ts
+++ b/toolbox/mdcode/src/libts/semantic/constraint_eval.ts
@@ -317,6 +317,9 @@ function renderPredicate(
 //   op         := >= | <= | != | <> | = | > | <
 //   literal    := a number, a single-quoted string, TRUE, FALSE, or NULL
 //
+// `= NULL` and `!= NULL` are read as null tests and lowered to IS NULL /
+// IS NOT NULL; NULL with an ordering operator is refused. See parseComparison.
+//
 // Parentheses, function calls, IN/BETWEEN/LIKE, and metric references are all
 // outside it -- on purpose. Each is a real thing a constraint might want, and
 // each needs a decision (how to evaluate a metric inside a row-level probe, for
@@ -406,10 +409,36 @@ function parseComparison(segment: string): Comparison|{error: string} {
           `<Entity>.<field> reference`,
     };
   }
+
+  const operator = normalizeOperator(found.operator);
+
+  // NULL is not an operand any comparison operator accepts -- GoogleSQL rejects
+  // `col = NULL` outright rather than evaluating it to unknown, so lowering it
+  // verbatim would emit a probe that can never run. An author writing
+  // `Account.ownerId != NULL` means the column must be populated, which SQL
+  // spells IS NOT NULL, so translate the two operators that have a null-test
+  // reading and refuse the four that do not: an ordering comparison against
+  // NULL has no meaning to preserve.
+  if (/^NULL$/i.test(rhs)) {
+    if (operator !== '=' && operator !== '!=') {
+      return {
+        error: `'${text}' compares with NULL using '${operator}', which has no ` +
+            `meaning; write '= NULL' or '!= NULL' to test whether the field is ` +
+            `set`,
+      };
+    }
+    return {
+      entity: left.entity,
+      field: left.field,
+      operator: operator === '=' ? 'IS' : 'IS NOT',
+      literal: 'NULL',
+    };
+  }
+
   return {
     entity: left.entity,
     field: left.field,
-    operator: normalizeOperator(found.operator),
+    operator,
     literal: rhs,
   };
 }

--- a/toolbox/mdcode/src/libts/semantic/constraint_eval.ts
+++ b/toolbox/mdcode/src/libts/semantic/constraint_eval.ts
@@ -1,0 +1,461 @@
+// Lowering a model's constraints to SQL probes.
+//
+// A constraint is a logical invariant over the ontology (`Account.balance >=
+// 0`). To enforce it against a live store, something has to turn that logical
+// statement into a query the store can answer. That is this module: given a
+// model and a constraint, it produces a PROBE -- a SELECT that returns the rows
+// which VIOLATE the constraint. No violating rows means the invariant holds.
+//
+// Two properties matter more than expressive power here:
+//
+//   * The probe is scoped. An action touches a handful of rows, so re-checking
+//     the whole table on every write would make the gate cost grow with the
+//     data. When the caller knows which keys it touched, the probe restricts to
+//     them.
+//   * The lowering FAILS CLOSED. An expression this module cannot lower does
+//     not silently pass -- it returns an error, and the runtime aborts the
+//     action. A gate that quietly lets writes through is worse than no gate,
+//     because it is believed.
+//
+// The grammar is deliberately small (see parseConstraint): comparisons between
+// a field and a literal or another field of the same entity, joined by AND/OR.
+// It covers the invariants an operational action actually trips -- a balance
+// going negative, a quantity going to zero -- and everything outside it is
+// reported rather than approximated.
+//
+
+import {Constraint, Entity, SemanticModel} from './ir';
+import {quoteIdentifier, quoteIfReserved} from './sql_identifiers';
+import {spannerTable} from './spanner';
+
+
+// The comparison operators the grammar accepts. Ordered longest-first so the
+// tokenizer matches `>=` before `>`.
+const OPERATORS = ['>=', '<=', '!=', '<>', '=', '>', '<'] as const;
+
+
+// A single `<Entity>.<field> <op> <operand>` comparison, as parsed.
+interface Comparison {
+  entity: string;
+  field: string;
+  operator: string;
+  // Exactly one of these is set: a literal (kept verbatim, already SQL-shaped)
+  // or a reference to another field on the same entity.
+  literal?: string;
+  rightField?: string;
+}
+
+
+// A parsed constraint expression: comparisons joined by the logical operators
+// between them (`joiners[i]` sits between `comparisons[i]` and `[i+1]`).
+interface ParsedExpression {
+  comparisons: Comparison[];
+  joiners: string[];
+}
+
+
+// A lowered constraint, ready to run inside the action's transaction.
+export interface ConstraintProbe {
+  constraint: Constraint;
+  // The logical entity the constraint ranges over, and the physical table it
+  // resolves to under the model's current binding.
+  entity: string;
+  table: string;
+  // The entity's key columns, selected so a violation can name the offending
+  // instances rather than just report that one exists.
+  keyColumns: string[];
+  // A SELECT returning violating rows. Empty result means the invariant holds.
+  // Restricted to the caller's touched keys when `scoped` is true.
+  sql: string;
+  // The same probe over the whole table. Both forms are emitted rather than one
+  // being derived from the other, so a caller that turns out not to know the
+  // touched keys has a correct query to fall back to instead of editing SQL.
+  unscopedSql: string;
+  // Whether `sql` differs from `unscopedSql`. False when the caller asked for
+  // no scoping, or when the entity's composite key rules it out.
+  scoped: boolean;
+}
+
+
+export type LoweringResult = {
+  ok: true; probe: ConstraintProbe;
+}|{
+  ok: false;
+  // Why this constraint could not be lowered, phrased for the person who wrote
+  // the model -- the runtime surfaces it when it aborts the action.
+  reason: string;
+};
+
+
+export interface LowerOptions {
+  // The query parameter holding the touched key values (an ARRAY<STRING>), when
+  // the caller can scope the probe. Only usable on a single-key entity: a
+  // composite key needs a struct-array comparison, which the MVP does not emit,
+  // so a composite-key entity is probed unscoped.
+  touchedKeysParam?: string;
+  // Cap on the violating rows returned. A gate only needs enough to explain
+  // itself, not the full violation set.
+  limit?: number;
+}
+
+
+const DEFAULT_LIMIT = 5;
+
+
+// Lowers one constraint against `model`, or explains why it cannot.
+export function lowerConstraint(
+    model: SemanticModel, constraint: Constraint,
+    opts: LowerOptions = {}): LoweringResult {
+  const fail = (reason: string): LoweringResult => ({
+    ok: false,
+    reason: `constraint '${constraint.name}' cannot be evaluated: ${reason}`,
+  });
+
+  const parsed = parseConstraint(constraint.expression);
+  if ('error' in parsed) return fail(parsed.error);
+
+  const entityNames =
+      new Set(parsed.comparisons.map(c => c.entity));
+  if (entityNames.size > 1) {
+    return fail(
+        `it spans more than one entity (${
+            [...entityNames].sort().join(', ')}); the evaluator probes a ` +
+        `single entity's table, so split it into one constraint per entity`);
+  }
+
+  const entityName = parsed.comparisons[0].entity;
+  const entity = (model.entities ?? []).find(e => e.name === entityName);
+  if (!entity) {
+    return fail(`entity '${entityName}' is not declared in the model`);
+  }
+  if (entity.abstract) {
+    return fail(
+        `entity '${entityName}' is abstract, so it has no table to probe`);
+  }
+
+  // Every field the expression mentions has to resolve to a real column.
+  const columns = new Map<string, string>();
+  for (const c of parsed.comparisons) {
+    for (const fieldName of [c.field, c.rightField]) {
+      if (!fieldName || columns.has(fieldName)) continue;
+      const col = columnFor(entity, fieldName);
+      if ('error' in col) return fail(col.error);
+      columns.set(fieldName, col.column);
+    }
+  }
+
+  const keys = keyColumns(entity);
+  if ('error' in keys) return fail(keys.error);
+
+  const predicate = renderPredicate(parsed, columns);
+  const warnings: string[] = [];
+  const table = spannerTable(
+      entity.dataSource, warnings, `entity '${entity.name}'`);
+  if (warnings.length) {
+    return fail(
+        `entity '${entityName}' has no usable table (${warnings.join('; ')})`);
+  }
+
+  // NOT COALESCE(<predicate>, FALSE) rather than a plain NOT: SQL three-valued
+  // logic makes `NULL >= 0` unknown, and `NOT unknown` is unknown, so a NULL
+  // column would slip past a plain negation. Treating unknown as "did not
+  // satisfy the invariant" makes the row a violation -- the fail-closed reading,
+  // and the right one for a gate.
+  const violating = `NOT COALESCE(${predicate}, FALSE)`;
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+  const select = (where: string) =>
+      `SELECT ${keys.columns.join(', ')} FROM ${table} WHERE ${where} LIMIT ${
+          limit}`;
+
+  const unscopedSql = select(violating);
+  let sql = unscopedSql;
+  let scoped = false;
+  if (opts.touchedKeysParam && keys.columns.length === 1) {
+    // The key values arrive as strings, so the comparison casts rather than
+    // requiring the caller to know whether the key is an INT64 or a STRING.
+    // That gives up the index on the key column; on the handful of rows one
+    // action touches that costs nothing, and it keeps the runtime from having
+    // to carry a type map alongside the keys.
+    sql = select(
+        `${violating} AND CAST(${keys.columns[0]} AS STRING) IN UNNEST(@${
+            opts.touchedKeysParam})`);
+    scoped = true;
+  }
+
+  return {
+    ok: true,
+    probe: {
+      constraint,
+      entity: entityName,
+      table,
+      keyColumns: keys.columns,
+      sql,
+      unscopedSql,
+      scoped,
+    },
+  };
+}
+
+
+// Lowers every constraint on the model. Returns the probes and the reasons for
+// the ones that could not be lowered; the runtime treats a non-empty `errors`
+// as an abort, since it cannot tell an un-checkable invariant from a satisfied
+// one.
+export function lowerConstraints(
+    model: SemanticModel, opts: LowerOptions = {}):
+    {probes: ConstraintProbe[]; errors: string[]} {
+  const probes: ConstraintProbe[] = [];
+  const errors: string[] = [];
+  for (const constraint of model.constraints ?? []) {
+    const result = lowerConstraint(model, constraint, opts);
+    if (result.ok) {
+      probes.push(result.probe);
+    } else {
+      errors.push(result.reason);
+    }
+  }
+  return {probes, errors};
+}
+
+
+// The message returned when a probe finds violating rows. `description` is the
+// model author's own words and leads, because it is what tells an agent what to
+// do differently; the constraint name and expression follow as the citation.
+export function violationMessage(
+    probe: ConstraintProbe, violatingKeys: string[][]): string {
+  const lead = probe.constraint.description ??
+      `Constraint '${probe.constraint.name}' does not hold.`;
+  const cite = `Rejected by constraint '${probe.constraint.name}' (${
+      probe.constraint.expression}).`;
+  if (!violatingKeys.length) return `${lead} ${cite}`;
+  const rows = violatingKeys.map(k => k.join('/')).join(', ');
+  return `${lead} ${cite} Violating ${probe.entity}: ${rows}.`;
+}
+
+
+// The physical column backing `fieldName` on `entity`, or why there is none.
+// The MVP requires a BARE column: an expression-bound field (`price * qty`)
+// would need the expression inlined and re-resolved, which the small grammar
+// here does not attempt.
+function columnFor(entity: Entity, fieldName: string):
+    {column: string}|{error: string} {
+  const field = entity.fields.find(f => f.name === fieldName);
+  if (!field) {
+    return {
+      error: `entity '${entity.name}' declares no field '${fieldName}'`,
+    };
+  }
+  if (field.unbound) {
+    return {
+      error: `field '${entity.name}.${fieldName}' is unbound under the ` +
+          `current binding, so there is nothing to check it against`,
+    };
+  }
+  const expr = (field.expression ?? '').trim();
+  if (!expr) {
+    return {
+      error: `field '${entity.name}.${fieldName}' has no expression`,
+    };
+  }
+  if (!/^[A-Za-z_]\w*$/.test(expr)) {
+    return {
+      error: `field '${entity.name}.${fieldName}' is bound to an expression (${
+          expr}) rather than a bare column; the evaluator lowers bare columns ` +
+          `only`,
+    };
+  }
+  return {column: quoteIfReserved(expr)};
+}
+
+
+// The entity's key columns, resolved through its fields.
+function keyColumns(entity: Entity): {columns: string[]}|{error: string} {
+  if (!entity.keys.length) {
+    return {
+      error: `entity '${entity.name}' declares no key, so a violation could ` +
+          `not be attributed to a row`,
+    };
+  }
+  const columns: string[] = [];
+  for (const key of entity.keys) {
+    const col = columnFor(entity, key);
+    if ('error' in col) {
+      return {error: `key ${col.error}`};
+    }
+    columns.push(col.column);
+  }
+  return {columns};
+}
+
+
+// Renders the parsed expression with logical field names replaced by their
+// physical columns. Each comparison is parenthesized, so a mixed AND/OR
+// expression keeps the precedence the SQL engine would give it rather than one
+// this module invents.
+function renderPredicate(
+    parsed: ParsedExpression, columns: Map<string, string>): string {
+  const parts = parsed.comparisons.map(c => {
+    const left = columns.get(c.field)!;
+    const right =
+        c.rightField !== undefined ? columns.get(c.rightField)! : c.literal!;
+    return `(${left} ${c.operator} ${right})`;
+  });
+  let out = parts[0];
+  for (let i = 1; i < parts.length; i++) {
+    out = `${out} ${parsed.joiners[i - 1]} ${parts[i]}`;
+  }
+  return out;
+}
+
+
+// Parses a constraint expression into comparisons and the AND/OR between them.
+//
+// The grammar:
+//
+//   expression := comparison (('AND'|'OR') comparison)*
+//   comparison := <Entity>.<field> <op> (literal | <Entity>.<field>)
+//   op         := >= | <= | != | <> | = | > | <
+//   literal    := a number, a single-quoted string, TRUE, FALSE, or NULL
+//
+// Parentheses, function calls, IN/BETWEEN/LIKE, and metric references are all
+// outside it -- on purpose. Each is a real thing a constraint might want, and
+// each needs a decision (how to evaluate a metric inside a row-level probe, for
+// one) that this prototype does not make. They are rejected with a reason
+// rather than partially handled.
+function parseConstraint(expression: string): ParsedExpression|{error: string} {
+  const expr = expression.trim();
+  if (!expr) return {error: 'the expression is empty'};
+  if (/[()]/.test(expr)) {
+    return {
+      error: `it uses parentheses or a function call (${
+          expr}), which the evaluator does not parse`,
+    };
+  }
+
+  const segments = splitOnLogicalOperators(expr);
+  const comparisons: Comparison[] = [];
+  for (const segment of segments.parts) {
+    const comparison = parseComparison(segment);
+    if ('error' in comparison) return comparison;
+    comparisons.push(comparison);
+  }
+  return {comparisons, joiners: segments.joiners};
+}
+
+
+// Splits an expression on top-level AND/OR, matching them as whole words so a
+// field named `brand` or `android_id` is not torn apart. There are no
+// parentheses to nest (parseConstraint rejects them), so every operator found
+// is top level.
+function splitOnLogicalOperators(expr: string):
+    {parts: string[]; joiners: string[]} {
+  const parts: string[] = [];
+  const joiners: string[] = [];
+  const pattern = /\s+(AND|OR)\s+/gi;
+  let last = 0;
+  let match: RegExpExecArray|null;
+  while ((match = pattern.exec(expr)) !== null) {
+    parts.push(expr.slice(last, match.index));
+    joiners.push(match[1].toUpperCase());
+    last = match.index + match[0].length;
+  }
+  parts.push(expr.slice(last));
+  return {parts, joiners};
+}
+
+
+function parseComparison(segment: string): Comparison|{error: string} {
+  const text = segment.trim();
+  const found = findOperator(text);
+  if (!found) {
+    return {
+      error: `'${text}' is not a comparison (expected ${
+          OPERATORS.join(', ')})`,
+    };
+  }
+  const lhs = text.slice(0, found.index).trim();
+  const rhs = text.slice(found.index + found.operator.length).trim();
+
+  const left = parseFieldRef(lhs);
+  if (!left) {
+    return {
+      error: `the left side of '${text}' is not an <Entity>.<field> reference`,
+    };
+  }
+  if (!rhs) return {error: `'${text}' has nothing on the right of the operator`};
+
+  const right = parseFieldRef(rhs);
+  if (right) {
+    if (right.entity !== left.entity) {
+      return {
+        error: `'${text}' compares fields of two entities (${left.entity}, ${
+            right.entity})`,
+      };
+    }
+    return {
+      entity: left.entity,
+      field: left.field,
+      operator: normalizeOperator(found.operator),
+      rightField: right.field,
+    };
+  }
+
+  if (!isLiteral(rhs)) {
+    return {
+      error: `'${rhs}' in '${text}' is neither a literal nor an ` +
+          `<Entity>.<field> reference`,
+    };
+  }
+  return {
+    entity: left.entity,
+    field: left.field,
+    operator: normalizeOperator(found.operator),
+    literal: rhs,
+  };
+}
+
+
+// The first comparison operator in `text`, longest match first so `>=` is not
+// read as `>` followed by a stray `=`.
+function findOperator(text: string): {operator: string; index: number}|null {
+  let best: {operator: string; index: number}|null = null;
+  for (const operator of OPERATORS) {
+    const index = text.indexOf(operator);
+    if (index < 0) continue;
+    if (!best || index < best.index ||
+        (index === best.index && operator.length > best.operator.length)) {
+      best = {operator, index};
+    }
+  }
+  return best;
+}
+
+
+// `!=` and `<>` mean the same thing; GoogleSQL accepts both, so pick one and
+// emit it consistently.
+function normalizeOperator(operator: string): string {
+  return operator === '<>' ? '!=' : operator;
+}
+
+
+function parseFieldRef(text: string): {entity: string; field: string}|null {
+  const m = text.match(/^([A-Za-z_]\w*)\.([A-Za-z_]\w*)$/);
+  return m ? {entity: m[1], field: m[2]} : null;
+}
+
+
+// A literal the probe can embed verbatim. Restricted to shapes with no quoting
+// hazard: a number, a single-quoted string with no embedded quote or backslash,
+// or one of the three keywords. Anything else is rejected rather than escaped,
+// because a constraint expression is model text, not user input, and a
+// surprising escape is harder to notice than a refusal.
+function isLiteral(text: string): boolean {
+  if (/^-?\d+(\.\d+)?$/.test(text)) return true;
+  if (/^'[^'\\]*'$/.test(text)) return true;
+  return /^(TRUE|FALSE|NULL)$/i.test(text);
+}
+
+
+// Re-exported so a caller building a probe by hand quotes identifiers the same
+// way this module does.
+export {quoteIdentifier};

--- a/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
@@ -689,12 +689,45 @@ async function writeEntry(
   if (isExists(res)) {
     // Idempotent re-push: refresh the existing entry's source + aspects.
     const upd = await cat.updateEntry(
-        entry, ['entry_source', 'aspects'], Object.keys(entry.aspects ?? {}));
+        entry, ['entry_source', 'aspects'], reconciledAspectKeys(entry, opts));
     if (!isOk(upd)) return {error: `entry '${entryId}': ${errText(upd)}`};
     return {updated: true};
   }
   if (!isOk(res)) return {error: `entry '${entryId}': ${errText(res)}`};
   return {};
+}
+
+// The built-in aspects the emitter attaches CONDITIONALLY. `guidelines` (only
+// when an object carries ai_context.instructions) can ride any entry, so it is
+// reconciled everywhere. `overview` (only when the model declares actions)
+// rides the model anchor alone, so it is reconciled only there -- naming it on
+// an entity/metric entry would be a harmless no-op, but scoping it keeps the
+// patch honest about where the aspect can live. Every other aspect the emitter
+// writes (semantic-*, schema) is unconditional, so it is always present on a
+// re-push and never needs explicit clearing.
+const OPTIONAL_ASPECT_TYPES = ['guidelines'] as const;
+const ANCHOR_ONLY_ASPECT_TYPES = ['overview'] as const;
+
+// The aspect keys to reconcile when updating an existing entry. A Dataplex
+// entries.patch clears an aspect only when its key is named in `aspectKeys` and
+// absent from the request body; a key that is present is upserted, and one the
+// server does not have is a no-op. Passing only the currently-attached keys
+// therefore leaves a *removed* optional aspect (e.g. the model dropped all its
+// actions, so `overview` is gone) stranded on the server, where a later `pull`
+// would resurrect it. Always naming the optional aspect keys -- present or not
+// -- makes a re-push converge: a still-present one is refreshed, a removed one
+// is deleted, and one that was never there stays absent. The anchor-only keys
+// are reconciled solely on the model anchor, where those aspects can appear.
+function reconciledAspectKeys(entry: Entry, opts: KcDeployOptions): string[] {
+  const proj = opts.systemTypeProject ?? 'dataplex-types';
+  const loc = opts.systemTypeLocation ?? 'global';
+  const keys = new Set(Object.keys(entry.aspects ?? {}));
+  const optional: string[] = [...OPTIONAL_ASPECT_TYPES];
+  if (entry.entryType?.endsWith('/semantic-model')) {
+    optional.push(...ANCHOR_ONLY_ASPECT_TYPES);
+  }
+  for (const type of optional) keys.add(`${proj}.${loc}.${type}`);
+  return [...keys];
 }
 
 // entries.create can briefly 404 on a just-created entry group; retry that

--- a/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/deploy_knowledge_catalog.ts
@@ -699,8 +699,8 @@ async function writeEntry(
 
 // The built-in aspects the emitter attaches CONDITIONALLY. `guidelines` (only
 // when an object carries ai_context.instructions) can ride any entry, so it is
-// reconciled everywhere. `overview` (only when the model declares actions)
-// rides the model anchor alone, so it is reconciled only there -- naming it on
+// reconciled everywhere. `overview` (only when the model declares actions or
+// constraints) rides the model anchor alone, so it is reconciled only there -- naming it on
 // an entity/metric entry would be a harmless no-op, but scoping it keeps the
 // patch honest about where the aspect can live. Every other aspect the emitter
 // writes (semantic-*, schema) is unconditional, so it is always present on a
@@ -713,7 +713,8 @@ const ANCHOR_ONLY_ASPECT_TYPES = ['overview'] as const;
 // absent from the request body; a key that is present is upserted, and one the
 // server does not have is a no-op. Passing only the currently-attached keys
 // therefore leaves a *removed* optional aspect (e.g. the model dropped all its
-// actions, so `overview` is gone) stranded on the server, where a later `pull`
+// actions and constraints, so `overview` is gone) stranded on the server, where
+// a later `pull`
 // would resurrect it. Always naming the optional aspect keys -- present or not
 // -- makes a re-push converge: a still-present one is refreshed, a removed one
 // is deleted, and one that was never there stays absent. The anchor-only keys

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -58,6 +58,12 @@ export interface SemanticModel {
   entities: Entity[];        // the open format's `datasets`
   relationships: Relationship[];
   metrics: Metric[];
+  // Model-level write operations over the ontology -- the write-side counterpart
+  // to metrics (which are the read side). Like metrics they are defined over the
+  // concepts and their relationships, not bound to a single entity. Optional and
+  // absent on models authored before actions existed, so consumers read it as
+  // `actions ?? []`. See Action.
+  actions?: Action[];
   // Vendor extension blocks carried verbatim (round-trip fidelity), including the
   // model-level GOOGLE block. A typed deployment-target view is derived by the
   // consumer that acts on it (e.g. the CLI push), not surfaced on the IR yet.
@@ -285,4 +291,77 @@ export interface Metric {
   type?: DataType;       // logical datatype of the result (the open format's `datatype`)
   aiContext?: AiContext;
   customExtensions?: CustomExtension[];
+}
+
+/**
+ * An action: a model-level, named write operation over the ontology -- the
+ * write-side counterpart to a metric's read. Like a metric it lives on the
+ * model (not a single entity) and may span several entities via its typed
+ * `parameters`.
+ *
+ * The model contributes only what the ontology can say that a plain tool schema
+ * cannot -- typed parameters (an entity-typed one is an object reference). The
+ * mechanics of running it are delegated to an `executor` (e.g. an MCP tool in
+ * Agent Registry); `description` is informational and does not affect runtime.
+ */
+export interface Action {
+  name: string;
+  description?: string;
+  // How the action is executed. Exactly one executor kind (mcp / rest / grpc);
+  // the loader normalizes the open format's single-key executor object to this
+  // discriminated form.
+  executor: Executor;
+  // Inputs, each typed by the ontology: an entity type is an object reference,
+  // a scalar type an ordinary value. See ActionParameter.
+  parameters: ActionParameter[];
+  aiContext?: AiContext;
+  customExtensions?: CustomExtension[];
+}
+
+/**
+ * One input to an action, typed by the ontology.
+ *
+ * `type` is the authored type name, kept verbatim for a lossless round-trip.
+ * `isEntityRef` is DERIVED by the loader: true when `type` resolves to a known
+ * entity (the parameter is an object reference to that entity), false when it
+ * is a scalar `DataType`. A type that resolves to neither leaves `isEntityRef`
+ * undefined and the loader warns.
+ */
+export interface ActionParameter {
+  name: string;
+  type: string;           // entity name (object reference) or a scalar DataType
+  isEntityRef?: boolean;  // derived: true when `type` names a known entity
+}
+
+/**
+ * The mechanics of how an action is executed: exactly one kind, tagged so
+ * consumers can switch on it. The open format expresses it as an object with a
+ * single kind key (`mcp` / `rest` / `grpc`); the loader normalizes that to this
+ * discriminated union. Other kinds (SQL DML, CLI, ...) can be added later.
+ */
+export type Executor =
+  | { kind: 'mcp'; mcp: McpExecutor }
+  | { kind: 'rest'; rest: RestExecutor }
+  | { kind: 'grpc'; grpc: GrpcExecutor };
+
+/**
+ * An MCP executor: references a tool already registered in Agent Registry, by
+ * the MCP server's resource name plus the tool's in-server selector. Agent
+ * Registry is the canonical source consumed at runtime (e.g. by an agent).
+ */
+export interface McpExecutor {
+  server: string;   // e.g. //agentregistry.googleapis.com/.../mcpServers/commerce
+  tool: string;     // the tool's name within that server
+}
+
+/** A REST executor: an HTTP endpoint and method. */
+export interface RestExecutor {
+  endpoint: string;
+  method: string;
+}
+
+/** A gRPC executor: a fully-qualified service and method. */
+export interface GrpcExecutor {
+  service: string;
+  method: string;
 }

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -64,6 +64,13 @@ export interface SemanticModel {
   // absent on models authored before actions existed, so consumers read it as
   // `actions ?? []`. See Action.
   actions?: Action[];
+  // Named invariants over the ontology -- a boolean `expression` that must hold
+  // for every instance (e.g. `Customer.accountBalance >= 0`). Model-level like
+  // metrics and actions; checked before an action commits, so a write that would
+  // break one is rejected. Optional and absent on models authored before
+  // constraints existed, so consumers read it as `constraints ?? []`. See
+  // Constraint.
+  constraints?: Constraint[];
   // Vendor extension blocks carried verbatim (round-trip fidelity), including the
   // model-level GOOGLE block. A typed deployment-target view is derived by the
   // consumer that acts on it (e.g. the CLI push), not surfaced on the IR yet.
@@ -364,4 +371,28 @@ export interface RestExecutor {
 export interface GrpcExecutor {
   service: string;
   method: string;
+}
+
+/**
+ * A constraint: a model-level, named invariant over the ontology -- a boolean
+ * `expression` that must hold for every instance. Written in the same
+ * expression language as a metric (`Customer.accountBalance >= 0`,
+ * `OrderedAs.quantity > 0`), and it may reference a metric by name when the
+ * check needs an aggregate.
+ *
+ * Constraints matter because actions change state: an operational agent running
+ * an action writes to a live store, and a bad write corrupts data. A constraint
+ * is checked before the action commits; if the write would leave any instance
+ * violating it, the action is rejected and the state is left untouched.
+ *
+ * `description` doubles as the error surfaced on a violation, so it is written
+ * to steer an agent's next move ("reduce the order quantity or choose another
+ * customer") rather than merely label the rule.
+ */
+export interface Constraint {
+  name: string;
+  expression: string;     // boolean invariant in the model's expression language
+  description?: string;   // human-readable; doubles as the violation error
+  aiContext?: AiContext;
+  customExtensions?: CustomExtension[];
 }

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -54,7 +54,8 @@
 
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
-import {AiContext, CustomExtension, DataType, Entity, Field, Metric, Relationship, SemanticModel} from './ir';
+import {Action, ActionParameter, AiContext, CustomExtension, DATA_TYPES, DataType, Entity, Executor, Field, Metric, Relationship, SemanticModel} from './ir';
+import {ACTIONS_OVERVIEW_MARKER} from './knowledge_catalog';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface ReadResult {
@@ -127,6 +128,11 @@ export function modelsFromCatalogResources(
     const model: SemanticModel = {name, entities, relationships, metrics};
     const description = anchor.entrySource?.description;
     if (description !== undefined) model.description = description;
+    // Actions ride the anchor's overview aspect (see
+    // actionsOverviewAspectData); recover them from its embedded JSON block.
+    // Absent overview -> no actions.
+    const actions = readActionsFromOverview(anchor, entityNames, warnings);
+    if (actions.length) model.actions = actions;
     // Deployment targets ride back in the same GOOGLE custom_extensions block
     // the author wrote them in (the inverse of the emitter's modelAspectData).
     const targets = readDeploymentTargets(anchor);
@@ -283,6 +289,143 @@ function readMetric(
   const ai = readAiContext(entry);
   if (ai) metric.aiContext = ai;
   return metric;
+}
+
+
+// Recovers the model's actions from the anchor's `overview` aspect, the inverse
+// of actionsOverviewAspectData. The overview's Markdown is for humans; the
+// machine-readable form is a fenced JSON array after ACTIONS_OVERVIEW_MARKER,
+// so this locates that block, parses it, and rebuilds each Action.
+// `isEntityRef` is re-derived against the reconstructed entities (as the loader
+// does) rather than trusted from the JSON, so it stays consistent with the
+// pulled model. Returns an empty list when there is no overview or no parseable
+// action block.
+function readActionsFromOverview(
+    anchor: Entry, entityNames: string[], warnings: string[]): Action[] {
+  const content = aspectData(anchor, 'overview').content;
+  if (typeof content !== 'string' || !content.includes(ACTIONS_OVERVIEW_MARKER))
+    return [];
+  const json = jsonBlockAfterMarker(content, ACTIONS_OVERVIEW_MARKER);
+  if (json === undefined) {
+    warnings.push(
+        `model actions: overview aspect has the actions marker but no parseable ` +
+        `JSON block; actions are not recovered`);
+    return [];
+  }
+  let parsed: any;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err: any) {
+    warnings.push(`model actions: overview action block is not valid JSON (${
+        err.message || err}); actions are not recovered`);
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    warnings.push(
+        `model actions: overview action block is not a JSON array; actions are ` +
+        `not recovered`);
+    return [];
+  }
+  const entitySet = new Set(entityNames);
+  return parsed.map((a: any) => readAction(a, entitySet, warnings))
+      .filter((a): a is Action => a !== undefined);
+}
+
+
+// Extracts the first ```json ... ``` fenced block that follows `marker` in the
+// content, returning the block's inner text (or undefined when none follows).
+function jsonBlockAfterMarker(content: string, marker: string): string|
+    undefined {
+  const afterMarker =
+      content.slice(content.lastIndexOf(marker) + marker.length);
+  const fence = afterMarker.match(/```json\s*\n([\s\S]*?)\n```/);
+  return fence ? fence[1] : undefined;
+}
+
+
+// Rebuilds one Action from its embedded JSON (the inverse of actionJson). A
+// record missing a usable name or executor is skipped with a warning, so a
+// malformed block degrades one action rather than the whole pull.
+function readAction(
+    a: any, entityNames: Set<string>, warnings: string[]): Action|undefined {
+  const name = typeof a?.name === 'string' ? a.name : '';
+  if (!name) {
+    warnings.push(
+        'model actions: an action in the overview has no name; skipped');
+    return undefined;
+  }
+  const executor = readExecutor(a?.executor);
+  if (!executor) {
+    warnings.push(
+        `action '${name}': overview executor is missing or malformed; the ` +
+        `action is skipped`);
+    return undefined;
+  }
+  const parameters =
+      asArray(a?.parameters)
+          .map((p: any) => readParameter(p, entityNames, name, warnings))
+          .filter((p): p is ActionParameter => p !== undefined);
+  const action: Action = {name, executor, parameters};
+  if (typeof a?.description === 'string' && a.description !== '')
+    action.description = a.description;
+  if (a?.aiContext && typeof a.aiContext === 'object')
+    action.aiContext = a.aiContext as AiContext;
+  if (Array.isArray(a?.customExtensions))
+    action.customExtensions = a.customExtensions as CustomExtension[];
+  return action;
+}
+
+
+// One action parameter from its JSON, re-deriving isEntityRef against the
+// model's entities (a scalar datatype otherwise). A record missing a name is
+// dropped.
+function readParameter(
+    p: any, entityNames: Set<string>, actionName: string,
+    warnings: string[]): ActionParameter|undefined {
+  const name = typeof p?.name === 'string' ? p.name : '';
+  const type = typeof p?.type === 'string' ? p.type : '';
+  if (!name) return undefined;
+  const param: ActionParameter = {name, type};
+  if (entityNames.has(type)) {
+    param.isEntityRef = true;
+  } else if ((DATA_TYPES as readonly string[]).includes(type)) {
+    param.isEntityRef = false;
+  } else {
+    // The type resolves to neither an entity in the pulled model nor a scalar
+    // datatype -- e.g. an entity-typed parameter whose entity was not part of
+    // this pull. Leave isEntityRef unset (push-side validate flags it) and warn
+    // so the gap is visible rather than silently dropped.
+    warnings.push(
+        `action '${actionName}': parameter '${name}' type '${type}' is ` +
+        `neither a known entity nor a scalar datatype; pulled without a ` +
+        `resolved type`);
+  }
+  return param;
+}
+
+
+// The IR executor from the embedded single-key JSON object
+// ({mcp}/{rest}/{grpc}, the inverse of executorJson). Returns undefined when no
+// known kind is present or a coordinate is not a string.
+function readExecutor(ex: any): Executor|undefined {
+  // A coordinate must be a present, NON-BLANK string. The overview JSON can
+  // carry an empty string (e.g. a hand-edited block); treat that as malformed
+  // so the reader rejects it exactly as push-side validate would, rather than
+  // recovering an action the next push cannot deploy.
+  const str = (v: any): v is string => typeof v === 'string' && v.trim() !== '';
+  if (ex?.mcp && str(ex.mcp.server) && str(ex.mcp.tool))
+    return {kind: 'mcp', mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+  if (ex?.rest && str(ex.rest.endpoint) && str(ex.rest.method))
+    return {
+      kind: 'rest',
+      rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}
+    };
+  if (ex?.grpc && str(ex.grpc.service) && str(ex.grpc.method))
+    return {
+      kind: 'grpc',
+      grpc: {service: ex.grpc.service, method: ex.grpc.method}
+    };
+  return undefined;
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -54,8 +54,8 @@
 
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
-import {Action, ActionParameter, AiContext, CustomExtension, DATA_TYPES, DataType, Entity, Executor, Field, Metric, Relationship, SemanticModel} from './ir';
-import {ACTIONS_OVERVIEW_MARKER} from './knowledge_catalog';
+import {Action, ActionParameter, AiContext, Constraint, CustomExtension, DATA_TYPES, DataType, Entity, Executor, Field, Metric, Relationship, SemanticModel} from './ir';
+import {ACTIONS_OVERVIEW_MARKER, CONSTRAINTS_OVERVIEW_MARKER} from './knowledge_catalog';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface ReadResult {
@@ -133,6 +133,10 @@ export function modelsFromCatalogResources(
     // Absent overview -> no actions.
     const actions = readActionsFromOverview(anchor, entityNames, warnings);
     if (actions.length) model.actions = actions;
+    // Constraints ride the same overview aspect under their own marker (see
+    // renderConstraintsOverview). Absent block -> no constraints.
+    const constraints = readConstraintsFromOverview(anchor, warnings);
+    if (constraints.length) model.constraints = constraints;
     // Deployment targets ride back in the same GOOGLE custom_extensions block
     // the author wrote them in (the inverse of the emitter's modelAspectData).
     const targets = readDeploymentTargets(anchor);
@@ -329,6 +333,70 @@ function readActionsFromOverview(
   const entitySet = new Set(entityNames);
   return parsed.map((a: any) => readAction(a, entitySet, warnings))
       .filter((a): a is Action => a !== undefined);
+}
+
+
+// Rebuilds the model's constraints from the overview aspect's constraints
+// block, the inverse of knowledge_catalog.renderConstraintsOverview. A missing
+// marker means the model declared none; a malformed block warns and yields
+// none, so a bad overview degrades the constraints rather than the whole pull.
+function readConstraintsFromOverview(
+    anchor: Entry, warnings: string[]): Constraint[] {
+  const content = aspectData(anchor, 'overview').content;
+  if (typeof content !== 'string' ||
+      !content.includes(CONSTRAINTS_OVERVIEW_MARKER))
+    return [];
+  const json = jsonBlockAfterMarker(content, CONSTRAINTS_OVERVIEW_MARKER);
+  if (json === undefined) {
+    warnings.push(
+        `model constraints: overview aspect has the constraints marker but no ` +
+        `parseable JSON block; constraints are not recovered`);
+    return [];
+  }
+  let parsed: any;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err: any) {
+    warnings.push(`model constraints: overview constraint block is not valid ` +
+                  `JSON (${err.message || err}); constraints are not recovered`);
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    warnings.push(
+        `model constraints: overview constraint block is not a JSON array; ` +
+        `constraints are not recovered`);
+    return [];
+  }
+  return parsed.map((c: any) => readConstraint(c, warnings))
+      .filter((c): c is Constraint => c !== undefined);
+}
+
+
+// Rebuilds one Constraint from its embedded JSON (the inverse of
+// constraintJson). A record missing a name or a non-empty expression is not a
+// checkable invariant, so it is skipped with a warning.
+function readConstraint(c: any, warnings: string[]): Constraint|undefined {
+  const name = typeof c?.name === 'string' ? c.name : '';
+  if (!name) {
+    warnings.push(
+        'model constraints: a constraint in the overview has no name; skipped');
+    return undefined;
+  }
+  const expression = typeof c?.expression === 'string' ? c.expression : '';
+  if (!expression.trim()) {
+    warnings.push(
+        `constraint '${name}': overview record has no expression; the ` +
+        `constraint is skipped`);
+    return undefined;
+  }
+  const constraint: Constraint = {name, expression};
+  if (typeof c?.description === 'string' && c.description !== '')
+    constraint.description = c.description;
+  if (c?.aiContext && typeof c.aiContext === 'object')
+    constraint.aiContext = c.aiContext as AiContext;
+  if (Array.isArray(c?.customExtensions))
+    constraint.customExtensions = c.customExtensions as CustomExtension[];
+  return constraint;
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -15,9 +15,15 @@
 // `required_aspects`; the emitted aspect set per entry is those plus the
 // optional `guidelines` aspect (attached only when the object carries
 // `ai_context.instructions`):
-//   * semantic-model entry -> { semantic-model, guidelines? }
+//   * semantic-model entry -> { semantic-model, overview?, guidelines? }
 //   * semantic-entity entry -> { semantic-entity, schema, guidelines? }
 //   * semantic-metric entry -> { semantic-metric, guidelines? }
+//
+// Actions (the model's write operations) have no semantic-* system type, so
+// they ride the anchor's built-in `overview` aspect: human-readable Markdown
+// plus an embedded JSON block a pull recovers them from (see
+// actionsOverviewAspectData). The overview is attached only when the model
+// declares actions.
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):
@@ -49,7 +55,7 @@
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
 import {googleDeploymentTargets} from './deployment_target';
-import {AiContext, DataType, Entity, Metric, Relationship, SemanticModel} from './ir';
+import {Action, AiContext, DataType, Entity, Executor, Metric, Relationship, SemanticModel} from './ir';
 
 // Where the `semantic-*` and `schema` system types live: built-in types in
 // project `dataplex-types`, location `global`. Callers may override to reference
@@ -127,12 +133,22 @@ export function generateCatalogResources(
   const modelEntryName = names.entry(modelId);
   claim(seen, modelId, 'entry', `model '${model.name}'`, warnings);
 
+  // The anchor's base aspects: always semantic-model; plus the built-in
+  // `overview` aspect when the model has actions. Actions are write-side and
+  // have no semantic-* system type of their own, so they ride the anchor's
+  // free-form overview (Markdown for humans + an embedded JSON block a pull
+  // recovers them from) rather than getting their own entries.
+  const anchorBase: Record<string, Record<string, any>> = {
+    'semantic-model': modelAspectData(model),
+  };
+  const overview = actionsOverviewAspectData(model, warnings);
+  if (overview) anchorBase['overview'] = overview;
+
   const entries: Entry[] = [{
     name: modelEntryName,
     entryType: names.typeName('entry', 'semantic-model'),
     entrySource: source(model.name, model.description),
-    aspects: aspectsFor(
-        names, {'semantic-model': modelAspectData(model)}, model.aiContext),
+    aspects: aspectsFor(names, anchorBase, model.aiContext),
   }];
 
   // Maps an entity's model name to its published entry name, so a relationship
@@ -347,6 +363,100 @@ function modelAspectData(model: SemanticModel): Record<string, any> {
   return compact({
     deploymentTargets: uris.length ? uris : undefined,
   });
+}
+
+// Fences the machine-readable action JSON inside the overview Markdown. The
+// reader (kc_converter.readActionsFromOverview) locates the block by this
+// marker and parses the fenced JSON, so publish and pull agree on one
+// delimiter.
+export const ACTIONS_OVERVIEW_MARKER = '<!-- kcmd:actions v1 -->';
+
+// The anchor's `overview` aspect carrying the model's actions, or undefined
+// when there are none (so a model without actions carries no overview and the
+// anchor is unchanged from before actions existed). Actions have no BigQuery
+// Graph or semantic-* representation; the overview is their only catalog home.
+// The content is human-readable Markdown followed by a fenced JSON block (after
+// ACTIONS_OVERVIEW_MARKER) that a pull round-trips losslessly.
+function actionsOverviewAspectData(
+    model: SemanticModel, warnings: string[]): Record<string, any>|undefined {
+  const actions = model.actions ?? [];
+  if (!actions.length) return undefined;
+  warnings.push(
+      `model '${model.name}': ${actions.length} action(s) published to the ` +
+      `model's overview aspect (actions have no BigQuery Graph representation).`);
+  return {
+    content: renderActionsOverview(actions),
+    contentType: 'MARKDOWN',
+  };
+}
+
+// Renders the actions overview: a Markdown section for humans, then the marker
+// and a fenced JSON array (the canonical IR form) for a lossless pull.
+function renderActionsOverview(actions: Action[]): string {
+  const md: string[] = [
+    '## Actions',
+    '',
+    'Write operations defined on this model -- the write-side counterpart to ' +
+        'metrics. Actions have no BigQuery Graph representation; they are ' +
+        'published here for discovery and are round-tripped by `kcmd pull`.',
+    '',
+  ];
+  for (const a of actions) {
+    md.push(`### ${a.name}`, '');
+    if (a.description) md.push(a.description, '');
+    md.push(`- Executor: ${describeExecutor(a.executor)}`);
+    if (a.parameters.length) {
+      md.push('- Parameters:');
+      for (const p of a.parameters) {
+        const kind = p.isEntityRef ? `${p.type} (entity reference)` : p.type;
+        md.push(`  - \`${p.name}\`: ${kind}`);
+      }
+    }
+    md.push('');
+  }
+  md.push(
+      ACTIONS_OVERVIEW_MARKER, '```json',
+      JSON.stringify(actions.map(actionJson), null, 2), '```', '');
+  return md.join('\n');
+}
+
+// A one-line human description of an executor for the Markdown body.
+function describeExecutor(ex: Executor): string {
+  switch (ex.kind) {
+    case 'mcp':
+      return `MCP tool \`${ex.mcp.tool}\` on server \`${ex.mcp.server}\``;
+    case 'rest':
+      return `REST ${ex.rest.method} \`${ex.rest.endpoint}\``;
+    case 'grpc':
+      return `gRPC \`${ex.grpc.service}/${ex.grpc.method}\``;
+  }
+}
+
+// The canonical JSON form of an action embedded in the overview, mirroring the
+// IR so kc_converter.readActionsFromOverview reconstructs it verbatim. The
+// executor's tagged union is flattened to the open format's single-key object,
+// matching how osi_converter emits it to YAML.
+function actionJson(a: Action): Record<string, any> {
+  return compact({
+    name: a.name,
+    description: a.description,
+    executor: executorJson(a.executor),
+    parameters: a.parameters.map(
+        p => compact({name: p.name, type: p.type, isEntityRef: p.isEntityRef})),
+    aiContext: a.aiContext,
+    customExtensions: a.customExtensions,
+  });
+}
+
+function executorJson(ex: Executor): Record<string, any> {
+  switch (ex.kind) {
+    case 'mcp':
+      return {mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+    case 'rest':
+      return {rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}};
+    case 'grpc':
+      return {grpc: {service: ex.grpc.service, method: ex.grpc.method}};
+  }
 }
 
 // semantic-entity: the base table(s) backing the entity. importedSystem/

--- a/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
+++ b/toolbox/mdcode/src/libts/semantic/knowledge_catalog.ts
@@ -19,11 +19,12 @@
 //   * semantic-entity entry -> { semantic-entity, schema, guidelines? }
 //   * semantic-metric entry -> { semantic-metric, guidelines? }
 //
-// Actions (the model's write operations) have no semantic-* system type, so
-// they ride the anchor's built-in `overview` aspect: human-readable Markdown
-// plus an embedded JSON block a pull recovers them from (see
-// actionsOverviewAspectData). The overview is attached only when the model
-// declares actions.
+// Actions (the model's write operations) and constraints (its invariants) have
+// no semantic-* system type, so they ride the anchor's built-in `overview`
+// aspect: human-readable Markdown plus an embedded JSON block a pull recovers
+// them from (see overviewAspectData). Each gets its own section and its own
+// marker, so the two share the aspect rather than overwrite each other. The
+// overview is attached only when the model declares at least one of them.
 //
 // Aspect data shapes mirror the aspect types' CLOSED metadataTemplates exactly
 // (a server aspect type rejects an undeclared data field):
@@ -55,7 +56,7 @@
 import type {Aspect, Entry, EntryLink} from '../gcp/dataplex';
 
 import {googleDeploymentTargets} from './deployment_target';
-import {Action, AiContext, DataType, Entity, Executor, Metric, Relationship, SemanticModel} from './ir';
+import {Action, AiContext, Constraint, DataType, Entity, Executor, Metric, Relationship, SemanticModel} from './ir';
 
 // Where the `semantic-*` and `schema` system types live: built-in types in
 // project `dataplex-types`, location `global`. Callers may override to reference
@@ -134,14 +135,14 @@ export function generateCatalogResources(
   claim(seen, modelId, 'entry', `model '${model.name}'`, warnings);
 
   // The anchor's base aspects: always semantic-model; plus the built-in
-  // `overview` aspect when the model has actions. Actions are write-side and
-  // have no semantic-* system type of their own, so they ride the anchor's
-  // free-form overview (Markdown for humans + an embedded JSON block a pull
-  // recovers them from) rather than getting their own entries.
+  // `overview` aspect when the model has actions or constraints. Neither has a
+  // semantic-* system type of its own, so both ride the anchor's free-form
+  // overview (Markdown for humans + an embedded JSON block a pull recovers them
+  // from) rather than getting their own entries.
   const anchorBase: Record<string, Record<string, any>> = {
     'semantic-model': modelAspectData(model),
   };
-  const overview = actionsOverviewAspectData(model, warnings);
+  const overview = overviewAspectData(model, warnings);
   if (overview) anchorBase['overview'] = overview;
 
   const entries: Entry[] = [{
@@ -371,21 +372,40 @@ function modelAspectData(model: SemanticModel): Record<string, any> {
 // delimiter.
 export const ACTIONS_OVERVIEW_MARKER = '<!-- kcmd:actions v1 -->';
 
-// The anchor's `overview` aspect carrying the model's actions, or undefined
-// when there are none (so a model without actions carries no overview and the
-// anchor is unchanged from before actions existed). Actions have no BigQuery
-// Graph or semantic-* representation; the overview is their only catalog home.
-// The content is human-readable Markdown followed by a fenced JSON block (after
-// ACTIONS_OVERVIEW_MARKER) that a pull round-trips losslessly.
-function actionsOverviewAspectData(
+// The same delimiter for the constraints block. Actions and constraints share
+// the one `overview` aspect, so each needs its own marker for the reader to
+// tell the two JSON blocks apart.
+export const CONSTRAINTS_OVERVIEW_MARKER = '<!-- kcmd:constraints v1 -->';
+
+// The anchor's `overview` aspect carrying the model's actions and constraints,
+// or undefined when it declares neither (so such a model carries no overview
+// and the anchor is unchanged from before either existed). Neither has a
+// BigQuery Graph or semantic-* representation; the overview is their only
+// catalog home. Each contributes a section of human-readable Markdown followed
+// by a fenced JSON block (after its own marker) that a pull round-trips
+// losslessly.
+function overviewAspectData(
     model: SemanticModel, warnings: string[]): Record<string, any>|undefined {
   const actions = model.actions ?? [];
-  if (!actions.length) return undefined;
-  warnings.push(
-      `model '${model.name}': ${actions.length} action(s) published to the ` +
-      `model's overview aspect (actions have no BigQuery Graph representation).`);
+  const constraints = model.constraints ?? [];
+  if (!actions.length && !constraints.length) return undefined;
+
+  const sections: string[] = [];
+  if (actions.length) {
+    warnings.push(
+        `model '${model.name}': ${actions.length} action(s) published to the ` +
+        `model's overview aspect (actions have no BigQuery Graph representation).`);
+    sections.push(renderActionsOverview(actions));
+  }
+  if (constraints.length) {
+    warnings.push(
+        `model '${model.name}': ${constraints.length} constraint(s) published ` +
+        `to the model's overview aspect (constraints have no BigQuery Graph ` +
+        `representation).`);
+    sections.push(renderConstraintsOverview(constraints));
+  }
   return {
-    content: renderActionsOverview(actions),
+    content: sections.join('\n'),
     contentType: 'MARKDOWN',
   };
 }
@@ -419,6 +439,45 @@ function renderActionsOverview(actions: Action[]): string {
       JSON.stringify(actions.map(actionJson), null, 2), '```', '');
   return md.join('\n');
 }
+
+// Renders the constraints overview: a Markdown section for humans, then the
+// marker and a fenced JSON array (the canonical IR form) for a lossless pull.
+function renderConstraintsOverview(constraints: Constraint[]): string {
+  const md: string[] = [
+    '## Constraints',
+    '',
+    'Named invariants over this model -- boolean expressions that must hold ' +
+        'for every instance. A constraint is checked before an action ' +
+        'commits, so a write that would break one is rejected and its ' +
+        'description is the error the caller sees. Constraints have no ' +
+        'BigQuery Graph representation; they are published here for discovery ' +
+        'and are round-tripped by `kcmd pull`.',
+    '',
+  ];
+  for (const c of constraints) {
+    md.push(`### ${c.name}`, '');
+    if (c.description) md.push(c.description, '');
+    md.push(`- Expression: \`${c.expression}\``, '');
+  }
+  md.push(
+      CONSTRAINTS_OVERVIEW_MARKER, '```json',
+      JSON.stringify(constraints.map(constraintJson), null, 2), '```', '');
+  return md.join('\n');
+}
+
+
+// The canonical JSON form of a constraint embedded in the overview, mirroring
+// the IR so kc_converter.readConstraintsFromOverview reconstructs it verbatim.
+function constraintJson(c: Constraint): Record<string, any> {
+  return compact({
+    name: c.name,
+    expression: c.expression,
+    description: c.description,
+    aiContext: c.aiContext,
+    customExtensions: c.customExtensions,
+  });
+}
+
 
 // A one-line human description of an executor for the Markdown body.
 function describeExecutor(ex: Executor): string {

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -13,7 +13,7 @@ import * as yaml from 'yaml';
 import * as z from 'zod';
 import {
   SemanticModel, Entity, Field, Relationship, Metric, AiContext, CustomExtension,
-  DATA_TYPES,
+  Action, ActionParameter, Executor, DATA_TYPES,
 } from './ir';
 import { referencedEntityNames } from './sql_expr_utils';
 
@@ -172,6 +172,43 @@ const metricSchema = z.object({
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
 
+// An action executor: exactly one kind. The open format expresses it as an
+// object with a single kind key (mcp/rest/grpc); we accept the union and enforce
+// the "exactly one" rule in a refinement so the message names the violation.
+const executorSchema = z.object({
+  mcp: z.object({ server: z.string(), tool: z.string() }).optional(),
+  rest: z.object({ endpoint: z.string(), method: z.string() }).optional(),
+  grpc: z.object({ service: z.string(), method: z.string() }).optional(),
+}).superRefine((ex, ctx) => {
+  const kinds = (['mcp', 'rest', 'grpc'] as const).filter(k => ex[k] !== undefined);
+  if (kinds.length !== 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: kinds.length === 0 ?
+        `executor requires exactly one kind (mcp, rest, or grpc); none given` :
+        `executor requires exactly one kind, but ${kinds.length} given ` +
+          `(${kinds.join(', ')})`,
+    });
+  }
+});
+
+// An action parameter: a name and an ontology type (an entity name for an object
+// reference, or a scalar DataType). The type is validated against the model in
+// convertAction, not here, so the schema stays a plain string.
+const parameterSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+});
+
+const actionSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  executor: executorSchema,
+  parameters: z.array(parameterSchema).optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+});
+
 const modelBase = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -180,6 +217,7 @@ const modelBase = z.object({
   datasets: z.array(datasetBase).min(1),
   relationships: z.array(relationshipSchema).optional(),
   metrics: z.array(metricSchema).optional(),
+  actions: z.array(actionSchema).optional(),
 });
 
 // Builds the document schema with the binding-completeness refinement applied
@@ -256,6 +294,9 @@ type FieldDoc = z.infer<typeof fieldBase>;
 type RelationshipDoc = z.infer<typeof relationshipSchema>;
 type MetricDoc = z.infer<typeof metricSchema>;
 type ModelDoc = z.infer<typeof modelBase>;
+type ActionDoc = z.infer<typeof actionSchema>;
+type ParameterDoc = z.infer<typeof parameterSchema>;
+type ExecutorDoc = z.infer<typeof executorSchema>;
 type CustomExtensionDoc = z.infer<typeof customExtensionSchema>;
 type AiContextDoc = z.infer<typeof aiContextSchema>;
 
@@ -462,9 +503,16 @@ function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): Seman
     mt => convertMetric(mt, entityNames, warnings, dialect));
   warnDuplicateNames(metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`, warnings);
 
+  // Actions reference entities as parameter types, so they are converted after
+  // entities are known.
+  const actions = (m.actions ?? []).map(
+    a => convertAction(a, entityNameSet, warnings));
+  warnDuplicateNames(actions.map(a => a.name), 'action name', `model '${m.name}'`, warnings);
+
   const description = composeDescription(m.description);
 
   const model: SemanticModel = { name: m.name, entities, relationships, metrics };
+  if (actions.length) model.actions = actions;
   if (description) model.description = description;
   const ai = aiContextOrUndefined(m.ai_context);
   if (ai) model.aiContext = ai;
@@ -606,6 +654,63 @@ function convertMetric(mt: MetricDoc, entityNames: string[],
   const ce = toCustomExtensions(mt.custom_extensions);
   if (ce) metric.customExtensions = ce;
   return metric;
+}
+
+// Maps an authored action onto the IR. Parameter types are resolved against the
+// model's entities; a type that is neither a known entity nor a scalar datatype
+// is kept verbatim and warned, so the loader stays lenient (a strict `validate`
+// gate can promote these later).
+function convertAction(
+    a: ActionDoc, entityNames: Set<string>, warnings: string[]): Action {
+  const parameters = (a.parameters ?? []).map(
+    p => convertParameter(p, a.name, entityNames, warnings));
+  // Parameter names address the inputs at dispatch, so a collision is as
+  // ambiguous as a duplicate field/metric name -- warn like everywhere else.
+  warnDuplicateNames(
+    parameters.map(p => p.name), 'parameter name', `action '${a.name}'`, warnings);
+
+  const action: Action = {
+    name: a.name,
+    executor: convertExecutor(a.executor),
+    parameters,
+  };
+
+  const description = composeDescription(a.description);
+  if (description) action.description = description;
+  const ai = aiContextOrUndefined(a.ai_context);
+  if (ai) action.aiContext = ai;
+  const ce = toCustomExtensions(a.custom_extensions);
+  if (ce) action.customExtensions = ce;
+  return action;
+}
+
+// Resolves a parameter's authored `type` against the ontology: a known entity
+// name makes it an object reference (isEntityRef = true); a scalar DataType makes
+// it a value (isEntityRef = false). A type that is neither is kept verbatim with
+// isEntityRef left unset, and warned.
+function convertParameter(
+    p: ParameterDoc, actionName: string, entityNames: Set<string>,
+    warnings: string[]): ActionParameter {
+  const param: ActionParameter = { name: p.name, type: p.type };
+  if (entityNames.has(p.type)) {
+    param.isEntityRef = true;
+  } else if ((DATA_TYPES as readonly string[]).includes(p.type)) {
+    param.isEntityRef = false;
+  } else {
+    warnings.push(
+      `action '${actionName}': parameter '${p.name}' type '${p.type}' is ` +
+      `neither a known entity nor a scalar datatype (${DATA_TYPES.join('/')})`);
+  }
+  return param;
+}
+
+// Normalizes the open format's single-key executor object to the IR's tagged
+// union. The schema already guaranteed exactly one kind is present.
+function convertExecutor(ex: ExecutorDoc): Executor {
+  if (ex.mcp) return { kind: 'mcp', mcp: { ...ex.mcp } };
+  if (ex.rest) return { kind: 'rest', rest: { ...ex.rest } };
+  // The schema's refinement guarantees one of mcp/rest/grpc is set.
+  return { kind: 'grpc', grpc: { ...ex.grpc! } };
 }
 
 // Collapses an expression's per-dialect variants into at most two forms:

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -13,7 +13,7 @@ import * as yaml from 'yaml';
 import * as z from 'zod';
 import {
   SemanticModel, Entity, Field, Relationship, Metric, AiContext, CustomExtension,
-  Action, ActionParameter, Executor, DATA_TYPES,
+  Action, ActionParameter, Executor, Constraint, DATA_TYPES,
 } from './ir';
 import { referencedEntityNames } from './sql_expr_utils';
 
@@ -209,6 +209,18 @@ const actionSchema = z.object({
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
 
+// A constraint: a named boolean invariant over the ontology. `expression` is a
+// logical expression in the model's own language (`Customer.accountBalance >=
+// 0`), not a physical binding, so it stays a plain string -- it is resolved
+// against the ontology by the consumer that evaluates it, not here.
+const constraintSchema = z.object({
+  name: z.string(),
+  expression: z.string(),
+  description: z.string().optional(),
+  ai_context: aiContextSchema.optional(),
+  custom_extensions: z.array(customExtensionSchema).optional(),
+});
+
 const modelBase = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -218,6 +230,7 @@ const modelBase = z.object({
   relationships: z.array(relationshipSchema).optional(),
   metrics: z.array(metricSchema).optional(),
   actions: z.array(actionSchema).optional(),
+  constraints: z.array(constraintSchema).optional(),
 });
 
 // Builds the document schema with the binding-completeness refinement applied
@@ -295,6 +308,7 @@ type RelationshipDoc = z.infer<typeof relationshipSchema>;
 type MetricDoc = z.infer<typeof metricSchema>;
 type ModelDoc = z.infer<typeof modelBase>;
 type ActionDoc = z.infer<typeof actionSchema>;
+type ConstraintDoc = z.infer<typeof constraintSchema>;
 type ParameterDoc = z.infer<typeof parameterSchema>;
 type ExecutorDoc = z.infer<typeof executorSchema>;
 type CustomExtensionDoc = z.infer<typeof customExtensionSchema>;
@@ -509,10 +523,15 @@ function convertModel(m: ModelDoc, opts: LoadOptions, warnings: string[]): Seman
     a => convertAction(a, entityNameSet, warnings));
   warnDuplicateNames(actions.map(a => a.name), 'action name', `model '${m.name}'`, warnings);
 
+  const constraints = (m.constraints ?? []).map(convertConstraint);
+  warnDuplicateNames(
+    constraints.map(c => c.name), 'constraint name', `model '${m.name}'`, warnings);
+
   const description = composeDescription(m.description);
 
   const model: SemanticModel = { name: m.name, entities, relationships, metrics };
   if (actions.length) model.actions = actions;
+  if (constraints.length) model.constraints = constraints;
   if (description) model.description = description;
   const ai = aiContextOrUndefined(m.ai_context);
   if (ai) model.aiContext = ai;
@@ -654,6 +673,20 @@ function convertMetric(mt: MetricDoc, entityNames: string[],
   const ce = toCustomExtensions(mt.custom_extensions);
   if (ce) metric.customExtensions = ce;
   return metric;
+}
+
+// Converts a constraint document to the IR. The `expression` is kept verbatim
+// (a logical invariant resolved by the evaluator, not the loader); description
+// and AI context round-trip like everywhere else.
+function convertConstraint(c: ConstraintDoc): Constraint {
+  const constraint: Constraint = { name: c.name, expression: c.expression };
+  const description = composeDescription(c.description);
+  if (description) constraint.description = description;
+  const ai = aiContextOrUndefined(c.ai_context);
+  if (ai) constraint.aiContext = ai;
+  const ce = toCustomExtensions(c.custom_extensions);
+  if (ce) constraint.customExtensions = ce;
+  return constraint;
 }
 
 // Maps an authored action onto the IR. Parameter types are resolved against the

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -39,7 +39,7 @@
 
 import * as yaml from 'yaml';
 
-import {AiContext, CustomExtension, Entity, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, AiContext, CustomExtension, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
 
 // The schema version the loader was written against; re-emitted verbatim so a
 // serialized document loads without a version-mismatch warning. Mirrors
@@ -180,6 +180,7 @@ function modelDoc(model: SemanticModel, warnings: string[], logical: boolean):
     relationships: nonEmpty(
         (model.relationships ?? []).map(r => relationshipDoc(r, warnings))),
     metrics: nonEmpty((model.metrics ?? []).map(m => metricDoc(m, warnings))),
+    actions: nonEmpty((model.actions ?? []).map(a => actionDoc(a))),
   });
 }
 
@@ -259,6 +260,34 @@ function metricDoc(metric: Metric, warnings: string[]): Record<string, any> {
     ai_context: aiContextDoc(metric.aiContext),
     custom_extensions: customExtensionsDoc(metric.customExtensions),
   });
+}
+
+// Inverts loader.convertAction. The executor collapses back to the open
+// format's single-key object; parameters emit as {name, type}. `isEntityRef` is
+// derived by the loader on reload, so it is intentionally not emitted.
+function actionDoc(action: Action): Record<string, any> {
+  return compact({
+    name: action.name,
+    description: action.description,
+    executor: executorDoc(action.executor),
+    parameters: nonEmpty(
+        (action.parameters ?? []).map(p => ({name: p.name, type: p.type}))),
+    ai_context: aiContextDoc(action.aiContext),
+    custom_extensions: customExtensionsDoc(action.customExtensions),
+  });
+}
+
+// Collapses the IR's tagged executor union back to the open format's single-key
+// object ({mcp: {...}} / {rest: {...}} / {grpc: {...}}).
+function executorDoc(ex: Executor): Record<string, any> {
+  switch (ex.kind) {
+    case 'mcp':
+      return {mcp: {server: ex.mcp.server, tool: ex.mcp.tool}};
+    case 'rest':
+      return {rest: {endpoint: ex.rest.endpoint, method: ex.rest.method}};
+    case 'grpc':
+      return {grpc: {service: ex.grpc.service, method: ex.grpc.method}};
+  }
 }
 
 // Inverts loader.convertRelationship: `from`/`to` are the endpoint entities and

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -39,7 +39,7 @@
 
 import * as yaml from 'yaml';
 
-import {Action, AiContext, CustomExtension, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, AiContext, Constraint, CustomExtension, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
 
 // The schema version the loader was written against; re-emitted verbatim so a
 // serialized document loads without a version-mismatch warning. Mirrors
@@ -181,6 +181,8 @@ function modelDoc(model: SemanticModel, warnings: string[], logical: boolean):
         (model.relationships ?? []).map(r => relationshipDoc(r, warnings))),
     metrics: nonEmpty((model.metrics ?? []).map(m => metricDoc(m, warnings))),
     actions: nonEmpty((model.actions ?? []).map(a => actionDoc(a))),
+    constraints:
+        nonEmpty((model.constraints ?? []).map(c => constraintDoc(c))),
   });
 }
 
@@ -274,6 +276,18 @@ function actionDoc(action: Action): Record<string, any> {
         (action.parameters ?? []).map(p => ({name: p.name, type: p.type}))),
     ai_context: aiContextDoc(action.aiContext),
     custom_extensions: customExtensionsDoc(action.customExtensions),
+  });
+}
+
+// Inverts loader.convertConstraint. The expression is a logical invariant, so
+// it round-trips verbatim -- there is nothing derived to drop.
+function constraintDoc(constraint: Constraint): Record<string, any> {
+  return compact({
+    name: constraint.name,
+    expression: constraint.expression,
+    description: constraint.description,
+    ai_context: aiContextDoc(constraint.aiContext),
+    custom_extensions: customExtensionsDoc(constraint.customExtensions),
   });
 }
 

--- a/toolbox/mdcode/src/libts/semantic/pull_kc.ts
+++ b/toolbox/mdcode/src/libts/semantic/pull_kc.ts
@@ -149,7 +149,13 @@ function semanticAspectTypes(entryType: string): string[]|undefined {
   const aspectType = (name: string) => `${typeBase}/aspectTypes/${name}`;
   switch (t) {
     case 'semantic-model':
-      return [aspectType('semantic-model'), aspectType('guidelines')];
+      // The anchor also carries the built-in `overview` aspect when the model
+      // has actions (see actionsOverviewAspectData); fetch it so a pull can
+      // recover them.
+      return [
+        aspectType('semantic-model'), aspectType('overview'),
+        aspectType('guidelines')
+      ];
     case 'semantic-entity':
       return [
         aspectType('semantic-entity'), aspectType('schema'),

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -1,0 +1,401 @@
+// The semantic runtime: executing a model's action against a live store, gated
+// by the model's constraints.
+//
+// A semantic model has always described what things MEAN. Actions describe what
+// can be DONE, and constraints describe what must stay true. This module is
+// where those three meet an actual database:
+//
+//   1. RESOLVE. An action's parameters are typed by the ontology, so an
+//      entity-typed argument is an object reference, not a value. The caller
+//      (often an agent) supplies something human -- an account id, a person's
+//      name -- and the runtime turns it into the row that argument denotes,
+//      failing loudly on "no such thing" and on "more than one such thing".
+//   2. APPLY. A read-write transaction is opened and the action's writes are
+//      run inside it. Nothing is visible to anyone else yet.
+//   3. GATE. Every constraint is lowered to a probe and run IN THE SAME
+//      transaction, so it observes the uncommitted writes (read-your-writes).
+//      A probe returning rows means the write would leave the store violating
+//      an invariant.
+//   4. DECIDE. Any violation rolls the transaction back and returns the
+//      constraint's own `description` -- text the model author wrote to tell
+//      the caller what to do differently. No violation commits.
+//
+// The gate fails closed. If a constraint cannot be lowered, the action is
+// aborted rather than run unchecked: the runtime cannot tell an unevaluated
+// invariant from a satisfied one, and guessing in favour of the write is how
+// data gets corrupted.
+//
+// What the runtime does NOT do is invent the write itself. An action declares
+// an executor -- it names where the operation lives, not what SQL it runs -- so
+// the caller supplies a handler that produces the statements. The ontology
+// contributes typed resolution and the constraint gate; the mutation body comes
+// from the handler. That split is deliberate and is where a real executor
+// dispatch (MCP, REST, gRPC) would later slot in.
+//
+
+import * as spanner from '../gcp/spanner';
+
+import {
+  ConstraintProbe,
+  lowerConstraints,
+  violationMessage,
+} from './constraint_eval';
+import {Action, Entity, SemanticModel} from './ir';
+import {spannerTable} from './spanner';
+import {quoteIfReserved} from './sql_identifiers';
+
+
+// An entity-typed argument, resolved to the row it denotes.
+export interface EntityRef {
+  entity: string;
+  // Key values in the entity's declared key order, as strings (Spanner's REST
+  // surface returns every scalar as a string, and the runtime keeps them that
+  // way so a caller need not know the physical types).
+  keys: string[];
+  // How the caller referred to it, kept for error messages.
+  input: string;
+}
+
+
+// The writes an action performs, produced by the caller's handler.
+export interface ActionPlan {
+  // DML to run inside the transaction, in order.
+  statements: spanner.Statement[];
+  // The rows the statements touch, by entity name. Used to scope the constraint
+  // probes: a probe restricted to these keys costs the same whether the table
+  // has a thousand rows or a billion. An entity omitted here is probed over its
+  // whole table, which is correct but slower -- so omit only when the touched
+  // set genuinely is not known.
+  touched?: Record<string, string[]>;
+}
+
+
+// What the handler is given: the action, its arguments with entity-typed ones
+// already resolved, and a reader scoped to the open transaction (so a handler
+// can look at the pre-state before deciding what to write).
+export interface ActionContext {
+  model: SemanticModel;
+  action: Action;
+  args: Record<string, unknown>;
+  refs: Record<string, EntityRef>;
+  query(stmt: spanner.Statement): Promise<string[][]>;
+}
+
+
+export type ActionHandler = (ctx: ActionContext) => Promise<ActionPlan>;
+
+
+// A constraint that the post-state violated.
+export interface Violation {
+  constraint: string;
+  entity: string;
+  message: string;
+  violatingKeys: string[][];
+}
+
+
+export type ActionOutcome = {
+  status: 'committed';
+  commitTimestamp?: string;
+  refs: Record<string, EntityRef>;
+  // The constraints that were checked, so a caller can show its work.
+  checked: string[];
+}|{
+  status: 'rejected';
+  // Why the write was refused, assembled from the violated constraints'
+  // descriptions. This is the text an agent reads to correct itself.
+  message: string;
+  violations: Violation[];
+}|{
+  status: 'error';
+  // A failure that is not a constraint violation: an argument that resolved to
+  // nothing, a constraint that could not be lowered, a store-level error. The
+  // transaction is rolled back in every case, so no partial write survives.
+  message: string;
+};
+
+
+export interface RunActionOptions {
+  model: SemanticModel;
+  actionName: string;
+  args: Record<string, unknown>;
+  client: spanner.SpannerDataClient;
+  handler: ActionHandler;
+  // Cap on the violating rows a probe reports. Defaults to the lowering
+  // module's own cap.
+  violationLimit?: number;
+}
+
+
+const TOUCHED_PARAM = 'touchedKeys';
+
+
+// Runs one action end to end. Never throws for an expected failure -- an
+// unresolvable argument, a violated constraint, a rejected statement all come
+// back as an outcome, because the caller is usually an agent that needs to read
+// the reason and try again.
+export async function runAction(opts: RunActionOptions):
+    Promise<ActionOutcome> {
+  const {model, client, args} = opts;
+  const action =
+      (model.actions ?? []).find(a => a.name === opts.actionName);
+  if (!action) {
+    return {
+      status: 'error',
+      message: `Model '${model.name}' declares no action '${opts.actionName}'.`,
+    };
+  }
+
+  // Lower the constraints BEFORE touching the store. A model whose invariants
+  // cannot be checked should fail without having opened a transaction at all.
+  const lowered = lowerConstraints(
+      model,
+      {touchedKeysParam: TOUCHED_PARAM, limit: opts.violationLimit});
+  if (lowered.errors.length) {
+    return {
+      status: 'error',
+      message: `Action '${action.name}' was not run because the model's ` +
+          `constraints cannot all be evaluated, and running an unchecked ` +
+          `write is not safe: ${lowered.errors.join('; ')}`,
+    };
+  }
+
+  try {
+    return await client.withSession(async sessionName => {
+      const begun = await client.beginReadWrite(sessionName);
+      const transactionId = begun.result?.id;
+      if (!transactionId) {
+        return {
+          status: 'error',
+          message: `Could not begin a transaction on ${client.database} (${
+              begun.status}${begun.message ? `: ${begun.message}` : ''}).`,
+        } as ActionOutcome;
+      }
+
+      const run = async(stmt: spanner.Statement) => {
+        const res = await client.executeSql(sessionName, transactionId, stmt);
+        if (res.status < 200 || res.status >= 300) {
+          throw new StoreError(
+              `${res.message ?? 'request failed'} (while running: ${stmt.sql})`);
+        }
+        return res.result ?? {};
+      };
+      const query = async(stmt: spanner.Statement) =>
+          (await run(stmt)).rows ?? [];
+
+      // Everything from here on is inside the transaction, so any failure must
+      // roll back rather than leave it open.
+      try {
+        const refs = await resolveArguments(model, action, args, query);
+        if ('error' in refs) {
+          await client.rollback(sessionName, transactionId);
+          return {status: 'error', message: refs.error} as ActionOutcome;
+        }
+
+        const plan = await opts.handler(
+            {model, action, args, refs: refs.refs, query});
+        for (const stmt of plan.statements) {
+          await run(stmt);
+        }
+
+        const violations = await checkConstraints(
+            lowered.probes, plan.touched ?? {}, query);
+        if (violations.length) {
+          await client.rollback(sessionName, transactionId);
+          return {
+            status: 'rejected',
+            message: violations.map(v => v.message).join(' '),
+            violations,
+          } as ActionOutcome;
+        }
+
+        const committed = await client.commit(sessionName, transactionId);
+        if (committed.status < 200 || committed.status >= 300) {
+          return {
+            status: 'error',
+            message: `The write passed every constraint but the commit ` +
+                `failed: ${committed.message ?? committed.status}.`,
+          } as ActionOutcome;
+        }
+        return {
+          status: 'committed',
+          commitTimestamp: committed.result?.commitTimestamp,
+          refs: refs.refs,
+          checked: lowered.probes.map(p => p.constraint.name),
+        } as ActionOutcome;
+      } catch (err) {
+        await client.rollback(sessionName, transactionId);
+        throw err;
+      }
+    });
+  } catch (err) {
+    return {
+      status: 'error',
+      message: `Action '${action.name}' failed and was rolled back: ${
+          err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+
+// A store-level failure, distinguished from a programming error so the message
+// surfaced to the caller stays about the store.
+class StoreError extends Error {}
+
+
+// Runs every probe and collects the violations. A probe whose entity has no
+// touched keys runs unscoped; one whose entity was touched is restricted to
+// those rows.
+async function checkConstraints(
+    probes: ConstraintProbe[], touched: Record<string, string[]>,
+    query: (stmt: spanner.Statement) => Promise<string[][]>):
+    Promise<Violation[]> {
+  const violations: Violation[] = [];
+  for (const probe of probes) {
+    const keys = touched[probe.entity];
+    let stmt: spanner.Statement;
+    if (probe.scoped && keys && keys.length) {
+      stmt = {
+        sql: probe.sql,
+        params: {[TOUCHED_PARAM]: keys},
+        paramTypes: {
+          [TOUCHED_PARAM]:
+              {code: 'ARRAY', arrayElementType: {code: 'STRING'}},
+        },
+      };
+    } else {
+      // No touched keys for this entity, so check the whole table. Passing an
+      // empty array to the scoped probe instead would match nothing and the
+      // constraint would pass vacuously -- the exact silent-success failure the
+      // gate exists to prevent.
+      stmt = {sql: probe.unscopedSql};
+    }
+    const rows = await query(stmt);
+    if (rows.length) {
+      violations.push({
+        constraint: probe.constraint.name,
+        entity: probe.entity,
+        message: violationMessage(probe, rows),
+        violatingKeys: rows,
+      });
+    }
+  }
+  return violations;
+}
+
+
+// Turns each entity-typed argument into the row it denotes. Scalar arguments
+// pass through untouched; this is only about object references.
+async function resolveArguments(
+    model: SemanticModel, action: Action, args: Record<string, unknown>,
+    query: (stmt: spanner.Statement) => Promise<string[][]>):
+    Promise<{refs: Record<string, EntityRef>}|{error: string}> {
+  const refs: Record<string, EntityRef> = {};
+  for (const param of action.parameters) {
+    if (!param.isEntityRef) continue;
+    const raw = args[param.name];
+    if (raw === undefined || raw === null || `${raw}`.trim() === '') {
+      return {
+        error: `Action '${action.name}' requires '${param.name}', a reference ` +
+            `to a ${param.type}, but none was given.`,
+      };
+    }
+    const entity = (model.entities ?? []).find(e => e.name === param.type);
+    if (!entity) {
+      return {
+        error: `Parameter '${param.name}' is typed '${param.type}', which the ` +
+            `model does not declare as an entity.`,
+      };
+    }
+    const resolved = await resolveEntityRef(entity, `${raw}`, query);
+    if ('error' in resolved) return {error: resolved.error};
+    refs[param.name] = resolved.ref;
+  }
+  return {refs};
+}
+
+
+// Resolves one object reference. `input` is matched against the entity's key
+// and, when it has one, its identifying text field -- so an agent can say
+// "Account 1" or "Alice" and the runtime finds the same row either way.
+//
+// Both failure modes are reported precisely, because both are things the caller
+// can act on: nothing matched (the reference is wrong) or several matched (the
+// reference is ambiguous, and the candidates are listed).
+async function resolveEntityRef(
+    entity: Entity, input: string,
+    query: (stmt: spanner.Statement) => Promise<string[][]>):
+    Promise<{ref: EntityRef}|{error: string}> {
+  const warnings: string[] = [];
+  const table =
+      spannerTable(entity.dataSource, warnings, `entity '${entity.name}'`);
+  if (warnings.length) {
+    return {
+      error: `Cannot resolve a ${entity.name}: ${warnings.join('; ')}.`,
+    };
+  }
+
+  const keyColumns: string[] = [];
+  for (const key of entity.keys) {
+    const field = entity.fields.find(f => f.name === key);
+    const expr = (field?.expression ?? '').trim();
+    if (!expr || !/^[A-Za-z_]\w*$/.test(expr)) {
+      return {
+        error: `Cannot resolve a ${entity.name}: its key field '${
+            key}' is not bound to a plain column.`,
+      };
+    }
+    keyColumns.push(quoteIfReserved(expr));
+  }
+  if (!keyColumns.length) {
+    return {error: `Cannot resolve a ${entity.name}: it declares no key.`};
+  }
+
+  const predicates =
+      keyColumns.map(c => `CAST(${c} AS STRING) = @ref`);
+  const label = identifyingColumn(entity);
+  if (label) predicates.push(`CAST(${label} AS STRING) = @ref`);
+
+  // LIMIT 2 is enough to tell "one match" from "more than one", and avoids
+  // dragging back a large candidate set just to reject it.
+  const rows = await query({
+    sql: `SELECT ${keyColumns.join(', ')} FROM ${table} WHERE ${
+        predicates.join(' OR ')} LIMIT 2`,
+    params: {ref: input},
+    paramTypes: {ref: {code: 'STRING'}},
+  });
+
+  if (!rows.length) {
+    return {
+      error: `No ${entity.name} matches '${input}'.`,
+    };
+  }
+  if (rows.length > 1) {
+    return {
+      error: `'${input}' matches more than one ${entity.name} (${
+          rows.map(r => r.join('/')).join(', ')}); use a key to disambiguate.`,
+    };
+  }
+  return {ref: {entity: entity.name, keys: rows[0], input}};
+}
+
+
+// The entity's identifying text field, if it has an obvious one: a String field
+// that is not part of the key and whose name reads as a name. Deliberately
+// conservative -- guessing wrong would make an agent's reference resolve to the
+// wrong row, which is worse than making it supply a key.
+function identifyingColumn(entity: Entity): string|null {
+  const keys = new Set(entity.keys);
+  for (const field of entity.fields) {
+    if (keys.has(field.name)) continue;
+    if (field.type !== 'String') continue;
+    if (!/^(name|full_name|fullname|title|label|display_name)$/i.test(
+            field.name)) {
+      continue;
+    }
+    const expr = (field.expression ?? '').trim();
+    if (!expr || !/^[A-Za-z_]\w*$/.test(expr)) continue;
+    return quoteIfReserved(expr);
+  }
+  return null;
+}

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -397,7 +397,9 @@ function physicalColumns(
 
 
 // Maps the IR's `dataSource` to the BARE Spanner table name the graph
-// references. A property graph names input tables within its own database, so
+// references. Exported because the semantic runtime resolves an entity to the
+// same table this leg deployed the graph over -- the gate must probe the table
+// the graph reads. A property graph names input tables within its own database, so
 // only the final segment of a qualified `project.dataset.table` (or any dotted
 // source) is meaningful; the leading qualifiers name where a BigQuery copy
 // lives and have no bearing on the Spanner table. A resource-name URI
@@ -406,7 +408,7 @@ function physicalColumns(
 // path locates the store, not the table. A verbatim query (contains whitespace)
 // cannot back a graph element table, so it is passed through parenthesized with
 // a warning.
-function spannerTable(
+export function spannerTable(
     dataSource: string, warnings: string[], context: string): string {
   const trimmed = (dataSource ?? '').trim();
   if (!trimmed) {

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -11,7 +11,7 @@
 import {BigQueryClient} from '../gcp/bigquery';
 
 import {googleDeploymentTargets} from './deploy_bigquery';
-import {SemanticModel} from './ir';
+import {Executor, SemanticModel} from './ir';
 import {LoadedModel} from './loader';
 
 // Checks every model against the push requirements and returns the collected
@@ -109,8 +109,63 @@ export function validatePushRequirements(
         }
       }
     }
+
+    // Actions have no BigQuery Graph representation, so their checks are
+    // target-independent: each parameter's type must resolve to something in
+    // the ontology, and the executor must carry the coordinates a runtime needs
+    // to dispatch it. (The "exactly one executor kind" rule is already
+    // guaranteed by the loader schema, so it cannot reach here.)
+    errors.push(...validateActions(model, document));
   }
   return errors;
+}
+
+// Static, target-independent checks for a model's actions. Returns one message
+// per violation. Two things can be statically wrong once the model has parsed:
+//   - a parameter's type resolves to neither a known entity nor a scalar
+//     datatype (the loader left isEntityRef unset and only warned) -- an
+//     unresolvable type is a malformed action, promoted to a hard error here;
+//   - an executor is missing a coordinate a runtime needs to dispatch it (an
+//     empty server/tool, endpoint/method, or service/method) -- the schema
+//     accepts empty strings, so this is caught here rather than at parse.
+function validateActions(model: SemanticModel, document: string): string[] {
+  const errors: string[] = [];
+  for (const action of model.actions ?? []) {
+    const where =
+        `action '${action.name}' in model '${model.name}' (${document})`;
+    for (const param of action.parameters) {
+      if (param.isEntityRef === undefined) {
+        errors.push(`${where} has parameter '${param.name}' whose type '${
+            param.type}' is neither a known entity nor a scalar datatype.`);
+      }
+    }
+    for (const missing of missingExecutorFields(action.executor)) {
+      errors.push(`${where} has an ${
+          action.executor.kind} executor missing its '${missing}'.`);
+    }
+  }
+  return errors;
+}
+
+
+// The executor coordinate fields that are absent or blank. An executor with no
+// gaps yields an empty list.
+function missingExecutorFields(ex: Executor): string[] {
+  const blank = (s: string) => s.trim().length === 0;
+  switch (ex.kind) {
+    case 'mcp':
+      return [['server', ex.mcp.server], ['tool', ex.mcp.tool]]
+          .filter(([, v]) => blank(v))
+          .map(([k]) => k);
+    case 'rest':
+      return [['endpoint', ex.rest.endpoint], ['method', ex.rest.method]]
+          .filter(([, v]) => blank(v))
+          .map(([k]) => k);
+    case 'grpc':
+      return [['service', ex.grpc.service], ['method', ex.grpc.method]]
+          .filter(([, v]) => blank(v))
+          .map(([k]) => k);
+  }
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -116,6 +116,9 @@ export function validatePushRequirements(
     // to dispatch it. (The "exactly one executor kind" rule is already
     // guaranteed by the loader schema, so it cannot reach here.)
     errors.push(...validateActions(model, document));
+
+    // Constraints are logical invariants, target-independent like actions.
+    errors.push(...validateConstraints(model, document));
   }
   return errors;
 }
@@ -147,6 +150,44 @@ function validateActions(model: SemanticModel, document: string): string[] {
   return errors;
 }
 
+
+// Static, target-independent checks for a model's constraints. A constraint's
+// `expression` is a logical boolean invariant, resolved against the ontology by
+// the evaluator at action time, so validation here is deliberately light:
+//   - the expression must be non-empty;
+//   - when it opens with a `<Entity>.<field>` qualifier that names a KNOWN
+//     entity, that entity must actually declare the field -- this catches a typo
+//     that would otherwise surface only inside an agent's rejected action.
+// A leading qualifier that is not a known entity (a relationship-qualified name
+// like `OrderedAs.quantity`, a metric reference, or compound logic) is left to
+// the evaluator rather than guessed at here, so a valid constraint is never
+// falsely rejected.
+function validateConstraints(model: SemanticModel, document: string): string[] {
+  const errors: string[] = [];
+  for (const c of model.constraints ?? []) {
+    const where =
+        `constraint '${c.name}' in model '${model.name}' (${document})`;
+    if (!c.expression.trim()) {
+      errors.push(`${where} has an empty expression.`);
+      continue;
+    }
+    const ref = leadingFieldRef(c.expression);
+    if (!ref) continue;
+    const entity = (model.entities ?? []).find(e => e.name === ref.entity);
+    if (entity && !entity.fields.some(f => f.name === ref.field)) {
+      errors.push(`${where} references '${ref.entity}.${ref.field}', but ` +
+          `entity '${ref.entity}' declares no field '${ref.field}'.`);
+    }
+  }
+  return errors;
+}
+
+// The leading `<name>.<field>` qualifier of a constraint expression, or null
+// when it does not open with one.
+function leadingFieldRef(expr: string): {entity: string; field: string}|null {
+  const m = expr.trim().match(/^([A-Za-z_]\w*)\.([A-Za-z_]\w*)/);
+  return m ? {entity: m[1], field: m[2]} : null;
+}
 
 // The executor coordinate fields that are absent or blank. An executor with no
 // gaps yields an empty list.

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -601,6 +601,27 @@ export async function push(options: PushOptions): Promise<number> {
           '.');
     }
 
+    // Actions have no BigQuery/Spanner Graph construct -- their only destination
+    // is Knowledge Catalog. A push that omits the KC leg (--no-kc) would
+    // validate a model's actions and then deploy them nowhere, so warn rather
+    // than drop them silently.
+    if (!kcEnabled) {
+      const kcProfileName =
+          namedProfile ?? snapshot.manifest.defaultProfile ?? DEFAULT_PROFILE;
+      const docs = mergeOnce(kcProfileName, false);
+      const prepared =
+          docs ? await prepareOnce(docs, kcProfileName, false) : null;
+      for (const {model} of prepared?.models ?? []) {
+        const n = model.actions?.length ?? 0;
+        if (n) {
+          console.warn(
+              `Warning: model '${model.name}' declares ${n} action(s), which ` +
+              `deploy only to Knowledge Catalog; --no-kc excludes that leg, so ` +
+              `they will not be deployed. Drop --no-kc to deploy them.`);
+        }
+      }
+    }
+
     // Knowledge Catalog records one canonical view of the logical model: the
     // single --profile selection, else the default binding. Alongside a graph
     // deploy the entries reflect that binding (pruned to what it answers); a

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -601,10 +601,10 @@ export async function push(options: PushOptions): Promise<number> {
           '.');
     }
 
-    // Actions have no BigQuery/Spanner Graph construct -- their only destination
-    // is Knowledge Catalog. A push that omits the KC leg (--no-kc) would
-    // validate a model's actions and then deploy them nowhere, so warn rather
-    // than drop them silently.
+    // Actions and constraints have no BigQuery/Spanner Graph construct -- their
+    // only destination is Knowledge Catalog. A push that omits the KC leg
+    // (--no-kc) would validate them and then deploy them nowhere, so warn
+    // rather than drop them silently.
     if (!kcEnabled) {
       const kcProfileName =
           namedProfile ?? snapshot.manifest.defaultProfile ?? DEFAULT_PROFILE;
@@ -612,10 +612,15 @@ export async function push(options: PushOptions): Promise<number> {
       const prepared =
           docs ? await prepareOnce(docs, kcProfileName, false) : null;
       for (const {model} of prepared?.models ?? []) {
-        const n = model.actions?.length ?? 0;
-        if (n) {
+        const declared: string[] = [];
+        const actionCount = model.actions?.length ?? 0;
+        if (actionCount) declared.push(`${actionCount} action(s)`);
+        const constraintCount = model.constraints?.length ?? 0;
+        if (constraintCount) declared.push(`${constraintCount} constraint(s)`);
+        if (declared.length) {
           console.warn(
-              `Warning: model '${model.name}' declares ${n} action(s), which ` +
+              `Warning: model '${model.name}' declares ${
+                  declared.join(' and ')}, which ` +
               `deploy only to Knowledge Catalog; --no-kc excludes that leg, so ` +
               `they will not be deployed. Drop --no-kc to deploy them.`);
         }

--- a/toolbox/mdcode/tests/libts/gcp/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/gcp/spanner.test.ts
@@ -1,0 +1,153 @@
+// Behavior spec for the Spanner data client's transaction surface. Spies on the
+// low-level _post so it pins the exact request bodies without a live Spanner.
+//
+// The seqno is the reason this file exists. Spanner requires a monotonically
+// increasing per-transaction sequence number on DML, and reuses it to recognize
+// a retried statement; getting it wrong does not fail at compile time or in a
+// single-statement test -- it fails on the SECOND statement of a transaction,
+// against the real service, with "Previously received a different request with
+// this seqno". That is exactly the kind of thing a client should handle once so
+// no caller ever meets it.
+//
+
+import {describe, expect, spyOn, test} from 'bun:test';
+
+import {ApiContext} from '../../../src/libts/gcp/context';
+import {SpannerDataClient} from '../../../src/libts/gcp/spanner';
+
+const CTX = new ApiContext('test-project', 'us', 'test-token');
+const SESSION =
+    'projects/test-project/instances/i/databases/d/sessions/s1';
+
+function client() {
+  const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+  const posts: Array<{path: string; body: any}> = [];
+  const spy = spyOn(c, '_post').mockImplementation(
+      async (path: string, body: any) => {
+        posts.push({path, body});
+        return {status: 200, result: {name: SESSION, id: 'txn-1'}} as never;
+      });
+  return {c, posts, spy};
+}
+
+
+describe('SpannerDataClient addressing', () => {
+  test('scopes every call to one database', () => {
+    const c = new SpannerDataClient(CTX, 'proj', 'inst', 'db');
+    expect(c.database).toBe('projects/proj/instances/inst/databases/db');
+  });
+
+  test('creates a session under the database', async () => {
+    const {c, posts} = client();
+    await c.createSession();
+    expect(posts[0].path).toBe(
+        'projects/test-project/instances/i/databases/d/sessions');
+  });
+
+  test('begins a READ-WRITE transaction, not a read-only one', async () => {
+    const {c, posts} = client();
+    await c.beginReadWrite(SESSION);
+    expect(posts[0].path).toBe(`${SESSION}:beginTransaction`);
+    expect(posts[0].body).toEqual({options: {readWrite: {}}});
+  });
+});
+
+
+describe('the per-transaction statement sequence number', () => {
+  test('starts at 1 and increases with each statement', async () => {
+    const {c, posts} = client();
+    await c.executeSql(SESSION, 'txn-1', {sql: 'DELETE FROM T WHERE TRUE'});
+    await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (1)'});
+    await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (2)'});
+    expect(posts.map(p => p.body.seqno)).toEqual(['1', '2', '3']);
+  });
+
+  test('is tracked per transaction, so two transactions do not share a counter',
+       async () => {
+         const {c, posts} = client();
+         await c.executeSql(SESSION, 'txn-a', {sql: 'INSERT INTO T (a) VALUES (1)'});
+         await c.executeSql(SESSION, 'txn-b', {sql: 'INSERT INTO T (a) VALUES (2)'});
+         await c.executeSql(SESSION, 'txn-a', {sql: 'INSERT INTO T (a) VALUES (3)'});
+         expect(posts.map(p => p.body.seqno)).toEqual(['1', '1', '2']);
+       });
+
+  test('restarts after a commit, since the next transaction is a new one',
+       async () => {
+         const {c, posts} = client();
+         await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (1)'});
+         await c.commit(SESSION, 'txn-1');
+         await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (2)'});
+         expect(posts.filter(p => p.body.seqno).map(p => p.body.seqno))
+           .toEqual(['1', '1']);
+       });
+
+  test('restarts after a rollback too', async () => {
+    const {c, posts} = client();
+    await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (1)'});
+    await c.rollback(SESSION, 'txn-1');
+    await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (2)'});
+    expect(posts.filter(p => p.body.seqno).map(p => p.body.seqno))
+      .toEqual(['1', '1']);
+  });
+});
+
+
+describe('executeSql request shape', () => {
+  test('carries the transaction id, the SQL, and its parameters', async () => {
+    const {c, posts} = client();
+    await c.executeSql(SESSION, 'txn-1', {
+      sql: 'SELECT x FROM T WHERE k = @k',
+      params: {k: 'abc'},
+      paramTypes: {k: {code: 'STRING'}},
+    });
+    expect(posts[0].path).toBe(`${SESSION}:executeSql`);
+    expect(posts[0].body).toEqual({
+      transaction: {id: 'txn-1'},
+      sql: 'SELECT x FROM T WHERE k = @k',
+      params: {k: 'abc'},
+      paramTypes: {k: {code: 'STRING'}},
+      seqno: '1',
+    });
+  });
+});
+
+
+describe('withSession', () => {
+  test('deletes the session it created', async () => {
+    const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+    spyOn(c, '_post').mockImplementation(
+        async () => ({status: 200, result: {name: SESSION}}) as never);
+    const deleted: string[] = [];
+    spyOn(c, '_delete').mockImplementation(async (path: string) => {
+      deleted.push(path);
+      return {status: 200, result: {}} as never;
+    });
+    await c.withSession(async name => name);
+    expect(deleted).toEqual([SESSION]);
+  });
+
+  test('deletes the session even when the body throws, so none is leaked',
+       async () => {
+         const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+         spyOn(c, '_post').mockImplementation(
+             async () => ({status: 200, result: {name: SESSION}}) as never);
+         const deleted: string[] = [];
+         spyOn(c, '_delete').mockImplementation(async (path: string) => {
+           deleted.push(path);
+           return {status: 200, result: {}} as never;
+         });
+         await expect(c.withSession(async () => {
+           throw new Error('boom');
+         })).rejects.toThrow('boom');
+         expect(deleted).toEqual([SESSION]);
+       });
+
+  test('reports a session that could not be created, naming the database',
+       async () => {
+         const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+         spyOn(c, '_post').mockImplementation(
+             async () => ({status: 403, message: 'denied'}) as never);
+         await expect(c.withSession(async () => 1))
+           .rejects.toThrow(/could not create a session on projects\/test-project/);
+       });
+});

--- a/toolbox/mdcode/tests/libts/semantic/actions.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/actions.test.ts
@@ -1,0 +1,261 @@
+// Behavior specification for model-level ACTIONS -- the write-side counterpart
+// to metrics -- across the pipeline: loader parsing (executor + typed
+// parameters), the push-time validation gate, and the Knowledge Catalog
+// publish/pull round trip (actions ride the anchor's `overview` aspect, as they
+// have no semantic-* system type of their own). Preconditions and `affects` are
+// intentionally out of scope for this prototype.
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
+import {ACTIONS_OVERVIEW_MARKER, generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
+import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
+import {validatePushRequirements} from '../../../src/libts/semantic/validate';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const OPTS = {
+  project: 'dest',
+  location: 'us',
+  entryGroup: 'eg'
+};
+
+function loadFixtureModel(name: string): SemanticModel {
+  const text = fs.readFileSync(path.join(FIXTURES, name), 'utf8');
+  return loadModels(text).models[0];
+}
+
+// A one-entity document with an actions array, for focused loader tests.
+function withActions(actions: any[], over: any = {}) {
+  return fromDocument({
+    semantic_model: [{
+      name: 'm',
+      datasets: [
+        {name: 'customer', source: 'p.d.c', primary_key: ['id'], fields: []}
+      ],
+      actions,
+      ...over,
+    }],
+  });
+}
+
+const MCP = {
+  mcp: {
+    server: '//agentregistry.googleapis.com/x/mcpServers/commerce',
+    tool: 'place_order'
+  },
+};
+
+
+describe('loader parses actions', () => {
+  test('reads name, description, executor, and typed parameters', () => {
+    const {models, warnings} = withActions([{
+      name: 'PlaceOrder',
+      description: 'Create an order',
+      executor: MCP,
+      parameters: [
+        {name: 'customer', type: 'customer'},
+        {name: 'quantity', type: 'Integer'}
+      ],
+    }]);
+    const [action] = models[0].actions!;
+    expect(action.name).toBe('PlaceOrder');
+    expect(action.description).toBe('Create an order');
+    expect(action.executor).toEqual({kind: 'mcp', mcp: MCP.mcp});
+    expect(action.parameters).toEqual([
+      {name: 'customer', type: 'customer', isEntityRef: true},
+      {name: 'quantity', type: 'Integer', isEntityRef: false},
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  test('a model without actions leaves model.actions unset', () => {
+    const {models} = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets:
+            [{name: 'c', source: 'p.d.c', primary_key: ['id'], fields: []}]
+      }],
+    });
+    expect(models[0].actions).toBeUndefined();
+  });
+
+  test('an unresolvable parameter type is kept verbatim and warned', () => {
+    const {models, warnings} = withActions([{
+      name: 'A',
+      executor: MCP,
+      parameters: [{name: 'x', type: 'Nope'}],
+    }]);
+    const [p] = models[0].actions![0].parameters;
+    expect(p).toEqual({name: 'x', type: 'Nope'});  // isEntityRef unset
+    expect(
+        warnings.some(w => w.includes('parameter \'x\'') && w.includes('Nope')))
+        .toBe(true);
+  });
+
+  test('an executor with two kinds is rejected at parse', () => {
+    expect(() => withActions([{
+             name: 'A',
+             executor: {mcp: MCP.mcp, rest: {endpoint: 'e', method: 'POST'}},
+           }]))
+        .toThrow(/exactly one kind/);
+  });
+
+  test('an executor with no kind is rejected at parse', () => {
+    expect(() => withActions([{name: 'A', executor: {}}]))
+        .toThrow(/exactly one kind/);
+  });
+
+  test('rest and grpc executors normalize to the tagged union', () => {
+    const {models} = withActions([
+      {
+        name: 'R',
+        executor: {rest: {endpoint: 'https://x/orders', method: 'POST'}}
+      },
+      {
+        name: 'G',
+        executor: {grpc: {service: 'commerce.Orders', method: 'Place'}}
+      },
+    ]);
+    expect(models[0].actions![0].executor).toEqual({
+      kind: 'rest',
+      rest: {endpoint: 'https://x/orders', method: 'POST'}
+    });
+    expect(models[0].actions![1].executor).toEqual({
+      kind: 'grpc',
+      grpc: {service: 'commerce.Orders', method: 'Place'}
+    });
+  });
+
+  test('duplicate action names warn', () => {
+    const {warnings} = withActions([
+      {name: 'Dup', executor: MCP},
+      {name: 'Dup', executor: MCP},
+    ]);
+    expect(warnings.some(w => w.includes('action name') && w.includes('Dup')))
+        .toBe(true);
+  });
+
+  test('duplicate parameter names within an action warn', () => {
+    const {warnings} = withActions([{
+      name: 'A',
+      executor: MCP,
+      parameters: [
+        {name: 'customer', type: 'customer'},
+        {name: 'customer', type: 'Integer'},
+      ],
+    }]);
+    expect(warnings.some(
+               w => w.includes('parameter name') && w.includes('customer') &&
+                   w.includes('A')))
+        .toBe(true);
+  });
+});
+
+
+describe('validatePushRequirements gates actions', () => {
+  const target =
+      '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
+  const googleExt = {
+    vendorName: 'GOOGLE',
+    data: JSON.stringify({deploymentTargets: [target]})
+  };
+
+  function loaded(actions: any[]): LoadedModel {
+    const model: SemanticModel = {
+      name: 'm',
+      entities:
+          [{name: 'customer', dataSource: 'p.d.c', keys: ['id'], fields: []}],
+      relationships: [],
+      metrics: [],
+      actions,
+      customExtensions: [googleExt],
+    };
+    return {document: 'doc', model};
+  }
+
+  test('a well-formed action passes', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'PlaceOrder',
+      executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+      parameters: [{name: 'customer', type: 'customer', isEntityRef: true}],
+    }])]);
+    expect(errs).toEqual([]);
+  });
+
+  test('an unresolved parameter type is a hard error', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'A',
+      executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+      parameters: [{name: 'x', type: 'Nope'}],  // isEntityRef unset
+    }])]);
+    expect(errs.some(e => e.includes('parameter \'x\'') && e.includes('Nope')))
+        .toBe(true);
+  });
+
+  test('a blank executor coordinate is a hard error', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'A',
+      executor: {kind: 'mcp', mcp: {server: '', tool: 't'}},
+      parameters: [],
+    }])]);
+    expect(errs.some(e => e.includes('executor') && e.includes('server')))
+        .toBe(true);
+  });
+});
+
+
+describe('Knowledge Catalog publish/pull round trip', () => {
+  const model = loadFixtureModel('actions_place_order.yaml');
+
+  test('actions are published to the anchor overview aspect', () => {
+    const {entries, warnings} = generateCatalogResources(model, OPTS);
+    const anchor = entries[0];
+    const overview = anchor.aspects?.['dataplex-types.global.overview'];
+    expect(overview).toBeDefined();
+    const content = overview!.data!.content as string;
+    expect(overview!.data!.contentType).toBe('MARKDOWN');
+    // Human-readable section + the machine-readable marker/JSON block.
+    expect(content).toContain('## Actions');
+    expect(content).toContain('### PlaceOrder');
+    expect(content).toContain(ACTIONS_OVERVIEW_MARKER);
+    expect(content).toContain('"place_order"');
+    // Author is warned actions are catalog-only.
+    expect(warnings.some(w => w.includes('action'))).toBe(true);
+  });
+
+  test('a pull recovers the actions from the overview', () => {
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    expect(models[0].actions).toEqual(model.actions);
+  });
+
+  test('a pull missing the referenced entity drops isEntityRef and warns', () => {
+    // Pull only the anchor: the `customer` entity entry is absent, so the
+    // action's entity-typed `customer` parameter can no longer be resolved.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const anchorOnly =
+        entries.filter(e => e.entryType.endsWith('/semantic-model'));
+    const {models, warnings} = modelsFromCatalogResources(anchorOnly);
+    const params = models[0].actions![0].parameters;
+    const customer = params.find(p => p.name === 'customer')!;
+    const quantity = params.find(p => p.name === 'quantity')!;
+    // The unresolvable entity type loses isEntityRef and is warned; the scalar
+    // `quantity` still resolves.
+    expect(customer.isEntityRef).toBeUndefined();
+    expect(quantity.isEntityRef).toBe(false);
+    expect(warnings.some(
+               w => w.includes('parameter \'customer\'') &&
+                   w.includes('resolved type')))
+        .toBe(true);
+  });
+
+  test('a model with no actions carries no overview aspect', () => {
+    const noActions: SemanticModel = {...model, actions: undefined};
+    const {entries} = generateCatalogResources(noActions, OPTS);
+    expect(entries[0].aspects?.['dataplex-types.global.overview'])
+        .toBeUndefined();
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/actions.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/actions.test.ts
@@ -252,10 +252,17 @@ describe('Knowledge Catalog publish/pull round trip', () => {
         .toBe(true);
   });
 
-  test('a model with no actions carries no overview aspect', () => {
-    const noActions: SemanticModel = {...model, actions: undefined};
-    const {entries} = generateCatalogResources(noActions, OPTS);
-    expect(entries[0].aspects?.['dataplex-types.global.overview'])
-        .toBeUndefined();
-  });
+  test('a model with neither actions nor constraints carries no overview aspect',
+       () => {
+         // The overview is shared with constraints, so both must be absent for
+         // the anchor to look the way it did before either existed.
+         const bare: SemanticModel = {
+           ...model,
+           actions: undefined,
+           constraints: undefined
+         };
+         const {entries} = generateCatalogResources(bare, OPTS);
+         expect(entries[0].aspects?.['dataplex-types.global.overview'])
+             .toBeUndefined();
+       });
 });

--- a/toolbox/mdcode/tests/libts/semantic/constraint_eval.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraint_eval.test.ts
@@ -198,11 +198,26 @@ describe('lowering an expression the evaluator understands', () => {
     expect(result.probe.sql).toContain('(balance >= -0.5)');
   });
 
-  test('TRUE, FALSE and NULL are literals', () => {
-    for (const literal of ['TRUE', 'FALSE', 'NULL']) {
+  test('TRUE and FALSE are literals', () => {
+    for (const literal of ['TRUE', 'FALSE']) {
       const result = lower(`Account.balance != ${literal}`);
       expect(result.ok).toBe(true);
     }
+  });
+
+  test('a NULL comparison becomes a null test, not a comparison', () => {
+    // GoogleSQL rejects `col != NULL` outright -- it is not a comparison that
+    // evaluates to unknown, it is a query that does not compile -- so lowering
+    // NULL verbatim would emit a probe that can never run. The reading an
+    // author intends by `!= NULL` is IS NOT NULL, so that is what is emitted.
+    const notNull = lower('Account.balance != NULL');
+    if (!notNull.ok) throw new Error(notNull.reason);
+    expect(notNull.probe.sql).toContain('(balance IS NOT NULL)');
+    expect(notNull.probe.sql).not.toContain('!= NULL');
+
+    const isNull = lower('Account.balance = NULL');
+    if (!isNull.ok) throw new Error(isNull.reason);
+    expect(isNull.probe.sql).toContain('(balance IS NULL)');
   });
 
   test('the violation-row cap is configurable', () => {
@@ -276,6 +291,15 @@ describe('refusing an expression the evaluator cannot check', () => {
 
   test('an entity with no key, so a violation could not be attributed', () => {
     expect(reason('Event.amount > 0')).toContain('declares no key');
+  });
+
+  test('NULL with an ordering operator, which has no reading to preserve', () => {
+    for (const op of ['>', '>=', '<', '<=']) {
+      const result = lower(`Account.balance ${op} NULL`);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toContain('NULL');
+    }
   });
 
   test('the refusal always names the constraint', () => {

--- a/toolbox/mdcode/tests/libts/semantic/constraint_eval.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraint_eval.test.ts
@@ -1,0 +1,347 @@
+// Lowering constraints to SQL probes: what the evaluator accepts, what it
+// refuses, and the exact SQL it emits.
+//
+// The refusals get as much attention as the successes here. The gate fails
+// closed -- an un-lowerable constraint aborts the action -- so a change that
+// quietly widened or narrowed what lowers would change which writes are allowed
+// through, and that should never happen unnoticed.
+//
+
+import {describe, expect, test} from 'bun:test';
+
+import {
+  lowerConstraint,
+  lowerConstraints,
+  violationMessage,
+} from '../../../src/libts/semantic/constraint_eval';
+import {Constraint, Entity, SemanticModel} from '../../../src/libts/semantic/ir';
+
+
+function field(name: string, expression?: string, extra: object = {}) {
+  return {name, expression: expression ?? name, ...extra};
+}
+
+const account: Entity = {
+  name: 'Account',
+  dataSource: 'demo.payments.Account',
+  keys: ['accountId'],
+  fields: [
+    field('accountId', 'account_id'),
+    field('balance'),
+    field('overdraftLimit', 'overdraft_limit'),
+    field('status', undefined, {type: 'String'}),
+    field('brand', undefined, {type: 'String'}),
+    field('projected', undefined, {unbound: true, expression: undefined}),
+    field('headroom', 'balance - overdraft_limit'),
+  ],
+};
+
+const ledgerEntry: Entity = {
+  name: 'LedgerEntry',
+  dataSource: 'demo.payments.LedgerEntry',
+  keys: ['accountId', 'seq'],
+  fields: [field('accountId', 'account_id'), field('seq'), field('amount')],
+};
+
+const party: Entity = {
+  name: 'Party',
+  dataSource: 'demo.payments.Party',
+  keys: ['partyId'],
+  abstract: true,
+  fields: [field('partyId', 'party_id'), field('score')],
+};
+
+const keyless: Entity = {
+  name: 'Event',
+  dataSource: 'demo.payments.Event',
+  keys: [],
+  fields: [field('amount')],
+};
+
+function modelWith(...constraints: Constraint[]): SemanticModel {
+  return {
+    name: 'payments',
+    entities: [account, ledgerEntry, party, keyless],
+    relationships: [],
+    metrics: [],
+    constraints,
+  };
+}
+
+function lower(expression: string, opts = {touchedKeysParam: 'touchedKeys'}) {
+  const constraint: Constraint = {name: 'C', expression};
+  return lowerConstraint(modelWith(constraint), constraint, opts);
+}
+
+// The reason text of a lowering that was expected to fail.
+function reason(expression: string): string {
+  const result = lower(expression);
+  if (result.ok) throw new Error(`expected '${expression}' to be refused`);
+  return result.reason;
+}
+
+
+describe('lowering an expression the evaluator understands', () => {
+  test('a field-to-literal comparison becomes a scoped violation probe', () => {
+    const result = lower('Account.balance >= 0');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.probe.sql).toBe(
+      'SELECT account_id FROM Account WHERE NOT COALESCE((balance >= 0), FALSE)' +
+      ' AND CAST(account_id AS STRING) IN UNNEST(@touchedKeys) LIMIT 5');
+    expect(result.probe.scoped).toBe(true);
+    expect(result.probe.entity).toBe('Account');
+    expect(result.probe.table).toBe('Account');
+    expect(result.probe.keyColumns).toEqual(['account_id']);
+  });
+
+  test('the probe selects rows that VIOLATE the constraint, not ones that hold',
+       () => {
+         const result = lower('Account.balance >= 0');
+         if (!result.ok) throw new Error(result.reason);
+         // NOT wraps the invariant: an empty result set is the passing case.
+         expect(result.probe.sql).toContain('NOT COALESCE((balance >= 0)');
+       });
+
+  test('a NULL column counts as a violation, not as a pass', () => {
+    // Plain SQL negation would let a NULL through: `NULL >= 0` is unknown and
+    // `NOT unknown` is unknown, so the row would not be returned. COALESCE to
+    // FALSE makes the unknown case a violation -- the fail-closed reading.
+    const result = lower('Account.balance >= 0');
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql).toContain('COALESCE(');
+    expect(result.probe.sql).toContain(', FALSE)');
+  });
+
+  test('both a scoped and a whole-table form are emitted', () => {
+    const result = lower('Account.balance >= 0');
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.unscopedSql).toBe(
+      'SELECT account_id FROM Account WHERE NOT COALESCE((balance >= 0), FALSE)' +
+      ' LIMIT 5');
+    expect(result.probe.unscopedSql).not.toContain('UNNEST');
+  });
+
+  test('without a touched-keys parameter the probe covers the whole table',
+       () => {
+         const result = lower('Account.balance >= 0', {} as never);
+         if (!result.ok) throw new Error(result.reason);
+         expect(result.probe.scoped).toBe(false);
+         expect(result.probe.sql).toBe(result.probe.unscopedSql);
+       });
+
+  test('a composite-key entity is probed unscoped', () => {
+    // Scoping a composite key needs a struct-array comparison the evaluator
+    // does not emit, so it falls back to the whole table -- slower, still
+    // correct. Silently scoping on one of the two key columns would be wrong.
+    const constraint: Constraint = {name: 'C', expression: 'LedgerEntry.amount != 0'};
+    const result = lowerConstraint(
+      modelWith(constraint), constraint, {touchedKeysParam: 'touchedKeys'});
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.scoped).toBe(false);
+    expect(result.probe.keyColumns).toEqual(['account_id', 'seq']);
+    expect(result.probe.sql).toContain('SELECT account_id, seq FROM LedgerEntry');
+  });
+
+  test('comparisons join with AND and OR, each parenthesized', () => {
+    const result = lower(
+      "Account.balance >= 0 AND Account.status != 'CLOSED' OR Account.balance > 100");
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql).toContain(
+      "(balance >= 0) AND (status != 'CLOSED') OR (balance > 100)");
+  });
+
+  test('a lowercase and/or joins the same way', () => {
+    const result = lower('Account.balance >= 0 and Account.balance < 1000000');
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql).toContain('(balance >= 0) AND (balance < 1000000)');
+  });
+
+  test('a field whose name contains "and" is not split on it', () => {
+    const result = lower('Account.brand != Account.status');
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql).toContain('(brand != status)');
+  });
+
+  test('two fields of the same entity can be compared', () => {
+    const result = lower('Account.balance >= Account.overdraftLimit');
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql).toContain('(balance >= overdraft_limit)');
+  });
+
+  test('logical field names lower to their physical columns', () => {
+    const result = lower('Account.overdraftLimit <= 0');
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql).toContain('overdraft_limit <= 0');
+    expect(result.probe.sql).not.toContain('overdraftLimit');
+  });
+
+  test('a two-character operator is not read as a one-character one', () => {
+    const ge = lower('Account.balance >= 0');
+    const le = lower('Account.balance <= 0');
+    const ne = lower('Account.balance != 0');
+    if (!ge.ok || !le.ok || !ne.ok) throw new Error('expected all three to lower');
+    expect(ge.probe.sql).toContain('(balance >= 0)');
+    expect(le.probe.sql).toContain('(balance <= 0)');
+    expect(ne.probe.sql).toContain('(balance != 0)');
+  });
+
+  test('<> is emitted as != so the probe uses one spelling', () => {
+    const result = lower('Account.balance <> 0');
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql).toContain('(balance != 0)');
+  });
+
+  test('a negative and a decimal literal are both accepted', () => {
+    const result = lower('Account.balance >= -0.5');
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql).toContain('(balance >= -0.5)');
+  });
+
+  test('TRUE, FALSE and NULL are literals', () => {
+    for (const literal of ['TRUE', 'FALSE', 'NULL']) {
+      const result = lower(`Account.balance != ${literal}`);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  test('the violation-row cap is configurable', () => {
+    const constraint: Constraint = {name: 'C', expression: 'Account.balance >= 0'};
+    const result =
+      lowerConstraint(modelWith(constraint), constraint, {limit: 1});
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.probe.sql.endsWith('LIMIT 1')).toBe(true);
+  });
+});
+
+
+describe('refusing an expression the evaluator cannot check', () => {
+  test('an empty expression', () => {
+    expect(reason('   ')).toContain('the expression is empty');
+  });
+
+  test('a parenthesized or function-call expression', () => {
+    expect(reason('ABS(Account.balance) > 0')).toContain('parentheses');
+  });
+
+  test('an expression with no comparison operator', () => {
+    expect(reason('Account.balance')).toContain('is not a comparison');
+  });
+
+  test('a left side that is not an <Entity>.<field> reference', () => {
+    expect(reason('0 <= Account.balance'))
+      .toContain('is not an <Entity>.<field> reference');
+  });
+
+  test('a right side that is neither a literal nor a field', () => {
+    expect(reason('Account.balance >= someLimit'))
+      .toContain('neither a literal nor an');
+  });
+
+  test('a string literal containing a quote or backslash', () => {
+    // Rejected rather than escaped: a surprising escape in generated SQL is
+    // harder to spot than a refusal.
+    expect(reason("Account.status != 'it\\'s'")).toContain('neither a literal');
+  });
+
+  test('an expression spanning two entities', () => {
+    expect(reason('Account.balance >= 0 AND LedgerEntry.amount > 0'))
+      .toContain('spans more than one entity');
+  });
+
+  test('a comparison between two entities', () => {
+    expect(reason('Account.balance >= LedgerEntry.amount'))
+      .toContain('compares fields of two entities');
+  });
+
+  test('an entity the model does not declare', () => {
+    expect(reason('Ghost.balance >= 0')).toContain("'Ghost' is not declared");
+  });
+
+  test('a field the entity does not declare', () => {
+    expect(reason('Account.nope >= 0')).toContain("declares no field 'nope'");
+  });
+
+  test('a field that is unbound under the current binding', () => {
+    expect(reason('Account.projected >= 0')).toContain('is unbound');
+  });
+
+  test('a field bound to an expression rather than a bare column', () => {
+    expect(reason('Account.headroom >= 0')).toContain('rather than a bare column');
+  });
+
+  test('an abstract entity, which has no table', () => {
+    expect(reason('Party.score > 0')).toContain('is abstract');
+  });
+
+  test('an entity with no key, so a violation could not be attributed', () => {
+    expect(reason('Event.amount > 0')).toContain('declares no key');
+  });
+
+  test('the refusal always names the constraint', () => {
+    expect(reason('Account.nope >= 0')).toStartWith("constraint 'C' cannot be evaluated");
+  });
+});
+
+
+describe('lowering every constraint on a model', () => {
+  test('probes and refusals come back separately', () => {
+    const model = modelWith(
+      {name: 'NonNegativeBalance', expression: 'Account.balance >= 0'},
+      {name: 'Unlowerable', expression: 'SUM(Account.balance) > 0'},
+    );
+    const {probes, errors} = lowerConstraints(model, {touchedKeysParam: 'k'});
+    expect(probes.map(p => p.constraint.name)).toEqual(['NonNegativeBalance']);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("constraint 'Unlowerable'");
+  });
+
+  test('a model with no constraints yields neither probes nor errors', () => {
+    const model: SemanticModel =
+      {name: 'payments', entities: [account], relationships: [], metrics: []};
+    expect(lowerConstraints(model)).toEqual({probes: [], errors: []});
+  });
+});
+
+
+describe('the message a violation returns', () => {
+  const probe = (() => {
+    const result = lowerConstraint(
+      modelWith({
+        name: 'NonNegativeBalance',
+        expression: 'Account.balance >= 0',
+        description: 'An account cannot go negative. Transfer less, or pick an account with more funds.',
+      }),
+      {
+        name: 'NonNegativeBalance',
+        expression: 'Account.balance >= 0',
+        description: 'An account cannot go negative. Transfer less, or pick an account with more funds.',
+      },
+      {touchedKeysParam: 'k'});
+    if (!result.ok) throw new Error(result.reason);
+    return result.probe;
+  })();
+
+  test("the author's description leads, because it is the actionable part",
+       () => {
+         const message = violationMessage(probe, [['7']]);
+         expect(message).toStartWith('An account cannot go negative.');
+       });
+
+  test('the constraint and its expression are cited', () => {
+    const message = violationMessage(probe, [['7']]);
+    expect(message).toContain("constraint 'NonNegativeBalance'");
+    expect(message).toContain('Account.balance >= 0');
+  });
+
+  test('the offending rows are named', () => {
+    expect(violationMessage(probe, [['7'], ['9']]))
+      .toContain('Violating Account: 7, 9.');
+  });
+
+  test('a constraint with no description still says which one failed', () => {
+    const bare = {...probe, constraint: {...probe.constraint, description: undefined}};
+    expect(violationMessage(bare, []))
+      .toStartWith("Constraint 'NonNegativeBalance' does not hold.");
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -1,0 +1,290 @@
+// Behavior specification for model-level CONSTRAINTS -- the named invariants
+// that gate an action -- across the pipeline: loader parsing, the push-time
+// validation gate, the OSI round trip, and the Knowledge Catalog publish/pull
+// round trip. Constraints have no semantic-* system type of their own, so they
+// ride the model anchor's `overview` aspect alongside actions, each under its
+// own marker.
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
+import {ACTIONS_OVERVIEW_MARKER, CONSTRAINTS_OVERVIEW_MARKER, generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
+import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
+import {serializeModel} from '../../../src/libts/semantic/osi_converter';
+import {validatePushRequirements} from '../../../src/libts/semantic/validate';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const OPTS = {
+  project: 'dest',
+  location: 'us',
+  entryGroup: 'eg'
+};
+
+function loadFixtureModel(name: string): SemanticModel {
+  const text = fs.readFileSync(path.join(FIXTURES, name), 'utf8');
+  return loadModels(text).models[0];
+}
+
+// A one-entity document with a constraints array, for focused loader tests.
+function withConstraints(constraints: any[], over: any = {}) {
+  return fromDocument({
+    semantic_model: [{
+      name: 'm',
+      datasets: [{
+        name: 'customer',
+        source: 'p.d.c',
+        primary_key: ['id'],
+        fields: [{
+          name: 'balance',
+          expression: {dialects: [{dialect: 'ANSI_SQL', expression: 'balance'}]},
+        }],
+      }],
+      constraints,
+      ...over,
+    }],
+  });
+}
+
+
+describe('loader parses constraints', () => {
+  test('reads name, expression, and description', () => {
+    const {models, warnings} = withConstraints([{
+      name: 'NonNegativeBalance',
+      expression: 'customer.balance >= 0',
+      description: 'A balance cannot go negative.',
+    }]);
+    // Scoped to constraints: the fixture's field expression emits an unrelated
+    // dialect note.
+    expect(warnings.filter(w => w.includes('constraint'))).toEqual([]);
+    expect(models[0].constraints).toEqual([{
+      name: 'NonNegativeBalance',
+      expression: 'customer.balance >= 0',
+      description: 'A balance cannot go negative.',
+    }]);
+  });
+
+  test('a model without constraints leaves model.constraints unset', () => {
+    const {models} = fromDocument({
+      semantic_model: [{
+        name: 'm',
+        datasets:
+            [{name: 'customer', source: 'p.d.c', primary_key: ['id'], fields: []}],
+      }],
+    });
+    expect(models[0].constraints).toBeUndefined();
+  });
+
+  test('description is optional', () => {
+    const {models} =
+        withConstraints([{name: 'C', expression: 'customer.balance >= 0'}]);
+    expect(models[0].constraints).toEqual([
+      {name: 'C', expression: 'customer.balance >= 0'}
+    ]);
+  });
+
+  test('the expression is kept verbatim, not parsed', () => {
+    // A compound expression the loader has no business interpreting: it belongs
+    // to the evaluator, so it must survive character for character.
+    const expr = 'customer.balance >= 0 AND (total_revenue > 100 OR NOT flagged)';
+    const {models} = withConstraints([{name: 'C', expression: expr}]);
+    expect(models[0].constraints![0].expression).toBe(expr);
+  });
+
+  test('a constraint with no expression is rejected at parse', () => {
+    expect(() => withConstraints([{name: 'C'}])).toThrow();
+  });
+
+  test('duplicate constraint names warn', () => {
+    const {warnings} = withConstraints([
+      {name: 'C', expression: 'customer.balance >= 0'},
+      {name: 'C', expression: 'customer.balance < 100'},
+    ]);
+    expect(warnings.some(w => w.includes('constraint name') && w.includes('C')))
+        .toBe(true);
+  });
+
+  test('ai_context and custom_extensions round-trip onto the IR', () => {
+    const {models} = withConstraints([{
+      name: 'C',
+      expression: 'customer.balance >= 0',
+      ai_context: {instructions: 'Explain the shortfall in currency terms.'},
+      custom_extensions: [{vendor_name: 'ACME', data: '{"severity":"hard"}'}],
+    }]);
+    const c = models[0].constraints![0];
+    expect(c.aiContext)
+        .toEqual({instructions: 'Explain the shortfall in currency terms.'});
+    expect(c.customExtensions).toEqual([
+      {vendorName: 'ACME', data: '{"severity":"hard"}'}
+    ]);
+  });
+});
+
+
+describe('validatePushRequirements gates constraints', () => {
+  const target =
+      '//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g';
+  const googleExt = {
+    vendorName: 'GOOGLE',
+    data: JSON.stringify({deploymentTargets: [target]})
+  };
+
+  function loaded(constraints: any[]): LoadedModel {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{
+        name: 'customer',
+        dataSource: 'p.d.c',
+        keys: ['id'],
+        fields: [{name: 'balance'}],
+      }],
+      relationships: [],
+      metrics: [],
+      constraints,
+      customExtensions: [googleExt],
+    };
+    return {document: 'doc', model};
+  }
+
+  test('a well-formed constraint passes', () => {
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'customer.balance >= 0'}])]);
+    expect(errs).toEqual([]);
+  });
+
+  test('an empty expression is a hard error', () => {
+    const errs =
+        validatePushRequirements([loaded([{name: 'C', expression: '   '}])]);
+    expect(errs.some(e => e.includes("constraint 'C'") &&
+                      e.includes('empty expression')))
+        .toBe(true);
+  });
+
+  test('an unknown field on a KNOWN entity is a hard error', () => {
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'customer.blance >= 0'}])]);
+    expect(errs.some(e => e.includes('customer.blance'))).toBe(true);
+  });
+
+  test('a leading qualifier that is not an entity is left to the evaluator',
+       () => {
+         // `OrderedAs` is a relationship, not an entity -- guessing here would
+         // falsely reject a valid constraint, so validation stays out of it.
+         const errs = validatePushRequirements(
+             [loaded([{name: 'C', expression: 'OrderedAs.quantity > 0'}])]);
+         expect(errs).toEqual([]);
+       });
+
+  test('an expression that does not open with a field ref passes', () => {
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'COUNT(*) > 0'}])]);
+    expect(errs).toEqual([]);
+  });
+});
+
+
+describe('OSI round trip', () => {
+  test('constraints survive serialize -> reload', () => {
+    const model = loadFixtureModel('actions_place_order.yaml');
+    expect(model.constraints).toHaveLength(2);
+    const {yaml} = serializeModel(model);
+    expect(yaml).toContain('constraints:');
+    const reloaded = loadModels(yaml).models[0];
+    expect(reloaded.constraints).toEqual(model.constraints);
+  });
+
+  test('a model with no constraints emits no constraints key', () => {
+    const model = loadFixtureModel('actions_place_order.yaml');
+    const {yaml} = serializeModel({...model, constraints: undefined});
+    expect(yaml).not.toContain('constraints:');
+  });
+});
+
+
+describe('Knowledge Catalog publish/pull round trip', () => {
+  const model = loadFixtureModel('actions_place_order.yaml');
+
+  test('constraints are published to the anchor overview aspect', () => {
+    const {entries, warnings} = generateCatalogResources(model, OPTS);
+    const overview = entries[0].aspects?.['dataplex-types.global.overview'];
+    expect(overview).toBeDefined();
+    const content = overview!.data!.content as string;
+    expect(overview!.data!.contentType).toBe('MARKDOWN');
+    // Human-readable section + the machine-readable marker/JSON block.
+    expect(content).toContain('## Constraints');
+    expect(content).toContain('### NonNegativeOrderTotal');
+    expect(content).toContain(CONSTRAINTS_OVERVIEW_MARKER);
+    expect(content).toContain('"orders.o_totalprice >= 0"');
+    // Author is warned constraints are catalog-only.
+    expect(warnings.some(w => w.includes('constraint'))).toBe(true);
+  });
+
+  test('actions and constraints share one overview without overwriting', () => {
+    const {entries} = generateCatalogResources(model, OPTS);
+    const content = entries[0]
+                        .aspects!['dataplex-types.global.overview']
+                        .data!.content as string;
+    expect(content).toContain(ACTIONS_OVERVIEW_MARKER);
+    expect(content).toContain(CONSTRAINTS_OVERVIEW_MARKER);
+    expect(content).toContain('## Actions');
+    expect(content).toContain('## Constraints');
+    // Each marker must be followed by its OWN JSON block, so a reader keyed on
+    // one marker never picks up the other's payload.
+    expect(content).toContain('"place_order"');
+    expect(content).toContain('"PositiveQuantity"');
+  });
+
+  test('a pull recovers the constraints from the overview', () => {
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    expect(models[0].constraints).toEqual(model.constraints);
+  });
+
+  test('a pull recovers actions and constraints together', () => {
+    const {entries, entryLinks} = generateCatalogResources(model, OPTS);
+    const {models} = modelsFromCatalogResources(entries, entryLinks);
+    expect(models[0].actions).toEqual(model.actions);
+    expect(models[0].constraints).toEqual(model.constraints);
+  });
+
+  test('a model with only constraints still carries an overview', () => {
+    const onlyConstraints: SemanticModel = {...model, actions: undefined};
+    const {entries} = generateCatalogResources(onlyConstraints, OPTS);
+    const overview = entries[0].aspects?.['dataplex-types.global.overview'];
+    expect(overview).toBeDefined();
+    const content = overview!.data!.content as string;
+    expect(content).toContain('## Constraints');
+    expect(content).not.toContain('## Actions');
+  });
+
+  test('a constraint with no name is skipped and warned', () => {
+    const {entries} = generateCatalogResources(model, OPTS);
+    const anchor = entries[0];
+    const overview = anchor.aspects!['dataplex-types.global.overview'];
+    overview.data!.content =
+        (overview.data!.content as string)
+            .replace('"name": "PositiveQuantity"', '"name": ""');
+    const {models, warnings} = modelsFromCatalogResources(entries);
+    expect(models[0].constraints!.map(c => c.name)).toEqual([
+      'NonNegativeOrderTotal'
+    ]);
+    expect(warnings.some(w => w.includes('no name'))).toBe(true);
+  });
+
+  test('a malformed constraint block warns and recovers none', () => {
+    const {entries} = generateCatalogResources(model, OPTS);
+    const overview = entries[0].aspects!['dataplex-types.global.overview'];
+    const content = overview.data!.content as string;
+    const marker = content.lastIndexOf(CONSTRAINTS_OVERVIEW_MARKER);
+    overview.data!.content =
+        content.slice(0, marker) + CONSTRAINTS_OVERVIEW_MARKER +
+        '\n```json\n{not json\n```\n';
+    const {models, warnings} = modelsFromCatalogResources(entries);
+    expect(models[0].constraints).toBeUndefined();
+    expect(warnings.some(w => w.includes('not valid JSON'))).toBe(true);
+    // The actions block, under its own marker, is unaffected.
+    expect(models[0].actions).toHaveLength(1);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/deploy_knowledge_catalog.test.ts
@@ -188,6 +188,25 @@ describe('deployKnowledgeCatalog: re-push upserts', () => {
     expect(create).toHaveBeenCalledTimes(3);
     expect(update).toHaveBeenCalledTimes(3);
   });
+
+  test('re-push names the optional overview key so a removed action aspect is cleared', async () => {
+    const {update} = stubClient({
+      create: () => err(409, 'entry already exists'),
+      update: ok({}),
+    });
+
+    // DOCS declares no actions, so the regenerated anchor carries no overview
+    // aspect. The anchor is written first (anchor-first).
+    await deployKnowledgeCatalog(models(DOCS), CTX, OPTS);
+
+    // Its update must still NAME the overview key in aspectKeys: Dataplex clears
+    // an aspect only when its key is listed and absent from the body. Otherwise
+    // a previously-published overview (an earlier push that HAD actions)
+    // survives on the server and a later pull resurrects the deleted actions.
+    const anchorAspectKeys = update.mock.calls[0][2] ?? [];
+    expect(anchorAspectKeys.some((k: string) => k.endsWith('.overview')))
+        .toBe(true);
+  });
 });
 
 

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -1,0 +1,76 @@
+# Test fixture -- AI-first semantics format (v0.2.0.dev0).
+#
+# A minimal star (orders -> customer) plus a model-level ACTION, the write-side
+# counterpart to a metric. PlaceOrder carries an MCP executor (a tool in Agent
+# Registry) and ontology-typed parameters: an entity-typed one (`customer`, an
+# object reference to the customer entity) and scalar ones. Preconditions and
+# affects are intentionally out of scope for this prototype. A GOOGLE BigQuery
+# Graph target keeps the model executable (actions produce no graph element).
+
+version: "0.2.0.dev0"
+
+semantic_model:
+  - name: sales
+    description: Sales orders with customer attributes
+    custom_extensions:
+      - vendor_name: GOOGLE
+        data: '{"deploymentTargets": ["//bigquery.googleapis.com/projects/sqlgen-testing/datasets/demo/propertyGraphs/sales"]}'
+    datasets:
+      - name: orders
+        source: samples.tpch.orders
+        primary_key: [o_orderkey]
+        fields:
+          - name: o_orderkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_orderkey
+          - name: o_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_custkey
+          - name: o_totalprice
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: o_totalprice
+      - name: customer
+        source: samples.tpch.customer
+        primary_key: [c_custkey]
+        fields:
+          - name: c_custkey
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_custkey
+          - name: c_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: c_name
+    relationships:
+      - name: orders_to_customer
+        from: orders
+        to: customer
+        from_columns: [o_custkey]
+        to_columns: [c_custkey]
+    metrics:
+      - name: total_revenue
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(orders.o_totalprice)
+        description: Total order revenue
+    actions:
+      - name: PlaceOrder
+        description: Create an order for a customer
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/commerce
+            tool: place_order
+        parameters:
+          - {name: customer, type: customer}
+          - {name: quantity, type: Integer}
+        ai_context:
+          instructions: "Resolve the buyer to a customer before calling."

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -1,11 +1,18 @@
 # Test fixture -- AI-first semantics format (v0.2.0.dev0).
 #
 # A minimal star (orders -> customer) plus a model-level ACTION, the write-side
-# counterpart to a metric. PlaceOrder carries an MCP executor (a tool in Agent
-# Registry) and ontology-typed parameters: an entity-typed one (`customer`, an
-# object reference to the customer entity) and scalar ones. Preconditions and
-# affects are intentionally out of scope for this prototype. A GOOGLE BigQuery
-# Graph target keeps the model executable (actions produce no graph element).
+# counterpart to a metric, and the CONSTRAINTS that gate it. PlaceOrder carries
+# an MCP executor (a tool in Agent Registry) and ontology-typed parameters: an
+# entity-typed one (`customer`, an object reference to the customer entity) and
+# scalar ones. Per-action preconditions and affects are intentionally out of
+# scope for this prototype; the gate here is model-level. A GOOGLE BigQuery
+# Graph target keeps the model executable (neither actions nor constraints
+# produce a graph element).
+#
+# The two constraints deliberately exercise both validation paths:
+# NonNegativeOrderTotal opens with a KNOWN entity, so its field is checked;
+# PositiveQuantity opens with `OrderedAs`, which is not an entity, so it is left
+# to the evaluator rather than falsely rejected.
 
 version: "0.2.0.dev0"
 
@@ -74,3 +81,12 @@ semantic_model:
           - {name: quantity, type: Integer}
         ai_context:
           instructions: "Resolve the buyer to a customer before calling."
+    constraints:
+      - name: NonNegativeOrderTotal
+        expression: orders.o_totalprice >= 0
+        description: >-
+          An order's total cannot be negative. Reduce the quantity or check the
+          unit price before retrying.
+      - name: PositiveQuantity
+        expression: OrderedAs.quantity > 0
+        description: An order line must be for at least one unit.

--- a/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_converter.test.ts
@@ -39,6 +39,7 @@ describe('loader <-> serialize round trip is IR-stable', () => {
     'vendor_dialects.yaml',
     'lineitem_databricks_ext.yaml',
     'sales_bq_graph_target.yaml',
+    'actions_place_order.yaml',
   ];
 
   for (const fixture of fixtures) {

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -115,6 +115,25 @@ function onlyLogicalGoldenDeviations(errors: typeof validate.errors): boolean {
     });
 }
 
+// `actions` (model-level write operations, the write-side counterpart to
+// metrics) are a deliberate SUPERSET of released Apache OSI: the Extended-spec
+// proposal adds them, but the vendored osi-schema.json -- pinned to released
+// v0.2.0.dev0 -- does not yet know the keyword, so a model carrying `actions`
+// trips `additionalProperties: false` on the semantic_model item. We tolerate
+// EXACTLY that one extra property (an additionalProperties error naming
+// `actions` on a /semantic_model/<n> path) and nothing else, so an actions
+// fixture validates while every other drift from the spec still fails. When
+// upstream OSI adopts actions, re-vendoring the schema makes this pass with no
+// special-casing and this tolerance can be removed.
+function onlyActionsExtension(errors: typeof validate.errors): boolean {
+  return !!errors && errors.length > 0 &&
+    errors.every(
+      e => e.keyword === 'additionalProperties' &&
+        (e.params as {additionalProperty?: string}).additionalProperty ===
+          'actions' &&
+        /\/semantic_model\/\d+$/.test(e.instancePath));
+}
+
 describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () => {
   test('at least one fixture is discovered', () => {
     expect(fixtures.length).toBeGreaterThan(0);
@@ -146,6 +165,15 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
         if ((rel === 'hierarchy_graph.yaml' ||
              rel === 'reserved_words_inherit.yaml') &&
             onlyExtendsExtension(validate.errors)) {
+          return;
+        }
+        // A model-level `actions` block is a deliberate superset of released
+        // OSI (the Extended-spec proposal); tolerate exactly that extra property
+        // and nothing else, and only on the actions fixtures that legitimately
+        // carry it -- so a stray `actions` slipping into any other fixture still
+        // fails.
+        if (rel.startsWith('actions_') &&
+            onlyActionsExtension(validate.errors)) {
           return;
         }
         const details = (validate.errors ?? [])

--- a/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/osi_schema.test.ts
@@ -125,12 +125,17 @@ function onlyLogicalGoldenDeviations(errors: typeof validate.errors): boolean {
 // fixture validates while every other drift from the spec still fails. When
 // upstream OSI adopts actions, re-vendoring the schema makes this pass with no
 // special-casing and this tolerance can be removed.
-function onlyActionsExtension(errors: typeof validate.errors): boolean {
+// The model-level write-side blocks that are a deliberate superset of released
+// OSI (the Extended-spec proposal): `actions` and the `constraints` that gate
+// them.
+const EXTENDED_MODEL_BLOCKS = new Set(['actions', 'constraints']);
+
+function onlyExtendedModelBlocks(errors: typeof validate.errors): boolean {
   return !!errors && errors.length > 0 &&
     errors.every(
       e => e.keyword === 'additionalProperties' &&
-        (e.params as {additionalProperty?: string}).additionalProperty ===
-          'actions' &&
+        EXTENDED_MODEL_BLOCKS.has(
+          (e.params as {additionalProperty?: string}).additionalProperty ?? '') &&
         /\/semantic_model\/\d+$/.test(e.instancePath));
 }
 
@@ -167,13 +172,13 @@ describe('fixtures are valid Apache OSI (osi-schema.json, Draft 2020-12)', () =>
             onlyExtendsExtension(validate.errors)) {
           return;
         }
-        // A model-level `actions` block is a deliberate superset of released
-        // OSI (the Extended-spec proposal); tolerate exactly that extra property
-        // and nothing else, and only on the actions fixtures that legitimately
-        // carry it -- so a stray `actions` slipping into any other fixture still
-        // fails.
+        // The model-level `actions` and `constraints` blocks are a deliberate
+        // superset of released OSI (the Extended-spec proposal); tolerate
+        // exactly those extra properties and nothing else, and only on the
+        // fixtures that legitimately carry them -- so a stray `actions` or
+        // `constraints` slipping into any other fixture still fails.
         if (rel.startsWith('actions_') &&
-            onlyActionsExtension(validate.errors)) {
+            onlyExtendedModelBlocks(validate.errors)) {
           return;
         }
         const details = (validate.errors ?? [])

--- a/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
@@ -1,0 +1,385 @@
+// Running an action against a store, gated by the model's constraints.
+//
+// The store is faked here rather than mocked at the HTTP layer: the fake
+// records the statements it is given, answers queries from a programmable
+// table, and tracks whether the transaction ended in a commit or a rollback.
+// That is exactly the surface the runtime's guarantees are stated in -- "a
+// violation rolls back", "an unevaluable constraint never opens a transaction"
+// -- so the assertions can be about those guarantees rather than about wire
+// format.
+//
+
+import {describe, expect, test} from 'bun:test';
+
+import * as spanner from '../../../src/libts/gcp/spanner';
+import {Action, SemanticModel} from '../../../src/libts/semantic/ir';
+import {ActionPlan, runAction} from '../../../src/libts/semantic/runtime';
+
+
+// A query the fake knows how to answer: rows returned when `match` is found in
+// the statement's SQL.
+interface Answer {
+  match: string;
+  rows: string[][];
+}
+
+
+class FakeSpanner {
+  readonly database = 'projects/p/instances/i/databases/d';
+  readonly statements: spanner.Statement[] = [];
+  committed = false;
+  rolledBack = false;
+  sessionsOpen = 0;
+  beginFails = false;
+  commitFails = false;
+  // Statements whose SQL contains one of these fragments fail, so a store-level
+  // error can be provoked at a chosen point.
+  failOn: string[] = [];
+
+  constructor(private readonly answers: Answer[] = []) {}
+
+  async withSession<T>(fn: (s: string) => Promise<T>): Promise<T> {
+    this.sessionsOpen++;
+    try {
+      return await fn('sessions/1');
+    } finally {
+      this.sessionsOpen--;
+    }
+  }
+
+  async beginReadWrite() {
+    return this.beginFails ? {status: 400, message: 'nope'} :
+                             {status: 200, result: {id: 'txn-1'}};
+  }
+
+  async executeSql(_s: string, _t: string, stmt: spanner.Statement) {
+    this.statements.push(stmt);
+    if (this.failOn.some(f => stmt.sql.includes(f))) {
+      return {status: 400, message: 'statement rejected'};
+    }
+    const answer = this.answers.find(a => stmt.sql.includes(a.match));
+    return {status: 200, result: {rows: answer?.rows ?? []}};
+  }
+
+  async commit() {
+    if (this.commitFails) return {status: 500, message: 'commit failed'};
+    this.committed = true;
+    return {status: 200, result: {commitTimestamp: '2026-09-06T00:00:00Z'}};
+  }
+
+  async rollback() {
+    this.rolledBack = true;
+    return {status: 200, result: {}};
+  }
+
+  get client(): spanner.SpannerDataClient {
+    return this as unknown as spanner.SpannerDataClient;
+  }
+
+  // The SQL of every statement run, for asserting what did and did not happen.
+  get sql(): string[] {
+    return this.statements.map(s => s.sql);
+  }
+}
+
+
+const transfer: Action = {
+  name: 'Transfer',
+  description: 'Move funds between two accounts.',
+  executor: {kind: 'mcp', mcp: {server: '//example/servers/payments', tool: 'transfer'}},
+  parameters: [
+    {name: 'source', type: 'Account', isEntityRef: true},
+    {name: 'target', type: 'Account', isEntityRef: true},
+    {name: 'amount', type: 'Float', isEntityRef: false},
+  ],
+};
+
+function model(overrides: Partial<SemanticModel> = {}): SemanticModel {
+  return {
+    name: 'payments',
+    entities: [
+      {
+        name: 'Account',
+        dataSource: 'demo.payments.Account',
+        keys: ['accountId'],
+        fields: [
+          {name: 'accountId', expression: 'account_id'},
+          {name: 'balance', expression: 'balance'},
+          {name: 'name', expression: 'name', type: 'String'},
+        ],
+      },
+    ],
+    relationships: [],
+    metrics: [],
+    actions: [transfer],
+    constraints: [{
+      name: 'NonNegativeBalance',
+      expression: 'Account.balance >= 0',
+      description: 'An account cannot go negative. Transfer less, or choose an account with more funds.',
+    }],
+    ...overrides,
+  };
+}
+
+
+// A handler that debits and credits, and reports both accounts as touched.
+const debitAndCredit = async (ctx: {refs: Record<string, {keys: string[]}>}):
+    Promise<ActionPlan> => ({
+  statements: [{sql: 'UPDATE Account SET balance = balance - 100 WHERE account_id = 1'}],
+  touched: {
+    Account: [ctx.refs.source.keys[0], ctx.refs.target.keys[0]],
+  },
+});
+
+// Answers that resolve 'A1' to account 1 and 'A2' to account 2, and report the
+// constraint as satisfied.
+function resolvingFake(extra: Answer[] = []) {
+  return new FakeSpanner([
+    {match: 'FROM Account WHERE CAST(account_id AS STRING) = @ref', rows: [['1']]},
+    ...extra,
+  ]);
+}
+
+function run(fake: FakeSpanner, over: Partial<Parameters<typeof runAction>[0]> = {}) {
+  return runAction({
+    model: model(),
+    actionName: 'Transfer',
+    args: {source: 'A1', target: 'A2', amount: 100},
+    client: fake.client,
+    handler: debitAndCredit as never,
+    ...over,
+  });
+}
+
+
+describe('a write that satisfies every constraint', () => {
+  test('commits', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(fake);
+    expect(outcome.status).toBe('committed');
+    expect(fake.committed).toBe(true);
+    expect(fake.rolledBack).toBe(false);
+  });
+
+  test('reports which constraints it checked', async () => {
+    const outcome = await run(resolvingFake());
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+    expect(outcome.checked).toEqual(['NonNegativeBalance']);
+    expect(outcome.commitTimestamp).toBe('2026-09-06T00:00:00Z');
+  });
+
+  test('checks the constraint AFTER applying the write, in the same transaction',
+       () => {
+         // Read-your-writes is the whole mechanism: a probe run before the
+         // update would see the pre-state and pass on a write that breaks the
+         // invariant.
+         const fake = resolvingFake();
+         return run(fake).then(() => {
+           const update = fake.sql.findIndex(s => s.startsWith('UPDATE'));
+           const probe = fake.sql.findIndex(s => s.includes('NOT COALESCE'));
+           expect(update).toBeGreaterThanOrEqual(0);
+           expect(probe).toBeGreaterThan(update);
+         });
+       });
+
+  test('scopes the probe to the rows the action touched', async () => {
+    const fake = resolvingFake();
+    await run(fake);
+    const probe = fake.statements.find(s => s.sql.includes('NOT COALESCE'));
+    expect(probe?.sql).toContain('IN UNNEST(@touchedKeys)');
+    expect(probe?.params?.touchedKeys).toEqual(['1', '1']);
+  });
+
+  test('closes the session even on the happy path', async () => {
+    const fake = resolvingFake();
+    await run(fake);
+    expect(fake.sessionsOpen).toBe(0);
+  });
+});
+
+
+describe('a write that would break a constraint', () => {
+  const violating = () => resolvingFake(
+    [{match: 'NOT COALESCE', rows: [['1']]}]);
+
+  test('is rolled back, not committed', async () => {
+    const fake = violating();
+    const outcome = await run(fake);
+    expect(outcome.status).toBe('rejected');
+    expect(fake.rolledBack).toBe(true);
+    expect(fake.committed).toBe(false);
+  });
+
+  test("returns the model author's description, so the caller can correct itself",
+       async () => {
+         const outcome = await run(violating());
+         if (outcome.status !== 'rejected') throw new Error('expected a rejection');
+         expect(outcome.message)
+           .toContain('An account cannot go negative. Transfer less');
+       });
+
+  test('names the constraint and the offending row', async () => {
+    const outcome = await run(violating());
+    if (outcome.status !== 'rejected') throw new Error('expected a rejection');
+    expect(outcome.violations).toHaveLength(1);
+    expect(outcome.violations[0].constraint).toBe('NonNegativeBalance');
+    expect(outcome.violations[0].entity).toBe('Account');
+    expect(outcome.violations[0].violatingKeys).toEqual([['1']]);
+  });
+});
+
+
+describe('a constraint the evaluator cannot lower', () => {
+  const unlowerable = model({
+    constraints: [{name: 'Aggregate', expression: 'SUM(Account.balance) > 0'}],
+  });
+
+  test('aborts the action rather than running it unchecked', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(fake, {model: unlowerable});
+    expect(outcome.status).toBe('error');
+    expect(fake.committed).toBe(false);
+  });
+
+  test('does not even open a transaction', async () => {
+    // Failing closed means failing early: nothing should reach the store.
+    const fake = resolvingFake();
+    await run(fake, {model: unlowerable});
+    expect(fake.statements).toHaveLength(0);
+  });
+
+  test('explains that an unchecked write is why it refused', async () => {
+    const outcome = await run(resolvingFake(), {model: unlowerable});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('cannot all be evaluated');
+    expect(outcome.message).toContain("constraint 'Aggregate'");
+  });
+});
+
+
+describe('resolving an entity-typed argument', () => {
+  test('matches on the key', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(fake);
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+    expect(outcome.refs.source).toEqual(
+      {entity: 'Account', keys: ['1'], input: 'A1'});
+  });
+
+  test('also matches on an identifying name column', async () => {
+    // An agent saying "Alice" should reach the same row as one saying "7".
+    const fake = resolvingFake();
+    await run(fake);
+    const lookup = fake.statements[0];
+    expect(lookup.sql).toContain('CAST(account_id AS STRING) = @ref');
+    expect(lookup.sql).toContain('CAST(name AS STRING) = @ref');
+  });
+
+  test('rejects a reference that matches nothing', async () => {
+    const fake = new FakeSpanner([]);
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toBe("No Account matches 'A1'.");
+    expect(fake.rolledBack).toBe(true);
+  });
+
+  test('rejects an ambiguous reference and lists the candidates', async () => {
+    const fake = new FakeSpanner(
+      [{match: 'FROM Account WHERE CAST', rows: [['1'], ['2']]}]);
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('matches more than one Account (1, 2)');
+  });
+
+  test('rejects a missing required reference', async () => {
+    const outcome = await run(
+      resolvingFake(), {args: {target: 'A2', amount: 100}});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain("requires 'source', a reference to a Account");
+  });
+
+  test('leaves scalar arguments alone', async () => {
+    const outcome = await run(resolvingFake());
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+    expect(Object.keys(outcome.refs)).toEqual(['source', 'target']);
+  });
+});
+
+
+describe('when the handler reports no touched rows', () => {
+  const wholeTable = async (): Promise<ActionPlan> =>
+    ({statements: [{sql: 'UPDATE Account SET balance = 0 WHERE TRUE'}]});
+
+  test('the constraint is checked over the whole table', async () => {
+    // The alternative -- passing an empty key array to the scoped probe --
+    // would match nothing and the constraint would pass vacuously.
+    const fake = resolvingFake();
+    await run(fake, {handler: wholeTable});
+    const probe = fake.statements.find(s => s.sql.includes('NOT COALESCE'));
+    expect(probe?.sql).not.toContain('UNNEST');
+    expect(probe?.params).toBeUndefined();
+  });
+
+  test('and a violation is still caught', async () => {
+    const fake = resolvingFake([{match: 'NOT COALESCE', rows: [['1']]}]);
+    const outcome = await run(fake, {handler: wholeTable});
+    expect(outcome.status).toBe('rejected');
+    expect(fake.rolledBack).toBe(true);
+  });
+});
+
+
+describe('failures that are not constraint violations', () => {
+  test('an unknown action is refused before any store call', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(fake, {actionName: 'Refund'});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain("declares no action 'Refund'");
+    expect(fake.statements).toHaveLength(0);
+  });
+
+  test('a transaction that will not begin is reported, not retried', async () => {
+    const fake = resolvingFake();
+    fake.beginFails = true;
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('Could not begin a transaction');
+  });
+
+  test('a rejected statement rolls the transaction back', async () => {
+    const fake = resolvingFake();
+    fake.failOn = ['UPDATE Account'];
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('statement rejected');
+    expect(fake.rolledBack).toBe(true);
+    expect(fake.committed).toBe(false);
+  });
+
+  test('a handler that throws rolls the transaction back', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(fake, {
+      handler: async () => {
+        throw new Error('handler blew up');
+      },
+    });
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('handler blew up');
+    expect(fake.rolledBack).toBe(true);
+  });
+
+  test('a commit that fails is reported as such, not as a violation', async () => {
+    const fake = resolvingFake();
+    fake.commitFails = true;
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('passed every constraint but the commit');
+  });
+
+  test('the session is closed even when the action fails', async () => {
+    const fake = resolvingFake();
+    fake.failOn = ['UPDATE Account'];
+    await run(fake);
+    expect(fake.sessionsOpen).toBe(0);
+  });
+});

--- a/toolbox/mdcode/tests/live/README.md
+++ b/toolbox/mdcode/tests/live/README.md
@@ -1,0 +1,92 @@
+# Live tests
+
+These tests run the constraints work against real Cloud Spanner and a real
+Knowledge Catalog instead of fakes. They exist because the hermetic suite can
+only prove that we generate the SQL we meant to generate; it cannot prove the
+server accepts it. Running them found a real bug: the lowering emitted
+`col != NULL`, which every hermetic test asserted was correct and which Spanner
+rejects outright.
+
+They are skipped unless you opt in, and they are not part of `npm test`.
+
+## What they cover
+
+| File | Proves |
+| --- | --- |
+| `spanner_live.test.ts` | The Spanner data client against the real API: sessions, the per-transaction statement sequence number, parameter binding, and the read-your-writes and rollback behaviour the runtime depends on. |
+| `constraint_eval_live.test.ts` | Every lowered constraint probe is SQL the server accepts, returns the rows it should, and scopes correctly to the keys an action touched. |
+| `runtime_live.test.ts` | An action commits when constraints hold and leaves the database untouched when one is violated, including failures the fake cannot produce (a probe the server type-checks and rejects). |
+| `knowledge_catalog_live.test.ts` | Constraints survive a push and pull through a real Dataplex: both markers land in the one overview aspect, and a pull recovers them byte for byte. |
+
+## Running them
+
+Everything is gated on `KCMD_LIVE`. The catalog leg needs a second opt-in,
+`KCMD_LIVE_KC`, because it writes entries to a real project.
+
+Authenticate first: the tests use application default credentials.
+
+```
+gcloud auth application-default login
+```
+
+Create and seed the Spanner database once. It is a database of its own, not the
+action demo's, so the tests cannot disturb anything else:
+
+```
+KCMD_LIVE=1 npx bun tests/live/setup.ts
+```
+
+Then run the Spanner and constraint legs:
+
+```
+KCMD_LIVE=1 npm run test:live
+```
+
+The catalog leg needs an entry group it can create, empty, and delete, and a
+project that hosts the `semantic-*` entry types. Point `DATAPLEX_ENDPOINT` and
+`KC_TYPE_PROJECT` at a surface where those types are published:
+
+```
+KCMD_LIVE=1 KCMD_LIVE_KC=1 \
+  DATAPLEX_ENDPOINT=... KC_TYPE_PROJECT=... \
+  npm run test:live
+```
+
+## Settings
+
+Each has a default, so you only set the ones you need to move.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `KCMD_LIVE` | unset | Master switch. Everything skips without it. |
+| `KCMD_LIVE_KC` | unset | Also run the catalog leg. |
+| `KCMD_LIVE_PROJECT` | `sqlgen-testing` | Project for both Spanner and the catalog. |
+| `KCMD_LIVE_SPANNER_INSTANCE` | `graph-unified-solution-demo` | Spanner instance. |
+| `KCMD_LIVE_SPANNER_DATABASE` | `kcmd_live_test` | Database the setup script creates. |
+| `KCMD_LIVE_KC_LOCATION` | `global` | Catalog location. |
+| `KCMD_LIVE_KC_ENTRY_GROUP` | `kcmd_live_test` | Entry group the catalog tests own. |
+| `DATAPLEX_ENDPOINT` | production | Catalog endpoint. |
+| `KC_TYPE_PROJECT` | `dataplex-types` | Project hosting the `semantic-*` entry types. |
+
+## What they assume about the data
+
+The Spanner tests reseed before every test and again when the file finishes, so
+a failed run leaves the database in a known state and the next run starts clean.
+The seed is three people and six accounts, two of which share a name so the
+ambiguous-reference path has two real rows to be ambiguous between.
+
+The catalog tests own their entry group outright: they empty it before each run
+and delete it afterwards. Point them at a group nothing else uses. They delete
+entry links before entries, because deleting an entry first orphans its links
+permanently.
+
+## Two things the servers taught us
+
+A session holds at most one read-write transaction. Beginning a second in the
+same session invalidates the first, and the failure surfaces later as a lock
+held by a transaction nobody is using any more. Tests that need two concurrent
+transactions use two sessions.
+
+An entry group answers `get` before it answers a list of its entries, so waiting
+on the wrong call still fails the first real request. The catalog tests poll the
+entries collection.

--- a/toolbox/mdcode/tests/live/constraint_eval_live.test.ts
+++ b/toolbox/mdcode/tests/live/constraint_eval_live.test.ts
@@ -1,0 +1,336 @@
+// Constraint lowering, checked by running the SQL it produces.
+//
+// The hermetic tests (tests/libts/semantic/constraint_eval.test.ts) compare the
+// lowered SQL to an expected string. That pins the shape, but a string is not a
+// query: a probe can be exactly the text we intended and still be invalid
+// GoogleSQL, or valid and mean something other than "the rows that violate
+// this". Two of the lowering decisions are semantic claims about the engine
+// rather than about our code, and only the engine can settle them:
+//
+//   * `NOT COALESCE(expr, FALSE)` treats a NULL column as a violation. The
+//     reason it is written that way is that `NOT (NULL >= 0)` is UNKNOWN, not
+//     TRUE, so the obvious spelling silently lets NULLs through. That is a
+//     claim about three-valued logic in Spanner, and there is a test below that
+//     runs both spellings side by side.
+//   * a scoped probe restricts to the touched rows with
+//     `CAST(key AS STRING) IN UNNEST(@touchedKeys)`, bound as an ARRAY<STRING>.
+//     Whether the server accepts that binding is not something a string
+//     comparison can know.
+//
+// Every test here runs inside a transaction that is rolled back, so the
+// database is untouched and the tests do not depend on each other's order.
+//
+
+import {afterAll, beforeAll, describe, expect, test} from 'bun:test';
+
+import * as spanner from '../../src/libts/gcp/spanner';
+import {
+  ConstraintProbe,
+  lowerConstraint,
+  lowerConstraints,
+  violationMessage,
+} from '../../src/libts/semantic/constraint_eval';
+import {SemanticModel} from '../../src/libts/semantic/ir';
+import {loadModels} from '../../src/libts/semantic/loader';
+
+import {
+  dataClient,
+  expectOk,
+  LIVE,
+  readModelYaml,
+  reseed,
+} from './live';
+
+
+const TOUCHED = 'touchedKeys';
+
+let model: SemanticModel;
+
+function lower(expression: string, opts: {limit?: number} = {}):
+    ConstraintProbe {
+  const res = lowerConstraint(
+      model, {name: 'UnderTest', expression},
+      {touchedKeysParam: TOUCHED, limit: opts.limit});
+  if (!res.ok) throw new Error(`could not lower "${expression}": ${res.reason}`);
+  return res.probe;
+}
+
+function byName(name: string): ConstraintProbe {
+  const {probes} =
+      lowerConstraints(model, {touchedKeysParam: TOUCHED});
+  const probe = probes.find(p => p.constraint.name === name);
+  if (!probe) throw new Error(`no probe for constraint '${name}'`);
+  return probe;
+}
+
+// Applies `setup`, then runs each query, then rolls back. The probes therefore
+// see the uncommitted state -- the same way the runtime's gate sees an action's
+// write -- and nothing survives the test.
+async function inRolledBackTransaction(
+    setup: spanner.Statement[],
+    queries: spanner.Statement[]): Promise<string[][][]> {
+  const client = dataClient();
+  return await client.withSession(async session => {
+    const txn =
+        expectOk(await client.beginReadWrite(session), 'beginTransaction');
+    try {
+      for (const stmt of setup) {
+        expectOk(
+            await client.executeSql(session, txn.id!, stmt),
+            `setup "${stmt.sql}"`);
+      }
+      const out: string[][][] = [];
+      for (const stmt of queries) {
+        out.push(
+            expectOk(
+                await client.executeSql(session, txn.id!, stmt),
+                `probe "${stmt.sql}"`)
+                .rows ??
+            []);
+      }
+      return out;
+    } finally {
+      await client.rollback(session, txn.id!);
+    }
+  });
+}
+
+// Runs one probe unscoped (over the whole table).
+async function runUnscoped(
+    probe: ConstraintProbe, setup: spanner.Statement[] = []):
+    Promise<string[][]> {
+  return (await inRolledBackTransaction(setup, [{sql: probe.unscopedSql}]))[0];
+}
+
+// Runs one probe restricted to the given keys, exactly as the runtime binds it.
+async function runScoped(
+    probe: ConstraintProbe, keys: string[],
+    setup: spanner.Statement[] = []): Promise<string[][]> {
+  return (await inRolledBackTransaction(setup, [{
+           sql: probe.sql,
+           params: {[TOUCHED]: keys},
+           paramTypes:
+               {[TOUCHED]: {code: 'ARRAY', arrayElementType: {code: 'STRING'}}},
+         }]))[0];
+}
+
+function setBalance(accountId: number, value: string): spanner.Statement {
+  return {sql: `UPDATE Account SET balance = ${value} WHERE account_id = ${
+              accountId}`};
+}
+
+
+describe.skipIf(!LIVE)('constraint probes on real Spanner', () => {
+  beforeAll(async () => {
+    model = loadModels(readModelYaml(), {dialect: 'ANSI_SQL'}).models[0];
+    await reseed();
+  });
+
+  afterAll(async () => {
+    await reseed();
+  });
+
+  describe('the shipped model', () => {
+    test('every constraint lowers', () => {
+      const {probes, errors} = lowerConstraints(model, {touchedKeysParam: TOUCHED});
+      expect(errors).toEqual([]);
+      expect(probes.map(p => p.constraint.name)).toEqual([
+        'NonNegativeBalance',
+        'AboveMinimumBalance',
+        'PositiveAmount',
+        'OpenAccountsOnly',
+      ]);
+    });
+
+    test('and every lowered probe is SQL the server accepts', async () => {
+      // The single most valuable thing this file does: a probe that does not
+      // parse fails the action it was supposed to guard, and no amount of
+      // string comparison would have caught it.
+      const {probes} = lowerConstraints(model, {touchedKeysParam: TOUCHED});
+      for (const probe of probes) {
+        await runUnscoped(probe);
+        await runScoped(probe, ['1']);
+      }
+    });
+
+    test('the seeded state satisfies the three balance and amount rules',
+         async () => {
+           for (const name
+                    of ['NonNegativeBalance', 'AboveMinimumBalance',
+                        'PositiveAmount']) {
+             expect(await runUnscoped(byName(name))).toEqual([]);
+           }
+         });
+
+    test('and violates OpenAccountsOnly, which is why scoping matters',
+         async () => {
+           // Account 4 is frozen in the seed. Whole-table, that is a violation;
+           // scoped to rows an action did not touch, it is none of that
+           // action's business. This is the enforcement contract -- an action
+           // must not INTRODUCE a violation among the rows it changes -- and it
+           // is only observable against data.
+           const probe = byName('OpenAccountsOnly');
+           expect(await runUnscoped(probe)).toEqual([['4']]);
+           expect(await runScoped(probe, ['1', '3'])).toEqual([]);
+           expect(await runScoped(probe, ['3', '4'])).toEqual([['4']]);
+         });
+  });
+
+  describe('what the probe selects', () => {
+    test('the rows that violate, named by key', async () => {
+      const rows = await runUnscoped(
+          byName('NonNegativeBalance'), [setBalance(1, '-5.0')]);
+      expect(rows).toEqual([['1']]);
+    });
+
+    test('nothing when the constraint holds', async () => {
+      expect(await runUnscoped(
+                 byName('NonNegativeBalance'), [setBalance(1, '0.0')]))
+          .toEqual([]);
+    });
+
+    test('a field-to-field comparison reads both columns', async () => {
+      // Account 2 keeps a floor of 5000; dropping it to 4000 breaks the rule
+      // without going anywhere near zero, so only the field-to-field form
+      // catches it.
+      const rows = await runUnscoped(
+          byName('AboveMinimumBalance'), [setBalance(2, '4000.0')]);
+      expect(rows).toEqual([['2']]);
+      expect(await runUnscoped(byName('NonNegativeBalance'),
+                               [setBalance(2, '4000.0')]))
+          .toEqual([]);
+    });
+
+    test('a rule on another entity probes that entity\'s table', async () => {
+      const rows = await runUnscoped(byName('PositiveAmount'), [{
+        sql: 'INSERT INTO Transfer (transfer_id, source_account_id, ' +
+            'target_account_id, amount) VALUES (7001, 1, 3, -5.0)',
+      }]);
+      expect(rows).toEqual([['7001']]);
+    });
+
+    test('the violation cap is honoured by the server, not just emitted',
+         async () => {
+           const setup = [
+             setBalance(1, '-1.0'), setBalance(2, '-1.0'), setBalance(3, '-1.0')
+           ];
+           const capped = lower('Account.balance >= 0', {limit: 2});
+           expect(await runUnscoped(capped, setup)).toHaveLength(2);
+           const uncapped = lower('Account.balance >= 0', {limit: 10});
+           expect(await runUnscoped(uncapped, setup)).toHaveLength(3);
+         });
+  });
+
+  describe('a NULL column', () => {
+    test('counts as a violation', async () => {
+      const rows = await runUnscoped(
+          byName('NonNegativeBalance'), [setBalance(1, 'NULL')]);
+      expect(rows).toEqual([['1']]);
+    });
+
+    test('and would NOT have, written the obvious way', async () => {
+      // The reason lowering emits `NOT COALESCE(expr, FALSE)`. `NULL >= 0` is
+      // UNKNOWN; `NOT UNKNOWN` is UNKNOWN; a WHERE clause keeps only TRUE. So
+      // the natural spelling lets exactly the rows we are least sure about
+      // through the gate. Run both against the same state and the difference is
+      // not an argument, it is two result sets.
+      const naive = {
+        sql: 'SELECT CAST(account_id AS STRING) FROM Account ' +
+            'WHERE NOT (balance >= 0) LIMIT 5',
+      };
+      const guarded = {sql: byName('NonNegativeBalance').unscopedSql};
+      const [naiveRows, guardedRows] =
+          await inRolledBackTransaction([setBalance(1, 'NULL')], [naive, guarded]);
+      expect(naiveRows).toEqual([]);
+      expect(guardedRows).toEqual([['1']]);
+    });
+  });
+
+  describe('scoping to the rows an action touched', () => {
+    test('binds the key array the runtime sends', async () => {
+      const probe = byName('NonNegativeBalance');
+      expect(probe.scoped).toBe(true);
+      const rows = await runScoped(
+          probe, ['1', '3'], [setBalance(1, '-1.0'), setBalance(2, '-1.0')]);
+      // Account 2 is broken too, but the action did not touch it.
+      expect(rows).toEqual([['1']]);
+    });
+
+    test('an empty key set matches nothing, which is why the runtime never ' +
+             'sends one',
+         async () => {
+           // Documents the trap the runtime avoids by falling back to
+           // unscopedSql: a scoped probe with no keys passes vacuously, and a
+           // gate that always passes is worse than no gate.
+           const probe = byName('NonNegativeBalance');
+           expect(await runScoped(probe, [], [setBalance(1, '-1.0')]))
+               .toEqual([]);
+           expect(await runUnscoped(probe, [setBalance(1, '-1.0')]))
+               .toEqual([['1']]);
+         });
+  });
+
+  describe('the expression forms the evaluator accepts', () => {
+    // Each of these has a hermetic test asserting the SQL text. Here the only
+    // assertion is that the server runs it: a lowering that produces valid text
+    // for an operator Spanner spells differently would pass there and fail
+    // here.
+    const forms = [
+      'Account.balance > 0',
+      'Account.balance >= 0',
+      'Account.balance < 1000000',
+      'Account.balance <= 1000000',
+      'Account.status = \'OPEN\'',
+      'Account.status != \'FROZEN\'',
+      'Account.status <> \'FROZEN\'',
+      'Account.balance >= -100.5',
+      'Account.balance >= Account.minimumBalance',
+      'Account.balance >= 0 AND Account.status != \'FROZEN\'',
+      'Account.balance >= 0 OR Account.status = \'FROZEN\'',
+      'Account.balance >= 0 and Account.status != \'FROZEN\'',
+      'Account.ownerId != NULL',
+      'Account.ownerId = NULL',
+      'Account.balance >= 0 AND Account.balance <= 1000000',
+    ];
+
+    for (const expression of forms) {
+      test(`${expression}`, async () => {
+        const probe = lower(expression);
+        await runUnscoped(probe);
+        await runScoped(probe, ['1', '4']);
+      });
+    }
+
+    test('a NULL comparison has to become a null test to run at all', async () => {
+      // The live suite found this one. `NOT COALESCE((owner_id != NULL), FALSE)`
+      // is the obvious lowering and GoogleSQL refuses to compile it -- "Operands
+      // of != cannot be literal NULL" -- so the probe was not merely wrong about
+      // NULLs, it could not run. Lowering emits IS NOT NULL instead, and this
+      // asserts against the server that the result is both accepted and correct.
+      const probe = lower('Account.ownerId != NULL');
+      expect(probe.unscopedSql).toContain('IS NOT NULL');
+      expect(await runUnscoped(probe)).toEqual([]);
+      expect(await runUnscoped(probe, [{
+        sql: 'UPDATE Account SET owner_id = NULL WHERE account_id = 3',
+      }])).toEqual([['3']]);
+    });
+
+    test('<> is emitted as != and still means the same thing to the server',
+         async () => {
+           const ne = lower('Account.status != \'FROZEN\'');
+           const angle = lower('Account.status <> \'FROZEN\'');
+           expect(angle.unscopedSql).toBe(ne.unscopedSql);
+           expect(await runUnscoped(angle)).toEqual([['4']]);
+         });
+  });
+
+  test('the message a violation returns names the row the server found',
+       async () => {
+         const probe = byName('NonNegativeBalance');
+         const rows = await runUnscoped(probe, [setBalance(1, '-5.0')]);
+         const message = violationMessage(probe, rows);
+         expect(message).toContain('An account cannot be overdrawn');
+         expect(message).toContain('NonNegativeBalance');
+         expect(message).toContain('1');
+       });
+});

--- a/toolbox/mdcode/tests/live/knowledge_catalog_live.test.ts
+++ b/toolbox/mdcode/tests/live/knowledge_catalog_live.test.ts
@@ -1,0 +1,233 @@
+// Constraints through a real Knowledge Catalog: push, then pull.
+//
+// Actions and constraints have no `semantic-*` system type of their own, so
+// both ride the model anchor entry's built-in `overview` aspect, each under its
+// own HTML-comment marker with its own fenced JSON block. The hermetic test
+// (tests/libts/semantic/constraints.test.ts) asserts that the emitter writes
+// that shape and the reader recovers it -- but it hands the emitter's output
+// straight back to the reader, so the catalog itself is never in the loop.
+//
+// Everything that could go wrong lives in the part it skips. Dataplex enforces
+// closed aspect schemas, `overview` is a built-in type this code does not own,
+// and markdown that survives a round trip in memory can come back re-wrapped or
+// re-escaped from a server. Whether two markers can share one aspect is a
+// question about Dataplex, and this asks it.
+//
+// Gated separately from the rest of the live suite (KCMD_LIVE_KC): pushing a
+// semantic model needs a catalog surface on which this project may USE the
+// published `semantic-*` entry types, which is not generally true on the
+// production endpoint. Point DATAPLEX_ENDPOINT and KC_TYPE_PROJECT at a surface
+// where it is, then set KCMD_LIVE_KC=1.
+//
+
+import {afterAll, beforeAll, describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {CatalogClient} from '../../src/libts/gcp/dataplex';
+import {SemanticModel} from '../../src/libts/semantic/ir';
+import {deployKnowledgeCatalog} from '../../src/libts/semantic/deploy_knowledge_catalog';
+import {
+  ACTIONS_OVERVIEW_MARKER,
+  CONSTRAINTS_OVERVIEW_MARKER,
+} from '../../src/libts/semantic/knowledge_catalog';
+import {LoadedModel, loadModels} from '../../src/libts/semantic/loader';
+import {pullKnowledgeCatalog} from '../../src/libts/semantic/pull_kc';
+
+import {apiContext, kcEntryGroup, kcLocation, LIVE_KC, project} from './live';
+
+
+// A catalog round trip is several sequential REST calls; the default 5s is not
+// a useful budget for one.
+const TIMEOUT = 180000;
+
+const FIXTURE = path.join(
+    __dirname, '..', 'libts', 'semantic', 'fixtures',
+    'actions_place_order.yaml');
+
+const deployOptions = {
+  project,
+  location: kcLocation,
+  entryGroup: kcEntryGroup,
+  systemTypeProject: process.env.KC_TYPE_PROJECT,
+};
+
+let cat: CatalogClient;
+let authored: SemanticModel;
+
+function loaded(model: SemanticModel): LoadedModel[] {
+  return [{document: 'actions_place_order.yaml', model}];
+}
+
+
+// Removes everything this suite may have written. Entry LINKS go first: a link
+// whose endpoint entries are deleted first is orphaned, and an orphaned link
+// cannot be addressed by name afterwards -- it survives even the entry group's
+// deletion and collides with the next run.
+async function purge(): Promise<void> {
+  // Only the entries a push owns. Creating a group also creates an `entrygroup`
+  // entry describing the group itself, which is not ours to delete.
+  const entries: string[] = [];
+  for await (const entry of cat.listEntries(project, kcLocation, kcEntryGroup)) {
+    if (entry.name && entry.entryType?.includes('/entryTypes/semantic-')) {
+      entries.push(entry.name);
+    }
+  }
+
+  const links = new Set<string>();
+  for (const entry of entries) {
+    const found = await cat.lookupEntryLinks(project, kcLocation, {entry});
+    for (const link of found.result ?? []) {
+      if (link.name) links.add(link.name.split('/entryLinks/')[1]);
+    }
+  }
+  for (const link of links) {
+    await cat.deleteEntryLink(project, kcLocation, kcEntryGroup, link);
+  }
+  for (const entry of entries) {
+    await cat._delete(entry);
+  }
+}
+
+
+// Polls until the group's entries collection answers. Getting the entry group
+// itself is not enough: it returns 200 while a list of its entries still 404s,
+// so waiting on the wrong call makes the first real request fail.
+async function waitForEntryGroup(): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    try {
+      for await (const _ of cat.listEntries(project, kcLocation, kcEntryGroup)) {
+        break;
+      }
+      return;
+    } catch (err) {
+      if (!`${err}`.includes('404') && !`${err}`.includes('does not exist')) {
+        throw err;
+      }
+    }
+    await new Promise(r => setTimeout(r, 2000));
+  }
+  throw new Error(`entry group ${kcEntryGroup} never became addressable`);
+}
+
+
+// The overview aspect as the SERVER holds it, fetched fresh rather than taken
+// from anything the emitter produced.
+async function serverOverview(): Promise<string> {
+  for await (const entry of cat.listEntries(project, kcLocation, kcEntryGroup)) {
+    if (!entry.entryType?.endsWith('/semantic-model')) continue;
+    // The aspect filter takes full aspect-type RESOURCE names, not the dotted
+    // key the aspect map is written under, and the type lives beside the entry
+    // type -- so derive it from the entry's own entryType rather than naming a
+    // project, which differs per surface.
+    const overviewType =
+        `${entry.entryType!.split('/entryTypes/')[0]}/aspectTypes/overview`;
+    const fetched = await cat.getEntry(
+        project, kcLocation, kcEntryGroup, entry.name!.split('/entries/')[1],
+        [overviewType]);
+    if (fetched.status !== 200) {
+      throw new Error(`getEntry failed with ${fetched.status}: ${fetched.message}`);
+    }
+    const aspects = fetched.result?.aspects ?? {};
+    // Read-back keys the aspect map by project NUMBER, not id, so match on the
+    // suffix rather than the key we wrote.
+    const key = Object.keys(aspects).find(k => k.endsWith('.overview'));
+    if (!key) throw new Error('the anchor entry came back with no overview aspect');
+    return (aspects[key].data as {content?: string})?.content ?? '';
+  }
+  throw new Error('no semantic-model anchor entry in the group');
+}
+
+
+describe.skipIf(!LIVE_KC)('constraints through a real Knowledge Catalog', () => {
+  beforeAll(async () => {
+    cat = new CatalogClient(apiContext());
+    authored =
+        loadModels(fs.readFileSync(FIXTURE, 'utf8')).models[0];
+
+    const created =
+        await cat.createEntryGroup(project, kcLocation, kcEntryGroup);
+    if (created.status !== 200 && created.status !== 409) {
+      throw new Error(
+          `could not create entry group ${kcEntryGroup}: ${created.status} ${
+              created.message ?? ''}`);
+    }
+    // Creating an entry group is a long-running operation: the call returns
+    // before the group is addressable, and the next request 404s. Wait for it
+    // rather than sleep a guessed interval.
+    await waitForEntryGroup();
+    // Start from empty so a previous interrupted run cannot make this one pass
+    // or fail for the wrong reason.
+    await purge();
+  }, TIMEOUT);
+
+  afterAll(async () => {
+    await purge();
+    await cat._delete(
+        `projects/${project}/locations/${kcLocation}/entryGroups/${
+            kcEntryGroup}`);
+  }, TIMEOUT);
+
+  test('a push writes the model, constraints and all', async () => {
+    const result =
+        await deployKnowledgeCatalog(loaded(authored), apiContext(), deployOptions);
+    expect(result.details ?? '').toBe('');
+    expect(result.success).toBe(true);
+    expect(result.created).toBeGreaterThan(0);
+    // The author is told constraints are catalog-only -- carried, not enforced
+    // by the catalog.
+    expect(result.warnings.some(w => w.includes('constraint'))).toBe(true);
+  }, TIMEOUT);
+
+  test('and Dataplex really stored both markers in the one overview aspect',
+       async () => {
+         // The question the hermetic test cannot ask: `overview` is a built-in
+         // aspect type, and two markers sharing one markdown body is our
+         // convention, not the server's.
+         const content = await serverOverview();
+         expect(content).toContain(ACTIONS_OVERVIEW_MARKER);
+         expect(content).toContain(CONSTRAINTS_OVERVIEW_MARKER);
+         expect(content).toContain('## Actions');
+         expect(content).toContain('## Constraints');
+         expect(content).toContain('"orders.o_totalprice >= 0"');
+       },
+       TIMEOUT);
+
+  test('a pull recovers the constraints byte for byte', async () => {
+    const pulled =
+        await pullKnowledgeCatalog(cat, {project, location: kcLocation, entryGroup: kcEntryGroup});
+    expect(pulled.models).toHaveLength(1);
+    expect(pulled.models[0].constraints).toEqual(authored.constraints);
+  }, TIMEOUT);
+
+  test('together with the actions that share the aspect', async () => {
+    const pulled =
+        await pullKnowledgeCatalog(cat, {project, location: kcLocation, entryGroup: kcEntryGroup});
+    expect(pulled.models[0].actions).toEqual(authored.actions);
+  }, TIMEOUT);
+
+  test('an edited constraint is updated in place, not duplicated', async () => {
+    // Re-push is the common case -- a model is edited far more often than it is
+    // first published -- and it takes a different path through the catalog
+    // (update, not create) that the hermetic test never exercises.
+    const edited: SemanticModel = {
+      ...authored,
+      constraints: authored.constraints!.map(
+          c => c.name === 'PositiveQuantity' ?
+              {...c, description: 'An order line must be for a positive number of units.'} :
+              c),
+    };
+    const result =
+        await deployKnowledgeCatalog(loaded(edited), apiContext(), deployOptions);
+    expect(result.details ?? '').toBe('');
+    expect(result.success).toBe(true);
+    expect(result.created).toBe(0);
+    expect(result.updated).toBeGreaterThan(0);
+
+    const pulled =
+        await pullKnowledgeCatalog(cat, {project, location: kcLocation, entryGroup: kcEntryGroup});
+    expect(pulled.models[0].constraints).toEqual(edited.constraints);
+    expect(pulled.models[0].constraints).toHaveLength(
+        authored.constraints!.length);
+  }, TIMEOUT);
+});

--- a/toolbox/mdcode/tests/live/live.ts
+++ b/toolbox/mdcode/tests/live/live.ts
@@ -1,0 +1,217 @@
+// Shared configuration for the LIVE suite: the tests that run against real
+// services instead of a fake.
+//
+// Every other test in this repository is hermetic, and should stay that way --
+// a unit test that needs credentials and a network is a unit test that stops
+// being run. But a hermetic test can only prove that the code does what its
+// author expected the service to want. It cannot prove the service agrees.
+// Three things in the constraints work are exactly of that kind:
+//
+//   * the SQL a constraint lowers to is asserted as a STRING, so a probe that
+//     is subtly invalid GoogleSQL passes the unit test and fails in production;
+//   * the Spanner request shapes are asserted against a spy, which by
+//     construction accepts whatever the client sends (the `seqno` bug was
+//     invisible to a spy and obvious on the first real two-statement
+//     transaction);
+//   * the runtime's central guarantee -- a constraint probe observes the
+//     action's own uncommitted writes, and a violation leaves nothing behind --
+//     is a property of the DATABASE's transaction semantics, not of our code.
+//
+// So this suite exists alongside the hermetic one, not instead of it. It is
+// skipped unless KCMD_LIVE is set, so `npm test` is unchanged; `npm run
+// test:live` opts in.
+//
+// Everything is overridable by environment variable. The defaults are the
+// project the suite was developed against; the Spanner database defaults to one
+// of its own (`kcmd_live_test`) rather than any existing database, because
+// these tests write, and a test that can disturb someone's data is a test
+// nobody will run.
+//
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as cp from 'node:child_process';
+
+import * as context from '../../src/libts/gcp/context';
+import * as spanner from '../../src/libts/gcp/spanner';
+
+
+// The master switch. Unset means every live describe() block is skipped, which
+// is what happens on a plain `npm test` and in CI.
+export const LIVE = !!process.env.KCMD_LIVE;
+
+// The catalog leg is opt-in separately: it needs a catalog surface on which
+// this project may USE the published `semantic-*` system entry types, which a
+// project generally cannot do on the production endpoint. Point DATAPLEX_ENDPOINT
+// and KC_TYPE_PROJECT at a surface where it can, then set KCMD_LIVE_KC.
+export const LIVE_KC = LIVE && !!process.env.KCMD_LIVE_KC;
+
+export const project = process.env.KCMD_LIVE_PROJECT ?? 'sqlgen-testing';
+export const instance =
+    process.env.KCMD_LIVE_SPANNER_INSTANCE ?? 'graph-unified-solution-demo';
+export const database =
+    process.env.KCMD_LIVE_SPANNER_DATABASE ?? 'kcmd_live_test';
+
+export const kcLocation = process.env.KCMD_LIVE_KC_LOCATION ?? 'global';
+export const kcEntryGroup =
+    process.env.KCMD_LIVE_KC_ENTRY_GROUP ?? 'kcmd_live_test';
+
+export const databaseName =
+    `projects/${project}/instances/${instance}/databases/${database}`;
+
+// The suite runs the model the action demo ships, so a change that breaks the
+// demo breaks a test rather than a reader.
+export const modelPath =
+    path.join(__dirname, '..', '..', 'demo', 'action', 'payments.yaml');
+
+export function readModelYaml(): string {
+  return fs.readFileSync(modelPath, 'utf8');
+}
+
+
+// ApiContext.default() also reads `compute/region` from gcloud and throws when
+// it is unset, which has nothing to do with Spanner; this builds the context
+// directly so the suite runs on a machine that never set one. The token is
+// fetched once per process -- ApiContext.refresh() re-fetches it on a 401.
+let ctx: context.ApiContext|undefined;
+
+export function apiContext(): context.ApiContext {
+  if (!ctx) {
+    const token =
+        cp.execSync('gcloud -q auth application-default print-access-token')
+            .toString()
+            .trim();
+    if (!token) {
+      throw new Error(
+          'No application-default credentials; run `gcloud auth ' +
+          'application-default login`.');
+    }
+    ctx = new context.ApiContext(project, kcLocation, token);
+  }
+  return ctx;
+}
+
+export function dataClient(): spanner.SpannerDataClient {
+  return new spanner.SpannerDataClient(
+      apiContext(), project, instance, database);
+}
+
+export function adminClient(): spanner.SpannerClient {
+  return new spanner.SpannerClient(apiContext());
+}
+
+
+// The physical schema the payments model binds to. Deliberately a copy of the
+// demo's rather than an import: the demo owns its own database and its own
+// seed, and the two must be able to drift without one breaking the other.
+export const SCHEMA: string[] = [
+  `CREATE TABLE IF NOT EXISTS Person (
+     person_id INT64 NOT NULL,
+     name STRING(128),
+     city STRING(128),
+   ) PRIMARY KEY (person_id)`,
+  `CREATE TABLE IF NOT EXISTS Account (
+     account_id INT64 NOT NULL,
+     owner_id INT64,
+     name STRING(128),
+     balance FLOAT64,
+     minimum_balance FLOAT64,
+     status STRING(16),
+   ) PRIMARY KEY (account_id)`,
+  `CREATE TABLE IF NOT EXISTS Transfer (
+     transfer_id INT64 NOT NULL,
+     source_account_id INT64,
+     target_account_id INT64,
+     amount FLOAT64,
+   ) PRIMARY KEY (transfer_id)`,
+];
+
+
+// The state every live test starts from. Accounts 1-4 are the demo's, so a
+// reader recognizes them; 5 and 6 exist only here, to give the runtime's
+// "ambiguous object reference" path two real rows to be ambiguous between.
+//
+//   1 Alice Checking   2500, floor  100, OPEN
+//   2 Alice Savings   18000, floor 5000, OPEN
+//   3 Bob Checking      400, floor    0, OPEN
+//   4 Carol Savings     900, floor    0, FROZEN
+//   5 Shared Name       100, floor    0, OPEN
+//   6 Shared Name       100, floor    0, OPEN
+export const SEED: string[] = [
+  'DELETE FROM Transfer WHERE TRUE',
+  'DELETE FROM Account WHERE TRUE',
+  'DELETE FROM Person WHERE TRUE',
+  `INSERT INTO Person (person_id, name, city) VALUES
+     (1, 'Alice', 'Seattle'), (2, 'Bob', 'Austin'), (3, 'Carol', 'Denver')`,
+  `INSERT INTO Account
+     (account_id, owner_id, name, balance, minimum_balance, status) VALUES
+     (1, 1, 'Alice Checking', 2500.0,  100.0, 'OPEN'),
+     (2, 1, 'Alice Savings', 18000.0, 5000.0, 'OPEN'),
+     (3, 2, 'Bob Checking',    400.0,    0.0, 'OPEN'),
+     (4, 3, 'Carol Savings',   900.0,    0.0, 'FROZEN'),
+     (5, 2, 'Shared Name',     100.0,    0.0, 'OPEN'),
+     (6, 2, 'Shared Name',     100.0,    0.0, 'OPEN')`,
+];
+
+
+// Fails with the response body attached. A live test that fails on an
+// unexpected status is nearly always debugged from the server's own message, so
+// losing it costs a whole re-run.
+export function expectOk<T>(res: {status: number; message?: string; result?: T},
+                            what: string): T {
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(`${what} failed with ${res.status}: ${res.message ?? ''}`);
+  }
+  return res.result as T;
+}
+
+
+// Runs `statements` in one read-write transaction and commits.
+export async function commitAll(statements: spanner.Statement[]):
+    Promise<void> {
+  const client = dataClient();
+  await client.withSession(async session => {
+    const txn = expectOk(await client.beginReadWrite(session), 'beginTransaction');
+    for (const stmt of statements) {
+      const res = await client.executeSql(session, txn.id!, stmt);
+      if (res.status < 200 || res.status >= 300) {
+        await client.rollback(session, txn.id!);
+        throw new Error(`"${stmt.sql}" failed: ${res.message}`);
+      }
+    }
+    expectOk(await client.commit(session, txn.id!), 'commit');
+  });
+}
+
+
+// Restores the seed state. Called before each test that writes, so no test
+// depends on the order it ran in.
+export async function reseed(): Promise<void> {
+  await commitAll(SEED.map(sql => ({sql})));
+}
+
+
+// A committed read, outside any test transaction: what the database actually
+// holds now. This is how a live test proves a rollback really discarded
+// something -- reading inside the transaction would prove nothing.
+export async function readCommitted(
+    sql: string, params?: Record<string, any>,
+    paramTypes?: spanner.ParamTypes): Promise<string[][]> {
+  const client = dataClient();
+  return await client.withSession(async session => {
+    const txn =
+        expectOk(await client.beginReadWrite(session), 'beginTransaction');
+    const res =
+        await client.executeSql(session, txn.id!, {sql, params, paramTypes});
+    await client.rollback(session, txn.id!);
+    return expectOk(res, `query "${sql}"`).rows ?? [];
+  });
+}
+
+
+// The balances, keyed by account id, as the database currently holds them.
+export async function balances(): Promise<Record<string, string>> {
+  const rows = await readCommitted(
+      'SELECT CAST(account_id AS STRING), CAST(balance AS STRING) FROM Account');
+  return Object.fromEntries(rows.map(r => [r[0], r[1]]));
+}

--- a/toolbox/mdcode/tests/live/runtime_live.test.ts
+++ b/toolbox/mdcode/tests/live/runtime_live.test.ts
@@ -1,0 +1,369 @@
+// The semantic runtime against real Cloud Spanner.
+//
+// tests/libts/semantic/runtime.test.ts drives runAction() through a FakeSpanner
+// whose answers are programmed by the test. That is the right way to pin the
+// runtime's SEQUENCING -- that the probe runs after the write, that a violation
+// rolls back, that an unevaluable constraint never opens a transaction -- and
+// it can assert things a live test cannot, such as which calls were made in
+// which order.
+//
+// What it cannot do is establish that the sequencing produces the intended
+// EFFECT, because the fake has no transaction. "Rolled back" against a fake
+// means `rollback` was called. Against Spanner it means the money is still in
+// the account it started in, and that is the claim the feature actually makes.
+// Each test below therefore ends by reading the committed state back.
+//
+
+import {afterAll, beforeEach, describe, expect, test} from 'bun:test';
+
+import {SemanticModel} from '../../src/libts/semantic/ir';
+import {loadModels} from '../../src/libts/semantic/loader';
+import {
+  ActionContext,
+  ActionOutcome,
+  ActionPlan,
+  runAction,
+} from '../../src/libts/semantic/runtime';
+
+import {
+  balances,
+  dataClient,
+  LIVE,
+  readCommitted,
+  readModelYaml,
+  reseed,
+} from './live';
+
+
+let model: SemanticModel;
+
+// Transfer ids have to be unique across a run, and several tests commit.
+let nextTransferId = 5000;
+
+// The demo's handler, kept here rather than imported so the live suite does not
+// depend on the demo's configuration (which points at the demo's own database).
+async function transferHandler(ctx: ActionContext): Promise<ActionPlan> {
+  const source = ctx.refs.source.keys[0];
+  const target = ctx.refs.target.keys[0];
+  const amount = Number(ctx.args.amount);
+  if (!Number.isFinite(amount)) {
+    throw new Error(`'${ctx.args.amount}' is not an amount.`);
+  }
+  const transferId = `${nextTransferId++}`;
+  const money = {
+    params: {amount, source, target},
+    paramTypes: {
+      amount: {code: 'FLOAT64'},
+      source: {code: 'STRING'},
+      target: {code: 'STRING'},
+    },
+  };
+  return {
+    statements: [
+      {
+        sql: 'UPDATE Account SET balance = balance - @amount ' +
+            'WHERE CAST(account_id AS STRING) = @source',
+        ...money,
+      },
+      {
+        sql: 'UPDATE Account SET balance = balance + @amount ' +
+            'WHERE CAST(account_id AS STRING) = @target',
+        ...money,
+      },
+      {
+        sql: 'INSERT INTO Transfer ' +
+            '(transfer_id, source_account_id, target_account_id, amount) ' +
+            'VALUES (@transferId, CAST(@source AS INT64), ' +
+            'CAST(@target AS INT64), @amount)',
+        params: {...money.params, transferId},
+        paramTypes: {...money.paramTypes, transferId: {code: 'INT64'}},
+      },
+    ],
+    touched: {Account: [source, target], Transfer: [transferId]},
+  };
+}
+
+function transfer(
+    source: string, target: string, amount: number,
+    over: Partial<SemanticModel> = {}): Promise<ActionOutcome> {
+  return runAction({
+    model: {...model, ...over},
+    actionName: 'TransferFunds',
+    args: {source, target, amount},
+    client: dataClient(),
+    handler: transferHandler,
+  });
+}
+
+
+describe.skipIf(!LIVE)('the semantic runtime on real Spanner', () => {
+  beforeEach(async () => {
+    model = loadModels(readModelYaml(), {dialect: 'ANSI_SQL'}).models[0];
+    await reseed();
+  });
+
+  afterAll(async () => {
+    await reseed();
+  });
+
+  describe('a write that satisfies every constraint', () => {
+    test('commits, and the money is where it was sent', async () => {
+      const outcome = await transfer('1', '3', 100);
+      expect(outcome.status).toBe('committed');
+      if (outcome.status !== 'committed') return;
+      expect(outcome.commitTimestamp).toBeTruthy();
+      // The claim the fake cannot make.
+      expect(await balances()).toMatchObject({'1': '2400', '3': '500'});
+    });
+
+    test('records the transfer it was asked to record', async () => {
+      await transfer('1', '3', 25);
+      const rows = await readCommitted(
+          'SELECT CAST(source_account_id AS STRING), ' +
+          'CAST(target_account_id AS STRING), CAST(amount AS STRING) ' +
+          'FROM Transfer');
+      expect(rows).toEqual([['1', '3', '25']]);
+    });
+
+    test('reports which constraints it checked', async () => {
+      const outcome = await transfer('1', '3', 10);
+      if (outcome.status !== 'committed') throw new Error(outcome.message);
+      expect(outcome.checked).toEqual([
+        'NonNegativeBalance',
+        'AboveMinimumBalance',
+        'PositiveAmount',
+        'OpenAccountsOnly',
+      ]);
+    });
+
+    test('and returns the rows its object references resolved to', async () => {
+      const outcome = await transfer('Alice Checking', 'Bob Checking', 10);
+      if (outcome.status !== 'committed') throw new Error(outcome.message);
+      expect(outcome.refs.source).toEqual(
+          {entity: 'Account', keys: ['1'], input: 'Alice Checking'});
+      expect(outcome.refs.target).toEqual(
+          {entity: 'Account', keys: ['3'], input: 'Bob Checking'});
+    });
+  });
+
+  describe('a write that would break a constraint', () => {
+    test('an overdraft is refused and the money never moves', async () => {
+      const before = await balances();
+      const outcome = await transfer('1', '3', 5000);
+      expect(outcome.status).toBe('rejected');
+      if (outcome.status !== 'rejected') return;
+      expect(outcome.message).toContain('An account cannot be overdrawn');
+      expect(outcome.violations.map(v => v.constraint)).toContain(
+          'NonNegativeBalance');
+      // Not "rollback was called" -- the balances are unchanged, and the
+      // transaction that briefly held the debited value is gone.
+      expect(await balances()).toEqual(before);
+      expect(await readCommitted('SELECT CAST(COUNT(*) AS STRING) FROM Transfer'))
+          .toEqual([['0']]);
+    });
+
+    test('a per-account floor is enforced separately from zero', async () => {
+      // Account 2 holds 18000 with a floor of 5000: 14000 leaves it solvent and
+      // still breaks its own rule.
+      const outcome = await transfer('2', '3', 14000);
+      expect(outcome.status).toBe('rejected');
+      if (outcome.status !== 'rejected') return;
+      expect(outcome.violations.map(v => v.constraint)).toEqual([
+        'AboveMinimumBalance'
+      ]);
+      expect(outcome.message).toContain('minimum balance');
+      expect(await balances()).toMatchObject({'2': '18000', '3': '400'});
+    });
+
+    test('a frozen account cannot be paid', async () => {
+      const outcome = await transfer('1', '4', 10);
+      expect(outcome.status).toBe('rejected');
+      if (outcome.status !== 'rejected') return;
+      expect(outcome.violations.map(v => v.constraint)).toEqual([
+        'OpenAccountsOnly'
+      ]);
+      expect(outcome.violations[0].violatingKeys).toEqual([['4']]);
+      expect(await balances()).toMatchObject({'1': '2500', '4': '900'});
+    });
+
+    test('a negative amount is refused by the rule on the transfer itself',
+         async () => {
+           const outcome = await transfer('1', '3', -50);
+           expect(outcome.status).toBe('rejected');
+           if (outcome.status !== 'rejected') return;
+           expect(outcome.violations.map(v => v.constraint)).toEqual([
+             'PositiveAmount'
+           ]);
+           expect(await balances()).toMatchObject({'1': '2500', '3': '400'});
+         });
+
+    test('a rejection leaves the database able to take the corrected write',
+         async () => {
+           // The loop the whole feature is for: an agent is told what it did
+           // wrong and retries. If a rejection left a transaction or a lock
+           // behind, this is where it would show.
+           const rejected = await transfer('1', '3', 5000);
+           expect(rejected.status).toBe('rejected');
+           const accepted = await transfer('1', '3', 500);
+           expect(accepted.status).toBe('committed');
+           expect(await balances()).toMatchObject({'1': '2000', '3': '900'});
+         });
+  });
+
+  describe('the gate fails closed', () => {
+    test('a constraint that cannot be lowered aborts the action', async () => {
+      const outcome = await transfer('1', '3', 10, {
+        constraints: [
+          ...model.constraints!,
+          {name: 'Unlowerable', expression: 'COUNT(*) > 0'},
+        ],
+      });
+      expect(outcome.status).toBe('error');
+      if (outcome.status !== 'error') return;
+      expect(outcome.message).toContain('unchecked');
+      expect(outcome.message).toContain('Unlowerable');
+      expect(await balances()).toMatchObject({'1': '2500', '3': '400'});
+    });
+
+    test('a constraint the SERVER rejects also aborts, rather than committing',
+         async () => {
+           // A lowering can be well-formed and still produce a query Spanner
+           // refuses -- here a STRING column compared to a BOOL. The hermetic
+           // suite cannot produce this case at all, because its fake answers
+           // every query. What matters is which way the runtime falls: the
+           // write must not commit merely because the check could not be run.
+           const outcome = await transfer('1', '3', 10, {
+             constraints: [
+               ...model.constraints!,
+               {name: 'TypeMismatch', expression: 'Account.status = TRUE'},
+             ],
+           });
+           expect(outcome.status).toBe('error');
+           if (outcome.status !== 'error') return;
+           expect(outcome.message).toContain('rolled back');
+           expect(await balances()).toMatchObject({'1': '2500', '3': '400'});
+         });
+
+    test('a handler that throws after writing leaves nothing behind',
+         async () => {
+           const outcome = await runAction({
+             model,
+             actionName: 'TransferFunds',
+             args: {source: '1', target: '3', amount: 10},
+             client: dataClient(),
+             handler: async ctx => {
+               // Write first, then fail: a partial plan is the case where a
+               // missing rollback would corrupt the data rather than just
+               // return an error.
+               await ctx.query({
+                 sql: 'UPDATE Account SET balance = 0 WHERE account_id = 1',
+               });
+               throw new Error('the executor gave up');
+             },
+           });
+           expect(outcome.status).toBe('error');
+           if (outcome.status !== 'error') return;
+           expect(outcome.message).toContain('the executor gave up');
+           expect(await balances()).toMatchObject({'1': '2500'});
+         });
+  });
+
+  describe('when the handler reports no touched rows', () => {
+    test('every constraint is checked over its whole table', async () => {
+      // Correct but blunt: account 4 is frozen in the seed, so an unscoped
+      // OpenAccountsOnly refuses a transfer that had nothing to do with it.
+      // This is exactly why the handler reports what it touched, and the live
+      // database is the only place the difference is visible.
+      const outcome = await runAction({
+        model,
+        actionName: 'TransferFunds',
+        args: {source: '1', target: '3', amount: 10},
+        client: dataClient(),
+        handler: async ctx => {
+          const plan = await transferHandler(ctx);
+          return {statements: plan.statements};
+        },
+      });
+      expect(outcome.status).toBe('rejected');
+      if (outcome.status !== 'rejected') return;
+      expect(outcome.violations.map(v => v.constraint)).toEqual([
+        'OpenAccountsOnly'
+      ]);
+      expect(await balances()).toMatchObject({'1': '2500', '3': '400'});
+    });
+
+    test('and a violation the action itself caused is still caught', async () => {
+      const outcome = await runAction({
+        model: {...model, constraints: [model.constraints![0]]},
+        actionName: 'TransferFunds',
+        args: {source: '1', target: '3', amount: 99999},
+        client: dataClient(),
+        handler: async ctx => {
+          const plan = await transferHandler(ctx);
+          return {statements: plan.statements};
+        },
+      });
+      expect(outcome.status).toBe('rejected');
+      if (outcome.status !== 'rejected') return;
+      expect(outcome.violations[0].constraint).toBe('NonNegativeBalance');
+      expect(await balances()).toMatchObject({'1': '2500'});
+    });
+  });
+
+  describe('resolving an object reference against real rows', () => {
+    test('matches on the key', async () => {
+      const outcome = await transfer('1', '3', 1);
+      if (outcome.status !== 'committed') throw new Error(outcome.message);
+      expect(outcome.refs.source.keys).toEqual(['1']);
+    });
+
+    test('matches on the display name', async () => {
+      const outcome = await transfer('Alice Savings', '3', 1);
+      if (outcome.status !== 'committed') throw new Error(outcome.message);
+      expect(outcome.refs.source.keys).toEqual(['2']);
+    });
+
+    test('refuses a reference that matches nothing', async () => {
+      const outcome = await transfer('Nobody Checking', '3', 1);
+      expect(outcome.status).toBe('error');
+      if (outcome.status !== 'error') return;
+      expect(outcome.message).toBe("No Account matches 'Nobody Checking'.");
+      expect(await readCommitted(
+                 'SELECT CAST(COUNT(*) AS STRING) FROM Transfer'))
+          .toEqual([['0']]);
+    });
+
+    test('refuses an ambiguous reference and names the candidates', async () => {
+      // Accounts 5 and 6 are both called 'Shared Name'. Guessing between two
+      // real rows is the one failure an agent must never be allowed to make
+      // silently.
+      const outcome = await transfer('Shared Name', '3', 1);
+      expect(outcome.status).toBe('error');
+      if (outcome.status !== 'error') return;
+      expect(outcome.message).toContain('matches more than one Account');
+      expect(outcome.message).toContain('5');
+      expect(outcome.message).toContain('6');
+    });
+
+    test('refuses a missing required reference before any store call',
+         async () => {
+           const outcome = await transfer('', '3', 1);
+           expect(outcome.status).toBe('error');
+           if (outcome.status !== 'error') return;
+           expect(outcome.message).toContain("requires 'source'");
+         });
+  });
+
+  test('an unknown action is refused', async () => {
+    const outcome = await runAction({
+      model,
+      actionName: 'CloseAccount',
+      args: {},
+      client: dataClient(),
+      handler: async () => ({statements: []}),
+    });
+    expect(outcome.status).toBe('error');
+    if (outcome.status !== 'error') return;
+    expect(outcome.message).toContain("declares no action 'CloseAccount'");
+  });
+});

--- a/toolbox/mdcode/tests/live/setup.ts
+++ b/toolbox/mdcode/tests/live/setup.ts
@@ -1,0 +1,81 @@
+// Provisions the database the live Spanner suite runs against.
+//
+//   KCMD_LIVE=1 npx bun tests/live/setup.ts
+//
+// Safe to re-run: the database is created only if it is missing, the schema
+// statements are IF NOT EXISTS, and the seed replaces the rows it owns. Run it
+// once before `npm run test:live`; the tests themselves only write rows, never
+// schema, so the suite stays fast and a failed run leaves nothing to repair.
+//
+
+import {
+  adminClient,
+  database,
+  databaseName,
+  expectOk,
+  instance,
+  project,
+  reseed,
+  SCHEMA,
+} from './live';
+
+import {Operation} from '../../src/libts/gcp/spanner';
+
+
+// Database create and get are not on SpannerClient -- it exists to push DDL,
+// and provisioning a database is not something the tool does. Calling the REST
+// surface through the client's own request methods keeps auth, retry and
+// logging identical to every other call the suite makes, which is worth more
+// here than a tidier signature.
+const admin = adminClient();
+const databases = `projects/${project}/instances/${instance}/databases`;
+
+
+async function awaitOperation(op: Operation, what: string): Promise<void> {
+  if (!op.name) return;
+  for (let i = 0; i < 120; i++) {
+    const polled = expectOk(await admin.getOperation(op.name), `${what} poll`);
+    if (polled.done) {
+      if (polled.error) {
+        throw new Error(`${what} failed: ${JSON.stringify(polled.error)}`);
+      }
+      return;
+    }
+    await new Promise(r => setTimeout(r, 2000));
+  }
+  throw new Error(`${what} did not finish in four minutes.`);
+}
+
+
+async function main(): Promise<void> {
+  const existing = await admin._get<{name?: string}>(databaseName);
+  if (existing.status === 404) {
+    console.log(`Creating Spanner database ${database} ...`);
+    const created = expectOk(
+        await admin._post<Operation>(
+            databases, {createStatement: `CREATE DATABASE \`${database}\``}),
+        'databases.create');
+    await awaitOperation(created, 'databases.create');
+  } else {
+    expectOk(existing, 'databases.get');
+    console.log(`Spanner database ${database} already exists.`);
+  }
+
+  console.log('Applying the schema ...');
+  const ddl = expectOk(
+      await admin.updateDatabaseDdl(project, instance, database, SCHEMA),
+      'updateDatabaseDdl');
+  await awaitOperation(ddl, 'updateDatabaseDdl');
+
+  console.log('Seeding ...');
+  await reseed();
+
+  console.log();
+  console.log(`Ready: ${databaseName}`);
+  console.log('Next: KCMD_LIVE=1 npm run test:live');
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/toolbox/mdcode/tests/live/spanner_live.test.ts
+++ b/toolbox/mdcode/tests/live/spanner_live.test.ts
@@ -1,0 +1,330 @@
+// SpannerDataClient against real Cloud Spanner.
+//
+// The hermetic version of this file (tests/libts/gcp/spanner.test.ts) asserts
+// the request bodies the client builds. That is worth having -- it pins the
+// shapes cheaply -- but a spy accepts anything, so it can only prove the client
+// sends what we decided it should, never that Spanner wants that. The `seqno`
+// requirement is the standing proof: the client was correct against its spy and
+// failed on the first real transaction that ran two statements.
+//
+// So these tests re-prove the same facts by making the server the oracle, and
+// add the ones a spy cannot express at all -- that a rollback really discards,
+// and that a statement can see its own transaction's uncommitted writes.
+//
+
+import {afterAll, beforeEach, describe, expect, test} from 'bun:test';
+
+import * as spanner from '../../src/libts/gcp/spanner';
+
+import {
+  apiContext,
+  dataClient,
+  expectOk,
+  instance,
+  LIVE,
+  project,
+  readCommitted,
+  reseed,
+} from './live';
+
+
+// A Transfer row is the cheapest thing to write: it has no foreign-key
+// constraints in the schema, so a test can insert one, look at it, and roll
+// back without arranging anything else.
+function insertTransfer(id: number, amount = 1.0): spanner.Statement {
+  return {
+    sql: 'INSERT INTO Transfer ' +
+        '(transfer_id, source_account_id, target_account_id, amount) ' +
+        'VALUES (@id, 1, 3, @amount)',
+    params: {id: `${id}`, amount},
+    paramTypes: {id: {code: 'INT64'}, amount: {code: 'FLOAT64'}},
+  };
+}
+
+function countTransfers(): spanner.Statement {
+  return {sql: 'SELECT CAST(COUNT(*) AS STRING) FROM Transfer'};
+}
+
+
+describe.skipIf(!LIVE)('SpannerDataClient on real Spanner', () => {
+  beforeEach(async () => {
+    await reseed();
+  });
+
+  afterAll(async () => {
+    await reseed();
+  });
+
+  describe('sessions', () => {
+    test('creates a session that belongs to the configured database',
+         async () => {
+           const client = dataClient();
+           const session =
+               expectOk(await client.createSession(), 'createSession');
+           expect(session.name).toContain(`${client.database}/sessions/`);
+           expectOk(await client.deleteSession(session.name!), 'deleteSession');
+         });
+
+    test('deleting a session really removes it, not just locally', async () => {
+      const client = dataClient();
+      const session = expectOk(await client.createSession(), 'createSession');
+      expectOk(await client.deleteSession(session.name!), 'deleteSession');
+      // The spy version could only observe that a DELETE was sent. The server
+      // is the only thing that can say the session is gone.
+      const after = await client._get(session.name!);
+      expect(after.status).toBe(404);
+    });
+
+    test('withSession deletes the session even when the body throws',
+         async () => {
+           const client = dataClient();
+           let leaked = '';
+           await expect(client.withSession(async session => {
+             leaked = session;
+             throw new Error('deliberate');
+           })).rejects.toThrow('deliberate');
+           expect(leaked).not.toBe('');
+           expect((await client._get(leaked)).status).toBe(404);
+         });
+
+    test('a session that cannot be created is reported, naming the database',
+         async () => {
+           const missing = new spanner.SpannerDataClient(
+               apiContext(), project, instance, 'no_such_database_here');
+           await expect(missing.withSession(async () => 'unreachable'))
+               .rejects.toThrow('no_such_database_here');
+         });
+  });
+
+  describe('the per-transaction statement sequence number', () => {
+    test('lets several statements run in one transaction', async () => {
+      // The regression. Without the counter the SECOND statement fails, so a
+      // single-statement smoke test would still pass.
+      const client = dataClient();
+      await client.withSession(async session => {
+        const txn = expectOk(
+            await client.beginReadWrite(session), 'beginTransaction');
+        for (const id of [9001, 9002, 9003]) {
+          expectOk(
+              await client.executeSql(session, txn.id!, insertTransfer(id)),
+              `insert ${id}`);
+        }
+        expectOk(await client.rollback(session, txn.id!), 'rollback');
+      });
+    });
+
+    test('is genuinely required -- reusing one is rejected by the server',
+         async () => {
+           // Pins the REASON the counter exists. If Spanner ever stopped
+           // enforcing this, the counter would become dead code and this test
+           // is what would say so.
+           const client = dataClient();
+           await client.withSession(async session => {
+             const txn = expectOk(
+                 await client.beginReadWrite(session), 'beginTransaction');
+             const raw = (sql: string) => client._post<spanner.ResultSet>(
+                 `${session}:executeSql`,
+                 {transaction: {id: txn.id}, sql, seqno: '1'});
+             expectOk(await raw('INSERT INTO Transfer ' +
+                                '(transfer_id, source_account_id, ' +
+                                'target_account_id, amount) ' +
+                                'VALUES (9101, 1, 3, 1.0)'),
+                      'first statement');
+             const second = await raw('INSERT INTO Transfer ' +
+                                      '(transfer_id, source_account_id, ' +
+                                      'target_account_id, amount) ' +
+                                      'VALUES (9102, 1, 3, 1.0)');
+             expect(second.status).toBe(400);
+             expect(second.message).toContain('seqno');
+             await client.rollback(session, txn.id!);
+           });
+         });
+
+    test('is tracked per transaction, so two open at once do not collide',
+         async () => {
+           // Two sessions, not two transactions in one: Spanner allows a single
+           // session at most one active read-write transaction and invalidates
+           // the earlier one ("This transaction has been invalidated by a later
+           // transaction in the same session"), which is exactly the kind of
+           // rule a spy cannot tell you. The counter is keyed by transaction id
+           // regardless, and interleaving the two statements is what would
+           // expose a shared one.
+           const a = dataClient();
+           const b = dataClient();
+           await a.withSession(async sessionA => {
+             await b.withSession(async sessionB => {
+               const txnA = expectOk(
+                   await a.beginReadWrite(sessionA), 'begin a');
+               const txnB = expectOk(
+                   await b.beginReadWrite(sessionB), 'begin b');
+               expectOk(
+                   await a.executeSql(sessionA, txnA.id!, insertTransfer(9201)),
+                   'a1');
+               expectOk(
+                   await b.executeSql(sessionB, txnB.id!, insertTransfer(9301)),
+                   'b1');
+               expectOk(
+                   await a.executeSql(sessionA, txnA.id!, insertTransfer(9202)),
+                   'a2');
+               expectOk(
+                   await b.executeSql(sessionB, txnB.id!, insertTransfer(9302)),
+                   'b2');
+               await a.rollback(sessionA, txnA.id!);
+               await b.rollback(sessionB, txnB.id!);
+             });
+           });
+         });
+
+    test('restarts after a commit, so a reused session keeps working',
+         async () => {
+           const client = dataClient();
+           await client.withSession(async session => {
+             const first = expectOk(
+                 await client.beginReadWrite(session), 'begin first');
+             expectOk(
+                 await client.executeSql(
+                     session, first.id!, insertTransfer(9401)),
+                 'first insert');
+             expectOk(await client.commit(session, first.id!), 'commit');
+
+             const second = expectOk(
+                 await client.beginReadWrite(session), 'begin second');
+             expectOk(
+                 await client.executeSql(
+                     session, second.id!, insertTransfer(9402)),
+                 'second insert');
+             expectOk(
+                 await client.executeSql(
+                     session, second.id!, insertTransfer(9403)),
+                 'third insert');
+             await client.rollback(session, second.id!);
+           });
+         });
+
+    test('restarts after a rollback too', async () => {
+      const client = dataClient();
+      await client.withSession(async session => {
+        const first =
+            expectOk(await client.beginReadWrite(session), 'begin first');
+        expectOk(
+            await client.executeSql(session, first.id!, insertTransfer(9501)),
+            'first insert');
+        expectOk(await client.rollback(session, first.id!), 'rollback');
+
+        const second =
+            expectOk(await client.beginReadWrite(session), 'begin second');
+        expectOk(
+            await client.executeSql(session, second.id!, insertTransfer(9502)),
+            'second insert');
+        expectOk(
+            await client.executeSql(session, second.id!, insertTransfer(9503)),
+            'third insert');
+        await client.rollback(session, second.id!);
+      });
+    });
+  });
+
+  describe('executeSql', () => {
+    test('binds named parameters and returns the columns it was asked for',
+         async () => {
+           const rows = await readCommitted(
+               'SELECT name, CAST(balance AS STRING) FROM Account ' +
+                   'WHERE CAST(account_id AS STRING) = @id',
+               {id: '1'}, {id: {code: 'STRING'}});
+           expect(rows).toEqual([['Alice Checking', '2500']]);
+         });
+
+    test('declares an array parameter Spanner could not otherwise infer',
+         async () => {
+           // The constraint probes bind exactly this shape; if the paramTypes
+           // spelling were wrong, every scoped probe would fail at runtime.
+           const rows = await readCommitted(
+               'SELECT CAST(account_id AS STRING) FROM Account ' +
+                   'WHERE CAST(account_id AS STRING) IN UNNEST(@ids) ' +
+                   'ORDER BY account_id',
+               {ids: ['1', '3']},
+               {ids: {code: 'ARRAY', arrayElementType: {code: 'STRING'}}});
+           expect(rows).toEqual([['1'], ['3']]);
+         });
+
+    test('names the result columns in the response metadata', async () => {
+      const client = dataClient();
+      await client.withSession(async session => {
+        const txn =
+            expectOk(await client.beginReadWrite(session), 'beginTransaction');
+        const res = expectOk(
+            await client.executeSql(
+                session, txn.id!,
+                {sql: 'SELECT account_id, balance FROM Account LIMIT 1'}),
+            'select');
+        expect(res.metadata?.rowType?.fields?.map(f => f.name)).toEqual([
+          'account_id', 'balance'
+        ]);
+        await client.rollback(session, txn.id!);
+      });
+    });
+  });
+
+  describe('transaction semantics the runtime depends on', () => {
+    test('a statement sees its own transaction\'s uncommitted writes',
+         async () => {
+           // Read-your-writes is what makes the constraint gate meaningful: the
+           // probe has to observe the action's write before anyone commits it.
+           const client = dataClient();
+           await client.withSession(async session => {
+             const txn = expectOk(
+                 await client.beginReadWrite(session), 'beginTransaction');
+             const before = expectOk(
+                 await client.executeSql(session, txn.id!, countTransfers()),
+                 'count before');
+             expect(before.rows).toEqual([['0']]);
+
+             expectOk(
+                 await client.executeSql(
+                     session, txn.id!, insertTransfer(9601)),
+                 'insert');
+
+             const after = expectOk(
+                 await client.executeSql(session, txn.id!, countTransfers()),
+                 'count after');
+             expect(after.rows).toEqual([['1']]);
+             await client.rollback(session, txn.id!);
+           });
+         });
+
+    test('a rollback discards the write, and nothing outside ever saw it',
+         async () => {
+           const client = dataClient();
+           await client.withSession(async session => {
+             const txn = expectOk(
+                 await client.beginReadWrite(session), 'beginTransaction');
+             expectOk(
+                 await client.executeSql(
+                     session, txn.id!, insertTransfer(9701)),
+                 'insert');
+             expectOk(await client.rollback(session, txn.id!), 'rollback');
+           });
+           expect(await readCommitted(
+                      'SELECT CAST(COUNT(*) AS STRING) FROM Transfer'))
+               .toEqual([['0']]);
+         });
+
+    test('a commit makes the write visible to a later reader', async () => {
+      const client = dataClient();
+      const stamp = await client.withSession(async session => {
+        const txn =
+            expectOk(await client.beginReadWrite(session), 'beginTransaction');
+        expectOk(
+            await client.executeSql(session, txn.id!, insertTransfer(9801, 7.5)),
+            'insert');
+        return expectOk(await client.commit(session, txn.id!), 'commit')
+            .commitTimestamp;
+      });
+      expect(stamp).toBeTruthy();
+      expect(await readCommitted(
+                 'SELECT CAST(amount AS STRING) FROM Transfer ' +
+                 'WHERE transfer_id = 9801'))
+          .toEqual([['7.5']]);
+    });
+  });
+});


### PR DESCRIPTION
Stacked on #398, which is stacked on the actions prototype, #346. The diff
against `main` therefore includes those two; the new material is
`docs/semantic-model/actions.md` plus two lines in
`docs/semantic-model/README.md`.

The guide is the missing page between the deployment README, which introduces
actions and constraints in two short sections, and `demo/action/`, which runs
them but assumes you already know what they are. It walks one model end to
end: declare an action, state the rules as constraints, push it, run it
against a live store, and expose it to an agent. It also states what the
prototype does not do yet — no per-action `precondition` or `affects`, no
executor dispatch, a Spanner write path, and no CLI command that runs an
action.

Verification: the example model was run through the loader and the constraint
evaluator on this branch. It loads with no warnings, its parameters type as the
guide says (two object references and one scalar), and all four constraints
lower to probes. The grammar limits, the mixed AND/OR precedence, and the NULL
reading were confirmed the same way, with negative cases for cross-entity
comparisons, aggregates, and function calls. Every quoted output is copied from
`demo/action/README.md`.