### PR TITLE
feat(mdcode): declare what an action changes with affects

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -126,8 +126,10 @@ write-side counterpart to a metric. An action names a business operation, points
 at the executor that carries it out (an MCP tool, a REST endpoint, or a gRPC
 method), and types each parameter against the ontology, so an entity-typed
 parameter is an object reference rather than a bare string. An action also
-names, in `guards`, the constraints that gate it. Knowledge Catalog is the only
-system an action reaches, and the only place it is governed. See
+names, in `guards`, the constraints that gate it, and in `affects`, the concepts
+the call changes — the executor is an opaque handle, so its blast radius is
+declared or it is unknown. Knowledge Catalog is the only system an action
+reaches, and the only place it is governed. See
 [Modeling write operations](actions.md).
 
 A model can also state **constraints**: named boolean invariants over the

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -6,7 +6,8 @@ changes state, declared over the same concepts as everything else in the model.
 
 An action does not contain the write. It names the operation, points at the
 **executor** that performs it — an MCP tool, a REST endpoint, a gRPC method —
-and types the operation's inputs against the ontology. Publishing it puts the
+types the operation's inputs against the ontology, and says which concepts the
+call changes. Publishing it puts the
 operation in the same place as the data it acts on, so an agent that discovers
 the model discovers what it can do as well as what it can ask.
 
@@ -45,6 +46,13 @@ semantic_model:
         fields:
           - { name: transferId, datatype: Integer, expression: transfer_id }
           - { name: amount,     datatype: Float,   expression: amount }
+          - { name: debitedId,  datatype: Integer, expression: debited_account_id }
+    relationships:
+      - name: TransferDebits
+        from: Transfer
+        to: Account
+        from_columns: [debitedId]
+        to_columns: [accountId]
     actions:
       - name: TransferFunds
         description: Move money from one account to another.
@@ -146,13 +154,75 @@ warning, because nothing will ever evaluate it.
 name, publishes the list, and reads it back. No component checks a guard against
 live data, so a guard states what must hold before the call and blocks no call.
 
-## 3. Check it before pushing
+## 3. Say what it changes
+
+An executor is opaque. `mcp: {server, tool}` says where the operation lives and
+nothing more — no reader of the model can see what that tool writes. So the blast
+radius of a call is declared or it is unknown, and `affects` is where the author
+declares it:
+
+```yaml
+        affects: [Account, Transfer]
+```
+
+That is the coarse form: these concepts are touched, in a way the model does not
+spell out. It is enough to answer *which actions can change an account at all*,
+which is already more than an executor name answers.
+
+A record says more — which operation, and which fields the call writes:
+
+```yaml
+        affects:
+          - concept: Account
+            operation: modify
+            fields: [balance]
+          - concept: Transfer
+            operation: create
+          - concept: TransferDebits
+            operation: create
+```
+
+The two shapes mix freely in one list, so an author can be precise about the
+concepts they know and coarse about the rest. Every `concept` — bare or named
+under the key — must be something the same model declares.
+
+### One key for both kinds
+
+`concept` names an entity or a relationship, and the model already knows which.
+Asking the author to repeat it would add a second place to get it wrong and
+change nothing about what the action affects. `TransferDebits` above is the edge
+from the example model; it is written exactly like the two entities beside it.
+
+### The operations
+
+`create`, `modify`, `delete` — the same three whatever the concept is.
+
+An edge is not only attached and detached. A many-to-many relationship is backed
+by a junction table with fields of its own, so *modify the grade on an
+Enrollment* is as ordinary a change as *modify an order's total*, and a
+vocabulary that gave edges only `add` and `remove` could not express it.
+
+`fields` narrows a `create` or a `modify` to the fields the call writes, which is
+what makes *which actions can change `Account.balance`* answerable. A `delete`
+takes the whole instance, so naming fields beside one is rejected rather than
+ignored.
+
+Both the operation and the fields are optional. `- concept: Account` on its own
+says the same thing the bare `Account` does, and is written back as the bare
+form.
+
+**Status: nothing consumes `affects` yet.** `kcmd` parses it, checks every
+concept against the model, publishes it and reads it back. No component computes
+an impact from it, routes on it, or checks it against what the executor actually
+does.
+
+## 4. Check it before pushing
 
 ```bash
 kcmd push --validate-only
 ```
 
-Three things about an action can be statically wrong once the document parses,
+Four things about an action can be statically wrong once the document parses,
 and each one is a hard error:
 
 ```
@@ -165,6 +235,9 @@ whose 'tool' is missing or blank.
 
 action 'TransferFunds' in model 'payments' (payments.yaml) is guarded by
 'AmountIsPostive', but model 'payments' declares no constraint of that name.
+
+action 'TransferFunds' in model 'payments' (payments.yaml) affects 'Acount',
+which is neither an entity nor a relationship this model declares.
 ```
 
 A parameter type that resolves to neither an entity nor a scalar means the model
@@ -172,10 +245,17 @@ cannot say what that argument denotes, which is the whole contribution an action
 makes. An executor missing a coordinate cannot be dispatched by whatever picks
 the action up. A guard that names no constraint — `AmountIsPostive` here, a
 misspelling of the `AmountIsPositive` declared above — leaves the author
-believing the write is checked when nothing checks it. All three checks are
-static, so they run on every push whatever the destination.
+believing the write is checked when nothing checks it. An `affects` entry naming
+`Acount` describes a blast radius over a concept that does not exist, so
+anything reading it reads about nothing.
 
-## 4. Push it
+The rest of an entry is checked the same way and for the same reason: fields
+beside a `delete`, and a field the concept does not declare, are each a hard
+error too. An operation outside `create` / `modify` / `delete` never gets this
+far — the vocabulary is closed, so the document does not parse at all. All of
+these checks are static, so they run on every push whatever the destination.
+
+## 5. Push it
 
 ```bash
 kcmd push
@@ -212,8 +292,17 @@ aspects:
       - {name: source, type: Account, isEntityRef: true}
       - {name: target, type: Account, isEntityRef: true}
       - {name: amount, type: Float, isEntityRef: false}
+    affects:
+      - {concept: Account, operation: modify, fields: [balance]}
+      - {concept: Transfer, operation: create}
+      - {concept: TransferDebits, operation: create}
     instructions: Resolve both accounts before calling. Name the account the money leaves as `source`.
 ```
+
+`affects` is published as the author wrote it and nothing more. Whether
+`TransferDebits` is an entity or an edge is not stored: a consumer that needs to
+know reads it off the model, which is the only thing that can say so correctly
+after a rename.
 
 Removing an action from the document deletes its entry on the next push, because
 the model owns the `<model>.actions.` id prefix. A catalog search can list the
@@ -228,7 +317,7 @@ Publishing an action needs the permission to attach its aspect, in addition to
 the permissions any push needs — see
 [Reference → Permissions](reference.md#permissions).
 
-## 5. Pull it back
+## 6. Pull it back
 
 ```bash
 kcmd pull
@@ -236,17 +325,14 @@ kcmd pull
 
 Pull collects the `semantic-action` entries under the model entry and rebuilds
 each action, so a name, a description, an executor, typed parameters, its
-`guards`, and `ai_context.instructions` survive the round trip unchanged. What
-every part of a model does and does not survive is in
+`guards`, its `affects`, and `ai_context.instructions` survive the round trip
+unchanged. What every part of a model does and does not survive is in
 [What push and pull preserve](fidelity.md).
 
 ## What is not modeled yet
 
-This is a prototype. Four things a reader reasonably expects are absent.
+This is a prototype. Three things a reader reasonably expects are absent.
 
-- **An action declares no effects.** `affects` — what the call changes — is out
-  of scope here. What must hold *before* the call is modeled: a constraint the
-  action names in [`guards`](#2-gate-it-with-a-constraint).
 - **Nothing checks the write.** No component evaluates a constraint or a guard,
   so an action is a declaration and the correctness of what the executor does
   belongs to the executor.

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -11,8 +11,8 @@ Which backend a push deploys to — BigQuery or Spanner — is set by the model'
 deployment target, or by the binding profile you select; it is not a
 command-line flag. What reaches Knowledge Catalog depends on the push as well: a
 catalog-only or purely logical push records the whole model, while a push that
-also deploys a graph records only the part the graph binds. Both effects are
-detailed under [To Knowledge Catalog](#to-knowledge-catalog).
+also deploys a graph records only the part the graph binds. Both are detailed
+under [To Knowledge Catalog](#to-knowledge-catalog).
 
 ## The round-trip matrix
 
@@ -106,8 +106,8 @@ agree on every structural row and differ only where a Spanner target has no
     about the name it kept, and a push rejects the model until the constraint
     is back. A name the aspect repeats is the one exception, dropped to its
     single occurrence because the loader rejects a repeat and the document has
-    to stay loadable. Prototype scope: an action's `affects` is not modelled,
-    so nothing about it is stored. See
+    to stay loadable. Its `affects` round-trips the same way, with the same
+    exception for a repeated concept-and-operation pair. See
     [Modeling write operations](actions.md).
 13. **Constraints.** A constraint reaches Knowledge Catalog only, as one
     `semantic-constraint` entry under the model entry, and `pull` reads it back.
@@ -148,13 +148,27 @@ expressions are still used when generating graph SQL.
 
 **Actions** follow the same one-entry-per-element rule as everything else: each
 becomes a `semantic-action` entry under the model entry, carrying its executor,
-typed parameters, and `guards` in a `semantic-action` aspect. They round-trip
-losslessly through `pull` (name, description, executor, typed parameters,
-`guards`, and `instructions`). A parameter's `isEntityRef` is re-derived against
-the entities the pull recovered rather than read back from the aspect, so it
-stays consistent with the model the pull hands you. Their `affects` is out of
-scope for this prototype and is not stored. The entry type is custom, so `kcmd
-init` creates it; a model that declares no action never needs it.
+typed parameters, `guards`, and `affects` in a `semantic-action` aspect. They
+round-trip losslessly through `pull` (name, description, executor, typed
+parameters, `guards`, `affects`, and `instructions`). A parameter's
+`isEntityRef` is re-derived against the entities the pull recovered rather than
+read back from the aspect, so it stays consistent with the model the pull hands
+you. The entry type is custom, so `kcmd init` creates it; a model that declares
+no action never needs it.
+
+What an action affects round-trips as a fact, not as the text it was authored
+in. The two authored shapes — the bare name and the record — are one shape in
+the model, so a record carrying nothing but a concept (`- concept: Account`)
+comes back as the bare `Account`, which says the same thing. Everything after
+that first pass is byte-for-byte stable.
+
+`affects` stores only what the author wrote, which is why it survives a partial
+pull intact. Whether a `concept` is an entity or an edge is not recorded, so
+nothing about it has to be re-resolved — and nothing can go stale. That matters
+most for a many-to-many relationship, which never reaches the catalog at all: a
+pull recovers relationships from the schema-join entry links, which carry the
+foreign-key edges only, so a concept naming an M:N edge would look unresolvable
+on a model that is perfectly well-formed. It comes back untouched instead.
 
 **Constraints** publish the same way: each becomes a `semantic-constraint` entry
 under the model entry, with the expression and any `instructions` in a

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -458,9 +458,21 @@ reads the document ([§6](#6-the-extension-mechanism)).
   executor that performs it, and types each parameter against the ontology, so an
   entity-typed parameter is an object reference. Its optional `guards` lists, by
   name, the constraints that gate it; each name MUST resolve to a constraint the
-  same model declares, and a repeated name is a **hard load error**. Accepted
-  only under `0.2.0.dev0/google`. `kcmd` publishes an action and never calls its
-  executor. See [Modeling write operations](actions.md).
+  same model declares, and a repeated name is a **hard load error**. Its
+  optional `affects` lists what the call changes. Each entry is either a bare
+  concept name or a record — `{concept, operation?, fields?}` — and both forms
+  normalize to the same thing. Every `concept` MUST resolve to an entity or a
+  relationship the same model declares; the two are named the same way, because
+  the model already records which one a name is. `operation` is drawn from one
+  closed vocabulary, `create` / `modify` / `delete`, whatever the concept is: a
+  many-to-many relationship is backed by a junction table with fields of its
+  own, so an edge is modified exactly as an entity is. `fields` MUST name fields
+  of the concept and MUST NOT accompany a `delete`, which takes the whole
+  instance. A repeated concept-and-operation pair is a **hard load error**.
+  Accepted only under
+  `0.2.0.dev0/google`. `kcmd` publishes an action and never calls its executor,
+  so `affects` is the author's declaration and nothing verifies it against what
+  the executor does. See [Modeling write operations](actions.md).
 
 - **`constraints` (extended profile only).** Model-level named boolean
   invariants over the ontology, written in the same expression language as a

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -285,16 +285,18 @@ relationship detail — the paired columns and foreign-key direction — in its
 aspect. Any element with `ai_context.instructions` (the model, an entity, or a
 metric) also gets a built-in `guidelines` aspect holding that text.
 
-An **action** entry carries its executor, its typed parameters, and the names
-of the constraints that gate it (`guards`) in a `semantic-action` aspect, along
-with the action's `ai_context.instructions`. A guard is stored as the constraint
-name, matching a sibling `semantic-constraint` entry on the same model, so a
-reader holding one action entry can find the rules it is checked against.
+An **action** entry carries its executor, its typed parameters, the names of the
+constraints that gate it (`guards`), and the concepts it changes (`affects`) in
+a `semantic-action` aspect, along with the action's `ai_context.instructions`. A
+guard is stored as the constraint name, matching a sibling `semantic-constraint`
+entry on the same model, so a reader holding one action entry can find the rules
+it is checked against. An affected concept is stored as its name — an entity or
+a relationship, named the same way, since the model is what says which.
 That aspect type is provisioned in your project rather than referenced from
 `dataplex-types`, because Dataplex has no built-in action type yet; when one
 ships, the entries move to it and their shape does not change. (This is the
-prototype scope — an action's `precondition` and `affects` are not modeled
-yet.)
+prototype scope — an action's `precondition` is not modeled yet, and nothing
+consumes its `affects`.)
 
 A **constraint** entry carries its expression in a `semantic-constraint`
 aspect, together with the whole of any `ai_context` declared on it. The
@@ -357,11 +359,26 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   altogether is rejected earlier, when the model is parsed. Each name in the
   action's `guards` must resolve to a constraint that the same model declares. A
   guard resolving to nothing leaves the author believing the write is checked
-  when nothing checks it. Two further rules are enforced at parse time: exactly
-  one executor kind (`executor requires exactly one kind, but 2 given (mcp,
-  rest)`) and the rejection of a repeated guard name. Every check here is
-  static, so it runs on every push, regardless of destination. Note
-  that actions themselves deploy **only** through the Knowledge Catalog leg — a
+  when nothing checks it. Every `concept` in the action's `affects` must
+  likewise resolve to an entity or a relationship the same model declares, and
+  its `fields` must be fields of that concept — for a relationship, the
+  properties of the junction table backing a many-to-many edge, so a plain
+  foreign-key edge has none. Naming fields beside a `delete` is rejected,
+  because a `delete` takes the whole instance. An affected concept that resolves
+  to nothing is reported and then left alone, since every later check about it
+  is meaningless; undeclared fields do not chain that way, so a concept that
+  does resolve reports every field it does not have. Everything that reads the
+  ontology — the concept check and the field check both — stands down on a
+  profile push, because pruning drops whole entities and whole relationships as
+  well as unbound fields, leaves actions untouched, and an action reaches no
+  graph in any case; the fields-beside-a-`delete` check reads only the entry, so
+  it still applies. Four further rules are enforced at parse time: exactly one
+  executor kind (`executor requires exactly one kind, but 2 given (mcp, rest)`),
+  the closed `create` / `modify` / `delete` vocabulary for `operation`, the
+  rejection of a repeated guard name, and the rejection of a repeated
+  concept-and-operation pair in `affects`. Every check here is static, so it
+  runs on every push, regardless of destination. Note that actions themselves
+  deploy **only** through the Knowledge Catalog leg — a
   graph-only `--no-kc` push validates them but has nowhere to put them, and
   warns that they will not be deployed. *(static)*
 * **Every constraint is checkable.** A constraint's `expression` must be

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -327,9 +327,52 @@ export interface Action {
   // and needs no reference here. Naming a constraint adds an earlier check and
   // does not switch its enforcement on.
   guards?: string[];
+  // What the call changes: its blast radius, one entry per concept touched.
+  // Declared rather than derived, because the executor is opaque -- nothing
+  // reading the model can see what an MCP tool writes. See AffectedConcept.
+  affects?: AffectedConcept[];
   aiContext?: AiContext;
   customExtensions?: CustomExtension[];
 }
+
+/**
+ * One concept an action changes, and how.
+ *
+ * `concept` is the authored name of an entity or a relationship, kept verbatim
+ * for a lossless round-trip. Which of the two it is, is deliberately NOT
+ * recorded: it is a fact about the model, it changes nothing about what the
+ * entry means, and the same three operations apply either way. Whoever needs
+ * the distinction -- validate does, to know which fields the concept has --
+ * resolves it against the model, so there is one place it can be wrong instead
+ * of two. The loader warns about a name that resolves to neither.
+ *
+ * `operation` and `fields` are optional, and their absence means "unspecified"
+ * rather than "nothing". The open format accepts a bare name as shorthand for
+ * an entry with neither -- `affects: [Order]` is the coarse blast radius the
+ * proposal describes -- so a model can start there and add precision only
+ * where a rule needs it.
+ */
+export interface AffectedConcept {
+  concept: string;  // entity or relationship name, as authored
+  operation?: ConceptOperation;
+  // The fields the operation touches, when it touches only some of them. Each
+  // must be a field of `concept`. Meaningless for a `delete`, which takes the
+  // whole instance, which is why validate rejects that pairing.
+  fields?: string[];
+}
+
+/**
+ * What an action does to a concept it affects.
+ *
+ * One vocabulary covers entities and relationships alike, because both admit
+ * the same three acts. An edge is not only added and removed: a many-to-many
+ * relationship is backed by a junction table with fields of its own (see
+ * Association), so modifying an enrollment's grade is as ordinary as modifying
+ * an order's total. Splitting the vocabulary by kind would make that change
+ * inexpressible and would buy a policy predicate nothing.
+ */
+export const CONCEPT_OPERATIONS = ['create', 'modify', 'delete'] as const;
+export type ConceptOperation = typeof CONCEPT_OPERATIONS[number];
 
 /**
  * One input to an action, typed by the ontology.

--- a/toolbox/mdcode/src/libts/semantic/kc_actions.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_actions.ts
@@ -33,7 +33,7 @@
 
 import {Entry} from '../gcp/dataplex';
 
-import {Action, ActionParameter, AiContext, DATA_TYPES, Executor, SemanticModel} from './ir';
+import {Action, ActionParameter, AffectedConcept, AiContext, CONCEPT_OPERATIONS, ConceptOperation, DATA_TYPES, Executor, SemanticModel} from './ir';
 import {ACTION_TYPE_ID, customAspectKey, customAspectTypeName, customEntryTypeName} from './kc_custom_types';
 
 // Full resource name of the action entry type for a destination.
@@ -101,6 +101,14 @@ export function actionEntries(
   const actions = model.actions ?? [];
   if (!actions.length) return [];
 
+  // A relationship is a perfectly good `affects` concept but is never in
+  // publishedEntities, so the check below reads the model's own edges for it.
+  // Pruning drops a whole relationship from the model, so a dropped one is
+  // absent from this set for the same reason a dropped entity is absent from
+  // publishedEntities.
+  const relationshipNames =
+      new Set((model.relationships ?? []).map(r => r.name));
+
   const entries: Entry[] = [];
   for (const action of actions) {
     const id = actionEntryId(modelId, action.name);
@@ -116,6 +124,21 @@ export function actionEntries(
             `not publish (abstract or unavailable), so a pull will not ` +
             `recover it as an entity reference.`);
       }
+    }
+    // The same hazard for the concepts the action declares it changes. The
+    // entry is still published -- the action does change that concept, and
+    // dropping the claim would understate the blast radius -- but the catalog
+    // then names a concept it has no entry for, and pulling that model and
+    // pushing it unpruned fails hard on the same name. Say it where the
+    // divergence is created rather than two commands later.
+    for (const affected of action.affects ?? []) {
+      if (ctx.publishedEntities.has(affected.concept)) continue;
+      if (relationshipNames.has(affected.concept)) continue;
+      warnings.push(
+          `model '${model.name}': action '${action.name}' affects ` +
+          `'${affected.concept}', which this push does not publish ` +
+          `(abstract or unavailable), so the catalog records a blast radius ` +
+          `naming a concept it has no entry for.`);
     }
     entries.push({
       name: ctx.entry(id),
@@ -143,17 +166,31 @@ export function actionEntries(
 }
 
 // The aspect payload for one action: the executor flattened to the fields of
-// its kind, the typed parameters, the constraints that gate it, and any AI
-// instructions. Guards are the constraint NAMES, matching the sibling
-// `semantic-constraint` entries by display name, so a reader holding one action
-// entry can find the rules it is checked against.
+// its kind, the typed parameters, the constraints that gate it, what it
+// changes, and any AI instructions. Guards are the constraint NAMES, matching
+// the sibling `semantic-constraint` entries by display name, so a reader
+// holding one action entry can find the rules it is checked against; an
+// an affected concept names an entity or relationship entry the same way.
 function actionAspectData(action: Action): Record<string, any> {
   return compact({
     ...executorData(action.executor),
     parameters: action.parameters.map(
         p => compact({name: p.name, type: p.type, isEntityRef: p.isEntityRef})),
     guards: action.guards?.length ? action.guards : undefined,
+    affects: action.affects?.length ? action.affects.map(affectedConceptData) :
+                                      undefined,
     instructions: action.aiContext?.instructions || undefined,
+  });
+}
+
+// One affected concept as its aspect record: exactly the three fields the IR
+// carries, so
+// the round-trip is a rename away from an identity.
+function affectedConceptData(affected: AffectedConcept): Record<string, any> {
+  return compact({
+    concept: affected.concept,
+    operation: affected.operation,
+    fields: affected.fields?.length ? [...affected.fields] : undefined,
   });
 }
 
@@ -203,11 +240,14 @@ export function actionAspectTypes(entryTypeBase: string): string[] {
 /**
  * Recovers one action from its entry, the inverse of actionEntries.
  *
- * `isEntityRef` is re-derived against `entityNames` (as the loader does) rather
- * than trusted from the stored aspect, so it stays consistent with the model
- * actually pulled. Returns undefined, with a warning, for an entry whose
- * executor is missing or malformed: one bad entry degrades itself rather than
- * the pull.
+ * `isEntityRef` is re-derived against the entity names this pull actually
+ * recovered (as the loader does) rather than trusted from the stored aspect,
+ * so it stays consistent with the model actually pulled. An affected concept
+ * needs no
+ * such treatment: it stores only what the author wrote.
+ *
+ * Returns undefined, with a warning, for an entry whose executor is missing or
+ * malformed: one bad entry degrades itself rather than the pull.
  */
 export function readAction(
     entry: Entry, entityNames: string[], warnings: string[]): Action|undefined {
@@ -248,6 +288,29 @@ export function readAction(
     guards.push(g);
   }
   if (guards.length) action.guards = guards;
+
+  // Affected concepts, deduplicated on the pair the loader rejects a repeat
+  // of, for the
+  // same reason a repeated guard is dropped here: keeping it would hand back a
+  // document that cannot be reloaded.
+  const affects: AffectedConcept[] = [];
+  const seen = new Set<string>();
+  for (const raw of asArray(data.affects)) {
+    const affected = readAffectedConcept(raw, name, warnings);
+    if (!affected) continue;
+    const key = `${affected.concept}/${affected.operation ?? ''}`;
+    if (seen.has(key)) {
+      warnings.push(
+          `action '${name}': the ${ACTION_TYPE_ID} aspect repeats the entry ` +
+          `on '${affected.concept}'; the duplicate is dropped so the ` +
+          `document still loads`);
+      continue;
+    }
+    seen.add(key);
+    affects.push(affected);
+  }
+  if (affects.length) action.affects = affects;
+
   const description = entry.entrySource?.description;
   if (description !== undefined && description !== '')
     action.description = description;
@@ -281,6 +344,41 @@ function readParameter(
         `resolved type`);
   }
   return param;
+}
+
+// One affected concept from its aspect record, the inverse of
+// affectedConceptData. A record with no concept is dropped: it names nothing,
+// so there is nothing to recover.
+//
+// Unlike readParameter, this resolves nothing against the pulled model. It
+// could not do so honestly if it tried: a pull recovers relationships from the
+// schema-join entry links, so a many-to-many edge is never among them, and
+// every entry naming one would look unresolvable on a model that is perfectly
+// well-formed. Nothing here needs the answer, so nothing asks.
+function readAffectedConcept(
+    raw: any, actionName: string,
+    warnings: string[]): AffectedConcept|undefined {
+  const concept = typeof raw?.concept === 'string' ? raw.concept : '';
+  if (!concept) return undefined;
+  const affected: AffectedConcept = {concept};
+
+  if ((CONCEPT_OPERATIONS as readonly string[]).includes(raw.operation)) {
+    affected.operation = raw.operation as ConceptOperation;
+  } else if (raw.operation !== undefined && raw.operation !== '') {
+    // An aspect edited by hand can carry anything. Dropping the operation
+    // keeps the entry (the blast radius is still true) and says why.
+    warnings.push(
+        `action '${actionName}': affects '${concept}' with an unknown ` +
+        `operation '${raw.operation}'; recovered with the operation dropped`);
+  }
+
+  const fields: string[] = [];
+  for (const f of asArray(raw.fields)) {
+    if (typeof f !== 'string' || f === '' || fields.includes(f)) continue;
+    fields.push(f);
+  }
+  if (fields.length) affected.fields = fields;
+  return affected;
 }
 
 // The IR executor from the aspect's flat fields, the inverse of executorData.

--- a/toolbox/mdcode/src/libts/semantic/kc_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_converter.ts
@@ -155,9 +155,10 @@ export function modelsFromCatalogResources(
     const model: SemanticModel = {name, entities, relationships, metrics};
     const description = anchor.entrySource?.description;
     if (description !== undefined) model.description = description;
-    const actions = childrenOf(anchor.name, actionEntries)
-                        .map(e => readAction(e, entityNames, warnings))
-                        .filter((a): a is Action => a !== undefined);
+    const actions =
+        childrenOf(anchor.name, actionEntries)
+            .map(e => readAction(e, entityNames, warnings))
+            .filter((a): a is Action => a !== undefined);
     if (actions.length) model.actions = actions;
     const constraints = childrenOf(anchor.name, constraintEntries)
                             .map(e => readConstraint(e, warnings))

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -312,6 +312,61 @@ const ACTION_ASPECT_TYPE: Omit<AspectType, 'name'> = {
               'checked before the action runs.',
         },
       },
+      {
+        index: 11,
+        name: 'affects',
+        type: 'array',
+        arrayItems: {
+          name: 'affectedConcept',
+          type: 'record',
+          recordFields: [
+            {
+              index: 1,
+              name: 'concept',
+              type: 'string',
+              constraints: {required: true},
+              annotations: {
+                displayName: 'Concept',
+                description:
+                    'The entity or relationship this action changes, by name.',
+              },
+            },
+            {
+              index: 2,
+              name: 'operation',
+              type: 'string',
+              annotations: {
+                displayName: 'Operation',
+                description:
+                    'How the concept is changed: `create`, `modify` or ' +
+                    '`delete`. The same three apply to an entity and to a ' +
+                    'relationship. Absent means unspecified.',
+              },
+            },
+            {
+              index: 3,
+              name: 'fields',
+              type: 'array',
+              arrayItems: {name: 'field', type: 'string'},
+              annotations: {
+                displayName: 'Fields',
+                description:
+                    'The fields the operation touches, when it touches only ' +
+                    'some of them. Absent means the whole instance.',
+              },
+            },
+          ],
+        },
+        annotations: {
+          displayName: 'Affects',
+          description:
+              'What a call changes: one record per concept -- an entity or ' +
+              'a relationship -- the action touches, with the operation and ' +
+              'the fields where the model states them. Declared, because an ' +
+              'executor is opaque and nothing reading the model can see ' +
+              'what it writes.',
+        },
+      },
     ],
   },
 };

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -12,7 +12,7 @@
 import * as yaml from 'yaml';
 import * as z from 'zod';
 
-import {Action, ActionParameter, AiContext, Constraint, CustomExtension, DATA_TYPES, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, ActionParameter, AffectedConcept, AiContext, CONCEPT_OPERATIONS, Constraint, CustomExtension, DATA_TYPES, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface LoadOptions {
@@ -227,6 +227,25 @@ const parameterSchema = z.object({
   type: z.string(),
 });
 
+// One thing an action changes. Two authored shapes: a bare name, which is the
+// coarse blast radius (`affects: [Order, OrderedAs]`), or a record naming the
+// `concept` plus how it is changed. One key covers an entity and a
+// relationship alike, because the same three operations apply to either. The
+// bare name is not a lesser form -- it is the same entry with the operation
+// left unspecified -- so the two mix freely in one list.
+//
+// The name is resolved against the model in toAffectedConcept, not here, for
+// the same reason a parameter type is: the schema sees one action, and only
+// the model knows what `Order` is.
+const affectedConceptSchema = z.union([
+  z.string(),
+  z.object({
+     concept: z.string(),
+     operation: z.enum(CONCEPT_OPERATIONS).optional(),
+     fields: z.array(z.string()).optional(),
+   }).strict(),
+]);
+
 const actionSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -236,6 +255,8 @@ const actionSchema = z.object({
   // are resolved against the model's own constraints in validate.ts, which sees
   // the whole model, whereas the schema sees one action.
   guards: z.array(z.string()).optional(),
+  // What the call changes. See affectedConceptSchema.
+  affects: z.array(affectedConceptSchema).optional(),
   ai_context: aiContextSchema.optional(),
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
@@ -415,6 +436,7 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
                     executor: executorSchema,
                     parameters: z.array(parameter).optional(),
                     guards: z.array(z.string()).optional(),
+                    affects: z.array(affectedConceptSchema).optional(),
                     ai_context: aiContextSchema.optional(),
                     ...ce,
                   }).strict();
@@ -484,6 +506,7 @@ type ModelDoc = z.infer<typeof modelBase>;
 type ActionDoc = z.infer<typeof actionSchema>;
 type ConstraintDoc = z.infer<typeof constraintSchema>;
 type ParameterDoc = z.infer<typeof parameterSchema>;
+type AffectedConceptDoc = z.infer<typeof affectedConceptSchema>;
 type ExecutorDoc = z.infer<typeof executorSchema>;
 type CustomExtensionDoc = z.infer<typeof customExtensionSchema>;
 // The whole document, as the convert functions see it: `version` plus the
@@ -703,10 +726,13 @@ function convertModel(
   rejectDuplicateNames(
       metrics.map(mt => mt.name), 'metric name', `model '${m.name}'`);
 
-  // Actions reference entities as parameter types, so they are converted after
-  // entities are known.
-  const actions =
-      (m.actions ?? []).map(a => convertAction(a, entityNameSet, warnings));
+  // Actions reference entities as parameter types and both entities and
+  // relationships as affected concepts, so they are converted after each is
+  // known.
+  const relationshipNameSet = new Set(relationships.map(r => r.name));
+  const actions = (m.actions ?? [])
+                      .map(a => convertAction(
+                               a, entityNameSet, relationshipNameSet, warnings));
   rejectDuplicateNames(
       actions.map(a => a.name), 'action name', `model '${m.name}'`);
 
@@ -906,7 +932,8 @@ function convertConstraint(c: ConstraintDoc): Constraint {
 // is kept verbatim and warned, so the loader stays lenient (a strict `validate`
 // gate can promote these later).
 function convertAction(
-    a: ActionDoc, entityNames: Set<string>, warnings: string[]): Action {
+    a: ActionDoc, entityNames: Set<string>, relationshipNames: Set<string>,
+    warnings: string[]): Action {
   const parameters = (a.parameters ?? [])
                          .map(p => convertParameter(
                                   p, a.name, entityNames, warnings));
@@ -926,6 +953,14 @@ function convertAction(
     rejectDuplicateNames(a.guards, 'guard', `action '${a.name}'`);
     action.guards = [...a.guards];
   }
+  if (a.affects?.length) {
+    const affects = a.affects.map(
+        e => toAffectedConcept(
+            e, a.name, entityNames, relationshipNames, warnings));
+    rejectDuplicateAffectedConcepts(affects, a.name);
+    warnMixedAffectsPrecision(affects, a.name, warnings);
+    action.affects = affects;
+  }
 
   const description = composeDescription(a.description);
   if (description) action.description = description;
@@ -934,6 +969,69 @@ function convertAction(
   const ce = toCustomExtensions(a.custom_extensions);
   if (ce) action.customExtensions = ce;
   return action;
+}
+
+// Maps one authored entry onto the IR, normalizing the two shapes to one.
+//
+// A bare name and a record with no `operation` mean the same thing, so both
+// land as an entry whose operation is unset. Whether `Order` is an entity or
+// an edge is neither authored nor stored -- it is a fact about the model, and
+// nothing about the entry depends on it -- so the names are consulted only to
+// warn about one that matches nothing, the way an unresolvable parameter type
+// does. validate is where it becomes an error.
+function toAffectedConcept(
+    e: AffectedConceptDoc, actionName: string, entityNames: Set<string>,
+    relationshipNames: Set<string>, warnings: string[]): AffectedConcept {
+  const concept = typeof e === 'string' ? e : e.concept;
+
+  const affected: AffectedConcept = {concept};
+  if (!entityNames.has(concept) && !relationshipNames.has(concept)) {
+    warnings.push(
+        `action '${actionName}': affects names '${concept}', which is ` +
+        `neither an entity nor a relationship in this model.`);
+  }
+
+  if (typeof e !== 'string') {
+    if (e.operation !== undefined) affected.operation = e.operation;
+    if (e.fields?.length) {
+      // Naming one field twice says nothing the single mention does not.
+      rejectDuplicateNames(
+          e.fields, 'affected field',
+          `action '${actionName}' affects '${concept}'`);
+      affected.fields = [...e.fields];
+    }
+  }
+  return affected;
+}
+
+// Two entries on the same concept with the same operation are one entry
+// written twice. Rejected rather than warned, like a repeated guard: it states
+// no second fact, and leaving it in would put a duplicate record in the catalog.
+function rejectDuplicateAffectedConcepts(
+    affects: AffectedConcept[], actionName: string): void {
+  rejectDuplicateNames(
+      affects.map(e => `${e.concept}/${e.operation ?? '(unspecified)'}`),
+      'affected concept', `action '${actionName}'`);
+}
+
+// An entry with no operation covers the whole concept, so pairing it with a
+// specific operation on that same concept says both "in some unstated way" and
+// "in this exact way". That is almost always a half-finished edit -- the author
+// added precision to one line and left the coarse one behind -- but it is not
+// contradictory, so it warns rather than fails.
+function warnMixedAffectsPrecision(
+    affects: AffectedConcept[], actionName: string, warnings: string[]): void {
+  const unspecified =
+      new Set(affects.filter(e => !e.operation).map(e => e.concept));
+  if (!unspecified.size) return;
+  for (const concept of new Set(
+           affects.filter(e => e.operation && unspecified.has(e.concept))
+               .map(e => e.concept))) {
+    warnings.push(
+        `action '${actionName}': affects lists '${concept}' both with an ` +
+        `operation and without one. The bare entry already covers every ` +
+        `operation on '${concept}'; drop it, or give it an operation too.`);
+  }
 }
 
 // A constraint that reads an action's parameter describes that call, so the

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -42,7 +42,7 @@
 
 import * as yaml from 'yaml';
 
-import {Action, AiContext, Constraint, CustomExtension, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, AffectedConcept, AiContext, Constraint, CustomExtension, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
 
 // The version stamped on every serialized document. Pull emits kcmd's extended
 // profile: it uses native extension keys (`entities`, `deployment_target`)
@@ -293,7 +293,28 @@ function actionDoc(action: Action, warnings: string[]): Record<string, any> {
     parameters: nonEmpty(
         (action.parameters ?? []).map(p => ({name: p.name, type: p.type}))),
     guards: nonEmpty(action.guards),
+    affects: nonEmpty((action.affects ?? []).map(affectedConceptDoc)),
     ai_context: aiContextDoc(action.aiContext),
+  });
+}
+
+// One affected concept back to the open format. An entry that says nothing
+// beyond which
+// concept it touches emits as the bare name, which is the shorthand the author
+// most likely wrote and the form the proposal uses; anything with an operation
+// or fields needs the record.
+//
+// This NORMALIZES rather than reproducing the document byte for byte: an
+// authored `{concept: Order}` with no operation comes back as `Order`. The two
+// mean the same thing, so the emit is a fixed point after one pass, which is
+// what the round-trip tests assert.
+function affectedConceptDoc(affected: AffectedConcept):
+    string|Record<string, any> {
+  if (!affected.operation && !affected.fields?.length) return affected.concept;
+  return compact({
+    concept: affected.concept,
+    operation: affected.operation,
+    fields: nonEmpty(affected.fields),
   });
 }
 

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -11,7 +11,7 @@
 import {BigQueryClient} from '../gcp/bigquery';
 
 import {googleDeploymentTargets} from './deploy_bigquery';
-import {Executor, SemanticModel} from './ir';
+import {Action, Executor, SemanticModel} from './ir';
 import {LoadedModel} from './loader';
 import {resolveInheritance} from './resolve_inheritance';
 
@@ -123,7 +123,7 @@ export function validatePushRequirements(
     // dispatch it, and each guard must name a constraint the model declares.
     // (The "exactly one executor kind" rule is already guaranteed by the loader
     // schema, so it cannot reach here.)
-    errors.push(...validateActions(model, document));
+    errors.push(...validateActions(model, document, !!opts.fieldsPruned));
 
     // Constraints are logical invariants, target-independent like actions.
     errors.push(
@@ -133,20 +133,40 @@ export function validatePushRequirements(
 }
 
 // Static, target-independent checks for a model's actions. Returns one message
-// per violation. Three things can be statically wrong once the model has
-// parsed:
+// per violation. What can be statically wrong once the model has parsed:
 //   - a parameter's type resolves to neither a known entity nor a scalar
 //     datatype (the loader left isEntityRef unset and only warned) -- an
 //     unresolvable type is a malformed action, promoted to a hard error here;
 //   - an executor is missing a coordinate a runtime needs to dispatch it (an
 //     empty server/tool, endpoint/method, or service/method) -- the schema
 //     accepts empty strings, so this is caught here rather than at parse;
-//   - a guard names a constraint the model does not declare.
-function validateActions(model: SemanticModel, document: string): string[] {
+//   - a guard names a constraint the model does not declare;
+//   - an `affects` entry names a concept the model does not declare, names
+//     fields on a 'delete' (which takes the whole instance), or names a field
+//     the concept does not have.
+//
+// Every `affects` check is a hard error for the reason the guard check is: an
+// entry that names nothing real leaves a reader believing the blast radius is
+// described when it is not, and a consumer routing on it would route on a
+// concept that does not exist.
+function validateActions(
+    model: SemanticModel, document: string, fieldsPruned: boolean): string[] {
   const errors: string[] = [];
+  const actions = model.actions ?? [];
+  if (!actions.length) return errors;
   const constraintNames =
       new Set((model.constraints ?? []).map(c => c.name));
-  for (const action of model.actions ?? []) {
+  // Built only when an `affects` entry will actually read it, which is not a
+  // cost argument: declaredFields resolves inheritance, and that THROWS on an
+  // `extends` naming an entity the model does not declare. The loader accepts
+  // such a model, a KC-only push reaches no graph leg to catch it, and a
+  // profile push can create one by pruning a supertype whole. Building this
+  // eagerly would turn any of those into a stack trace out of the validation
+  // gate, for a model this check has nothing to say about.
+  const concepts = !fieldsPruned && actions.some(a => a.affects?.length) ?
+      declaredConcepts(model) :
+      undefined;
+  for (const action of actions) {
     const where =
         `action '${action.name}' in model '${model.name}' (${document})`;
     for (const param of action.parameters) {
@@ -169,8 +189,89 @@ function validateActions(model: SemanticModel, document: string): string[] {
             model.name}' declares no constraint of that name.`);
       }
     }
+    errors.push(...affectedConceptErrors(action, where, concepts));
   }
   return errors;
+}
+
+// The errors in one action's `affects`. Split out because the checks chain: a
+// concept that does not resolve makes every later check about it meaningless,
+// so an entry that fails one of those says nothing more. Undeclared fields do
+// not chain -- each is an independent fact about a concept that did resolve --
+// so an entry reports all of them.
+//
+// An absent `concepts` says the model reaching this point is a profile's view
+// of the author's model, not the author's model. Everything that reads the
+// ontology stands down there, because pruneUnavailable drops whole entities
+// and whole relationships -- not only unbound fields -- when a profile does
+// not bind their keys or join columns. An action survives that pruning
+// untouched, so an entry on a dropped concept is the profile's doing rather
+// than the author's, and failing the deploy over it would fail it for no
+// reason. An action reaches no graph in any case. What is left is the one
+// check that reads only the entry itself.
+function affectedConceptErrors(
+    action: Action, where: string,
+    concepts: Map<string, DeclaredConcept>|undefined): string[] {
+  const errors: string[] = [];
+  for (const affected of action.affects ?? []) {
+    // A `delete` takes the whole instance, so naming fields alongside one is
+    // self-contradictory whatever the ontology says.
+    if (affected.fields?.length && affected.operation === 'delete') {
+      errors.push(
+          `${where} affects '${affected.concept}' with operation 'delete' ` +
+          `and also names fields. A 'delete' takes the whole instance; drop ` +
+          `the fields.`);
+      continue;
+    }
+    if (!concepts) continue;
+
+    const concept = concepts.get(affected.concept);
+    if (!concept) {
+      errors.push(
+          `${where} affects '${affected.concept}', which is neither an ` +
+          `entity nor a relationship this model declares.`);
+      continue;
+    }
+    for (const field of affected.fields ?? []) {
+      if (!concept.fields.has(field)) {
+        errors.push(`${where} affects '${affected.concept}.${field}', but ${
+            concept.kind} '${affected.concept}' declares no field '${field}'.`);
+      }
+    }
+  }
+  return errors;
+}
+
+// What an `affects` entry's `concept` may name, and the fields it has.
+// Entities are indexed first, so a name that is both resolves to the entity.
+// `kind` is local: it never leaves this check, and exists only to say
+// `entity 'X'` or `relationship 'X'` in a message and to pick which fields
+// count.
+//
+// Inheritance is resolved through declaredFields for the same reason the
+// constraint check does it: a subtype's own `fields` omit what it inherits.
+interface DeclaredConcept {
+  kind: 'entity'|'relationship';
+  fields: Set<string>;
+}
+function declaredConcepts(model: SemanticModel): Map<string, DeclaredConcept> {
+  const concepts = new Map<string, DeclaredConcept>();
+  for (const [name, fields] of declaredFields(model)) {
+    concepts.set(name, {kind: 'entity', fields});
+  }
+  for (const r of model.relationships ?? []) {
+    if (concepts.has(r.name)) continue;
+    // Only a many-to-many edge has fields of its own (they live on the junction
+    // table it is backed by), and those are exactly what a `modify` on an edge
+    // names -- an enrollment's grade. A plain foreign-key edge carries none, so
+    // naming fields on one is an error: the properties an author means in that
+    // case belong to an endpoint entity.
+    concepts.set(r.name, {
+      kind: 'relationship',
+      fields: new Set((r.association?.fields ?? []).map(f => f.name)),
+    });
+  }
+  return concepts;
 }
 
 

--- a/toolbox/mdcode/tests/libts/semantic/action_affects.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/action_affects.test.ts
@@ -1,0 +1,627 @@
+// Behavior specification for an action's `affects`: the concepts a call
+// changes, its blast radius.
+//
+// Nothing in the model can derive this. An executor is an opaque handle to an
+// MCP tool or an HTTP endpoint, and no reader can see what that tool writes, so
+// the blast radius is declared or it is unknown. That makes `affects` unlike
+// every other cross-reference in the model: it is the author's claim, and the
+// only thing checking it is the check written here.
+//
+// Two authored shapes reach the same IR. A bare name is the coarse claim the
+// proposal document uses -- this concept is touched, in some way not spelled
+// out. A record adds an operation and the fields it writes. One key and one set
+// of verbs cover entities and relationships alike: an edge with properties of
+// its own is modified exactly the way a row is, and nothing downstream branches
+// on which kind a name turned out to be.
+
+import {describe, expect, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {SemanticModel} from '../../../src/libts/semantic/ir';
+import {modelsFromCatalogResources} from '../../../src/libts/semantic/kc_converter';
+import {generateCatalogResources} from '../../../src/libts/semantic/knowledge_catalog';
+import {fromDocument, LoadedModel, loadModels} from '../../../src/libts/semantic/loader';
+import {serializeModel} from '../../../src/libts/semantic/osi_converter';
+import {validatePushRequirements} from '../../../src/libts/semantic/validate';
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+const OPTS = {
+  project: 'dest',
+  location: 'us',
+  entryGroup: 'eg'
+};
+
+const MCP_EXECUTOR = {
+  mcp: {server: '//agentregistry.googleapis.com/x', tool: 'place_order'},
+};
+
+// Two entities and the edge between them, so a test can name a concept of each
+// kind. `affects` is passed through verbatim: a test names something that does
+// not exist by writing it, exactly as an author would.
+function withAffects(affects: any[]|undefined, version = '0.2.0.dev0/google') {
+  return fromDocument({
+    version,
+    semantic_model: [{
+      name: 'm',
+      datasets: [
+        {
+          name: 'orders',
+          source: 'p.d.o',
+          primary_key: ['id'],
+          fields: [
+            {
+              name: 'id',
+              expression: {dialects: [{dialect: 'ANSI_SQL', expression: 'id'}]},
+            },
+            {
+              name: 'total',
+              expression:
+                  {dialects: [{dialect: 'ANSI_SQL', expression: 'total'}]},
+            },
+          ],
+        },
+        {
+          name: 'customer',
+          source: 'p.d.c',
+          primary_key: ['cid'],
+          fields: [{
+            name: 'cid',
+            expression: {dialects: [{dialect: 'ANSI_SQL', expression: 'cid'}]},
+          }],
+        },
+      ],
+      relationships: [{
+        name: 'orders_to_customer',
+        from: 'orders',
+        to: 'customer',
+        from_columns: ['id'],
+        to_columns: ['cid'],
+      }],
+      actions: [{
+        name: 'PlaceOrder',
+        executor: MCP_EXECUTOR,
+        parameters: [{name: 'quantity', type: 'Integer'}],
+        ...(affects ? {affects} : {}),
+      }],
+    }],
+  });
+}
+
+
+describe('the loader normalizes both authored shapes', () => {
+  test('a bare name is the whole entry', () => {
+    // The coarse form the proposal document uses. It says only that the
+    // concept is touched, in a way the model does not spell out.
+    const {models, warnings} = withAffects(['orders']);
+    expect(models[0].actions![0].affects).toEqual([{concept: 'orders'}]);
+    expect(warnings.some(w => w.includes('affects'))).toBe(false);
+  });
+
+  test('a record keeps its operation and fields', () => {
+    const {models} = withAffects([
+      {concept: 'orders', operation: 'create', fields: ['id', 'total']},
+    ]);
+    expect(models[0].actions![0].affects).toEqual([{
+      concept: 'orders',
+      operation: 'create',
+      fields: ['id', 'total'],
+    }]);
+  });
+
+  test('an entry on a relationship uses the same key and the same verbs',
+       () => {
+         // The point of the single vocabulary: nothing about this entry
+         // differs from one on an entity, and the IR records nothing that says
+         // which kind `orders_to_customer` turned out to be.
+         const {models, warnings} =
+             withAffects([{concept: 'orders_to_customer', operation: 'create'}]);
+         expect(models[0].actions![0].affects).toEqual([{
+           concept: 'orders_to_customer',
+           operation: 'create',
+         }]);
+         expect(warnings.some(w => w.includes('affects'))).toBe(false);
+       });
+
+  test('the two shapes mix freely in one list', () => {
+    const {models} = withAffects([
+      {concept: 'orders', operation: 'create'},
+      'customer',
+    ]);
+    expect(models[0].actions![0].affects!.map(e => e.concept)).toEqual([
+      'orders', 'customer'
+    ]);
+  });
+
+  test('an action that declares nothing carries no affects', () => {
+    expect(withAffects(undefined).models[0].actions![0].affects)
+        .toBeUndefined();
+  });
+
+  test('an empty list carries no affects either', () => {
+    expect(withAffects([]).models[0].actions![0].affects).toBeUndefined();
+  });
+
+  test('a concept that resolves to nothing is kept, with a warning', () => {
+    // Kept rather than dropped: the push is where an unresolvable name fails,
+    // and dropping it here would make that failure impossible to reach.
+    const {models, warnings} = withAffects(['Shipment']);
+    expect(models[0].actions![0].affects).toEqual([{concept: 'Shipment'}]);
+    const w = warnings.find(x => x.includes('Shipment'));
+    expect(w).toBeDefined();
+    expect(w).toContain('neither an entity nor a relationship');
+  });
+});
+
+
+describe('the loader rejects an entry that states no single fact', () => {
+  test('the old `entity:` key, now that one key covers both kinds', () => {
+    expect(() => withAffects([{entity: 'orders'}])).toThrow();
+  });
+
+  test('a record naming no concept', () => {
+    expect(() => withAffects([{operation: 'create'}])).toThrow();
+  });
+
+  test('an unknown operation', () => {
+    // The vocabulary is closed. A consumer routing on the operation cannot be
+    // handed a verb it has no case for.
+    expect(() => withAffects([{concept: 'orders', operation: 'upsert'}]))
+        .toThrow();
+  });
+
+  test('`add`, which an edge once had and no longer does', () => {
+    expect(() => withAffects([{
+             concept: 'orders_to_customer',
+             operation: 'add',
+           }])).toThrow();
+  });
+
+  test('an unknown key in the record', () => {
+    expect(() => withAffects([{concept: 'orders', opration: 'create'}]))
+        .toThrow();
+  });
+
+  test('the same concept and operation twice', () => {
+    expect(
+        () => withAffects([
+          {concept: 'orders', operation: 'create'},
+          {concept: 'orders', operation: 'create'},
+        ]))
+        .toThrow(/duplicate affected concept 'orders\/create'/);
+  });
+
+  test('the same bare concept twice', () => {
+    expect(() => withAffects(['orders', 'orders']))
+        .toThrow(/duplicate affected concept/);
+  });
+
+  test('a field named twice in one entry', () => {
+    expect(
+        () => withAffects(
+            [{concept: 'orders', operation: 'modify', fields: ['id', 'id']}]))
+        .toThrow(/duplicate affected field 'id'/);
+  });
+
+  test('two operations on one concept are two distinct facts', () => {
+    const {models} = withAffects([
+      {concept: 'orders', operation: 'create'},
+      {concept: 'orders', operation: 'modify'},
+    ]);
+    expect(models[0].actions![0].affects).toHaveLength(2);
+  });
+
+  test('a bare concept beside a specific one warns about the mix', () => {
+    // Not contradictory, so it loads -- but it says both "in some unstated
+    // way" and "in this exact way", which is almost always a half-finished
+    // edit.
+    const {warnings} = withAffects(['orders', {
+                                     concept: 'orders',
+                                     operation: 'create',
+                                   }]);
+    const w = warnings.find(x => x.includes('both with an operation'));
+    expect(w).toBeDefined();
+    expect(w).toContain(`'orders'`);
+  });
+
+  test('affects is rejected under vanilla Ossie, as actions themselves are',
+       () => {
+         expect(() => withAffects(['orders'], '0.2.0.dev0')).toThrow(/actions/);
+       });
+});
+
+
+describe('validatePushRequirements checks every affected concept', () => {
+  const googleExt = {
+    vendorName: 'GOOGLE',
+    data: JSON.stringify({
+      deploymentTargets:
+          ['//bigquery.googleapis.com/projects/p/datasets/d/propertyGraphs/g']
+    }),
+  };
+
+  // One entity, one plain foreign-key edge, and one many-to-many edge with a
+  // property of its own -- the three things an entry can name.
+  function loaded(affects: any[]): LoadedModel {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [{
+        name: 'orders',
+        dataSource: 'p.d.o',
+        keys: ['id'],
+        fields: [{name: 'id'}, {name: 'total'}],
+      }],
+      relationships: [
+        {
+          name: 'orders_to_customer',
+          source: {entity: 'orders', columns: ['id']},
+          destination: {entity: 'orders', columns: ['id']},
+        },
+        {
+          name: 'OrderedAs',
+          source: {entity: 'orders', columns: ['id']},
+          destination: {entity: 'orders', columns: ['id']},
+          association: {
+            dataSource: 'p.d.lineitem',
+            keys: ['lid'],
+            sourceColumns: ['oid'],
+            destinationColumns: ['pid'],
+            fields: [{name: 'quantity'}],
+          },
+        },
+      ],
+      metrics: [],
+      actions: [{
+        name: 'PlaceOrder',
+        executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+        parameters: [],
+        affects,
+      }],
+      customExtensions: [googleExt],
+    };
+    return {document: 'doc', model};
+  }
+
+  test('an entry naming a declared entity and its own fields passes', () => {
+    expect(validatePushRequirements([loaded([{
+             concept: 'orders',
+             operation: 'create',
+             fields: ['id', 'total'],
+           }])]))
+        .toEqual([]);
+  });
+
+  test('modifying a property of a many-to-many edge passes', () => {
+    // The change the split vocabulary could not express: a junction table has
+    // fields of its own, so an edge is modified exactly the way a row is.
+    expect(validatePushRequirements([loaded([{
+             concept: 'OrderedAs',
+             operation: 'modify',
+             fields: ['quantity'],
+           }])]))
+        .toEqual([]);
+  });
+
+  test('a concept the model does not declare is a hard error', () => {
+    // The author believes the blast radius is described; it names a concept
+    // that does not exist, so anything routing on it routes on nothing.
+    const errs = validatePushRequirements([loaded([{concept: 'Shipment'}])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain(`action 'PlaceOrder'`);
+    expect(errs[0]).toContain(`affects 'Shipment'`);
+    expect(errs[0]).toContain('neither an entity nor a relationship');
+  });
+
+  test('fields on a delete are a hard error', () => {
+    const errs = validatePushRequirements([loaded([{
+      concept: 'orders',
+      operation: 'delete',
+      fields: ['total'],
+    }])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain('takes the whole instance');
+  });
+
+  test('a field the concept does not declare is a hard error', () => {
+    const errs = validatePushRequirements([loaded([{
+      concept: 'orders',
+      operation: 'modify',
+      fields: ['total', 'shipped_at'],
+    }])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain(`affects 'orders.shipped_at'`);
+    expect(errs[0]).toContain(`entity 'orders' declares no field 'shipped_at'`);
+  });
+
+  test('naming fields on a plain foreign-key edge is always an error', () => {
+    // Only a many-to-many junction carries properties of its own, so a field
+    // on any other edge cannot resolve to anything.
+    const errs = validatePushRequirements([loaded([{
+      concept: 'orders_to_customer',
+      operation: 'modify',
+      fields: ['quantity'],
+    }])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain(
+        `relationship 'orders_to_customer' declares no field 'quantity'`);
+  });
+
+  test('each entry reports one problem, not a cascade', () => {
+    // A concept that does not resolve makes every later check about it
+    // meaningless, so that is the only thing said about it.
+    const errs = validatePushRequirements([loaded(
+        [{concept: 'Shipment', operation: 'modify', fields: ['a', 'b']}])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain('neither an entity nor a relationship');
+  });
+
+  test('one error per bad entry', () => {
+    const errs = validatePushRequirements(
+        [loaded([{concept: 'Shipment'}, {concept: 'Invoice'}])]);
+    expect(errs).toHaveLength(2);
+  });
+
+  test('an entity wins a name that is also a relationship', () => {
+    // Resolution has to be a total function of the model, and the loader's
+    // warning indexes entities first for the same reason: the two must agree,
+    // or a model would load clean and be checked against the other concept.
+    // `id` is a field of the entity and of no edge, so this passes only if the
+    // entity won.
+    const {document, model} =
+        loaded([{concept: 'dual', operation: 'modify', fields: ['id']}]);
+    model.entities.push({
+      name: 'dual',
+      dataSource: 'p.d.x',
+      keys: ['id'],
+      fields: [{name: 'id'}],
+    });
+    model.relationships!.push({
+      name: 'dual',
+      source: {entity: 'orders', columns: ['id']},
+      destination: {entity: 'orders', columns: ['id']},
+    });
+    expect(validatePushRequirements([{document, model}])).toEqual([]);
+  });
+
+  test('a profile push stands down on everything that reads the ontology',
+       () => {
+         // pruneUnavailable drops whole entities and whole relationships, not
+         // only unbound fields, and leaves actions untouched -- so under a
+         // profile an entry naming a missing field OR a missing concept is
+         // the profile's doing, not the author's. An action reaches no graph
+         // in any case, so failing the deploy over either would fail it for no
+         // reason.
+         const field = [{
+           concept: 'orders',
+           operation: 'modify',
+           fields: ['not_bound_here'],
+         }];
+         const concept = [{concept: 'Shipment'}];
+         expect(validatePushRequirements([loaded(field)])).toHaveLength(1);
+         expect(validatePushRequirements([loaded(concept)])).toHaveLength(1);
+         expect(validatePushRequirements([loaded(field)], {fieldsPruned: true}))
+             .toEqual([]);
+         expect(
+             validatePushRequirements([loaded(concept)], {fieldsPruned: true}))
+             .toEqual([]);
+       });
+
+  test('a profile push still rejects fields on a delete', () => {
+    // The one check that reads only the entry, so pruning cannot excuse it.
+    expect(validatePushRequirements(
+               [loaded([{
+                 concept: 'orders',
+                 operation: 'delete',
+                 fields: ['total'],
+               }])],
+               {fieldsPruned: true}))
+        .toHaveLength(1);
+  });
+
+  // A model whose `extends` names an entity it does not declare. The loader
+  // does not check that, and a KC-only push runs no graph leg that would, so
+  // such a model reaches this gate intact -- and resolving its inheritance
+  // throws. The gate exists to PRINT problems, so it must not die with a stack
+  // trace on a model it has nothing to say about.
+  function withDanglingSupertype(affects: any[]): LoadedModel {
+    const m = loaded(affects);
+    m.model.entities.push({
+      name: 'RushOrder',
+      extends: ['PriorityOrder'],
+      dataSource: 'p.d.r',
+      keys: ['id'],
+      fields: [{name: 'id'}],
+    });
+    return m;
+  }
+
+  test('a dangling extends does not crash a model with no affects', () => {
+    // Nothing here reads the ontology, so nothing may resolve inheritance.
+    expect(validatePushRequirements([withDanglingSupertype([])])).toEqual([]);
+  });
+
+  test('a dangling extends does not crash a profile push', () => {
+    // Pruning can create the dangling `extends` itself, by dropping a concrete
+    // supertype whole when the profile leaves its key unbound. So the standdown
+    // has to come before the index is built, not inside the loop over entries.
+    const m = withDanglingSupertype([{concept: 'orders', operation: 'modify'}]);
+    expect(validatePushRequirements([m], {fieldsPruned: true})).toEqual([]);
+  });
+});
+
+
+describe('publishing says when a blast radius outruns the push', () => {
+  // An action is published whole while entities are not: an abstract one has no
+  // table to publish, and a binding profile drops any concept it cannot bind.
+  // `affects` is left untouched by both, so the catalog can end up recording a
+  // change to a concept it holds no entry for. That is the right entry to
+  // publish -- the action does change it -- but it is a divergence, and pulling
+  // the model back and pushing it unpruned fails hard on the same name. So it
+  // is reported where it is created.
+  function published(affects: any[]) {
+    const model: SemanticModel = {
+      name: 'm',
+      entities: [
+        {
+          name: 'orders',
+          dataSource: 'p.d.o',
+          keys: ['id'],
+          fields: [{name: 'id'}],
+        },
+        // No physical table, so no dataSource or keys -- exactly what
+        // the entity loop skips.
+        {
+          name: 'Party',
+          abstract: true,
+          dataSource: '',
+          keys: [],
+          fields: [{name: 'id'}],
+        },
+      ],
+      relationships: [{
+        name: 'orders_to_customer',
+        source: {entity: 'orders', columns: ['id']},
+        destination: {entity: 'orders', columns: ['id']},
+      }],
+      metrics: [],
+      actions: [{
+        name: 'PlaceOrder',
+        executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+        parameters: [],
+        affects,
+      }],
+    };
+    return generateCatalogResources(model, OPTS).warnings;
+  }
+
+  test('a concept this push publishes draws no warning', () => {
+    // Including a relationship, which is never in publishedEntities and would
+    // warn on every well-formed model if that were the only set consulted.
+    const w = published([{concept: 'orders'}, {concept: 'orders_to_customer'}]);
+    expect(w.filter(x => x.includes('affects'))).toEqual([]);
+  });
+
+  test('an abstract concept is published, with a warning', () => {
+    const w = published([{concept: 'Party', operation: 'modify'}]);
+    const about = w.filter(x => x.includes(`affects 'Party'`));
+    expect(about).toHaveLength(1);
+    expect(about[0]).toContain('has no entry for');
+  });
+});
+
+
+describe('affects survives every round trip', () => {
+  const model = (() => {
+    const text = fs.readFileSync(
+        path.join(FIXTURES, 'actions_place_order.yaml'), 'utf8');
+    return loadModels(text).models[0];
+  })();
+
+  const EXPECTED = [
+    {
+      concept: 'orders',
+      operation: 'create',
+      fields: ['o_orderkey', 'o_totalprice'],
+    },
+    {concept: 'orders_to_customer', operation: 'create'},
+    {concept: 'customer'},
+  ];
+
+  test('the fixture action declares all three shapes', () => {
+    expect(model.actions![0].affects).toEqual(EXPECTED as any);
+  });
+
+  test('OSI serialize -> reload', () => {
+    const {yaml} = serializeModel(model);
+    expect(loadModels(yaml).models[0].actions![0].affects)
+        .toEqual(EXPECTED as any);
+  });
+
+  test('the emitted document is a fixed point after one pass', () => {
+    // The emitter normalizes rather than reproducing what was authored: a
+    // record with nothing but a concept comes back as a bare name. Reloading
+    // and re-emitting therefore has to change nothing more.
+    const once = serializeModel(model).yaml;
+    const twice = serializeModel(loadModels(once).models[0]).yaml;
+    expect(twice).toBe(once);
+  });
+
+  test('an authored record with no operation emits as a bare name', () => {
+    const {models} = withAffects([{concept: 'orders'}]);
+    const {yaml} = serializeModel(models[0]);
+    expect(yaml).toContain('affects:\n          - orders\n');
+  });
+
+  test('Knowledge Catalog publish -> pull', () => {
+    const {entries} = generateCatalogResources(model, OPTS);
+    const pulled = modelsFromCatalogResources(entries).models[0];
+    expect(pulled.actions![0].affects).toEqual(EXPECTED as any);
+  });
+
+  test('a pull that recovers no relationships still round-trips the edge', () =>
+       {
+         // Relationships reach the catalog as `schema-join` entry LINKS, and a
+         // pull that did not fetch them recovers none -- which is also the
+         // permanent state of a many-to-many edge, since those are never
+         // published. The entry on the edge still comes back untouched and in
+         // silence, because nothing about it was ever resolved against the
+         // model. That is what dropping the derived kind bought.
+         const {entries} = generateCatalogResources(model, OPTS);
+         const {models, warnings} = modelsFromCatalogResources(entries);
+         expect(models[0].relationships).toEqual([]);
+         expect(models[0].actions![0].affects).toEqual(EXPECTED as any);
+         expect(warnings.some(w => w.includes('orders_to_customer')))
+             .toBe(false);
+       });
+
+  test('an action with no entries publishes no affects field', () => {
+    const bare: SemanticModel = {
+      ...model,
+      actions: [{...model.actions![0], affects: undefined}],
+    };
+    const {entries} = generateCatalogResources(bare, OPTS);
+    const action =
+        entries.find(e => e.entrySource?.displayName === 'PlaceOrder')!;
+    const data = Object.values(action.aspects!)[0].data!;
+    expect(Object.keys(data)).not.toContain('affects');
+  });
+
+  // The aspect an author edits by hand in the catalog console can carry
+  // anything, so the read side is written not to trust it.
+  function pullWithAspect(mutate: (data: any) => void) {
+    const {entries} = generateCatalogResources(model, OPTS);
+    const entry =
+        entries.find(e => e.entrySource?.displayName === 'PlaceOrder')!;
+    mutate(Object.values(entry.aspects!)[0].data! as any);
+    return modelsFromCatalogResources(entries);
+  }
+
+  test('a repeated entry in the aspect is dropped, with a warning', () => {
+    // The loader rejects the repeat outright, so keeping both would hand back
+    // a document the author cannot reload.
+    const {models, warnings} = pullWithAspect(data => {
+      data.affects = [data.affects[0], data.affects[0]];
+    });
+    expect(models[0].actions![0].affects).toHaveLength(1);
+    expect(warnings.some(w => w.includes('repeats the entry'))).toBe(true);
+  });
+
+  test('an unknown operation is dropped and the entry kept', () => {
+    // The blast radius is still true even when the verb is not one we know,
+    // and dropping the whole entry would lose that.
+    const {models, warnings} = pullWithAspect(data => {
+      data.affects[0].operation = 'upsert';
+    });
+    const affected = models[0].actions![0].affects![0];
+    expect(affected.concept).toBe('orders');
+    expect(affected.operation).toBeUndefined();
+    expect(warnings.some(w => w.includes('unknown operation'))).toBe(true);
+  });
+
+  test('a record naming no concept is dropped', () => {
+    const {models} = pullWithAspect(data => {
+      data.affects.push({operation: 'create'});
+    });
+    expect(models[0].actions![0].affects).toHaveLength(EXPECTED.length);
+  });
+});

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
@@ -155,6 +155,23 @@
             "guards": [
               "RequestedQuantityIsPositive"
             ],
+            "affects": [
+              {
+                "concept": "orders",
+                "operation": "create",
+                "fields": [
+                  "o_orderkey",
+                  "o_totalprice"
+                ]
+              },
+              {
+                "concept": "orders_to_customer",
+                "operation": "create"
+              },
+              {
+                "concept": "customer"
+              }
+            ],
             "instructions": "Resolve the buyer to a customer before calling."
           }
         }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
@@ -68,6 +68,15 @@ semantic_model:
             type: Integer
         guards:
           - RequestedQuantityIsPositive
+        affects:
+          - concept: orders
+            operation: create
+            fields:
+              - o_orderkey
+              - o_totalprice
+          - concept: orders_to_customer
+            operation: create
+          - customer
         ai_context:
           instructions: Resolve the buyer to a customer before calling.
     constraints:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
@@ -50,6 +50,15 @@ semantic_model:
             type: Integer
         guards:
           - RequestedQuantityIsPositive
+        affects:
+          - concept: orders
+            operation: create
+            fields:
+              - o_orderkey
+              - o_totalprice
+          - concept: orders_to_customer
+            operation: create
+          - customer
         ai_context:
           instructions: Resolve the buyer to a customer before calling.
     constraints:

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -13,6 +13,14 @@
 # falsely rejected. RequestedQuantityIsPositive reads the action's `quantity`
 # parameter, so PlaceOrder names it in `guards`.
 #
+# PlaceOrder's `affects` covers every authored shape at once: an entry on an
+# entity narrowed to the fields it writes, an entry on a relationship, and the
+# bare-name shorthand -- `customer` is touched in a way the model does not spell
+# out. The first two show that one vocabulary covers both kinds: creating the
+# edge to the customer is a `create`, the same verb as creating the order. The
+# OSI golden shows the normalization: the first two keep their record, the
+# third stays a bare name.
+#
 # Those last two are one business rule in its two bindings. The invariant holds
 # over stored order lines, whatever wrote them. The guard holds over the
 # argument a caller passed, and can be checked only before the call runs, which
@@ -88,6 +96,13 @@ semantic_model:
           - {name: customer, type: customer}
           - {name: quantity, type: Integer}
         guards: [RequestedQuantityIsPositive]
+        affects:
+          - concept: orders
+            operation: create
+            fields: [o_orderkey, o_totalprice]
+          - concept: orders_to_customer
+            operation: create
+          - customer
         ai_context:
           instructions: "Resolve the buyer to a customer before calling."
     constraints:


### PR DESCRIPTION
An action names an executor — an MCP tool, an HTTP endpoint — and that handle is
opaque. Nothing reading the model can see what the tool writes, so the blast
radius of a call is declared or it is unknown. This adds `affects`, where the
author declares it.

`affects` was previously marked out of scope in four places in the guides. It is
in the [actions proposal](https://docs.google.com/document/d/1GLufPOpXy5_swYW1DLqYGcmbpdGs-j-7GTFLrOPrdg0/edit?tab=t.0),
and it is the field a policy engine needs in order to route on a write
("escalate anything that changes a tax line item") without re-deriving what the
write does.

## Two authored shapes, one fact

The proposal's coarse form is a list of names, and it stays valid verbatim:

```yaml
        affects: [Account, Transfer]
```

A record adds an operation and the fields the call writes. The two mix freely in
one list, so an author is precise about the concepts they know and coarse about
the rest:

```yaml
        affects:
          - concept: Account
            operation: modify
            fields: [balance]
          - concept: Transfer
            operation: create
          - concept: TransferDebits
            operation: create
```

Both normalize to one IR record, so a consumer reads one shape.

## One key and one vocabulary for entities and relationships

`concept` names an entity or a relationship, and `create` / `modify` / `delete`
apply to either. `TransferDebits` above is the edge, written exactly like the
two entities beside it.

Splitting the vocabulary — `add` / `remove` for an edge — is not just redundant,
it leaves a hole. A many-to-many relationship is backed by a junction table with
fields of its own (`association.fields`), so *modify the grade on an Enrollment*
is an ordinary change, and under `add` / `remove` it was inexpressible: `remove`
takes the whole instance, leaving `add` as the only verb that could carry fields
on an edge.

Nothing about an entry depends on which kind its concept turned out to be, so
the kind is not stored either. The model is the one thing that can answer it
correctly after a rename, and a derived field can be added to the aspect
template later — an append-only template makes adding cheap and removing
impossible.

## Resolution and validation

The loader warns about a `concept` that names neither an entity nor a
relationship. `validate` promotes three conditions to hard push errors: a
concept the model does not declare, fields beside a `delete`, and a field the
concept does not have (for an edge, the junction's own properties, so a plain
foreign-key edge has none). An entry whose concept resolves to nothing is
reported and then left alone, since every later check about it is
meaningless; undeclared fields do not chain that way, so a concept that does
resolve reports every field it lacks. An operation outside the closed
vocabulary fails at parse time instead.

Everything that reads the ontology stands down on a profile push. `pruneUnavailable`
drops whole entities and whole relationships, not only unbound fields, and leaves
`model.actions` untouched — so under a profile an entry on a missing concept is
the profile's doing, not the author's, and an action reaches no graph in any
case. The fields-beside-a-`delete` check reads only the entry, so it still
applies.

Publishing warns when a declared concept is one the push does not publish —
abstract, or dropped by a profile — the way it already warns for an
entity-typed parameter. The entry is still written, because the action does
change that concept, but the catalog then names something it holds no entry
for.

The `semantic-action` aspect template gains `affects` at a fresh index, since
Dataplex rejects a backwards-incompatible template change.

## Status

Nothing consumes `affects` yet. `kcmd` parses it, checks it, publishes it and
reads it back; no component computes an impact from it or checks it against what
the executor does. The guides say so.

## Testing

- 43 new tests in `action_affects.test.ts`: loader normalization of both shapes,
  the single vocabulary on both kinds (including `modify` on an M:N edge's own
  property), unresolvable concepts, duplicate and mixed-precision handling,
  every `validate` error and both profile-push standdowns, the publish-time
  warning above, and the full YAML → IR → KC → pull → OSI round trip.
- The `actions_place_order` fixture exercises all three shapes in one golden;
  the OSI, catalog and pull goldens are regenerated.
- Full suite: 724 pass, 0 fail. `tsc --noEmit` clean.
- The worked example in `actions.md` was run through the loader, `validate` and
  the catalog generator; the published aspect matches what the guide shows.

