### PR TITLE
feat(mdcode): say what a violated constraint does, and how grave it is

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -173,9 +173,10 @@ on a model that is perfectly well-formed. It comes back untouched instead.
 **Constraints** publish the same way: each becomes a `semantic-constraint` entry
 under the model entry, with the expression and any `instructions` in a
 `semantic-constraint` aspect and the `description` as the entry's own summary.
-Name, expression, description, and instructions round-trip losslessly through
-`pull`. That entry type is custom too, and a model that declares no constraint
-never needs it.
+Name, expression, description, `on_violation`, `severity`, and instructions
+round-trip losslessly through `pull`. A constraint that declares neither routing
+word comes back without them rather than with a default filled in. That entry
+type is custom too, and a model that declares no constraint never needs it.
 
 ¹⁰ What you author is the `expression.dialects[]` list; the graph builds from the canonical (BigQuery/ANSI) variant. `importedExpression` / `importedDialect` are not authored keys — the loader *derives* them from a non-canonical dialect entry (e.g. the MAQL or Snowflake form a metric was imported from) and uses that verbatim as the fallback when no canonical variant exists. See [Model spec §2.5](model_spec.md#25-expressions).
 

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -485,6 +485,20 @@ reads the document ([§6](#6-the-extension-mechanism)).
   nothing today rejects a write that would break one. Rules in
   [Reference → Validation](reference.md#validation).
 
+  A constraint MAY say two things about a violation, under two separate keys.
+  **`on_violation`** is what the engine does to the write that tripped it:
+  `reject` refuses it outright and nobody may approve it, `escalate` holds it
+  for a human decision, `warn` lets it proceed and reports it. Absent means
+  `reject`, the safe reading of an author who did not say. **`severity`** is how
+  grave the violation is — `critical`, `high`, `medium` or `low` — for ranking
+  and reporting. It carries no default, and nothing ranks or routes on it yet.
+
+  They are two keys because they answer different questions, and neither one
+  implies the other. A `low` rule can still be an absolute refusal, and a
+  `critical` one can be a warning because the organization is not yet ready to
+  block on it. `escalate` states that an approver exists; it does not state who,
+  because an approver role is not modeled yet.
+
 - **Binding profiles.** A separate document that supplies only the physical
   bindings, so one logical model serves several stores. Not part of the Ossie
   document; a `kcmd`-specific file alongside it ([§7](#7-the-binding-layer)).

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -307,6 +307,16 @@ routed to the built-in `guidelines` aspect, which has a home for `instructions`
 alone: `kcmd` defines the constraint aspect itself, so it has no reason to keep
 that limit.
 
+The aspect also carries the constraint's two routing words: `onViolation` (what
+the engine does to the write — `reject`, `escalate` or `warn`) and `severity`
+(how grave the breach is — `critical`, `high`, `medium` or `low`). They ride the
+aspect rather than the entry source because they are machine-readable and not
+prose. A constraint that declares neither is published without both fields and
+reads back without them, so the defaults stay the model's to define. Each is
+read on its own, so an unrecognized word in one is dropped on pull with a
+warning without costing the reader the other: an unreadable `onViolation` falls
+back to `reject`, and an unreadable `severity` leaves the rule unranked.
+
 Push to Knowledge Catalog is lossy — the catalog holds metadata, not a full copy
 of your model. For exactly what is stored, what is gated behind
 `--emit-expressions`, and what is never stored, see

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -423,6 +423,54 @@ export interface GrpcExecutor {
 }
 
 /**
+ * What a violated constraint does to the write that tripped it.
+ *
+ *   - `reject`   the write is refused. Nobody is allowed to approve it, which
+ *                is what makes the rule an invariant rather than a policy.
+ *   - `escalate` the write is held and a human decides. The rule is a business
+ *                threshold, so somebody is allowed to say yes.
+ *   - `warn`     the write proceeds and the violation is reported.
+ *
+ * An engine reading the catalog needs this in order to route. Without it every
+ * rule publishes with the same shape, and a $30 credit that needs a supervisor
+ * is indistinguishable from one that is simply forbidden.
+ *
+ * This is a disposition, not a magnitude, and the two are deliberately separate
+ * keys. `escalate` is not "between" reject and warn on a scale of badness: it is
+ * a different control flow, and what it really states is that an approver
+ * exists. Two rules can be equally grave -- both guarding a million-dollar write
+ * -- and differ only in whether anyone in the organization is entitled to say
+ * yes. See CONSTRAINT_SEVERITIES for the magnitude.
+ *
+ * `escalate` names that an approver exists. It does not name who: an approver
+ * role is not modeled yet.
+ */
+export const VIOLATION_EFFECTS = ['reject', 'escalate', 'warn'] as const;
+
+export type ViolationEffect = (typeof VIOLATION_EFFECTS)[number];
+
+/**
+ * How grave a violation of a constraint is, independent of what the engine does
+ * about it.
+ *
+ * Ranking and reporting want this: which of forty violations in a batch to show
+ * a human first, which to page on. Enforcement does not -- that is
+ * `onViolation`, and the split is the point. A `low` rule may still be an
+ * absolute `reject`, and a `critical` one may be a `warn` because the
+ * organization is not ready to block on it yet.
+ *
+ * The scale is the ordinary four-point one, and it avoids `warning` on purpose:
+ * a severity called `warning` sitting beside an effect called `warn` would read
+ * as the same statement made twice.
+ *
+ * STATUS: authored, published and read back. Nothing ranks or routes on it yet.
+ */
+export const CONSTRAINT_SEVERITIES =
+    ['critical', 'high', 'medium', 'low'] as const;
+
+export type ConstraintSeverity = (typeof CONSTRAINT_SEVERITIES)[number];
+
+/**
  * A constraint: a model-level, named invariant over the ontology -- a boolean
  * `expression` that must hold for every instance. It is written in the same
  * expression language as a metric (`Customer.accountBalance >= 0`,
@@ -444,6 +492,14 @@ export interface Constraint {
   name: string;
   expression: string;     // boolean invariant in the model's expression language
   description?: string;   // human-readable summary; also the violation error
+  // What the engine does when this constraint does not hold. Defaults to
+  // `reject`: an unmarked rule refuses the write, which is the safe reading of
+  // an author who did not say. See VIOLATION_EFFECTS.
+  onViolation?: ViolationEffect;
+  // How grave a violation is, for ranking and reporting. Orthogonal to
+  // `onViolation` and carries no default -- an author who did not say has not
+  // said, and nothing reads it yet. See CONSTRAINT_SEVERITIES.
+  severity?: ConstraintSeverity;
   aiContext?: AiContext;
   // No `customExtensions`. Every other IR object has one because vanilla Ossie
   // accepts `custom_extensions` on it. A constraint is unreachable that way:

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -12,11 +12,19 @@
 // Dropping a constraint from the model deletes its entry, so the catalog never
 // advertises a rule the model stopped requiring.
 //
-// The three authored fields land in two places. `expression` and `ai_context`
-// go on the aspect, the latter whole -- aiContextField in kc_custom_types.ts
-// says why. `description` goes on the entry source, where a pull of an action
-// already reads it, and because a violation quotes that sentence back to the
-// caller as the error, which makes it the entry's summary.
+// The five authored fields land in two places. `expression`, `on_violation`,
+// `severity` and `ai_context` go on the aspect, the last whole --
+// aiContextField in kc_custom_types.ts says why. `description` goes on the
+// entry source, where a pull of an action already reads it, and because a
+// violation quotes that sentence back to the caller as the error, which makes
+// it the entry's summary.
+//
+// Both routing words are on the aspect because they are machine-readable, and
+// they are two fields because they answer different questions: what the engine
+// does about a breach, and how grave the breach is. A constraint that states
+// neither is published without them and reads back the same way, so a default
+// stays the IR's to define and a pull never invents a value the model never
+// stated.
 //
 // Call sites: knowledge_catalog.ts emits the entries, kc_converter.ts reads
 // them back, pull_kc.ts hydrates the aspect.
@@ -31,7 +39,7 @@
 
 import {Entry} from '../gcp/dataplex';
 
-import {Constraint, SemanticModel} from './ir';
+import {Constraint, CONSTRAINT_SEVERITIES, ConstraintSeverity, SemanticModel, VIOLATION_EFFECTS, ViolationEffect} from './ir';
 import {aiContextAspectValue, aiContextFromAspect, CONSTRAINT_TYPE_ID, customAspectKey, customAspectTypeName, customEntryTypeName} from './kc_custom_types';
 
 // Full resource name of the constraint entry type for a destination.
@@ -127,12 +135,14 @@ export function constraintEntries(
   return entries;
 }
 
-// The aspect payload for one constraint: the invariant, and the whole of any
-// `ai_context` declared on it.
+// The aspect payload for one constraint: the invariant, what a violation of it
+// does, how grave it is, and the whole of any `ai_context` declared on it.
 function constraintAspectData(constraint: Constraint): Record<string, any> {
   return compact({
     expression: constraint.expression,
     aiContext: aiContextAspectValue(constraint.aiContext),
+    onViolation: constraint.onViolation,
+    severity: constraint.severity,
   });
 }
 
@@ -182,9 +192,36 @@ export function readConstraint(entry: Entry, warnings: string[]): Constraint|
   const description = entry.entrySource?.description;
   if (description !== undefined && description !== '')
     constraint.description = description;
+  const onViolation = readEnum(
+      name, 'onViolation', data.onViolation, VIOLATION_EFFECTS, warnings);
+  if (onViolation) constraint.onViolation = onViolation as ViolationEffect;
+  const severity = readEnum(
+      name, 'severity', data.severity, CONSTRAINT_SEVERITIES, warnings);
+  if (severity) constraint.severity = severity as ConstraintSeverity;
   const aiContext = aiContextFromAspect(data.aiContext);
   if (aiContext) constraint.aiContext = aiContext;
   return constraint;
+}
+
+// The value an aspect field states, or undefined when it states none.
+//
+// A value outside the ones the IR defines is dropped with a warning rather than
+// kept, because an unrecognized word would fail the pulled model's own
+// push-side validation. What dropping costs differs by field and both are safe:
+// an unreadable `onViolation` falls back to `reject`, which refuses more than
+// the catalog asked for and never less, and an unreadable `severity` leaves a
+// rule unranked, which nothing reads yet.
+function readEnum(
+    name: string, field: string, value: unknown, allowed: readonly string[],
+    warnings: string[]): string|undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const text = String(value).trim();
+  if (allowed.includes(text)) return text;
+  warnings.push(
+      `constraint '${name}': the ${CONSTRAINT_TYPE_ID} aspect states ` +
+      `${field} '${text}', which is not one of ${allowed.join(', ')}; the ` +
+      `constraint reads back without one`);
+  return undefined;
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -387,6 +387,15 @@ export const CONSTRAINT_TYPE_ID = 'semantic-constraint';
 // the error, which makes it the entry's summary rather than part of the rule.
 // `ai_context` rides this aspect whole
 // (see aiContextField).
+//
+// `onViolation` and `severity` ride the aspect rather than the entry source
+// because they are machine-readable routing and not prose. They answer
+// different questions and are separate fields for that reason: `onViolation` is
+// what the engine does about a breach, `severity` is how grave the breach is.
+// A `low` rule can still be an absolute refusal, and a `critical` one can be a
+// warning because the organization is not ready to block on it. Published
+// without `onViolation`, a rule a supervisor may override reads the same as one
+// nobody can.
 const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
   displayName: 'Semantic Constraint',
   description:
@@ -410,6 +419,33 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
         },
       },
       aiContextField(2),
+      {
+        index: 3,
+        name: 'onViolation',
+        type: 'string',
+        annotations: {
+          displayName: 'On Violation',
+          description:
+              'What a violation does to the write that tripped it: ' +
+              '`reject` refuses the write and nobody may approve it, ' +
+              '`escalate` holds the write for a human decision, `warn` lets ' +
+              'it proceed and reports it. Absent means `reject`. `escalate` ' +
+              'states that an approver exists, not who they are.',
+        },
+      },
+      {
+        index: 4,
+        name: 'severity',
+        type: 'string',
+        annotations: {
+          displayName: 'Severity',
+          description:
+              'How grave a violation is, for ranking and reporting: ' +
+              '`critical`, `high`, `medium` or `low`. Independent of what ' +
+              'the engine does about it, which is `onViolation`. Absent ' +
+              'means the model did not say; there is no default.',
+        },
+      },
     ],
   },
 };

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -12,7 +12,7 @@
 import * as yaml from 'yaml';
 import * as z from 'zod';
 
-import {Action, ActionParameter, AffectedConcept, AiContext, CONCEPT_OPERATIONS, Constraint, CustomExtension, DATA_TYPES, Entity, Executor, Field, Metric, Relationship, SemanticModel,} from './ir';
+import {Action, ActionParameter, AffectedConcept, AiContext, CONCEPT_OPERATIONS, CONSTRAINT_SEVERITIES, Constraint, CustomExtension, DATA_TYPES, Entity, Executor, Field, Metric, Relationship, SemanticModel, VIOLATION_EFFECTS,} from './ir';
 import {referencedEntityNames} from './sql_expr_utils';
 
 export interface LoadOptions {
@@ -270,6 +270,11 @@ const constraintSchema = z.object({
   name: z.string(),
   expression: z.string(),
   description: z.string().optional(),
+  // What the engine does; absent means `reject`. See VIOLATION_EFFECTS.
+  on_violation: z.enum(VIOLATION_EFFECTS).optional(),
+  // How grave it is; no default, and nothing reads it yet. See
+  // CONSTRAINT_SEVERITIES.
+  severity: z.enum(CONSTRAINT_SEVERITIES).optional(),
   ai_context: aiContextSchema.optional(),
   // No `custom_extensions`: it is a vanilla-Ossie surface, and `constraints` is
   // an extended-profile-only key, so the two never co-occur. See Constraint.
@@ -445,6 +450,12 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
                         name: z.string(),
                         expression: z.string(),
                         description: z.string().optional(),
+                        // What the engine does; absent means `reject`. See
+                        // VIOLATION_EFFECTS.
+                        on_violation: z.enum(VIOLATION_EFFECTS).optional(),
+                        // How grave it is; no default. See
+                        // CONSTRAINT_SEVERITIES.
+                        severity: z.enum(CONSTRAINT_SEVERITIES).optional(),
                         ai_context: aiContextSchema.optional(),
                         ...ce,
                       }).strict();
@@ -920,6 +931,8 @@ function convertMetric(
 // evaluates it. Description and AI context round-trip like everywhere else.
 function convertConstraint(c: ConstraintDoc): Constraint {
   const constraint: Constraint = { name: c.name, expression: c.expression };
+  if (c.on_violation) constraint.onViolation = c.on_violation;
+  if (c.severity) constraint.severity = c.severity;
   const description = composeDescription(c.description);
   if (description) constraint.description = description;
   const ai = aiContextOrUndefined(c.ai_context);

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -326,6 +326,8 @@ function constraintDoc(constraint: Constraint): Record<string, any> {
     name: constraint.name,
     expression: constraint.expression,
     description: constraint.description,
+    on_violation: constraint.onViolation,
+    severity: constraint.severity,
     ai_context: aiContextDoc(constraint.aiContext),
   });
 }

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -261,7 +261,7 @@ describe('validatePushRequirements gates constraints', () => {
 describe('OSI round trip', () => {
   test('constraints survive serialize -> reload', () => {
     const model = loadFixtureModel('actions_place_order.yaml');
-    expect(model.constraints).toHaveLength(3);
+    expect(model.constraints).toHaveLength(4);
     const {yaml} = serializeModel(model);
     expect(yaml).toContain('constraints:');
     const reloaded = loadModels(yaml).models[0];
@@ -294,6 +294,7 @@ describe('Knowledge Catalog publish/pull round trip', () => {
          expect(constraints.map(e => e.name.split('/entries/')[1])).toEqual([
            'sales.constraints.NonNegativeOrderTotal',
            'sales.constraints.PositiveQuantity',
+           'sales.constraints.OrderWithinStandingLimit',
            'sales.constraints.RequestedQuantityIsPositive',
          ]);
          for (const e of constraints) expect(e.parentEntry).toBe(entries[0].name);
@@ -405,6 +406,69 @@ describe('Knowledge Catalog publish/pull round trip', () => {
         .toEqual(constraintsOf(first.entries));
   });
 
+  test('both routing words survive publish and pull', () => {
+    // Without these the catalog states every rule the same way, and a credit a
+    // supervisor may approve reads as one nobody can.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const held = entries.find(
+        e => e.entrySource?.displayName === 'OrderWithinStandingLimit')!;
+    expect(held.aspects![CONSTRAINT_ASPECT].data!.onViolation)
+        .toBe('escalate');
+    expect(held.aspects![CONSTRAINT_ASPECT].data!.severity).toBe('high');
+
+    const {models} = modelsFromCatalogResources(entries);
+    const byName = new Map(models[0].constraints!.map(c => [c.name, c]));
+    expect(byName.get('OrderWithinStandingLimit')!.onViolation)
+        .toBe('escalate');
+    expect(byName.get('OrderWithinStandingLimit')!.severity).toBe('high');
+    // A constraint that states neither publishes without both fields and reads
+    // back without them, so the defaults stay the IR's to define.
+    expect(byName.get('PositiveQuantity')!.onViolation).toBeUndefined();
+    expect(byName.get('PositiveQuantity')!.severity).toBeUndefined();
+  });
+
+  test('an unrecognized onViolation is dropped with a warning', () => {
+    // A hand-edited aspect can say anything. Keeping the word would fail the
+    // pulled model's own push-side validation; dropping it falls back to
+    // `reject`, which refuses more than the catalog asked for and never less.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const held = entries.find(
+        e => e.entrySource?.displayName === 'OrderWithinStandingLimit')!;
+    held.aspects![CONSTRAINT_ASPECT].data!.onViolation = 'maybe';
+
+    const {models, warnings} = modelsFromCatalogResources(entries);
+    const held2 = models[0].constraints!.find(
+        c => c.name === 'OrderWithinStandingLimit')!;
+    expect(held2.onViolation).toBeUndefined();
+    // The two words are read separately, so one bad one does not cost the
+    // reader the other.
+    expect(held2.severity).toBe('high');
+    expect(warnings.some(
+               w => w.includes("constraint 'OrderWithinStandingLimit'") &&
+                   w.includes("onViolation 'maybe'")))
+        .toBe(true);
+  });
+
+  test('an unrecognized severity is dropped with a warning', () => {
+    // Severity ranks and reports rather than routes, so an unreadable one
+    // leaves the rule unranked rather than changing what the engine does. That
+    // is the cheaper of the two failures, and it is still said out loud.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const held = entries.find(
+        e => e.entrySource?.displayName === 'OrderWithinStandingLimit')!;
+    held.aspects![CONSTRAINT_ASPECT].data!.severity = 'urgent';
+
+    const {models, warnings} = modelsFromCatalogResources(entries);
+    const held2 = models[0].constraints!.find(
+        c => c.name === 'OrderWithinStandingLimit')!;
+    expect(held2.severity).toBeUndefined();
+    expect(held2.onViolation).toBe('escalate');
+    expect(warnings.some(
+               w => w.includes("constraint 'OrderWithinStandingLimit'") &&
+                   w.includes("severity 'urgent'")))
+        .toBe(true);
+  });
+
   test('an entry whose expression is blank is skipped and warned', () => {
     // A hand-edited aspect can carry a blank expression. Such a constraint
     // states no invariant, so it degrades itself rather than the pull.
@@ -415,6 +479,7 @@ describe('Knowledge Catalog publish/pull round trip', () => {
     const {models, warnings} = modelsFromCatalogResources(entries);
     expect(models[0].constraints!.map(c => c.name)).toEqual([
       'NonNegativeOrderTotal',
+      'OrderWithinStandingLimit',
       'RequestedQuantityIsPositive',
     ]);
     expect(warnings.some(
@@ -440,12 +505,12 @@ describe('a graph leg says what it dropped', () => {
   ] as const) {
     test(`the ${backend} leg warns about actions and constraints`, () => {
       const {warnings} = generate(model());
-      // The fixture declares one action and three constraints.
+      // The fixture declares one action and four constraints.
       expect(warnings.some(
                  w => /1 action\(s\) reach Knowledge Catalog only/.test(w)))
           .toBe(true);
       expect(warnings.some(
-                 w => /3 constraint\(s\) reach Knowledge Catalog only/.test(w)))
+                 w => /4 constraint\(s\) reach Knowledge Catalog only/.test(w)))
           .toBe(true);
       // Named the system it does reach, and the one that drops it.
       expect(warnings.some(w => w.includes(`the ${backend} push deploys none`)))

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
@@ -222,6 +222,25 @@
       }
     },
     {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.constraints.OrderWithinStandingLimit",
+      "entryType": "projects/sqlgen-testing/locations/global/entryTypes/semantic-constraint",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "OrderWithinStandingLimit",
+        "description": "An order this large is above the standing limit and needs a sales manager to sign off. Ask for approval, or split the order."
+      },
+      "aspects": {
+        "sqlgen-testing.global.semantic-constraint": {
+          "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
+          "data": {
+            "expression": "orders.o_totalprice <= 100000",
+            "onViolation": "escalate",
+            "severity": "high"
+          }
+        }
+      }
+    },
+    {
       "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.constraints.RequestedQuantityIsPositive",
       "entryType": "projects/sqlgen-testing/locations/global/entryTypes/semantic-constraint",
       "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
@@ -283,7 +302,7 @@
   ],
   "warnings": [
     "model 'sales': 1 action(s) published as semantic-action entries (Knowledge Catalog is the only system an action reaches).",
-    "model 'sales': 3 constraint(s) published as semantic-constraint entries (Knowledge Catalog is the only system a constraint reaches).",
+    "model 'sales': 4 constraint(s) published as semantic-constraint entries (Knowledge Catalog is the only system a constraint reaches).",
     "relationship 'orders_to_customer': Knowledge Catalog stores the name only in the normalized link id, so a pull returns it lowercased/hyphenated (e.g. 'orders-to-customer'), not 'orders_to_customer'."
   ]
 }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
@@ -94,6 +94,12 @@ semantic_model:
       - name: PositiveQuantity
         expression: OrderedAs.quantity > 0
         description: An order line must be for at least one unit.
+      - name: OrderWithinStandingLimit
+        expression: orders.o_totalprice <= 100000
+        description: An order this large is above the standing limit and needs a sales
+          manager to sign off. Ask for approval, or split the order.
+        on_violation: escalate
+        severity: high
       - name: RequestedQuantityIsPositive
         expression: quantity > 0
         description: A request must be for at least one unit. Ask the caller for the

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
@@ -76,6 +76,12 @@ semantic_model:
       - name: PositiveQuantity
         expression: OrderedAs.quantity > 0
         description: An order line must be for at least one unit.
+      - name: OrderWithinStandingLimit
+        expression: orders.o_totalprice <= 100000
+        description: An order this large is above the standing limit and needs a sales
+          manager to sign off. Ask for approval, or split the order.
+        on_violation: escalate
+        severity: high
       - name: RequestedQuantityIsPositive
         expression: quantity > 0
         description: A request must be for at least one unit. Ask the caller for the

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -119,6 +119,13 @@ semantic_model:
       - name: PositiveQuantity
         expression: OrderedAs.quantity > 0
         description: An order line must be for at least one unit.
+      - name: OrderWithinStandingLimit
+        expression: orders.o_totalprice <= 100000
+        description: >-
+          An order this large is above the standing limit and needs a sales
+          manager to sign off. Ask for approval, or split the order.
+        on_violation: escalate
+        severity: high
       - name: RequestedQuantityIsPositive
         expression: quantity > 0
         description: >-


### PR DESCRIPTION
A constraint today states the rule and nothing about what breaking it costs.
Every rule reads the same, so a credit limit a supervisor may sign off on is
indistinguishable from one nobody may override.

This adds two optional keys to a constraint, kept deliberately apart because
they answer different questions.

```yaml
constraints:
  - name: OrderWithinStandingLimit
    expression: orders.o_totalprice <= 100000
    description: >-
      An order this large is above the standing limit and needs a sales
      manager to sign off. Ask for approval, or split the order.
    on_violation: escalate
    severity: high
```

**`on_violation: reject | escalate | warn`** is what the engine does to the
write that tripped the rule. Absent means `reject` — an author who did not say
is read as refusing, which is the safe direction. `escalate` states that an
approver *exists*; it does not state *who*, because an approver role is not
modeled yet.

**`severity: critical | high | medium | low`** is how grave the breach is, for
ranking and reporting. It carries no default — an author who did not say has not
said — and nothing ranks or routes on it yet.

### Why two keys and not one

Folding these into one key was the first cut and it was wrong. `escalate` is not
"between" `reject` and `warn` on a scale of badness; it is a different control
flow. And neither axis implies the other: a `low` rule can still be an absolute
refusal, and a `critical` one can be a warning because the organization is not
yet ready to block on it.

dbt (`severity: warn|error`) and ESLint (`off|warn|error`) do overload
"severity" for a disposition, but both are pure two-point orderings where the
two axes happen to collapse. SARIF keeps `level` separate from what the tool
does; OPA Gatekeeper has `enforcementAction`; Kubernetes Pod Security has modes.
This follows those.

There is a third axis this does not model — *who* may override. `escalate` names
that an approver exists and stops there; the docs say so explicitly rather than
letting the gap read as an oversight.

### What is wired

Both words are authored in YAML, validated by the loader, published to the
`semantic-constraint` aspect (one new field each; the metadata template is
append-only, so `onViolation` takes index 3 and `severity` index 4), emitted by
the OSI converter, and read back on `pull`. Each is read on its own, so an
unrecognized word in one is dropped with a warning without costing the reader
the other: an unreadable `onViolation` falls back to `reject`, an unreadable
`severity` leaves the rule unranked.

Nothing evaluates a constraint yet, so nothing acts on either key. This is the
vocabulary, so the runtime that follows has something to route on.

### Testing

`npx tsc --noEmit` clean; `bun test` 727 pass / 0 fail. The
`actions_place_order` fixture gains a fourth constraint carrying both keys, so
all three goldens (Knowledge Catalog, OSI, pull) show the round trip.
