### PR TITLE
feat(mdcode): gate an action with the constraints it names in guards

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -127,7 +127,7 @@ at the executor that carries it out (an MCP tool, a REST endpoint, or a gRPC
 method), and types each parameter against the ontology, so an entity-typed
 parameter is an object reference rather than a bare string. An action also
 names, in `guards`, the constraints that gate it. Knowledge Catalog is the only
-system an action reaches, and where it is governed. See
+system an action reaches, and the only place it is governed. See
 [Modeling write operations](actions.md).
 
 A model can also state **constraints**: named boolean invariants over the
@@ -135,10 +135,10 @@ ontology that hold for every instance, whatever writes to the model. A
 constraint is part of what the model asserts, written in the same expression
 language as a metric, and `Account.balance >= 0` is as much a fact about an
 account as the fields beside it. A constraint that reads an action's parameters
-describes that call instead, so it is checked only before the call runs and the
-action must name it in `guards`. A constraint reaches Knowledge Catalog only: it
-is validated, published there, and read back by `pull`. No component checks one
-against live data yet.
+describes one call rather than the stored data. It can be checked only before
+that call runs, so the action names it in `guards`. A constraint reaches
+Knowledge Catalog only: it is validated, published there, and read back by
+`pull`. No component checks one against live data yet.
 
 This model names no table and no store, so it is complete enough to govern in
 Knowledge Catalog as-is (step 2). Where each entity reads from — the store and the

--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -125,15 +125,18 @@ A model can also declare **actions**: model-level write operations, the
 write-side counterpart to a metric. An action names a business operation, points
 at the executor that carries it out (an MCP tool, a REST endpoint, or a gRPC
 method), and types each parameter against the ontology, so an entity-typed
-parameter is an object reference rather than a bare string. Knowledge Catalog is
-the only system an action reaches, and where it is governed. See
+parameter is an object reference rather than a bare string. An action also
+names, in `guards`, the constraints that gate it. Knowledge Catalog is the only
+system an action reaches, and where it is governed. See
 [Modeling write operations](actions.md).
 
 A model can also state **constraints**: named boolean invariants over the
 ontology that hold for every instance, whatever writes to the model. A
 constraint is part of what the model asserts, written in the same expression
 language as a metric, and `Account.balance >= 0` is as much a fact about an
-account as the fields beside it. A constraint reaches Knowledge Catalog only: it
+account as the fields beside it. A constraint that reads an action's parameters
+describes that call instead, so it is checked only before the call runs and the
+action must name it in `guards`. A constraint reaches Knowledge Catalog only: it
 is validated, published there, and read back by `pull`. No component checks one
 against live data yet.
 

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -95,8 +95,10 @@ above.
 ## 2. Gate it with a constraint
 
 A **constraint** is a named boolean invariant a model states over its ontology.
-One that quantifies over stored data holds for every write, whatever performed
-it, and needs no reference from anywhere:
+Where it applies depends on what its expression reads.
+
+An expression over stored data holds for every write, no matter what performed
+that write. No action has to name such a constraint:
 
 ```yaml
     constraints:
@@ -106,9 +108,9 @@ it, and needs no reference from anywhere:
           An account cannot be taken below its minimum balance.
 ```
 
-A constraint that reads an action's **parameters** is a different thing. It
-describes one call rather than the stored data, so the only moment it can be
-checked is before that call runs. Name it on the action, in `guards`:
+An expression that reads an action's **parameters** describes one call rather
+than the stored data. The only moment it can be checked is before that call
+runs, so the action names it in `guards`:
 
 ```yaml
     constraints:
@@ -130,26 +132,17 @@ checked is before that call runs. Name it on the action, in `guards`:
         guards: [AmountIsPositive]
 ```
 
-`guards` holds constraint names. Each must name a constraint the same model
-declares; one that names nothing fails the push:
+`guards` holds constraint names. Each name must resolve to a constraint that the
+same model declares, and one that resolves to nothing fails the push:
 
 ```
 Error: action 'TransferFunds' in model 'payments' (payments.yaml) is guarded by
 'AmountIsPostive', but model 'payments' declares no constraint of that name.
 ```
 
-Naming a constraint adds a check and does not switch its enforcement on. An
-invariant over stored data is in force whether or not an action names it, so
-`guards` earns its place for the constraints that would otherwise have no moment
-to run. Naming an invariant as a guard is still meaningful. It means refuse to
-act on data that is already broken, and it moves that check to before the call.
-
-The reference lives on the action rather than on the constraint. The same rule
-may gate `TransferFunds` and leave `CloseAccount` alone, so gating is a property
-of the pairing.
-
-A constraint that reads a parameter and that no action guards is text nothing
-will ever check, so `kcmd` reports it when it loads the model:
+A constraint that reads a parameter is checked only as a guard. One that no
+action names is therefore text that nothing will ever evaluate, and `kcmd`
+reports it at load time:
 
 ```
 Warning: model 'payments': constraint 'AmountIsPositive' reads 'amount', a
@@ -158,10 +151,19 @@ parameter of action 'TransferFunds', but 'TransferFunds' does not list
 checked only as a guard of that action.
 ```
 
+Naming a constraint adds an earlier check; it does not switch enforcement on. An
+invariant over stored data is in force whether or not an action names it, so
+`guards` exists for the constraints that have no other moment to run. Naming an
+invariant as a guard is still useful. It states that the call must not proceed
+on data that is already broken, and it puts that check before the call.
+
+The reference lives on the action rather than on the constraint. The same rule
+may gate `TransferFunds` and leave `CloseAccount` alone, so gating is a property
+of the pairing.
+
 **Status: nothing evaluates a guard yet.** `kcmd` parses `guards`, resolves each
 name, publishes the list, and reads it back. No component checks a guard against
-live data, so a guard today tells a reader and an agent what must hold before
-the call, and refuses nothing.
+live data, so a guard states what must hold before the call and blocks no call.
 
 ## 3. Check it before pushing
 
@@ -258,10 +260,10 @@ kcmd pull
 
 Pull collects the `semantic-action` entries under the model entry and rebuilds
 each action, so a name, a description, an executor, typed parameters, its
-`guards`, and `ai_context.instructions` survive the round trip unchanged. `isEntityRef` is
-re-derived against the entities the pull recovered rather than read back, so it
-stays consistent with the model you get. What every part of a model does and
-does not survive is in
+`guards`, and `ai_context.instructions` survive the round trip unchanged.
+`isEntityRef` is re-derived against the entities the pull recovered rather than
+read back, so it stays consistent with the model you get. What every part of a
+model does and does not survive is in
 [What push and pull preserve](fidelity.md).
 
 ## What is not modeled yet
@@ -270,8 +272,8 @@ This is a prototype. Four things a reader reasonably expects are absent, and
 knowing which they are decides how much you can lean on it.
 
 - **An action declares no effects.** `affects` — what the call changes — is out
-  of scope here. What must hold before the call does have a home: a constraint
-  the action names in [`guards`](#2-gate-it-with-a-constraint).
+  of scope here. What must hold *before* the call is modeled: a constraint the
+  action names in [`guards`](#2-gate-it-with-a-constraint).
 - **Nothing checks the write.** No component evaluates a constraint or a guard,
   so an action is a declaration and the correctness of what the executor does
   belongs to the executor.

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -132,8 +132,9 @@ runs, so the action names it in `guards`:
         guards: [AmountIsPositive]
 ```
 
-`guards` holds constraint names. Each name must resolve to a constraint that the
-same model declares, and one that resolves to nothing fails the push:
+`guards` holds constraint names. Each name must resolve to a constraint that
+the same model declares. Misspell one — `AmountIsPostive` below, for the
+`AmountIsPositive` declared above — and the push fails:
 
 ```
 Error: action 'TransferFunds' in model 'payments' (payments.yaml) is guarded by
@@ -189,9 +190,9 @@ action 'TransferFunds' in model 'payments' (payments.yaml) is guarded by
 A parameter type that resolves to neither an entity nor a scalar means the model
 cannot say what that argument denotes, which is the whole contribution an action
 makes. An executor missing a coordinate cannot be dispatched by whatever picks
-the action up. A guard that names no constraint leaves the author believing the
-write is checked when nothing checks it. All three checks are static, so they
-run on every push whatever the destination.
+the action up. A guard that names no constraint — the misspelling above —
+leaves the author believing the write is checked when nothing checks it. All
+three checks are static, so they run on every push whatever the destination.
 
 An executor coordinate that is absent altogether is caught earlier, when the
 document is parsed, so the message above is what a blank one produces.

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -17,23 +17,8 @@ the data this model describes, and you want that operation described where the
 data is described. Anything reading the model then knows the operation exists,
 what it takes, and where it lives.
 
-Do not declare an action for a question about the data; that is a
-[metric](README.md#1-author-the-logical-model). Do not expect an action to run: `kcmd`
-publishes the declaration and never calls the executor. What each caller has to
-supply is covered in [What is not modeled yet](#what-is-not-modeled-yet).
-
-## The one thing the model adds
-
-A hand-written tool schema can already say that an input is an integer or a
-string. Only a model that knows the ontology can say what an input *denotes*:
-
-> **A parameter typed by an entity is an object reference.**
-
-`{name: source, type: Account}` says the argument names an account. The loader
-resolves `Account` against the model's entities and marks the parameter as an
-entity reference, so a consumer generating a tool schema knows to accept an
-identifier and resolve it against `Account`'s key rather than pass a number
-through. A parameter typed by a scalar datatype is an ordinary value.
+An action does not answer a question about the data. Use a
+[metric](README.md#1-author-the-logical-model) for that.
 
 ## 1. Declare the action
 
@@ -85,20 +70,31 @@ The executor says where the operation lives. `mcp` (`{server, tool}`) references
 a tool already registered in Agent Registry by the server's resource name plus
 the tool's name within it. `rest` (`{endpoint, method}`) and `grpc`
 (`{service, method}`) are the other kinds, and exactly one kind is required.
-Naming two is a parse error: `executor requires exactly one kind, but 2 given
-(mcp, rest)`.
 
 `description` and `ai_context.instructions` are both carried through to the
 catalog. Write the instructions for the agent that will call the action, as
 above.
 
+### What an entity-typed parameter adds
+
+A hand-written tool schema can say that an input is an integer or a string. A
+parameter typed against the model says what the input *denotes*:
+
+> **A parameter typed by an entity is an object reference.**
+
+`{name: source, type: Account}` says the argument names an account, so a
+consumer generating a tool schema knows to accept an identifier and resolve it
+against `Account`'s key rather than pass a number through. A parameter typed by
+a scalar datatype, such as `amount` above, is an ordinary value.
+
 ## 2. Gate it with a constraint
 
 A **constraint** is a named boolean invariant a model states over its ontology.
-Where it applies depends on what its expression reads.
+An action needs none; declare one when a rule decides whether a call may proceed
+at all. Where a constraint applies depends on what its expression reads.
 
-An expression over stored data holds for every write, no matter what performed
-that write. No action has to name such a constraint:
+An expression over stored data holds for every write, whatever performed that
+write. No action has to name such a constraint:
 
 ```yaml
     constraints:
@@ -132,35 +128,19 @@ runs, so the action names it in `guards`:
         guards: [AmountIsPositive]
 ```
 
-`guards` holds constraint names. Each name must resolve to a constraint that
-the same model declares. Misspell one — `AmountIsPostive` below, for the
-`AmountIsPositive` declared above — and the push fails:
+`guards` holds the names of constraints the same model declares. Naming one adds
+an earlier check; it does not switch enforcement on. An invariant over stored
+data is in force whether or not an action names it, so `guards` exists for the
+constraints that have no other moment to run. Naming an invariant over stored
+data as a guard is still useful. It states that the call must not proceed on
+data that is already broken, and it puts that check before the call.
 
-```
-Error: action 'TransferFunds' in model 'payments' (payments.yaml) is guarded by
-'AmountIsPostive', but model 'payments' declares no constraint of that name.
-```
+The reference lives on the action rather than on the constraint, because the
+same rule may gate `TransferFunds` and leave `CloseAccount` alone.
 
-A constraint that reads a parameter is checked only as a guard. One that no
-action names is therefore text that nothing will ever evaluate, and `kcmd`
-reports it at load time:
-
-```
-Warning: model 'payments': constraint 'AmountIsPositive' reads 'amount', a
-parameter of action 'TransferFunds', but 'TransferFunds' does not list
-'AmountIsPositive' in guards. A constraint over an action's parameters is
-checked only as a guard of that action.
-```
-
-Naming a constraint adds an earlier check; it does not switch enforcement on. An
-invariant over stored data is in force whether or not an action names it, so
-`guards` exists for the constraints that have no other moment to run. Naming an
-invariant as a guard is still useful. It states that the call must not proceed
-on data that is already broken, and it puts that check before the call.
-
-The reference lives on the action rather than on the constraint. The same rule
-may gate `TransferFunds` and leave `CloseAccount` alone, so gating is a property
-of the pairing.
+`kcmd` reports a mismatch from either side. A guard that names no constraint
+fails the push. A constraint over parameters that no action names loads with a
+warning, because nothing will ever evaluate it.
 
 **Status: nothing evaluates a guard yet.** `kcmd` parses `guards`, resolves each
 name, publishes the list, and reads it back. No component checks a guard against
@@ -173,7 +153,7 @@ kcmd push --validate-only
 ```
 
 Three things about an action can be statically wrong once the document parses,
-and all are hard errors:
+and each one is a hard error:
 
 ```
 action 'TransferFunds' in model 'payments' (payments.yaml) has parameter
@@ -190,12 +170,10 @@ action 'TransferFunds' in model 'payments' (payments.yaml) is guarded by
 A parameter type that resolves to neither an entity nor a scalar means the model
 cannot say what that argument denotes, which is the whole contribution an action
 makes. An executor missing a coordinate cannot be dispatched by whatever picks
-the action up. A guard that names no constraint — the misspelling above —
-leaves the author believing the write is checked when nothing checks it. All
-three checks are static, so they run on every push whatever the destination.
-
-An executor coordinate that is absent altogether is caught earlier, when the
-document is parsed, so the message above is what a blank one produces.
+the action up. A guard that names no constraint — `AmountIsPostive` here, a
+misspelling of the `AmountIsPositive` declared above — leaves the author
+believing the write is checked when nothing checks it. All three checks are
+static, so they run on every push whatever the destination.
 
 ## 4. Push it
 
@@ -203,17 +181,20 @@ document is parsed, so the message above is what a blank one produces.
 kcmd push
 ```
 
-Knowledge Catalog is the only system an action reaches. Every other push
-target deploys nothing for it and warns once:
+Knowledge Catalog is the only system an action reaches. Every other push target
+deploys nothing for it and warns once:
 
 ```
 Warning: [payments] 1 action(s) reach Knowledge Catalog only; the BigQuery
 push deploys none of them.
 ```
 
-Knowledge Catalog is where actions land. Each action becomes its own entry,
-parented to the model entry, exactly as a metric does. The entry carries one
-aspect holding the executor and the typed parameters:
+A graph-only `kcmd push --no-kc` therefore validates the actions and then warns
+that they will not be deployed.
+
+In Knowledge Catalog, each action becomes its own entry, parented to the model
+entry, the same way a metric does. The entry carries one aspect holding the
+executor and the typed parameters:
 
 ```yaml
 # .../entryGroups/<group>/entries/payments.actions.TransferFunds
@@ -234,20 +215,14 @@ aspects:
     instructions: Resolve both accounts before calling. Name the account the money leaves as `source`.
 ```
 
-The `semantic-action` entry type and aspect type are the one pair `kcmd` creates
-rather than references. Every other element of a model maps to a built-in system
-type under `dataplex-types/global`; there is no built-in type for an action yet,
-so `kcmd init --semantic-model` provisions the pair in your own project at
-`global`, beside the entry group. A later push writes only entries.
+Removing an action from the document deletes its entry on the next push, because
+the model owns the `<model>.actions.` id prefix. A catalog search can list the
+actions in a project by entry type, the way it lists entities or metrics.
 
-Two consequences follow from the entry shape. A catalog search can list the
-actions in a project by entry type, the way it lists entities or metrics. And
-removing an action from the document deletes its entry on the next push, because
-the model owns the `<model>.actions.` id prefix.
-
-Because Knowledge Catalog is the only destination an action has, a graph-only
-push has nowhere to put one. `kcmd push --no-kc` validates the actions and then
-warns that they will not be deployed.
+`semantic-action` is a custom entry type, because Dataplex has no built-in type
+for an action yet. `kcmd init --semantic-model` provisions the entry type and
+its aspect type in your own project. Run init once before the first push of a
+model that declares actions.
 
 Publishing an action needs the permission to attach its aspect, in addition to
 the permissions any push needs — see
@@ -261,16 +236,13 @@ kcmd pull
 
 Pull collects the `semantic-action` entries under the model entry and rebuilds
 each action, so a name, a description, an executor, typed parameters, its
-`guards`, and `ai_context.instructions` survive the round trip unchanged.
-`isEntityRef` is re-derived against the entities the pull recovered rather than
-read back, so it stays consistent with the model you get. What every part of a
-model does and does not survive is in
+`guards`, and `ai_context.instructions` survive the round trip unchanged. What
+every part of a model does and does not survive is in
 [What push and pull preserve](fidelity.md).
 
 ## What is not modeled yet
 
-This is a prototype. Four things a reader reasonably expects are absent, and
-knowing which they are decides how much you can lean on it.
+This is a prototype. Four things a reader reasonably expects are absent.
 
 - **An action declares no effects.** `affects` — what the call changes — is out
   of scope here. What must hold *before* the call is modeled: a constraint the

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -92,14 +92,85 @@ Naming two is a parse error: `executor requires exactly one kind, but 2 given
 catalog. Write the instructions for the agent that will call the action, as
 above.
 
-## 2. Check it before pushing
+## 2. Gate it with a constraint
+
+A **constraint** is a named boolean invariant a model states over its ontology.
+One that quantifies over stored data holds for every write, whatever performed
+it, and needs no reference from anywhere:
+
+```yaml
+    constraints:
+      - name: BalanceStaysPositive
+        expression: Account.balance >= Account.minimumBalance
+        description: >-
+          An account cannot be taken below its minimum balance.
+```
+
+A constraint that reads an action's **parameters** is a different thing. It
+describes one call rather than the stored data, so the only moment it can be
+checked is before that call runs. Name it on the action, in `guards`:
+
+```yaml
+    constraints:
+      - name: AmountIsPositive
+        expression: amount > 0
+        description: >-
+          A transfer must move at least one unit. Ask the caller for the
+          amount again before retrying.
+    actions:
+      - name: TransferFunds
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/payments
+            tool: transfer_funds
+        parameters:
+          - { name: source, type: Account }
+          - { name: target, type: Account }
+          - { name: amount, type: Float }
+        guards: [AmountIsPositive]
+```
+
+`guards` holds constraint names. Each must name a constraint the same model
+declares; one that names nothing fails the push:
+
+```
+Error: action 'TransferFunds' in model 'payments' (payments.yaml) is guarded by
+'AmountIsPostive', but model 'payments' declares no constraint of that name.
+```
+
+Naming a constraint adds a check and does not switch its enforcement on. An
+invariant over stored data is in force whether or not an action names it, so
+`guards` earns its place for the constraints that would otherwise have no moment
+to run. Naming an invariant as a guard is still meaningful. It means refuse to
+act on data that is already broken, and it moves that check to before the call.
+
+The reference lives on the action rather than on the constraint. The same rule
+may gate `TransferFunds` and leave `CloseAccount` alone, so gating is a property
+of the pairing.
+
+A constraint that reads a parameter and that no action guards is text nothing
+will ever check, so `kcmd` reports it when it loads the model:
+
+```
+Warning: model 'payments': constraint 'AmountIsPositive' reads 'amount', a
+parameter of action 'TransferFunds', but 'TransferFunds' does not list
+'AmountIsPositive' in guards. A constraint over an action's parameters is
+checked only as a guard of that action.
+```
+
+**Status: nothing evaluates a guard yet.** `kcmd` parses `guards`, resolves each
+name, publishes the list, and reads it back. No component checks a guard against
+live data, so a guard today tells a reader and an agent what must hold before
+the call, and refuses nothing.
+
+## 3. Check it before pushing
 
 ```bash
 kcmd push --validate-only
 ```
 
-Two things about an action can be statically wrong once the document parses, and
-both are hard errors:
+Three things about an action can be statically wrong once the document parses,
+and all are hard errors:
 
 ```
 action 'TransferFunds' in model 'payments' (payments.yaml) has parameter
@@ -108,18 +179,22 @@ datatype.
 
 action 'TransferFunds' in model 'payments' (payments.yaml) has an mcp executor
 whose 'tool' is missing or blank.
+
+action 'TransferFunds' in model 'payments' (payments.yaml) is guarded by
+'AmountIsPostive', but model 'payments' declares no constraint of that name.
 ```
 
 A parameter type that resolves to neither an entity nor a scalar means the model
 cannot say what that argument denotes, which is the whole contribution an action
 makes. An executor missing a coordinate cannot be dispatched by whatever picks
-the action up. Both checks are static, so they run on every push whatever the
-destination.
+the action up. A guard that names no constraint leaves the author believing the
+write is checked when nothing checks it. All three checks are static, so they
+run on every push whatever the destination.
 
 An executor coordinate that is absent altogether is caught earlier, when the
 document is parsed, so the message above is what a blank one produces.
 
-## 3. Push it
+## 4. Push it
 
 ```bash
 kcmd push
@@ -175,15 +250,15 @@ Publishing an action needs the permission to attach its aspect, in addition to
 the permissions any push needs — see
 [Reference → Permissions](reference.md#permissions).
 
-## 4. Pull it back
+## 5. Pull it back
 
 ```bash
 kcmd pull
 ```
 
 Pull collects the `semantic-action` entries under the model entry and rebuilds
-each action, so a name, a description, an executor, typed parameters, and
-`ai_context.instructions` survive the round trip unchanged. `isEntityRef` is
+each action, so a name, a description, an executor, typed parameters, its
+`guards`, and `ai_context.instructions` survive the round trip unchanged. `isEntityRef` is
 re-derived against the entities the pull recovered rather than read back, so it
 stays consistent with the model you get. What every part of a model does and
 does not survive is in
@@ -194,13 +269,12 @@ does not survive is in
 This is a prototype. Four things a reader reasonably expects are absent, and
 knowing which they are decides how much you can lean on it.
 
-- **An action declares no precondition and no effects.** `precondition` (what
-  has to hold before the call) and `affects` (what the call changes) are out of
-  scope here. Model-level **constraints** state the invariants a model requires,
-  and no constraint is attached to an action.
-- **Nothing checks the write.** No component evaluates a constraint, so an action
-  is a declaration and the correctness of what the executor does belongs to the
-  executor.
+- **An action declares no effects.** `affects` — what the call changes — is out
+  of scope here. What must hold before the call does have a home: a constraint
+  the action names in [`guards`](#2-gate-it-with-a-constraint).
+- **Nothing checks the write.** No component evaluates a constraint or a guard,
+  so an action is a declaration and the correctness of what the executor does
+  belongs to the executor.
 - **`kcmd` does not call the executor.** Push publishes the action. Dispatching
   it is the job of whatever reads the model, which is why the executor names
   coordinates rather than a statement.

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -150,9 +150,11 @@ expressions are still used when generating graph SQL.
 becomes a `semantic-action` entry under the model entry, carrying its executor,
 typed parameters, and `guards` in a `semantic-action` aspect. They round-trip
 losslessly through `pull` (name, description, executor, typed parameters,
-`guards`, and `instructions`). Their `affects` is out of scope for this
-prototype and is not stored. The entry type is custom, so `kcmd init` creates
-it; a model that declares no action never needs it.
+`guards`, and `instructions`). A parameter's `isEntityRef` is re-derived against
+the entities the pull recovered rather than read back from the aspect, so it
+stays consistent with the model the pull hands you. Their `affects` is out of
+scope for this prototype and is not stored. The entry type is custom, so `kcmd
+init` creates it; a model that declares no action never needs it.
 
 **Constraints** publish the same way: each becomes a `semantic-constraint` entry
 under the model entry, with the expression and any `instructions` in a

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -100,10 +100,10 @@ agree on every structural row and differ only where a Spanner target has no
 12. **Actions.** An action reaches Knowledge Catalog only, as one
     `semantic-action` entry under the model entry, and `pull` reads it back from
     that entry. Every other push target deploys nothing for it and warns once.
-    Its `guards` are stored as constraint names and round-trip verbatim; a name
-    whose constraint is absent from a pull is kept rather than dropped, so the
-    author's model is never silently rewritten. Prototype scope: an action's
-    `affects` is not modelled, so nothing about it is stored. See
+    Its `guards` are stored as constraint names and round-trip verbatim. A name
+    whose constraint is absent from a pull is kept rather than dropped, so a
+    partial pull never silently rewrites the author's model. Prototype scope:
+    an action's `affects` is not modelled, so nothing about it is stored. See
     [Modeling write operations](actions.md).
 13. **Constraints.** A constraint reaches Knowledge Catalog only, as one
     `semantic-constraint` entry under the model entry, and `pull` reads it back.
@@ -146,8 +146,8 @@ expressions are still used when generating graph SQL.
 becomes a `semantic-action` entry under the model entry, carrying its executor,
 typed parameters, and `guards` in a `semantic-action` aspect. They round-trip
 losslessly through `pull` (name, description, executor, typed parameters,
-guards, and `instructions`). Their `affects` is out of scope for this prototype
-and is not stored. The entry type is custom, so `kcmd init` creates
+`guards`, and `instructions`). Their `affects` is out of scope for this
+prototype and is not stored. The entry type is custom, so `kcmd init` creates
 it; a model that declares no action never needs it.
 
 **Constraints** publish the same way: each becomes a `semantic-constraint` entry

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -100,8 +100,10 @@ agree on every structural row and differ only where a Spanner target has no
 12. **Actions.** An action reaches Knowledge Catalog only, as one
     `semantic-action` entry under the model entry, and `pull` reads it back from
     that entry. Every other push target deploys nothing for it and warns once.
-    Prototype scope: an action's `precondition` and `affects` are not modelled,
-    so nothing about them is stored. See
+    Its `guards` are stored as constraint names and round-trip verbatim; a name
+    whose constraint is absent from a pull is kept rather than dropped, so the
+    author's model is never silently rewritten. Prototype scope: an action's
+    `affects` is not modelled, so nothing about it is stored. See
     [Modeling write operations](actions.md).
 13. **Constraints.** A constraint reaches Knowledge Catalog only, as one
     `semantic-constraint` entry under the model entry, and `pull` reads it back.
@@ -141,11 +143,11 @@ imported from). Those stay in your authored document; the vendor SQL and
 expressions are still used when generating graph SQL.
 
 **Actions** follow the same one-entry-per-element rule as everything else: each
-becomes a `semantic-action` entry under the model entry, carrying its executor
-and typed parameters in a `semantic-action` aspect. They round-trip losslessly
-through `pull` (name, description, executor, typed parameters, and
-`instructions`). Their `precondition` / `affects` are out of scope for this
-prototype and are not stored. The entry type is custom, so `kcmd init` creates
+becomes a `semantic-action` entry under the model entry, carrying its executor,
+typed parameters, and `guards` in a `semantic-action` aspect. They round-trip
+losslessly through `pull` (name, description, executor, typed parameters,
+guards, and `instructions`). Their `affects` is out of scope for this prototype
+and is not stored. The entry type is custom, so `kcmd init` creates
 it; a model that declares no action never needs it.
 
 **Constraints** publish the same way: each becomes a `semantic-constraint` entry

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -102,8 +102,12 @@ agree on every structural row and differ only where a Spanner target has no
     that entry. Every other push target deploys nothing for it and warns once.
     Its `guards` are stored as constraint names and round-trip verbatim. A name
     whose constraint is absent from a pull is kept rather than dropped, so a
-    partial pull never silently rewrites the author's model. Prototype scope:
-    an action's `affects` is not modelled, so nothing about it is stored. See
+    partial pull never silently rewrites the author's model; the pull warns
+    about the name it kept, and a push rejects the model until the constraint
+    is back. A name the aspect repeats is the one exception, dropped to its
+    single occurrence because the loader rejects a repeat and the document has
+    to stay loadable. Prototype scope: an action's `affects` is not modelled,
+    so nothing about it is stored. See
     [Modeling write operations](actions.md).
 13. **Constraints.** A constraint reaches Knowledge Catalog only, as one
     `semantic-constraint` entry under the model entry, and `pull` reads it back.

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -468,8 +468,9 @@ reads the document ([§6](#6-the-extension-mechanism)).
   A constraint that quantifies over stored data applies to every write without
   being referenced anywhere. A constraint that reads an action's parameters can
   be checked only before that call, so it applies only where an action names it
-  in `guards`. Status: authored, validated and published; no component evaluates
-  a constraint, so nothing today rejects a write that would break one. Rules in
+  in `guards`; one that no action names at all draws a load warning. Status:
+  authored, validated and published; no component evaluates a constraint, so
+  nothing today rejects a write that would break one. Rules in
   [Reference → Validation](reference.md#validation).
 
 - **Binding profiles.** A separate document that supplies only the physical

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -456,15 +456,20 @@ reads the document ([§6](#6-the-extension-mechanism)).
 - **`actions` (extended profile only).** Model-level write operations, the
   write-side counterpart to a metric. An action names an operation, points at the
   executor that performs it, and types each parameter against the ontology, so an
-  entity-typed parameter is an object reference. Accepted only under
-  `0.2.0.dev0/google`. `kcmd` publishes an action and never calls its executor.
-  See [Modeling write operations](actions.md).
+  entity-typed parameter is an object reference. Its optional `guards` lists, by
+  name, the constraints that gate it; each name MUST resolve to a constraint the
+  same model declares, and a repeated name is a **hard load error**. Accepted
+  only under `0.2.0.dev0/google`. `kcmd` publishes an action and never calls its
+  executor. See [Modeling write operations](actions.md).
 
 - **`constraints` (extended profile only).** Model-level named boolean
   invariants over the ontology, written in the same expression language as a
   metric — `Account.balance >= 0`. Accepted only under `0.2.0.dev0/google`.
-  Status: authored, validated and published; no component evaluates a constraint,
-  so nothing today rejects a write that would break one. Rules in
+  A constraint that quantifies over stored data applies to every write without
+  being referenced anywhere. A constraint that reads an action's parameters can
+  be checked only before that call, so it applies only where an action names it
+  in `guards`. Status: authored, validated and published; no component evaluates
+  a constraint, so nothing today rejects a write that would break one. Rules in
   [Reference → Validation](reference.md#validation).
 
 - **Binding profiles.** A separate document that supplies only the physical

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -354,14 +354,14 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   a known entity (an object reference) or a scalar datatype, and each executor
   must carry its coordinates (an `mcp` server + tool, a `rest` endpoint + method,
   or a `grpc` service + method) with no blank field. Each name in the action's
-  `guards` must resolve to a constraint the same model declares, because a guard
-  that resolves to nothing leaves the author believing the write is checked when
-  nothing checks it. (The "exactly one executor kind" rule, and the rejection of
-  a repeated guard, are both enforced when the model is parsed.) These checks are static, so
-  they run on every push, regardless of destination. Note that actions themselves
-  deploy **only** through the Knowledge Catalog leg — a graph-only `--no-kc` push
-  validates them but has nowhere to put them, and warns that they will not be
-  deployed. *(static)*
+  `guards` must resolve to a constraint that the same model declares. A guard
+  resolving to nothing leaves the author believing the write is checked when
+  nothing checks it. The "exactly one executor kind" rule and the rejection of a
+  repeated guard are enforced earlier still, when the model is parsed. These
+  checks are static, so they run on every push, regardless of destination. Note
+  that actions themselves deploy **only** through the Knowledge Catalog leg — a
+  graph-only `--no-kc` push validates them but has nowhere to put them, and
+  warns that they will not be deployed. *(static)*
 * **Every constraint is checkable.** A constraint's `expression` must be
   non-empty. When the expression opens with an `<Entity>.<field>` qualifier
   naming a **known** entity, that entity must declare the field; this catches a
@@ -374,12 +374,13 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
 * **A constraint over an action's parameters is guarded.** A constraint whose
   expression reads a bare name that is a parameter of some action describes that
   call rather than the stored data, so it can be checked only before the call
-  runs — which happens only when the action lists it in `guards`. Loading a model
-  where no action does warns, because such a constraint is text nothing will
-  evaluate. This is a warning rather than an error: the scan matches identifiers,
-  and an expression may use a bare name that merely coincides with a parameter
-  name. A qualified name (`OrderedAs.quantity`) is read whole and never counts as
-  a parameter. *(warning, at load)*
+  runs — which happens only when the action lists it in `guards`. A model that
+  declares such a constraint and no matching guard loads with a warning, because
+  the constraint is text that nothing will ever evaluate. It warns rather than
+  fails because the scan matches identifiers, and an expression may use a bare
+  name that merely coincides with a parameter name. A qualified name
+  (`OrderedAs.quantity`) is read whole and never counts as a parameter.
+  *(warning, at load)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it
   exactly as the deploy will — a three-part `project.dataset.table`, a four-part

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -285,8 +285,11 @@ relationship detail — the paired columns and foreign-key direction — in its
 aspect. Any element with `ai_context.instructions` (the model, an entity, or a
 metric) also gets a built-in `guidelines` aspect holding that text.
 
-An **action** entry carries its executor and its typed parameters in a
-`semantic-action` aspect, along with the action's `ai_context.instructions`.
+An **action** entry carries its executor, its typed parameters, and the names
+of the constraints that gate it (`guards`) in a `semantic-action` aspect, along
+with the action's `ai_context.instructions`. A guard is stored as the constraint
+name, matching a sibling `semantic-constraint` entry on the same model, so a
+reader holding one action entry can find the rules it is checked against.
 That aspect type is provisioned in your project rather than referenced from
 `dataplex-types`, because Dataplex has no built-in action type yet; when one
 ships, the entries move to it and their shape does not change. (This is the
@@ -350,8 +353,11 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
 * **Every action is well-formed.** Each action parameter's `type` must resolve to
   a known entity (an object reference) or a scalar datatype, and each executor
   must carry its coordinates (an `mcp` server + tool, a `rest` endpoint + method,
-  or a `grpc` service + method) with no blank field. (The "exactly one executor
-  kind" rule is enforced when the model is parsed.) These checks are static, so
+  or a `grpc` service + method) with no blank field. Each name in the action's
+  `guards` must resolve to a constraint the same model declares, because a guard
+  that resolves to nothing leaves the author believing the write is checked when
+  nothing checks it. (The "exactly one executor kind" rule, and the rejection of
+  a repeated guard, are both enforced when the model is parsed.) These checks are static, so
   they run on every push, regardless of destination. Note that actions themselves
   deploy **only** through the Knowledge Catalog leg — a graph-only `--no-kc` push
   validates them but has nowhere to put them, and warns that they will not be
@@ -365,6 +371,15 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   alone rather than guessed at, so a valid constraint is never falsely rejected.
   Like an action, a constraint reaches Knowledge Catalog only, and a `--no-kc`
   push warns that it will not be deployed. *(static)*
+* **A constraint over an action's parameters is guarded.** A constraint whose
+  expression reads a bare name that is a parameter of some action describes that
+  call rather than the stored data, so it can be checked only before the call
+  runs — which happens only when the action lists it in `guards`. Loading a model
+  where no action does warns, because such a constraint is text nothing will
+  evaluate. This is a warning rather than an error: the scan matches identifiers,
+  and an expression may use a bare name that merely coincides with a parameter
+  name. A qualified name (`OrderedAs.quantity`) is read whole and never counts as
+  a parameter. *(warning, at load)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it
   exactly as the deploy will — a three-part `project.dataset.table`, a four-part

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -374,12 +374,16 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
 * **A constraint over an action's parameters is guarded.** A constraint whose
   expression reads a bare name that is a parameter of some action describes that
   call rather than the stored data, so it can be checked only before the call
-  runs — which happens only when the action lists it in `guards`. A model that
-  declares such a constraint and no matching guard loads with a warning, because
-  the constraint is text that nothing will ever evaluate. It warns rather than
-  fails because the scan matches identifiers, and an expression may use a bare
-  name that merely coincides with a parameter name. A qualified name
-  (`OrderedAs.quantity`) is read whole and never counts as a parameter.
+  runs — which happens only when the action lists it in `guards`. A model in
+  which no action at all lists it loads with a warning, because the constraint
+  is text that nothing will ever evaluate. One action naming it is enough to
+  settle it: another action that takes a parameter of the same name and does not
+  guard the constraint is a modeling choice, since the same rule may gate one
+  action and leave another alone. It warns rather than fails because the scan
+  matches identifiers, and an expression may use a bare name that merely
+  coincides with a parameter name. Neither a qualified name
+  (`OrderedAs.quantity`) nor a quoted literal (`status = 'quantity'`) counts as
+  a parameter read.
   *(warning, at load)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -353,12 +353,14 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
 * **Every action is well-formed.** Each action parameter's `type` must resolve to
   a known entity (an object reference) or a scalar datatype, and each executor
   must carry its coordinates (an `mcp` server + tool, a `rest` endpoint + method,
-  or a `grpc` service + method) with no blank field. Each name in the action's
-  `guards` must resolve to a constraint that the same model declares. A guard
-  resolving to nothing leaves the author believing the write is checked when
-  nothing checks it. The "exactly one executor kind" rule and the rejection of a
-  repeated guard are enforced earlier still, when the model is parsed. These
-  checks are static, so they run on every push, regardless of destination. Note
+  or a `grpc` service + method) with no blank field. A coordinate omitted
+  altogether is rejected earlier, when the model is parsed. Each name in the
+  action's `guards` must resolve to a constraint that the same model declares. A
+  guard resolving to nothing leaves the author believing the write is checked
+  when nothing checks it. Two further rules are enforced at parse time: exactly
+  one executor kind (`executor requires exactly one kind, but 2 given (mcp,
+  rest)`) and the rejection of a repeated guard name. Every check here is
+  static, so it runs on every push, regardless of destination. Note
   that actions themselves deploy **only** through the Knowledge Catalog leg — a
   graph-only `--no-kc` push validates them but has nowhere to put them, and
   warns that they will not be deployed. *(static)*

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -305,9 +305,10 @@ export interface Metric {
  * `parameters`.
  *
  * The model contributes only what the ontology can say that a plain tool schema
- * cannot -- typed parameters (an entity-typed one is an object reference). The
- * mechanics of running it are delegated to an `executor` (e.g. an MCP tool in
- * Agent Registry); `description` is informational and does not affect runtime.
+ * cannot: typed parameters (an entity-typed one is an object reference) and the
+ * constraints that gate the call. The mechanics of running it are delegated to
+ * an `executor` (e.g. an MCP tool in Agent Registry); `description` is
+ * informational and does not affect runtime.
  */
 export interface Action {
   name: string;
@@ -319,6 +320,13 @@ export interface Action {
   // Inputs, each typed by the ontology: an entity type is an object reference,
   // a scalar type an ordinary value. See ActionParameter.
   parameters: ActionParameter[];
+  // The constraints that gate this action, by name. A constraint reaches this
+  // list only when it has to: one that reads an action's parameters describes
+  // the call rather than the data, so the only moment it can be checked is
+  // before that call runs. A constraint over data alone holds for every write
+  // and needs no reference here. Naming a constraint adds an earlier check and
+  // does not switch its enforcement on.
+  guards?: string[];
   aiContext?: AiContext;
   customExtensions?: CustomExtension[];
 }

--- a/toolbox/mdcode/src/libts/semantic/kc_actions.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_actions.ts
@@ -228,10 +228,25 @@ export function readAction(
 
   const action: Action = {name, executor, parameters};
   // Guard names round-trip verbatim. A name whose constraint is not part of
-  // this pull is kept rather than dropped: push-side validate reports it, and
-  // dropping it here would silently rewrite the author's model.
-  const guards = asArray(data.guards).filter(
-      (g: any): g is string => typeof g === 'string' && g !== '');
+  // this pull is kept rather than dropped, because dropping it here would
+  // silently rewrite the author's model. It is not kept in silence:
+  // kc_converter warns once it has both lists in hand, and push-side validate
+  // rejects it.
+  //
+  // A REPEATED name is the exception, because the loader rejects one outright:
+  // keeping it would hand back a document that cannot be reloaded. A duplicate
+  // guard checks the same constraint twice, so dropping it loses no meaning.
+  const guards: string[] = [];
+  for (const g of asArray(data.guards)) {
+    if (typeof g !== 'string' || g === '') continue;
+    if (guards.includes(g)) {
+      warnings.push(
+          `action '${name}': the ${ACTION_TYPE_ID} aspect repeats guard ` +
+          `'${g}'; the duplicate is dropped so the document still loads`);
+      continue;
+    }
+    guards.push(g);
+  }
   if (guards.length) action.guards = guards;
   const description = entry.entrySource?.description;
   if (description !== undefined && description !== '')

--- a/toolbox/mdcode/src/libts/semantic/kc_actions.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_actions.ts
@@ -137,18 +137,22 @@ export function actionEntries(
   // collision that skipped an action does not inflate the number.
   if (entries.length) warnings.push(
       `model '${model.name}': ${entries.length} action(s) published as ` +
-      `${ACTION_TYPE_ID} entries (actions have no BigQuery Graph ` +
-      `representation).`);
+      `${ACTION_TYPE_ID} entries (Knowledge Catalog is the only system an ` +
+      `action reaches).`);
   return entries;
 }
 
 // The aspect payload for one action: the executor flattened to the fields of
-// its kind, the typed parameters, and any AI instructions.
+// its kind, the typed parameters, the constraints that gate it, and any AI
+// instructions. Guards are the constraint NAMES, matching the sibling
+// `semantic-constraint` entries by display name, so a reader holding one action
+// entry can find the rules it is checked against.
 function actionAspectData(action: Action): Record<string, any> {
   return compact({
     ...executorData(action.executor),
     parameters: action.parameters.map(
         p => compact({name: p.name, type: p.type, isEntityRef: p.isEntityRef})),
+    guards: action.guards?.length ? action.guards : undefined,
     instructions: action.aiContext?.instructions || undefined,
   });
 }
@@ -223,6 +227,12 @@ export function readAction(
           .filter((p): p is ActionParameter => p !== undefined);
 
   const action: Action = {name, executor, parameters};
+  // Guard names round-trip verbatim. A name whose constraint is not part of
+  // this pull is kept rather than dropped: push-side validate reports it, and
+  // dropping it here would silently rewrite the author's model.
+  const guards = asArray(data.guards).filter(
+      (g: any): g is string => typeof g === 'string' && g !== '');
+  if (guards.length) action.guards = guards;
   const description = entry.entrySource?.description;
   if (description !== undefined && description !== '')
     action.description = description;

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -122,8 +122,8 @@ export function constraintEntries(
   if (entries.length)
     warnings.push(
         `model '${model.name}': ${entries.length} constraint(s) published as ` +
-        `${CONSTRAINT_TYPE_ID} entries (constraints have no BigQuery Graph ` +
-        `representation).`);
+        `${CONSTRAINT_TYPE_ID} entries (Knowledge Catalog is the only ` +
+        `system a constraint reaches).`);
   return entries;
 }
 

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -64,6 +64,27 @@ export interface ReadResult {
   warnings: string[];
 }
 
+// A guard naming a constraint this pull did not recover -- because its entry was
+// absent, or was skipped as unreadable. readAction keeps the name so the
+// author's model is not silently rewritten, which leaves the document one that
+// push will reject. Reporting it here puts the message on the command that
+// produced the document rather than on the next one.
+function warnDanglingGuards(
+    actions: Action[], constraints: Constraint[], modelName: string,
+    warnings: string[]): void {
+  if (!actions.length) return;
+  const recovered = new Set(constraints.map(c => c.name));
+  for (const action of actions) {
+    for (const guard of action.guards ?? []) {
+      if (recovered.has(guard)) continue;
+      warnings.push(
+          `model '${modelName}': action '${action.name}' is guarded by ` +
+          `'${guard}', but no constraint of that name was recovered; the ` +
+          `name is kept, and a push rejects it until the constraint is back`);
+    }
+  }
+}
+
 /**
  * Reconstructs the Semantic Model IR from Knowledge Catalog entries.
  *
@@ -142,6 +163,7 @@ export function modelsFromCatalogResources(
                             .map(e => readConstraint(e, warnings))
                             .filter((c): c is Constraint => c !== undefined);
     if (constraints.length) model.constraints = constraints;
+    warnDanglingGuards(actions, constraints, name, warnings);
     // Deployment targets ride back in the same GOOGLE custom_extensions block
     // the author wrote them in (the inverse of the emitter's modelAspectData).
     const targets = readDeploymentTargets(anchor);

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -299,6 +299,19 @@ const ACTION_ASPECT_TYPE: Omit<AspectType, 'name'> = {
               'instructions).',
         },
       },
+      {
+        index: 10,
+        name: 'guards',
+        type: 'array',
+        arrayItems: {name: 'guard', type: 'string'},
+        annotations: {
+          displayName: 'Guards',
+          description:
+              'Names of the constraints that gate this action, each a ' +
+              '`semantic-constraint` entry on the same model. They are ' +
+              'checked before the action runs.',
+        },
+      },
     ],
   },
 };

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -232,6 +232,10 @@ const actionSchema = z.object({
   description: z.string().optional(),
   executor: executorSchema,
   parameters: z.array(parameterSchema).optional(),
+  // Names of the constraints that gate this action. Kept as plain strings: they
+  // are resolved against the model's own constraints in validate.ts, which sees
+  // the whole model, whereas the schema sees one action.
+  guards: z.array(z.string()).optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
@@ -410,6 +414,7 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
                     description: z.string().optional(),
                     executor: executorSchema,
                     parameters: z.array(parameter).optional(),
+                    guards: z.array(z.string()).optional(),
                     ai_context: aiContextSchema.optional(),
                     ...ce,
                   }).strict();
@@ -708,6 +713,7 @@ function convertModel(
   const constraints = (m.constraints ?? []).map(convertConstraint);
   rejectDuplicateNames(
       constraints.map(c => c.name), 'constraint name', `model '${m.name}'`);
+  warnUnguardedParameterConstraints(actions, constraints, m.name, warnings);
 
   const description = composeDescription(m.description);
 
@@ -914,6 +920,12 @@ function convertAction(
     executor: convertExecutor(a.executor),
     parameters,
   };
+  if (a.guards?.length) {
+    // A repeated guard would check one constraint twice while reading as two
+    // rules, so it is rejected like any other duplicate name.
+    rejectDuplicateNames(a.guards, 'guard', `action '${a.name}'`);
+    action.guards = [...a.guards];
+  }
 
   const description = composeDescription(a.description);
   if (description) action.description = description;
@@ -922,6 +934,47 @@ function convertAction(
   const ce = toCustomExtensions(a.custom_extensions);
   if (ce) action.customExtensions = ce;
   return action;
+}
+
+// A constraint that reads an action's parameter describes that call, so the
+// only moment it can be checked is before the call runs -- which happens only
+// when the action names it in `guards`. Such a constraint left unnamed is text
+// nothing will ever evaluate, so say so at load time.
+//
+// This warns rather than fails because the scan matches identifiers, and an
+// expression may use a bare name that merely coincides with a parameter name.
+// One message per pair, naming the first parameter that matched.
+function warnUnguardedParameterConstraints(
+    actions: Action[], constraints: Constraint[], modelName: string,
+    warnings: string[]): void {
+  if (!actions.length || !constraints.length) return;
+  for (const c of constraints) {
+    const identifiers = bareIdentifiers(c.expression);
+    if (!identifiers.size) continue;
+    for (const a of actions) {
+      if (a.guards?.includes(c.name)) continue;
+      const read = a.parameters.find(p => identifiers.has(p.name));
+      if (!read) continue;
+      warnings.push(
+          `model '${modelName}': constraint '${c.name}' reads '${read.name}', ` +
+          `a parameter of action '${a.name}', but '${a.name}' does not list ` +
+          `'${c.name}' in guards. A constraint over an action's parameters is ` +
+          `checked only as a guard of that action.`);
+    }
+  }
+}
+
+// The names an expression uses on their own. A qualified `Entity.field` is
+// consumed whole so its field half is never mistaken for a bare name, which is
+// what makes `Part.availableStock >= quantity` yield `quantity` alone. Action
+// parameters are referenced by bare name, so this is the set that can name one.
+function bareIdentifiers(expression: string): Set<string> {
+  const found = new Set<string>();
+  const token = /[A-Za-z_]\w*\s*\.\s*[A-Za-z_]\w*|([A-Za-z_]\w*)/g;
+  for (let m = token.exec(expression); m; m = token.exec(expression)) {
+    if (m[1]) found.add(m[1]);
+  }
+  return found;
 }
 
 // Resolves a parameter's authored `type` against the ontology: a known entity

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -938,8 +938,14 @@ function convertAction(
 
 // A constraint that reads an action's parameter describes that call, so the
 // only moment it can be checked is before the call runs -- which happens only
-// when the action names it in `guards`. Such a constraint left unnamed is text
-// nothing will ever evaluate, so say so at load time.
+// when the action names it in `guards`. Such a constraint left unnamed by EVERY
+// action is text nothing will ever evaluate, so say so at load time.
+//
+// Being guarded anywhere is enough. An action that shares the parameter name and
+// does not name the constraint is a deliberate modeling choice, since the same
+// rule may gate one action and leave another alone; warning about it would
+// report a constraint that does run and would teach an author to ignore this
+// message.
 //
 // This warns rather than fails because the scan matches identifiers, and an
 // expression may use a bare name that merely coincides with a parameter name.
@@ -949,10 +955,10 @@ function warnUnguardedParameterConstraints(
     warnings: string[]): void {
   if (!actions.length || !constraints.length) return;
   for (const c of constraints) {
+    if (actions.some(a => a.guards?.includes(c.name))) continue;
     const identifiers = bareIdentifiers(c.expression);
     if (!identifiers.size) continue;
     for (const a of actions) {
-      if (a.guards?.includes(c.name)) continue;
       const read = a.parameters.find(p => identifiers.has(p.name));
       if (!read) continue;
       warnings.push(
@@ -968,10 +974,15 @@ function warnUnguardedParameterConstraints(
 // consumed whole so its field half is never mistaken for a bare name, which is
 // what makes `Part.availableStock >= quantity` yield `quantity` alone. Action
 // parameters are referenced by bare name, so this is the set that can name one.
+//
+// A quoted literal is data rather than a reference, so it is blanked before the
+// scan: `status = 'quantity'` must not look like a read of a parameter named
+// `quantity`.
 function bareIdentifiers(expression: string): Set<string> {
   const found = new Set<string>();
+  const code = expression.replace(/'[^']*'|"[^"]*"/g, ' ');
   const token = /[A-Za-z_]\w*\s*\.\s*[A-Za-z_]\w*|([A-Za-z_]\w*)/g;
-  for (let m = token.exec(expression); m; m = token.exec(expression)) {
+  for (let m = token.exec(code); m; m = token.exec(code)) {
     if (m[1]) found.add(m[1]);
   }
   return found;

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -292,6 +292,7 @@ function actionDoc(action: Action, warnings: string[]): Record<string, any> {
     executor: executorDoc(action.executor),
     parameters: nonEmpty(
         (action.parameters ?? []).map(p => ({name: p.name, type: p.type}))),
+    guards: nonEmpty(action.guards),
     ai_context: aiContextDoc(action.aiContext),
   });
 }

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -117,11 +117,12 @@ export function validatePushRequirements(
       }
     }
 
-    // Actions have no BigQuery Graph representation, so their checks are
+    // An action reaches Knowledge Catalog only, so its checks are
     // target-independent: each parameter's type must resolve to something in
-    // the ontology, and the executor must carry the coordinates a runtime needs
-    // to dispatch it. (The "exactly one executor kind" rule is already
-    // guaranteed by the loader schema, so it cannot reach here.)
+    // the ontology, the executor must carry the coordinates a runtime needs to
+    // dispatch it, and each guard must name a constraint the model declares.
+    // (The "exactly one executor kind" rule is already guaranteed by the loader
+    // schema, so it cannot reach here.)
     errors.push(...validateActions(model, document));
 
     // Constraints are logical invariants, target-independent like actions.
@@ -132,15 +133,19 @@ export function validatePushRequirements(
 }
 
 // Static, target-independent checks for a model's actions. Returns one message
-// per violation. Two things can be statically wrong once the model has parsed:
+// per violation. Three things can be statically wrong once the model has
+// parsed:
 //   - a parameter's type resolves to neither a known entity nor a scalar
 //     datatype (the loader left isEntityRef unset and only warned) -- an
 //     unresolvable type is a malformed action, promoted to a hard error here;
 //   - an executor is missing a coordinate a runtime needs to dispatch it (an
 //     empty server/tool, endpoint/method, or service/method) -- the schema
-//     accepts empty strings, so this is caught here rather than at parse.
+//     accepts empty strings, so this is caught here rather than at parse;
+//   - a guard names a constraint the model does not declare.
 function validateActions(model: SemanticModel, document: string): string[] {
   const errors: string[] = [];
+  const constraintNames =
+      new Set((model.constraints ?? []).map(c => c.name));
   for (const action of model.actions ?? []) {
     const where =
         `action '${action.name}' in model '${model.name}' (${document})`;
@@ -153,6 +158,16 @@ function validateActions(model: SemanticModel, document: string): string[] {
     for (const missing of missingExecutorFields(action.executor)) {
       errors.push(`${where} has an ${
           action.executor.kind} executor whose '${missing}' is missing or blank.`);
+    }
+    // An unresolved guard leaves the author believing the write is checked when
+    // nothing checks it, so it fails the push rather than warning. Constraint
+    // names are model-scoped and the loader rejects duplicates, so a name
+    // either resolves here or names nothing at all.
+    for (const guard of action.guards ?? []) {
+      if (!constraintNames.has(guard)) {
+        errors.push(`${where} is guarded by '${guard}', but model '${
+            model.name}' declares no constraint of that name.`);
+      }
     }
   }
   return errors;

--- a/toolbox/mdcode/tests/libts/semantic/action_guards.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/action_guards.test.ts
@@ -1,0 +1,271 @@
+// Behavior specification for the link between an action and the constraints
+// that gate it: the action's `guards` list.
+//
+// A constraint that quantifies over data alone holds for every write and is
+// enforced without being named anywhere. A constraint that reads an action's
+// parameters describes the call instead, so the only moment it can be checked
+// is before that call runs -- which happens only when the action names it. That
+// asymmetry is what these tests pin down: naming resolves (or fails to resolve)
+// at push time, and an unnamed parameter-reading constraint is reported at load
+// time as text nothing will evaluate.
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
+import {generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
+import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
+import {serializeModel} from '../../../src/libts/semantic/osi_converter';
+import {validatePushRequirements} from '../../../src/libts/semantic/validate';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const OPTS = {
+  project: 'dest',
+  location: 'us',
+  entryGroup: 'eg'
+};
+
+const MCP_EXECUTOR = {
+  mcp: {server: '//agentregistry.googleapis.com/x', tool: 'place_order'},
+};
+
+// One entity, one action, and whatever constraints a test needs. `guards` is
+// passed through verbatim so a test can name a constraint that does not exist.
+function withGuards(
+    guards: string[]|undefined, constraints: any[] = [],
+    parameters: any[] = [{name: 'quantity', type: 'Integer'}]) {
+  return fromDocument({
+    version: '0.2.0.dev0/google',
+    semantic_model: [{
+      name: 'm',
+      datasets: [{
+        name: 'customer',
+        source: 'p.d.c',
+        primary_key: ['id'],
+        fields: [{
+          name: 'balance',
+          expression:
+              {dialects: [{dialect: 'ANSI_SQL', expression: 'balance'}]},
+        }],
+      }],
+      actions: [{
+        name: 'PlaceOrder',
+        executor: MCP_EXECUTOR,
+        parameters,
+        ...(guards ? {guards} : {}),
+      }],
+      constraints,
+    }],
+  });
+}
+
+
+describe('loader parses an action\'s guards', () => {
+  test('carries the constraint names onto the action', () => {
+    const {models} = withGuards(
+        ['PositiveQuantity'],
+        [{name: 'PositiveQuantity', expression: 'quantity > 0'}]);
+    expect(models[0].actions![0].guards).toEqual(['PositiveQuantity']);
+  });
+
+  test('omits guards entirely when the action names none', () => {
+    const {models} = withGuards(undefined);
+    expect(models[0].actions![0].guards).toBeUndefined();
+  });
+
+  test('a repeated guard is a hard load error', () => {
+    // Checking one constraint twice reads as two rules, so it is rejected the
+    // way every other duplicate name is.
+    expect(
+        () => withGuards(['C', 'C'], [{name: 'C', expression: 'quantity > 0'}]))
+        .toThrow(/duplicate guard 'C'/);
+  });
+
+  test(
+      'guards are rejected under vanilla Ossie, as actions themselves are',
+      () => {
+        expect(
+            () => fromDocument({
+              version: '0.2.0.dev0',
+              semantic_model: [{
+                name: 'm',
+                datasets: [{
+                  name: 'c',
+                  source: 'p.d.c',
+                  primary_key: ['id'],
+                  fields: [{
+                    name: 'balance',
+                    expression: {
+                      dialects: [{dialect: 'ANSI_SQL', expression: 'balance'}]
+                    },
+                  }],
+                }],
+                actions: [{
+                  name: 'PlaceOrder',
+                  executor: MCP_EXECUTOR,
+                  guards: ['C'],
+                }],
+              }],
+            }))
+            .toThrow(/actions/);
+      });
+});
+
+
+describe('validatePushRequirements resolves every guard', () => {
+  const googleExt = {
+    vendorName: 'GOOGLE',
+    data: JSON.stringify({
+      deploymentTargets:
+          ['//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g']
+    }),
+  };
+
+  function loaded(guards: string[], constraintNames: string[]): LoadedModel {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{
+        name: 'customer',
+        dataSource: 'p.d.c',
+        keys: ['id'],
+        fields: [{name: 'balance'}],
+      }],
+      relationships: [],
+      metrics: [],
+      actions: [{
+        name: 'PlaceOrder',
+        executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+        parameters: [{name: 'quantity', type: 'Integer', isEntityRef: false}],
+        guards,
+      }],
+      constraints: constraintNames.map(
+          name => ({name, expression: 'customer.balance >= 0'})),
+      customExtensions: [googleExt],
+    };
+    return {document: 'doc', model};
+  }
+
+  test('a guard naming a declared constraint passes', () => {
+    expect(validatePushRequirements([loaded(['C'], ['C'])])).toEqual([]);
+  });
+
+  test('a guard naming no constraint is a hard error', () => {
+    // The author believes the write is checked; nothing checks it. Failing the
+    // push is the only way that belief gets corrected.
+    const errs = validatePushRequirements([loaded(['Typo'], ['C'])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain(`action 'PlaceOrder'`);
+    expect(errs[0]).toContain(`guarded by 'Typo'`);
+    expect(errs[0]).toContain('declares no constraint');
+  });
+
+  test(
+      'a model that declares no constraints at all still reports the guard',
+      () => {
+        const errs = validatePushRequirements([loaded(['C'], [])]);
+        expect(errs).toHaveLength(1);
+        expect(errs[0]).toContain(`guarded by 'C'`);
+      });
+
+  test('one error per unresolved guard', () => {
+    const errs = validatePushRequirements([loaded(['A', 'B'], [])]);
+    expect(errs).toHaveLength(2);
+  });
+});
+
+
+describe(
+    'an unguarded parameter-reading constraint is reported at load', () => {
+      test('warns when a constraint reads a parameter no action guards', () => {
+        const {warnings} = withGuards(
+            undefined,
+            [{name: 'PositiveQuantity', expression: 'quantity > 0'}]);
+        const w = warnings.find(x => x.includes('PositiveQuantity'));
+        expect(w).toBeDefined();
+        expect(w).toContain(`reads 'quantity'`);
+        expect(w).toContain(`parameter of action 'PlaceOrder'`);
+        expect(w).toContain('guards');
+      });
+
+      test('stays silent once the action names it', () => {
+        const {warnings} = withGuards(
+            ['PositiveQuantity'],
+            [{name: 'PositiveQuantity', expression: 'quantity > 0'}]);
+        expect(warnings.some(w => w.includes('PositiveQuantity'))).toBe(false);
+      });
+
+      test('a qualified name is not a parameter read', () => {
+        // `OrderedAs.quantity` is a field of something in the ontology that
+        // happens to share the parameter's name. Warning here would train an
+        // author to ignore the warning, so the scan consumes a qualified name
+        // whole.
+        const {warnings} = withGuards(
+            undefined,
+            [{name: 'PositiveQuantity', expression: 'OrderedAs.quantity > 0'}]);
+        expect(warnings.some(w => w.includes('PositiveQuantity'))).toBe(false);
+      });
+
+      test(
+          'a constraint over data alone needs no guard and draws no warning',
+          () => {
+            const {warnings} = withGuards(
+                undefined,
+                [{name: 'NonNegative', expression: 'customer.balance >= 0'}]);
+            expect(warnings.some(w => w.includes('NonNegative'))).toBe(false);
+          });
+
+      test('the parameter must belong to the action being reported', () => {
+        // `quantity` is not a parameter of an action that takes only a
+        // customer, so that action is not the one told to guard the constraint.
+        const {warnings} = withGuards(
+            undefined, [{name: 'PositiveQuantity', expression: 'quantity > 0'}],
+            [{name: 'customer', type: 'customer'}]);
+        expect(warnings.some(w => w.includes('PositiveQuantity'))).toBe(false);
+      });
+    });
+
+
+describe('guards survive every round trip', () => {
+  const model = (() => {
+    const text = fs.readFileSync(
+        path.join(FIXTURES, 'actions_place_order.yaml'), 'utf8');
+    return loadModels(text).models[0];
+  })();
+
+  test(
+      'the fixture action is guarded by a constraint the model declares',
+      () => {
+        expect(model.actions![0].guards).toEqual([
+          'RequestedQuantityIsPositive'
+        ]);
+        expect(model.constraints!.map(c => c.name))
+            .toContain('RequestedQuantityIsPositive');
+      });
+
+  test('OSI serialize -> reload', () => {
+    const {yaml} = serializeModel(model);
+    expect(loadModels(yaml).models[0].actions![0].guards).toEqual([
+      'RequestedQuantityIsPositive'
+    ]);
+  });
+
+  test('Knowledge Catalog publish -> pull', () => {
+    const {entries} = generateCatalogResources(model, OPTS);
+    const pulled = modelsFromCatalogResources(entries).models[0];
+    expect(pulled.actions![0].guards).toEqual(['RequestedQuantityIsPositive']);
+  });
+
+  test('an action with no guards publishes no guards field', () => {
+    const bare: SemanticModel = {
+      ...model,
+      actions: [{...model.actions![0], guards: undefined}],
+    };
+    const {entries} = generateCatalogResources(bare, OPTS);
+    const action =
+        entries.find(e => e.entrySource?.displayName === 'PlaceOrder')!;
+    const data = Object.values(action.aspects!)[0].data!;
+    expect(Object.keys(data)).not.toContain('guards');
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/action_guards.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/action_guards.test.ts
@@ -31,6 +31,42 @@ const MCP_EXECUTOR = {
   mcp: {server: '//agentregistry.googleapis.com/x', tool: 'place_order'},
 };
 
+// Two actions that both take a `quantity` parameter, the first guarded by
+// `guardOnFirst`. Used to check that being guarded by ONE action settles the
+// constraint for the whole model.
+function withTwoActions(guardOnFirst: string[]|undefined, constraints: any[]) {
+  return fromDocument({
+    version: '0.2.0.dev0/google',
+    semantic_model: [{
+      name: 'm',
+      datasets: [{
+        name: 'customer',
+        source: 'p.d.c',
+        primary_key: ['id'],
+        fields: [{
+          name: 'balance',
+          expression:
+              {dialects: [{dialect: 'ANSI_SQL', expression: 'balance'}]},
+        }],
+      }],
+      actions: [
+        {
+          name: 'PlaceOrder',
+          executor: MCP_EXECUTOR,
+          parameters: [{name: 'quantity', type: 'Integer'}],
+          ...(guardOnFirst ? {guards: guardOnFirst} : {}),
+        },
+        {
+          name: 'CancelOrder',
+          executor: MCP_EXECUTOR,
+          parameters: [{name: 'quantity', type: 'Integer'}],
+        },
+      ],
+      constraints,
+    }],
+  });
+}
+
 // One entity, one action, and whatever constraints a test needs. `guards` is
 // passed through verbatim so a test can name a constraint that does not exist.
 function withGuards(
@@ -224,6 +260,39 @@ describe(
             [{name: 'customer', type: 'customer'}]);
         expect(warnings.some(w => w.includes('PositiveQuantity'))).toBe(false);
       });
+
+      test('a string literal is not a parameter read', () => {
+        // `'quantity'` here is a value the expression compares against, not a
+        // reference to the parameter that shares its spelling.
+        const {warnings} = withGuards(undefined, [{
+                                        name: 'OpenOnly',
+                                        expression:
+                                            "customer.balance > 0 AND customer.status = 'quantity'",
+                                      }]);
+        expect(warnings.some(w => w.includes('OpenOnly'))).toBe(false);
+      });
+
+      test('one action guarding it settles it for every action', () => {
+        // `CancelOrder` also takes a `quantity`, and deliberately does not
+        // guard the constraint -- the same rule may gate one action and leave
+        // another alone. The constraint still runs, as PlaceOrder's guard, so
+        // reporting it as text nothing evaluates would be false.
+        const {warnings} = withTwoActions(
+            ['PositiveQuantity'],
+            [{name: 'PositiveQuantity', expression: 'quantity > 0'}]);
+        expect(warnings.some(w => w.includes('PositiveQuantity'))).toBe(false);
+      });
+
+      test('no action guarding it reports every action that could', () => {
+        const {warnings} = withTwoActions(
+            undefined, [{name: 'PositiveQuantity', expression: 'quantity > 0'}]);
+        const reported =
+            warnings.filter(w => w.includes(`constraint 'PositiveQuantity'`));
+        expect(reported).toHaveLength(2);
+        expect(reported.some(w => w.includes(`action 'PlaceOrder'`))).toBe(true);
+        expect(reported.some(w => w.includes(`action 'CancelOrder'`)))
+            .toBe(true);
+      });
     });
 
 
@@ -267,5 +336,38 @@ describe('guards survive every round trip', () => {
         entries.find(e => e.entrySource?.displayName === 'PlaceOrder')!;
     const data = Object.values(action.aspects!)[0].data!;
     expect(Object.keys(data)).not.toContain('guards');
+  });
+
+  test('a repeated guard in the aspect is dropped, with a warning', () => {
+    // The loader rejects a repeated guard outright, so keeping both would hand
+    // back a document the author cannot reload.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const entry = entries.find(e => e.entrySource?.displayName === 'PlaceOrder')!;
+    const data = Object.values(entry.aspects!)[0].data! as any;
+    data.guards = ['RequestedQuantityIsPositive', 'RequestedQuantityIsPositive'];
+    const {models, warnings} = modelsFromCatalogResources(entries);
+    expect(models[0].actions![0].guards).toEqual([
+      'RequestedQuantityIsPositive'
+    ]);
+    expect(warnings.some(
+               w => w.includes('repeats guard') &&
+                   w.includes('RequestedQuantityIsPositive')))
+        .toBe(true);
+  });
+
+  test('a guard whose constraint the pull did not recover is reported', () => {
+    // The name is kept on purpose, so the report has to come from the pull:
+    // otherwise the author meets the failure on the next push instead.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const withoutConstraints =
+        entries.filter(e => !e.entryType?.includes('semantic-constraint'));
+    const {models, warnings} = modelsFromCatalogResources(withoutConstraints);
+    expect(models[0].actions![0].guards).toEqual([
+      'RequestedQuantityIsPositive'
+    ]);
+    const w = warnings.find(x => x.includes('no constraint of that name'));
+    expect(w).toBeDefined();
+    expect(w).toContain(`action 'PlaceOrder'`);
+    expect(w).toContain(`'RequestedQuantityIsPositive'`);
   });
 });

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -261,7 +261,7 @@ describe('validatePushRequirements gates constraints', () => {
 describe('OSI round trip', () => {
   test('constraints survive serialize -> reload', () => {
     const model = loadFixtureModel('actions_place_order.yaml');
-    expect(model.constraints).toHaveLength(2);
+    expect(model.constraints).toHaveLength(3);
     const {yaml} = serializeModel(model);
     expect(yaml).toContain('constraints:');
     const reloaded = loadModels(yaml).models[0];
@@ -294,6 +294,7 @@ describe('Knowledge Catalog publish/pull round trip', () => {
          expect(constraints.map(e => e.name.split('/entries/')[1])).toEqual([
            'sales.constraints.NonNegativeOrderTotal',
            'sales.constraints.PositiveQuantity',
+           'sales.constraints.RequestedQuantityIsPositive',
          ]);
          for (const e of constraints) expect(e.parentEntry).toBe(entries[0].name);
          // Author is warned constraints are catalog-only.
@@ -413,7 +414,8 @@ describe('Knowledge Catalog publish/pull round trip', () => {
     broken.aspects![CONSTRAINT_ASPECT].data!.expression = '  ';
     const {models, warnings} = modelsFromCatalogResources(entries);
     expect(models[0].constraints!.map(c => c.name)).toEqual([
-      'NonNegativeOrderTotal'
+      'NonNegativeOrderTotal',
+      'RequestedQuantityIsPositive',
     ]);
     expect(warnings.some(
                w => w.includes("constraint 'PositiveQuantity'") &&
@@ -438,12 +440,12 @@ describe('a graph leg says what it dropped', () => {
   ] as const) {
     test(`the ${backend} leg warns about actions and constraints`, () => {
       const {warnings} = generate(model());
-      // The fixture declares one action and two constraints.
+      // The fixture declares one action and three constraints.
       expect(warnings.some(
                  w => /1 action\(s\) reach Knowledge Catalog only/.test(w)))
           .toBe(true);
       expect(warnings.some(
-                 w => /2 constraint\(s\) reach Knowledge Catalog only/.test(w)))
+                 w => /3 constraint\(s\) reach Knowledge Catalog only/.test(w)))
           .toBe(true);
       // Named the system it does reach, and the one that drops it.
       expect(warnings.some(w => w.includes(`the ${backend} push deploys none`)))

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
@@ -152,6 +152,9 @@
                 "isEntityRef": false
               }
             ],
+            "guards": [
+              "RequestedQuantityIsPositive"
+            ],
             "instructions": "Resolve the buyer to a customer before calling."
           }
         }
@@ -200,6 +203,23 @@
           }
         }
       }
+    },
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.constraints.RequestedQuantityIsPositive",
+      "entryType": "projects/sqlgen-testing/locations/global/entryTypes/semantic-constraint",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "RequestedQuantityIsPositive",
+        "description": "A request must be for at least one unit. Ask the caller for the quantity again before retrying."
+      },
+      "aspects": {
+        "sqlgen-testing.global.semantic-constraint": {
+          "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
+          "data": {
+            "expression": "quantity > 0"
+          }
+        }
+      }
     }
   ],
   "entryLinks": [
@@ -245,8 +265,8 @@
     }
   ],
   "warnings": [
-    "model 'sales': 1 action(s) published as semantic-action entries (actions have no BigQuery Graph representation).",
-    "model 'sales': 2 constraint(s) published as semantic-constraint entries (constraints have no BigQuery Graph representation).",
+    "model 'sales': 1 action(s) published as semantic-action entries (Knowledge Catalog is the only system an action reaches).",
+    "model 'sales': 3 constraint(s) published as semantic-constraint entries (Knowledge Catalog is the only system a constraint reaches).",
     "relationship 'orders_to_customer': Knowledge Catalog stores the name only in the normalized link id, so a pull returns it lowercased/hyphenated (e.g. 'orders-to-customer'), not 'orders_to_customer'."
   ]
 }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
@@ -66,6 +66,8 @@ semantic_model:
             type: customer
           - name: quantity
             type: Integer
+        guards:
+          - RequestedQuantityIsPositive
         ai_context:
           instructions: Resolve the buyer to a customer before calling.
     constraints:
@@ -83,3 +85,7 @@ semantic_model:
       - name: PositiveQuantity
         expression: OrderedAs.quantity > 0
         description: An order line must be for at least one unit.
+      - name: RequestedQuantityIsPositive
+        expression: quantity > 0
+        description: A request must be for at least one unit. Ask the caller for the
+          quantity again before retrying.

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
@@ -48,6 +48,8 @@ semantic_model:
             type: customer
           - name: quantity
             type: Integer
+        guards:
+          - RequestedQuantityIsPositive
         ai_context:
           instructions: Resolve the buyer to a customer before calling.
     constraints:
@@ -65,3 +67,7 @@ semantic_model:
       - name: PositiveQuantity
         expression: OrderedAs.quantity > 0
         description: An order line must be for at least one unit.
+      - name: RequestedQuantityIsPositive
+        expression: quantity > 0
+        description: A request must be for at least one unit. Ask the caller for the
+          quantity again before retrying.

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -4,15 +4,19 @@
 # counterpart to a metric, and the CONSTRAINTS that gate it. PlaceOrder carries
 # an MCP executor (a tool in Agent Registry) and ontology-typed parameters: an
 # entity-typed one (`customer`, an object reference to the customer entity) and
-# scalar ones. Per-action preconditions and affects are out of scope for this
-# prototype; the gate here is model-level. The model also names a BigQuery
-# deployment target, so a push exercises the leg that deploys neither an action
-# nor a constraint.
+# scalar ones. The model also names a BigQuery deployment target, so a push
+# exercises the leg that deploys neither an action nor a constraint.
 #
-# The two constraints cover both validation paths. NonNegativeOrderTotal opens
+# The three constraints cover every validation path. NonNegativeOrderTotal opens
 # with a KNOWN entity, so its field is checked. PositiveQuantity opens with
 # `OrderedAs`, which is no entity, so it is left to the evaluator rather than
-# falsely rejected.
+# falsely rejected. RequestedQuantityIsPositive reads the action's `quantity`
+# parameter, so PlaceOrder names it in `guards`.
+#
+# Those last two are one business rule in its two bindings. The invariant holds
+# over stored order lines, whatever wrote them. The guard holds over the
+# argument a caller passed, and can be checked only before the call runs, which
+# is why a guard has to be named by the action and an invariant does not.
 #
 # They also cover both annotation shapes, which land in different places.
 # NonNegativeOrderTotal declares a full `ai_context` beside its description --
@@ -83,6 +87,7 @@ semantic_model:
         parameters:
           - {name: customer, type: customer}
           - {name: quantity, type: Integer}
+        guards: [RequestedQuantityIsPositive]
         ai_context:
           instructions: "Resolve the buyer to a customer before calling."
     constraints:
@@ -99,3 +104,8 @@ semantic_model:
       - name: PositiveQuantity
         expression: OrderedAs.quantity > 0
         description: An order line must be for at least one unit.
+      - name: RequestedQuantityIsPositive
+        expression: quantity > 0
+        description: >-
+          A request must be for at least one unit. Ask the caller for the
+          quantity again before retrying.


### PR DESCRIPTION
An action and a constraint were unconnected: a model could declare both, and
nothing said which rules applied to which write. This adds the one link that has
to be authored, `guards` on the action, and leaves every other constraint
applying on its own.

## Why the link goes one way

A constraint that quantifies over stored data holds for every write, whatever
performed it, so it needs no reference from anywhere. A constraint that reads an
action's parameters describes that one call instead, and the only moment it can
be checked is before the call runs — which happens only when the action names
it. So the reference exists for the constraints that would otherwise have no
moment to run, and naming one adds a check rather than switching its enforcement
on.

It lives on the action because the same rule may gate one action and leave
another alone, which makes gating a property of the pairing.

```yaml
constraints:
  - name: AmountIsPositive
    expression: amount > 0

actions:
  - name: TransferFunds
    parameters:
      - {name: source, type: Account}
      - {name: amount, type: Float}
    guards: [AmountIsPositive]
```

## What this change does

- `guards: [Name, ...]` on an action, extended profile only, as `actions`
  already is. A repeated name is a hard load error.
- Each name must resolve to a constraint the same model declares. One that does
  not fails the push, because an unresolved guard leaves the author believing
  the write is checked when nothing checks it.
- A constraint that reads a parameter no action guards is reported at load time.
  It is text nothing will evaluate. This warns rather than fails: the scan
  matches identifiers, so a qualified name (`OrderedAs.quantity`) is consumed
  whole and never counts as a parameter read.
- Guards round-trip through OSI serialize/reload and Knowledge Catalog
  publish/pull. The `semantic-action` aspect template gains a `guards` string
  array at index 10, appended so no existing field moves.
- A guard name whose constraint is absent from a pull is kept rather than
  dropped, so a partial pull never silently rewrites the author's model.

No component evaluates a guard yet, and the docs say so where a reader will look
— the same status the constraint construct itself carries today.

Two warning strings that described actions and constraints by what a property
graph lacks now name the system they reach instead, matching the rest of the
prose.

## Validation

- `npx tsc --noEmit` clean; `npx bun test` 681 pass / 0 fail across 33 files,
  including 22 new tests in `tests/libts/semantic/action_guards.test.ts`.
- Every quoted error and warning in `docs/semantic-model/actions.md` was
  produced by running the guide's own example through the real loader and
  validator, then compared byte for byte.
- Live against autopush Dataplex in `sqlgen-testing/global`: `kcmd init
  --semantic-model` appended `guards` to the already-deployed `semantic-action`
  aspect type without a backwards-compatibility rejection, `kcmd push` wrote
  `"guards": ["AmountIsPositive"]` into the published aspect, and `kcmd pull`
  recovered it into the regenerated document. The scratch entry group was
  deleted afterwards.

## Review fixes carried in this branch

- The load warning decided "unguarded" per (constraint, action) pair, so a
  constraint already named by one action still warned about every other action
  that happened to take a parameter of the same name. Being guarded anywhere is
  now enough.
- The identifier scan read string literals as code, so `status = 'quantity'`
  looked like a read of a parameter named `quantity`. Quoted spans are blanked
  before the scan.
- A repeated guard in an aspect was carried through into a document the loader
  then rejected. A repeat is now dropped to its single occurrence, with a
  warning. A guard whose constraint the pull did not recover is still kept, and
  the pull now reports it rather than leaving the failure for the next push.

## Guide restructure

`docs/semantic-model/actions.md` was reorganized around the order a reader
needs. "When to use it" had been answering four questions at once, including a
runtime limitation that arrived before the reader had seen an action; it now
answers only its own, and the limitation sits in the closing list of what is
not modeled yet. The argument for typed parameters moved under step 1, next to
the example that shows `type: Account`. Detail that belongs in lookup material
moved out of the walkthrough: the executor parse errors and the blank-versus-
omitted coordinate split joined the action validation rule in `reference.md`,
`isEntityRef` re-derivation joined the fidelity note, and the guard diagnostics
that appeared in two steps now appear once. Every diagnostic the guide still
quotes was re-verified against the real loader and validator.
