### PR TITLE
feat(mdcode): run an action against a live store with kcmd action, refusing what it cannot check

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -46,7 +46,7 @@ example that carries one model through the whole lifecycle, see the
 | [Binding profiles](profiles.md) | bind one logical model to several stores |
 | [Modeling class hierarchies](inheritance.md) | model subtypes with `extends` so a supertype query gathers them |
 | [Codelab: one semantic ontology, one data journey](codelab.md) | see the whole lifecycle: author, govern, hydrate, query |
-| [Modeling write operations](actions.md) | declare an action an agent can call, and publish it |
+| [Modeling write operations](actions.md) | declare an action an agent can call, publish it, and run it |
 | [Reference](reference.md) | look up a flag, what push creates, validation, or permissions |
 | [Model specification](model_spec.md) | the normative format: every YAML construct, what's OSI and what's a kcmd extension |
 | [What push and pull preserve](fidelity.md) | understand why something changed or wasn't recovered |
@@ -124,14 +124,16 @@ push enforces.
 A model can also declare **actions**: model-level write operations, the
 write-side counterpart to a metric. An action names a business operation, points
 at the executor that carries it out (an MCP tool, a REST endpoint, a gRPC
-method, or DML), and types each parameter against the ontology, so an
-entity-typed parameter is an object reference rather than a bare string. The
-executor is a physical binding, so a [binding profile](profiles.md) can supply a
-different one per store. An action also
-names, in `guards`, the constraints that gate it, and in `affects`, the concepts
-the call changes — the executor is an opaque handle, so its blast radius is
-declared or it is unknown. Knowledge Catalog is the only system an action
-reaches, and the only place it is governed. See
+method, or the write itself as DML), and types each parameter against the
+ontology, so an entity-typed parameter is an object reference rather than a bare
+string. The executor is a physical binding, so a
+[binding profile](profiles.md) can supply a different one per store. An action
+also names, in `guards`, the constraints that gate it, and in `affects`, the
+concepts the call changes — an executor in another system is an opaque handle,
+so its blast radius is declared or it is unknown. Knowledge Catalog is the only
+system an action is published to, and the only place it is governed; an action
+that carries its own DML is also the one kind `kcmd` runs itself, with
+`kcmd action run`. See
 [Modeling write operations](actions.md).
 
 A model can also state **constraints**: named invariants over the ontology that

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -745,7 +745,7 @@ That second command does not succeed against the model built up on this page,
 and the reason is worth knowing before the mechanics: `TransferFunds` is guarded
 by `AmountIsPositive`, nothing evaluates a constraint yet, and `kcmd` refuses a
 call rather than apply a write the model says must be checked first. What
-follows describes an action no constraint bears on, which is what runs today.
+follows describes an action that names no guard, which is what runs today.
 
 `kcmd action list` is what the model declares as runnable — parameters,
 executor, guards, blast radius — and each entry ends with the command line that
@@ -820,8 +820,8 @@ UPDATE account SET balance = balance - @amount WHERE account_id = @source
 This one updates a single row because it filters on the key. A statement reading
 `WHERE status = 'dormant'` would update every dormant account, and nothing would
 stop it. `affects` does not limit the blast radius either — it *declares* it, so
-that a reader and the refusal gate know what the write is about. The statement
-is what decides.
+that a reader knows what the write is about and an evaluator can one day check
+the statements against what was declared. The statement is what decides.
 
 `kcmd action run` does three things:
 
@@ -856,27 +856,12 @@ transaction and could not be rolled back if the commit failed. Supply a handler
 that performs the write as DML, or declare the action with a 'sql' executor.
 ```
 
-### An action a constraint should decide is refused, not run unchecked
+### A guarded action is refused, not run unchecked
 
 Nothing evaluates a constraint yet. A model that declares a rule and a runtime
 that quietly ignores it is worse than no runtime, because the model states the
 write is checked and nothing says otherwise — so `kcmd action run` refuses such
-a call instead. Three shapes say a constraint may bear on it:
-
-- the action names one in `guards`;
-- a constraint's expression reads a concept the action writes — either one it
-  declares in `affects`, or one its statements turn out to write. `affects` is a
-  declaration, so for a `sql` executor the statements are read too, and an
-  action that changes more than it declared is caught by what it does rather
-  than by what it said;
-- the model declares constraints and the action declares no `affects` at all,
-  which leaves nothing to compare. Reading that silence as "nothing is
-  constrained" is the one guess here that fails open.
-
-A constraint whose `onViolation` is `warn` is left out of all three. Such a rule
-reports a violation rather than rejecting one, so it could never refuse the
-write, and gating on it would leave a model that states advisory rules
-permanently unrunnable.
+a call instead:
 
 ```
 Error: Action 'TransferFunds' is guarded by 'AmountIsPositive', and this runtime
@@ -884,16 +869,30 @@ does not evaluate constraints yet. Running it would apply a write the model says
 must be checked first, so it is refused rather than run unchecked.
 ```
 
-An action over data no constraint mentions runs today. Every refusal is decided
-before a session is opened, so a refused action leaves no transaction behind.
+What makes a call "such a call" is `guards`, and only `guards` — the same rule
+[section 2](#2-gate-it-with-a-constraint) states, applied here. A constraint the
+action does not name is a rule this call does not consult, and the runtime does
+not go looking for one: a constraint that merely reads a concept the action
+writes gates nothing, and neither does declaring constraints in a model whose
+action leaves `affects` out. Refusing on either would mean publishing a rule
+could start refusing calls that succeeded the day before, which is exactly what
+making the reference explicit prevents.
+
+A guard whose constraint declares `onViolation: warn` is the one guard that does
+not refuse. Such a rule reports a violation rather than rejecting one, so an
+evaluator would let the write through, and gating on it would leave a model that
+states advisory rules permanently unrunnable.
+
+Every refusal is decided before a session is opened, so a refused action leaves
+no transaction behind.
 
 ## What is not modeled yet
 
 This is a prototype. Three things a reader reasonably expects are absent.
 
 - **Nothing checks the write.** No component evaluates a constraint or a guard.
-  An action whose outcome a constraint is supposed to decide is refused rather
-  than run, so the gap is loud, but it is still a gap: the correctness of what a
+  A guarded action is refused rather than run, so the gap is loud where a model
+  states a rule gates the call, but it is still a gap: the correctness of what a
   statement does belongs to whoever wrote it.
 - **`kcmd` calls no executor but its own.** A `sql` action runs; an `mcp`,
   `rest` or `grpc` one is published for whoever dispatches it, which is why

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -833,10 +833,14 @@ is what decides.
   and not. Nothing is interpolated into a statement.
 - **Apply.** A read-write transaction is opened, the action's statements run
   inside it in order, and it commits. Any failure before the commit rolls back,
-  so no partial write survives. A failure *of* the commit is the one thing
-  `kcmd` cannot resolve for you — the store may have applied the write and lost
-  the response — and it says so rather than claiming a rollback, because a
-  caller told "nothing happened" would retry a write that did.
+  so no partial write survives. A commit the store *refuses* wrote nothing
+  either, and is reported that way — the commonest refusal is Spanner's
+  `ABORTED` under lock contention, and the answer to it is to run the action
+  again. What `kcmd` cannot settle for you is a commit that is neither accepted
+  nor refused: a timeout or a 5xx, where the store may have applied the write
+  and lost the response. That one reports the outcome as unknown rather than
+  claiming a rollback, because a caller told "nothing happened" would retry a
+  write that did.
 
 Where the write goes is the model's Spanner deployment target under the selected
 profile. The command line never names a database: `--profile` changes the store,

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -155,8 +155,8 @@ that list against reality. The fourth kind, `sql`, contains the write instead.
         executor:
           sql:
             statements:
-              - UPDATE Account SET balance = balance - @amount WHERE accountId = @source
-              - UPDATE Account SET balance = balance + @amount WHERE accountId = @target
+              - UPDATE account SET balance = balance - @amount WHERE account_id = @source
+              - UPDATE account SET balance = balance + @amount WHERE account_id = @target
         parameters:
           - { name: source, type: Account }
           - { name: target, type: Account }
@@ -164,6 +164,34 @@ that list against reality. The fourth kind, `sql`, contains the write instead.
         affects:
           - { concept: Account, operation: modify, fields: [balance] }
 ```
+
+#### The statements are written in database names
+
+Look closely at what those statements say. The entity is `Account` and its field
+is `accountId`, but the statement writes `account` and `account_id` — the table
+and the column that entity is *bound* to, back in `source` and `expression`.
+
+A model gives everything two names, and a metric is written in the first of them:
+you write `Account.balance`, and `kcmd` translates it to `account.balance` before
+any SQL reaches the store. **An action's statements are not translated.** They
+are handed to the store exactly as written, so every table and column in one
+must be the database's own name. The only model names in a statement are the
+`@parameter` references, which name the action's declared parameters.
+
+That is the price of carrying the write verbatim: a rewrite is a place where
+what runs and what was reviewed could come apart.
+
+Nothing catches a model name before the call. Validation checks that each
+statement is one DML verb, contains no `;`, and binds only declared parameters —
+it never asks the store whether a table exists. A model name therefore fails at
+run time, from the store, and the message is not always legible: an entity named
+`Order` bound to a table named `Orders` produces
+
+```
+Syntax error: Unexpected keyword ORDER [at 1:8]
+```
+
+rather than "no such table", because `ORDER` is a reserved word.
 
 Containing the write buys three things a pointer cannot:
 
@@ -198,7 +226,7 @@ refer to the generated key as `@new<Concept>Key`:
           sql:
             statements:
               - >-
-                INSERT INTO Transfer (transferId, amount, debitedId)
+                INSERT INTO transfer (transfer_id, amount, debited_account_id)
                 VALUES (@newTransferKey, @amount, @source)
         affects:
           - { concept: Transfer, operation: create }
@@ -713,6 +741,12 @@ kcmd action run TransferFunds --arg source="Alice Checking" \
     --arg target=ACC-2 --arg amount=250
 ```
 
+That second command does not succeed against the model built up on this page,
+and the reason is worth knowing before the mechanics: `TransferFunds` is guarded
+by `AmountIsPositive`, nothing evaluates a constraint yet, and `kcmd` refuses a
+call rather than apply a write the model says must be checked first. What
+follows describes an action no constraint bears on, which is what runs today.
+
 `kcmd action list` is what the model declares as runnable — parameters,
 executor, guards, blast radius — and each entry ends with the command line that
 runs it, so reading the listing is enough to make the call:
@@ -727,14 +761,72 @@ Model 'payments' (payments_eg), profile 'operational':
     run:        kcmd action run TransferFunds --arg source=<Account> --arg target=<Account> --arg amount=<Float>
 ```
 
+### How a row is identified
+
+An entity-typed parameter takes an object reference rather than a value, so
+`--arg source="Alice Checking"` has to become one specific row before anything
+can run. Two separate things decide which rows an action touches, and conflating
+them is the easiest way to misread what an action does.
+
+**Resolving an argument — one row, chosen by `kcmd`.** For each entity-typed
+parameter, `kcmd` runs one lookup against that entity's table before the write:
+
+```sql
+SELECT account_id FROM account
+WHERE account_id = @ref0 OR name = @ref LIMIT 2
+```
+
+The `WHERE` is built from two things the entity declares:
+
+- **its `primary_key`.** `Account` declares `primary_key: [accountId]`, and
+  `accountId` is bound to the column `account_id`, so the input is compared
+  against that column. This is the answer to "how does it know which column is
+  the key" — the model says so; nothing is inferred from the database. One
+  argument cannot name a key of several columns, so an entity keyed that way is
+  reachable only through the identifying field below.
+- **an identifying text field, if the entity has one.** A `String` field that is
+  not part of the key, bound to a plain column, and *named* `name`, `full_name`,
+  `title`, `label` or `display_name`. `Account` declares `name`, so
+  `"Alice Checking"` and the account id both find the same row. The match is on
+  the field's name in the model, not the column's name in the store.
+
+The input is compared against each column as that column's own type, so a key
+declared `Integer` is only compared when the input is a number — `"Alice
+Checking"` is not, so that predicate is dropped rather than cast. If nothing is
+left to compare, no query is sent at all.
+
+Exactly one row must come back. Zero is `No Account matches 'Alice Checking'.`
+Two or more is ambiguous, and the candidates are listed by key so the caller can
+pick one — a name is not required to be unique, and if two accounts carried this
+one:
+
+```
+Error: 'Alice Checking' matches more than one Account (7, 12); use a key to
+disambiguate.
+```
+
+Both are reported rather than guessed at, because both are things the caller can
+act on.
+
+**Targeting the write — however many rows the statement says.** Resolution
+produces a *value*, which the statement then uses. Which rows the write lands on
+is decided entirely by the statement's own `WHERE`, and `kcmd` does not
+constrain it:
+
+```sql
+UPDATE account SET balance = balance - @amount WHERE account_id = @source
+```
+
+This one updates a single row because it filters on the key. A statement reading
+`WHERE status = 'dormant'` would update every dormant account, and nothing would
+stop it. `affects` does not limit the blast radius either — it *declares* it, so
+that a reader and the refusal gate know what the write is about. The statement
+is what decides.
+
 `kcmd action run` does three things:
 
-- **Resolve.** An entity-typed parameter takes an object reference, not a value,
-  so `--arg source="Alice Checking"` is matched against `Account`'s key and,
-  when the entity has one, an identifying text field (`name`, `title`, `label`,
-  `display_name`). The account id and the account's name therefore find the same
-  row. Nothing matched and more than one matched are both reported as such, with
-  the candidates listed, because both are things the caller can act on.
+- **Resolve.** Each entity-typed argument becomes the one row it denotes, as
+  above.
 - **Bind.** Every argument becomes a query parameter of the store type its
   declared ontology type implies — a `Decimal` amount is compared as a number
   rather than as text, which is the difference between `9` being less than `10`
@@ -768,10 +860,19 @@ write is checked and nothing says otherwise — so `kcmd action run` refuses suc
 a call instead. Three shapes say a constraint may bear on it:
 
 - the action names one in `guards`;
-- a constraint's expression reads an entity the action `affects`;
+- a constraint's expression reads a concept the action writes — either one it
+  declares in `affects`, or one its statements turn out to write. `affects` is a
+  declaration, so for a `sql` executor the statements are read too, and an
+  action that changes more than it declared is caught by what it does rather
+  than by what it said;
 - the model declares constraints and the action declares no `affects` at all,
   which leaves nothing to compare. Reading that silence as "nothing is
   constrained" is the one guess here that fails open.
+
+A constraint whose `onViolation` is `warn` is left out of all three. Such a rule
+reports a violation rather than rejecting one, so it could never refuse the
+write, and gating on it would leave a model that states advisory rules
+permanently unrunnable.
 
 ```
 Error: Action 'TransferFunds' is guarded by 'AmountIsPositive', and this runtime

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -204,9 +204,9 @@ refer to the generated key as `@new<Concept>Key`:
           - { concept: Transfer, operation: create }
 ```
 
-Nothing executes a statement yet. `kcmd` validates the statements, publishes
-them to the catalog and reads them back; what runs them is the action runtime,
-which lands separately.
+A `sql` executor is the only kind `kcmd` itself runs — see
+[Run it](#7-run-it). The other three are published and dispatched by whoever
+reads the model.
 
 ## 2. Gate it with a constraint
 
@@ -523,7 +523,10 @@ read of that parameter.
 
 **Status: nothing evaluates a guard yet.** `kcmd` parses `guards`, resolves each
 name, publishes the list, and reads it back. No component checks a guard against
-live data, so a guard states what must hold before the call and blocks no call.
+live data, so a guard states what must hold before the call and stops no call by
+itself. What it does stop is the call running unchecked:
+[`kcmd action run`](#7-run-it) refuses a guarded action outright rather than
+apply a write the model says is checked first.
 
 ## 3. Say what it changes
 
@@ -700,16 +703,93 @@ each action, so a name, a description, an executor, typed parameters, its
 unchanged. What every part of a model does and does not survive is in
 [What push and pull preserve](fidelity.md).
 
+## 7. Run it
+
+An action with a `sql` executor is a write `kcmd` can perform. Two commands:
+
+```bash
+kcmd action list
+kcmd action run TransferFunds --arg source="Alice Checking" \
+    --arg target=ACC-2 --arg amount=250
+```
+
+`kcmd action list` is what the model declares as runnable — parameters,
+executor, guards, blast radius — and each entry ends with the command line that
+runs it, so reading the listing is enough to make the call:
+
+```
+Model 'payments' (payments_eg), profile 'operational':
+  TransferFunds: Move money from one account to another.
+    parameters: source (Account, reference), target (Account, reference), amount (Float)
+    executor:   sql
+    guards:     AmountIsPositive
+    affects:    Account (modify), Transfer (create)
+    run:        kcmd action run TransferFunds --arg source=<Account> --arg target=<Account> --arg amount=<Float>
+```
+
+`kcmd action run` does three things:
+
+- **Resolve.** An entity-typed parameter takes an object reference, not a value,
+  so `--arg source="Alice Checking"` is matched against `Account`'s key and,
+  when the entity has one, an identifying text field (`name`, `title`, `label`,
+  `display_name`). The account id and the account's name therefore find the same
+  row. Nothing matched and more than one matched are both reported as such, with
+  the candidates listed, because both are things the caller can act on.
+- **Bind.** Every argument becomes a query parameter of the store type its
+  declared ontology type implies — a `Decimal` amount is compared as a number
+  rather than as text, which is the difference between `9` being less than `10`
+  and not. Nothing is interpolated into a statement.
+- **Apply.** A read-write transaction is opened, the action's statements run
+  inside it in order, and it commits. Any failure rolls back, so no partial
+  write survives.
+
+Where the write goes is the model's Spanner deployment target under the selected
+profile. The command line never names a database: `--profile` changes the store,
+the same rule [push](profiles.md) follows.
+
+Only a `sql` executor runs. An `mcp`, `rest` or `grpc` executor names an
+operation in another system, which `kcmd` cannot call and could not roll back if
+the commit failed, so it refuses rather than half-perform the write:
+
+```
+Error: Action 'TransferFunds' is executed by MCP, which runs outside this
+transaction and could not be rolled back if the commit failed. Supply a handler
+that performs the write as DML, or declare the action with a 'sql' executor.
+```
+
+### An action a constraint should decide is refused, not run unchecked
+
+Nothing evaluates a constraint yet. A model that declares a rule and a runtime
+that quietly ignores it is worse than no runtime, because the model states the
+write is checked and nothing says otherwise — so `kcmd action run` refuses such
+a call instead. Three shapes say a constraint may bear on it:
+
+- the action names one in `guards`;
+- a constraint's expression reads an entity the action `affects`;
+- the model declares constraints and the action declares no `affects` at all,
+  which leaves nothing to compare. Reading that silence as "nothing is
+  constrained" is the one guess here that fails open.
+
+```
+Error: Action 'TransferFunds' is guarded by 'AmountIsPositive', and this runtime
+does not evaluate constraints yet. Running it would apply a write the model says
+must be checked first, so it is refused rather than run unchecked.
+```
+
+An action over data no constraint mentions runs today. Every refusal is decided
+before a session is opened, so a refused action leaves no transaction behind.
+
 ## What is not modeled yet
 
 This is a prototype. Three things a reader reasonably expects are absent.
 
-- **Nothing checks the write.** No component evaluates a constraint or a guard,
-  so an action is a declaration and the correctness of what the executor does
-  belongs to the executor.
-- **`kcmd` does not call the executor.** Push publishes the action. Dispatching
-  it is the job of whatever reads the model, which is why the executor names
-  coordinates rather than a statement.
-- **Parameter types are the whole type story.** An entity-typed parameter says
-  which entity an argument denotes. Resolving a caller's `"Alice Checking"` to
-  a row is left to the consumer.
+- **Nothing checks the write.** No component evaluates a constraint or a guard.
+  An action whose outcome a constraint is supposed to decide is refused rather
+  than run, so the gap is loud, but it is still a gap: the correctness of what a
+  statement does belongs to whoever wrote it.
+- **`kcmd` calls no executor but its own.** A `sql` action runs; an `mcp`,
+  `rest` or `grpc` one is published for whoever dispatches it, which is why
+  those three name coordinates rather than a statement.
+- **The store is Spanner.** `kcmd action run` resolves, binds and transacts
+  against the Spanner database the profile's deployment target names. A model
+  bound to BigQuery publishes its actions and runs none of them.

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -740,8 +740,11 @@ Model 'payments' (payments_eg), profile 'operational':
   rather than as text, which is the difference between `9` being less than `10`
   and not. Nothing is interpolated into a statement.
 - **Apply.** A read-write transaction is opened, the action's statements run
-  inside it in order, and it commits. Any failure rolls back, so no partial
-  write survives.
+  inside it in order, and it commits. Any failure before the commit rolls back,
+  so no partial write survives. A failure *of* the commit is the one thing
+  `kcmd` cannot resolve for you — the store may have applied the write and lost
+  the response — and it says so rather than claiming a rollback, because a
+  caller told "nothing happened" would retry a write that did.
 
 Where the write goes is the model's Spanner deployment target under the selected
 profile. The command line never names a database: `--profile` changes the store,

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -73,7 +73,8 @@ kcmd action run <name> --arg <name>=<value> ...
 `list` prints every action the models in the scope declare, with the command
 line that runs each one. `run` executes one against the Spanner database the
 selected profile's deployment target names; only a `sql` executor runs, and an
-action a constraint may bear on is refused rather than run unchecked. See
+action that names a constraint in `guards` is refused rather than run
+unchecked, because nothing evaluates a constraint yet. See
 [Run it](actions.md#7-run-it).
 
 | Flag | Effect |

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -63,6 +63,24 @@ scope you authored under. See [Pull](README.md#pull) for behavior.
 | `--dry-run` | Reconstruct from the catalog and report what would be written, but write no files. |
 | `--force-remove` | Replace a differently-named local model with the catalog's (see [Pull](README.md#pull)); without it, a pull that would leave the entry group holding two models fails. |
 
+### action
+
+```bash
+kcmd action list
+kcmd action run <name> --arg <name>=<value> ...
+```
+
+`list` prints every action the models in the scope declare, with the command
+line that runs each one. `run` executes one against the Spanner database the
+selected profile's deployment target names; only a `sql` executor runs, and an
+action a constraint may bear on is refused rather than run unchecked. See
+[Run it](actions.md#7-run-it).
+
+| Flag | Effect |
+|------|--------|
+| `--arg <name>=<value>` | Bind one action parameter. Repeat the flag for each one; the value is text, parsed against the parameter's declared ontology type. `run` only. |
+| `--profile [name]` | Read the model under this binding profile. Its deployment target names the database the action runs against, so this is how you change stores. Defaults to `default_profile`, else the model's inline bindings. |
+
 ## What gets created in BigQuery
 
 `push` executes a single `CREATE OR REPLACE PROPERTY GRAPH` per deployment

--- a/toolbox/mdcode/src/libts/gcp/spanner.ts
+++ b/toolbox/mdcode/src/libts/gcp/spanner.ts
@@ -167,20 +167,6 @@ export class SpannerDataClient extends api.ApiClient {
     });
   }
 
-  // Runs one statement outside any read-write transaction, as a single-use
-  // strong read. For a plain read -- showing state, resolving a display name --
-  // there is nothing to commit, and holding a transaction open for it would add
-  // a round trip and a rollback that say nothing.
-  async executeQuery(sessionName: string, stmt: Statement):
-      Promise<api.ApiResult<ResultSet>> {
-    return await this._post<ResultSet>(`${sessionName}:executeSql`, {
-      transaction: {singleUse: {readOnly: {strong: true}}},
-      sql: stmt.sql,
-      params: stmt.params,
-      paramTypes: stmt.paramTypes,
-    });
-  }
-
   async commit(sessionName: string, transactionId: string):
       Promise<api.ApiResult<{commitTimestamp?: string}>> {
     this._seqno.delete(transactionId);

--- a/toolbox/mdcode/src/libts/gcp/spanner.ts
+++ b/toolbox/mdcode/src/libts/gcp/spanner.ts
@@ -1,9 +1,15 @@
-// API client for Cloud Spanner (Database Admin surface).
+// API client for Cloud Spanner.
 //
-// The semantic-model Spanner leg only needs to run DDL and a table existence
-// probe, so this exposes just those: updateDatabaseDdl (which returns a
-// long-running operation), getOperation (to poll it), and getTable (a cheap
-// pre-flight over information schema is out of scope here; see the deploy leg).
+// Two surfaces, on two hosts:
+//
+//   * Database Admin -- updateDatabaseDdl (which returns a long-running
+//     operation) and getOperation (to poll it). This is what the semantic-model
+//     push leg needs to create a property graph.
+//   * Data (SpannerDataClient) -- sessions and read-write transactions, so a
+//     caller can run DML and queries and decide whether to commit. This is what
+//     the semantic runtime needs: it applies an action's writes and then
+//     commits or rolls back, and everything in between can read the
+//     transaction's own UNCOMMITTED state.
 //
 
 import * as api from './api';
@@ -46,5 +52,162 @@ export class SpannerClient extends api.ApiClient {
   // `projects/.../instances/.../databases/.../operations/...`).
   async getOperation(operationName: string): Promise<api.ApiResult<Operation>> {
     return await this._get<Operation>(operationName);
+  }
+}
+
+
+// A Spanner session, the handle every data-API call is scoped to. Sessions are
+// server resources with a finite lifetime, so a caller creates one, uses it,
+// and deletes it (see SpannerDataClient.withSession).
+export interface Session {
+  name?: string;
+  [key: string]: any;
+}
+
+
+// A transaction handle returned by beginTransaction. `id` is the opaque token
+// that subsequent executeSql / commit / rollback calls quote.
+export interface Transaction {
+  id?: string;
+  [key: string]: any;
+}
+
+
+// One row of a query result. The Spanner REST surface returns values
+// positionally in `rows` with the column layout in `metadata.rowType.fields`,
+// and encodes every scalar as a STRING (an INT64 comes back as "42"), so a
+// caller converts as needed.
+export interface ResultSet {
+  metadata?: {rowType?: {fields?: Array<{name?: string; type?: any}>}};
+  rows?: string[][];
+  stats?: {rowCountExact?: string; [key: string]: any};
+  [key: string]: any;
+}
+
+
+// The parameter types accompanying a parameterized statement. Spanner infers
+// most types from the JSON value, but cannot infer one for a NULL or for an
+// empty array, so those must be declared. Codes are Spanner TypeCode names
+// (e.g. 'INT64', 'STRING', 'FLOAT64', 'TIMESTAMP').
+export type ParamTypes = Record<string, {code: string; arrayElementType?: {code: string}}>;
+
+
+// A statement to run inside a transaction: SQL plus its named parameters
+// (referenced as @name in the SQL).
+export interface Statement {
+  sql: string;
+  params?: Record<string, any>;
+  paramTypes?: ParamTypes;
+}
+
+
+// The Spanner DATA surface (spanner.googleapis.com/v1), a separate client from
+// the Database Admin one above because the two share a host but nothing else:
+// this one is scoped to a single database and speaks sessions, not operations.
+//
+// Read-write transactions here are explicit rather than a callback wrapper, so
+// the caller keeps the decision to commit -- which is the whole point for the
+// semantic runtime, whose gate runs between the write and the commit.
+export class SpannerDataClient extends api.ApiClient {
+  private readonly _database: string;
+  // Per-transaction statement counter. Spanner REQUIRES a monotonically
+  // increasing `seqno` on every DML statement in a read-write transaction --
+  // it is how the server recognizes a retry of a statement it has already
+  // applied, so that a retried DML is not applied twice. Sending the same seqno
+  // with a DIFFERENT statement fails with "Previously received a different
+  // request with this seqno", which is what makes a hand-rolled client fail on
+  // its second statement. Tracking it here means a caller running several
+  // statements in one transaction does not have to know about it at all.
+  private readonly _seqno = new Map<string, number>();
+
+  constructor(
+      ctx: context.ApiContext, project: string, instance: string,
+      database: string) {
+    super('https://spanner.googleapis.com', 'v1', ctx);
+    this._database =
+        `projects/${project}/instances/${instance}/databases/${database}`;
+  }
+
+  get database(): string {
+    return this._database;
+  }
+
+  async createSession(): Promise<api.ApiResult<Session>> {
+    return await this._post<Session>(`${this._database}/sessions`, {});
+  }
+
+  async deleteSession(sessionName: string): Promise<api.ApiResult<{}>> {
+    return await this._delete<{}>(sessionName);
+  }
+
+  // Starts a read-write transaction. Spanner also allows a single-use
+  // transaction inlined on executeSql, but the runtime needs a durable id it
+  // can hold across the write and the commit.
+  async beginReadWrite(sessionName: string): Promise<api.ApiResult<Transaction>> {
+    return await this._post<Transaction>(
+        `${sessionName}:beginTransaction`, {options: {readWrite: {}}});
+  }
+
+  // Runs one statement inside `transactionId`, DML or query alike. A read here
+  // observes the transaction's own uncommitted writes (read-your-writes), so a
+  // caller can inspect what it just wrote before deciding to commit.
+  async executeSql(
+      sessionName: string, transactionId: string,
+      stmt: Statement): Promise<api.ApiResult<ResultSet>> {
+    const seqno = (this._seqno.get(transactionId) ?? 0) + 1;
+    this._seqno.set(transactionId, seqno);
+    return await this._post<ResultSet>(`${sessionName}:executeSql`, {
+      transaction: {id: transactionId},
+      sql: stmt.sql,
+      params: stmt.params,
+      paramTypes: stmt.paramTypes,
+      // Ignored for queries, required for DML; sent unconditionally so the
+      // counter stays in step with the statements actually issued.
+      seqno: `${seqno}`,
+    });
+  }
+
+  // Runs one statement outside any read-write transaction, as a single-use
+  // strong read. For a plain read -- showing state, resolving a display name --
+  // there is nothing to commit, and holding a transaction open for it would add
+  // a round trip and a rollback that say nothing.
+  async executeQuery(sessionName: string, stmt: Statement):
+      Promise<api.ApiResult<ResultSet>> {
+    return await this._post<ResultSet>(`${sessionName}:executeSql`, {
+      transaction: {singleUse: {readOnly: {strong: true}}},
+      sql: stmt.sql,
+      params: stmt.params,
+      paramTypes: stmt.paramTypes,
+    });
+  }
+
+  async commit(sessionName: string, transactionId: string):
+      Promise<api.ApiResult<{commitTimestamp?: string}>> {
+    this._seqno.delete(transactionId);
+    return await this._post<{commitTimestamp?: string}>(
+        `${sessionName}:commit`, {transactionId});
+  }
+
+  async rollback(sessionName: string, transactionId: string):
+      Promise<api.ApiResult<{}>> {
+    this._seqno.delete(transactionId);
+    return await this._post<{}>(`${sessionName}:rollback`, {transactionId});
+  }
+
+  // Runs `fn` with a fresh session and deletes it afterwards, including when
+  // `fn` throws -- a leaked session holds server resources until it ages out.
+  async withSession<T>(fn: (sessionName: string) => Promise<T>): Promise<T> {
+    const created = await this.createSession();
+    const sessionName = created.result?.name;
+    if (!sessionName) {
+      throw new Error(
+          `Spanner: could not create a session on ${this._database} (${
+              created.status}${created.message ? `: ${created.message}` : ''})`);
+    }
+    try {
+      return await fn(sessionName);
+    } finally {
+      await this.deleteSession(sessionName);
+    }
   }
 }

--- a/toolbox/mdcode/src/libts/gcp/spanner.ts
+++ b/toolbox/mdcode/src/libts/gcp/spanner.ts
@@ -207,7 +207,15 @@ export class SpannerDataClient extends api.ApiClient {
     try {
       return await fn(sessionName);
     } finally {
-      await this.deleteSession(sessionName);
+      // Cleaning up must not become the caller's result. A delete that fails
+      // after a successful commit would otherwise replace the outcome with an
+      // error, and a caller reading that as "the write did not happen" would
+      // apply it twice; a delete that fails after `fn` threw would hide the
+      // real reason. A leaked session ages out on its own.
+      try {
+        await this.deleteSession(sessionName);
+      } catch {
+      }
     }
   }
 }

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -1,0 +1,550 @@
+// The semantic runtime: executing a model's action against a live store.
+//
+// A semantic model has always described what things MEAN. Actions describe what
+// can be DONE. This module is where the two meet an actual database:
+//
+//   1. RESOLVE. An action's parameters are typed by the ontology, so an
+//      entity-typed argument is an object reference, not a value. The caller
+//      (often an agent) supplies something human -- an account id, a person's
+//      name -- and the runtime turns it into the row that argument denotes,
+//      failing loudly on "no such thing" and on "more than one such thing".
+//   2. BIND. Every argument becomes a query parameter of the store type its
+//      declared ontology type implies. Nothing is interpolated into SQL.
+//   3. APPLY. A read-write transaction is opened, the action's writes are run
+//      inside it, and it is committed. Any failure rolls back, so no partial
+//      write survives.
+//
+// Where the write comes from. An action with a `sql` executor carries its own
+// DML, and the runtime runs those statements itself. An action with an `mcp`,
+// `rest` or `grpc` executor names an operation that lives in another system,
+// which this module cannot call and could not roll back if it did; for those
+// the caller supplies a handler that produces the statements.
+//
+// What this does NOT do yet: evaluate the model's constraints. A constraint is
+// still text nothing checks, so an action whose outcome a constraint is
+// supposed to decide is REFUSED here rather than run unchecked -- see
+// `unsafeToRunUnchecked`. Refusing is the point. A model that declares a rule
+// and a runtime that quietly ignores it is worse than no runtime at all,
+// because the model states the write is checked and nothing says otherwise.
+
+import * as spanner from '../gcp/spanner';
+
+import {
+  Action,
+  ActionParameter,
+  Entity,
+  generatedKeyParam,
+  SemanticModel,
+} from './ir';
+import {spannerTable} from './spanner';
+import {referencedEntityNames} from './sql_expr_utils';
+import {quoteIfReserved, referencedParameters} from './sql_identifiers';
+
+
+// An entity-typed argument, resolved to the row it denotes.
+export interface EntityRef {
+  entity: string;
+  // Key values in the entity's declared key order, as strings (Spanner's REST
+  // surface returns every scalar as a string, and the runtime keeps them that
+  // way so a caller need not know the physical types).
+  keys: string[];
+  // How the caller referred to it, kept for error messages.
+  input: string;
+}
+
+
+// The writes an action performs: either built from its `sql` executor or
+// produced by the caller's handler.
+export interface ActionPlan {
+  // DML to run inside the transaction, in order.
+  statements: spanner.Statement[];
+}
+
+
+// What the handler is given: the action, its arguments with entity-typed ones
+// already resolved, and a reader scoped to the open transaction (so a handler
+// can look at the pre-state before deciding what to write).
+export interface ActionContext {
+  model: SemanticModel;
+  action: Action;
+  args: Record<string, unknown>;
+  refs: Record<string, EntityRef>;
+  query(stmt: spanner.Statement): Promise<string[][]>;
+}
+
+
+export type ActionHandler = (ctx: ActionContext) => Promise<ActionPlan>;
+
+
+export type ActionOutcome = {
+  status: 'committed';
+  commitTimestamp?: string;
+  refs: Record<string, EntityRef>;
+}|{
+  status: 'error';
+  // A failure that stopped the write: an argument that resolved to nothing, an
+  // action this runtime will not run unchecked, a store-level error. The
+  // transaction is rolled back in every case, so no partial write survives.
+  message: string;
+};
+
+
+export interface RunActionOptions {
+  model: SemanticModel;
+  actionName: string;
+  args: Record<string, unknown>;
+  client: spanner.SpannerDataClient;
+  // Supplies the writes for an action whose executor lives in another system.
+  // Omit it for a `sql` executor, whose writes are in the model.
+  handler?: ActionHandler;
+}
+
+
+// Runs one action end to end. Never throws for an expected failure -- an
+// unresolvable argument, a refused action, a rejected statement all come back
+// as an outcome, because the caller is usually an agent that needs to read the
+// reason and try again.
+export async function runAction(opts: RunActionOptions):
+    Promise<ActionOutcome> {
+  const {model, client, args} = opts;
+  const action = (model.actions ?? []).find(a => a.name === opts.actionName);
+  if (!action) {
+    return {
+      status: 'error',
+      message: `Model '${model.name}' declares no action '${opts.actionName}'.`,
+    };
+  }
+  if (!opts.handler && action.executor.kind !== 'sql') {
+    return {
+      status: 'error',
+      message: `Action '${action.name}' is executed by ${
+          action.executor.kind.toUpperCase()}, which runs outside this ` +
+          `transaction and could not be rolled back if the commit failed. ` +
+          `Supply a handler that performs the write as DML, or declare the ` +
+          `action with a 'sql' executor.`,
+    };
+  }
+
+  // Decided BEFORE touching the store, so an action this runtime will not run
+  // fails without having opened a transaction at all.
+  const unsafe = unsafeToRunUnchecked(model, action);
+  if (unsafe) return {status: 'error', message: unsafe};
+
+  try {
+    return await client.withSession(async sessionName => {
+      const begun = await client.beginReadWrite(sessionName);
+      const transactionId = begun.result?.id;
+      if (!transactionId) {
+        return {
+          status: 'error',
+          message: `Could not begin a transaction on ${client.database} (${
+              begun.status}${begun.message ? `: ${begun.message}` : ''}).`,
+        } as ActionOutcome;
+      }
+
+      const run = async (stmt: spanner.Statement) => {
+        const res = await client.executeSql(sessionName, transactionId, stmt);
+        if (res.status < 200 || res.status >= 300) {
+          throw new StoreError(
+              `${res.message ?? 'request failed'} (while running: ${stmt.sql})`);
+        }
+        return res.result ?? {};
+      };
+      const query = async (stmt: spanner.Statement) =>
+          (await run(stmt)).rows ?? [];
+
+      // Everything from here on is inside the transaction, so any failure must
+      // roll back rather than leave it open.
+      try {
+        const rollback = async (outcome: ActionOutcome) => {
+          await client.rollback(sessionName, transactionId);
+          return outcome;
+        };
+
+        const resolved = await resolveArguments(model, action, args, query);
+        if ('error' in resolved) {
+          return await rollback({status: 'error', message: resolved.error});
+        }
+        const refs = resolved.refs;
+
+        const bound = bindArguments(model, action, args, refs);
+        if ('error' in bound) {
+          return await rollback({status: 'error', message: bound.error});
+        }
+
+        const plan = opts.handler ?
+            await opts.handler({model, action, args, refs, query}) :
+            planFromExecutor(action, bound, generatedKeys(action));
+        if ('error' in plan) {
+          return await rollback({status: 'error', message: plan.error});
+        }
+        for (const stmt of plan.statements) {
+          await run(stmt);
+        }
+
+        const committed = await client.commit(sessionName, transactionId);
+        if (committed.status < 200 || committed.status >= 300) {
+          return {
+            status: 'error',
+            message: `The write ran but the commit failed: ${
+                committed.message ?? committed.status}.`,
+          } as ActionOutcome;
+        }
+        return {
+          status: 'committed',
+          commitTimestamp: committed.result?.commitTimestamp,
+          refs,
+        } as ActionOutcome;
+      } catch (err) {
+        await client.rollback(sessionName, transactionId);
+        throw err;
+      }
+    });
+  } catch (err) {
+    return {
+      status: 'error',
+      message: `Action '${action.name}' failed and was rolled back: ${
+          err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+
+// A store-level failure, distinguished from a programming error so the message
+// surfaced to the caller stays about the store.
+class StoreError extends Error {}
+
+
+// Why this runtime will not run `action`, or null if it is safe to run.
+//
+// Nothing here evaluates a constraint yet, so the only honest thing to do with
+// an action a constraint is supposed to decide is refuse it. Three shapes say a
+// constraint may bear on this call:
+//
+//   * The action NAMES one in `guards`. That is the author stating the
+//     constraint is checked before this call, which is precisely what is
+//     missing.
+//   * A constraint reads an entity the action `affects`. The author never had
+//     to link the two -- an invariant over stored data holds for every write,
+//     however the row arrived -- so the overlap is the only signal there is. It
+//     is computed from the expression's qualifiers, the same derivation the
+//     emitters use.
+//   * The model declares constraints and the action declares no `affects` at
+//     all. Then there is nothing to compare and no way to rule an overlap out,
+//     so this refuses too. Reading silence as "nothing is constrained" is the
+//     one guess that fails open, and `affects` is the fix the author can make.
+//
+// An action over entities no constraint mentions runs today, which is what
+// makes this runtime useful before the evaluator exists.
+function unsafeToRunUnchecked(
+    model: SemanticModel, action: Action): string|null {
+  const guards = action.guards ?? [];
+  if (guards.length) {
+    return `Action '${action.name}' is guarded by ${quoteList(guards)}, and ` +
+        `this runtime does not evaluate constraints yet. Running it would ` +
+        `apply a write the model says must be checked first, so it is ` +
+        `refused rather than run unchecked.`;
+  }
+
+  const constraints = model.constraints ?? [];
+  if (constraints.length && !(action.affects ?? []).length) {
+    return `Action '${action.name}' declares no 'affects', so there is no ` +
+        `way to tell whether the ${constraints.length} constraint(s) this ` +
+        `model states bear on its write, and this runtime does not evaluate ` +
+        `constraints yet. Declare what the action changes and it will run if ` +
+        `nothing constrains that data.`;
+  }
+
+  const bearing = constraintsOverAffected(model, action);
+  if (bearing.length) {
+    return `Action '${action.name}' writes data that ${quoteList(bearing)} ` +
+        `constrains, and this runtime does not evaluate constraints yet. The ` +
+        `write could leave the store violating a rule the model states, so ` +
+        `it is refused rather than run unchecked.`;
+  }
+  return null;
+}
+
+
+// The names of constraints whose expression reads an entity this action
+// affects, sorted so a message is stable.
+function constraintsOverAffected(
+    model: SemanticModel, action: Action): string[] {
+  const constraints = model.constraints ?? [];
+  const affected = new Set((action.affects ?? []).map(a => a.concept));
+  if (!constraints.length || !affected.size) return [];
+
+  const entityNames = (model.entities ?? []).map(e => e.name);
+  const names: string[] = [];
+  for (const c of constraints) {
+    const read = referencedEntityNames(c.expression, entityNames);
+    if (read.some(name => affected.has(name))) names.push(c.name);
+  }
+  return names.sort();
+}
+
+
+function quoteList(names: readonly string[]): string {
+  const quoted = names.map(n => `'${n}'`);
+  if (quoted.length === 1) return quoted[0];
+  return `${quoted.slice(0, -1).join(', ')} and ${quoted[quoted.length - 1]}`;
+}
+
+
+interface Bindings {
+  params: Record<string, unknown>;
+  types: Record<string, {code: string}>;
+}
+
+
+// Turns each declared parameter into a bound value: an entity-typed one into
+// the key of the row it resolved to, a scalar into a value of the store's
+// matching type. Nothing is interpolated into SQL, so no argument can reach the
+// store as anything but data.
+function bindArguments(
+    model: SemanticModel, action: Action, args: Record<string, unknown>,
+    refs: Record<string, EntityRef>): Bindings|{error: string} {
+  const params: Record<string, unknown> = {};
+  const types: Record<string, {code: string}> = {};
+  for (const param of action.parameters) {
+    const bound = param.isEntityRef ?
+        bindReference(model, param, refs[param.name]) :
+        bindScalar(param, args[param.name]);
+    if ('error' in bound) return {error: bound.error};
+    params[param.name] = bound.value;
+    types[param.name] = {code: bound.code};
+  }
+  return {params, types};
+}
+
+
+// An object reference as its key value, typed by the ontology. Resolution
+// returns every key as a string, because that is what the store's REST surface
+// gives back; binding it into a statement needs the type the KEY FIELD declares,
+// or an integer-keyed row would be handed to the store as text.
+function bindReference(
+    model: SemanticModel, param: ActionParameter, ref: EntityRef|undefined):
+    {value: unknown; code: string}|{error: string} {
+  if (!ref) return {error: `Parameter '${param.name}' was not resolved.`};
+  if (ref.keys.length !== 1) {
+    return {
+      error: `Parameter '${param.name}' refers to a ${param.type}, whose key ` +
+          `has ${ref.keys.length} parts; the runtime binds an object ` +
+          `reference as a single value, so a composite key cannot be passed ` +
+          `to a statement.`,
+    };
+  }
+  const entity = (model.entities ?? []).find(e => e.name === param.type);
+  const keyField = entity?.fields.find(f => f.name === (entity.keys ?? [])[0]);
+  return bindScalar(
+      {name: param.name, type: keyField?.type ?? 'String'}, ref.keys[0]);
+}
+
+
+// One scalar argument as a Spanner value. The declared ontology type picks the
+// store type, so a `Decimal` amount is compared as a number rather than as text
+// -- which is the difference between "9" being less than "10" and not.
+function bindScalar(param: ActionParameter, raw: unknown):
+    {value: unknown; code: string}|{error: string} {
+  if (raw === undefined || raw === null || `${raw}`.trim() === '') {
+    return {
+      error: `Action parameter '${param.name}' (${param.type}) was not given ` +
+          `a value.`,
+    };
+  }
+  const text = `${raw}`.trim();
+  switch (param.type) {
+    case 'Integer':
+      if (!/^[-+]?\d+$/.test(text)) {
+        return {error: `'${param.name}' is an Integer, but '${text}' is not.`};
+      }
+      // INT64 travels as a string over the REST surface; a JSON number would
+      // lose precision above 2^53.
+      return {value: text, code: 'INT64'};
+    case 'Float':
+      if (!Number.isFinite(Number(text))) {
+        return {error: `'${param.name}' is a Float, but '${text}' is not.`};
+      }
+      return {value: Number(text), code: 'FLOAT64'};
+    case 'Decimal':
+      if (!/^[-+]?\d+(\.\d+)?$/.test(text)) {
+        return {error: `'${param.name}' is a Decimal, but '${text}' is not.`};
+      }
+      // NUMERIC travels as a string, for the same reason: an exact decimal
+      // routed through a JSON number stops being exact.
+      return {value: text, code: 'NUMERIC'};
+    case 'Boolean':
+      if (!/^(true|false)$/i.test(text)) {
+        return {error: `'${param.name}' is a Boolean, but '${text}' is not.`};
+      }
+      return {value: /^true$/i.test(text), code: 'BOOL'};
+    case 'Date':
+      return {value: text, code: 'DATE'};
+    case 'DateTime':
+    case 'DateTimeTz':
+      return {value: text, code: 'TIMESTAMP'};
+    default:
+      return {value: text, code: 'STRING'};
+  }
+}
+
+
+// A key for every concept the action creates, named as the DML expects it. The
+// model's own statements bind `@new<Concept>Key`, so the value has to exist
+// before the statement runs -- which rules out letting the store assign it.
+function generatedKeys(action: Action): Record<string, string> {
+  const keys: Record<string, string> = {};
+  for (const affected of action.affects ?? []) {
+    if (affected.operation !== 'create') continue;
+    keys[affected.concept] = crypto.randomUUID();
+  }
+  return keys;
+}
+
+
+// Builds the plan from the action's own DML. Every `@name` in a statement is
+// either a declared parameter or a key this call generates; validate.ts refuses
+// a model where it is neither, so an unbound reference cannot reach here.
+function planFromExecutor(
+    action: Action, bound: Bindings,
+    generated: Record<string, string>): ActionPlan|{error: string} {
+  if (action.executor.kind !== 'sql') {
+    return {error: `Action '${action.name}' has no 'sql' executor.`};
+  }
+  const values: Record<string, unknown> = {...bound.params};
+  const types: Record<string, {code: string}> = {...bound.types};
+  for (const [concept, key] of Object.entries(generated)) {
+    values[generatedKeyParam(concept)] = key;
+    types[generatedKeyParam(concept)] = {code: 'STRING'};
+  }
+
+  const statements: spanner.Statement[] = [];
+  for (const sql of action.executor.sql.statements) {
+    const params: Record<string, unknown> = {};
+    const paramTypes: Record<string, {code: string}> = {};
+    for (const name of referencedParameters(sql)) {
+      if (!(name in values)) {
+        return {
+          error: `Action '${action.name}' binds '@${name}', which is neither ` +
+              `a parameter it declares nor a key it generates.`,
+        };
+      }
+      params[name] = values[name];
+      paramTypes[name] = types[name];
+    }
+    statements.push({sql, params, paramTypes});
+  }
+  return {statements};
+}
+
+
+// Turns each entity-typed argument into the row it denotes. Scalar arguments
+// pass through untouched; this is only about object references.
+async function resolveArguments(
+    model: SemanticModel, action: Action, args: Record<string, unknown>,
+    query: (stmt: spanner.Statement) => Promise<string[][]>):
+    Promise<{refs: Record<string, EntityRef>}|{error: string}> {
+  const refs: Record<string, EntityRef> = {};
+  for (const param of action.parameters) {
+    if (!param.isEntityRef) continue;
+    const raw = args[param.name];
+    if (raw === undefined || raw === null || `${raw}`.trim() === '') {
+      return {
+        error: `Action '${action.name}' requires '${param.name}', a reference ` +
+            `to a ${param.type}, but none was given.`,
+      };
+    }
+    const entity = (model.entities ?? []).find(e => e.name === param.type);
+    if (!entity) {
+      return {
+        error: `Parameter '${param.name}' is typed '${param.type}', which the ` +
+            `model does not declare as an entity.`,
+      };
+    }
+    const resolved = await resolveEntityRef(entity, `${raw}`, query);
+    if ('error' in resolved) return {error: resolved.error};
+    refs[param.name] = resolved.ref;
+  }
+  return {refs};
+}
+
+
+// Resolves one object reference. `input` is matched against the entity's key
+// and, when it has one, its identifying text field -- so an agent can say
+// "Account 1" or "Alice" and the runtime finds the same row either way.
+//
+// Both failure modes are reported precisely, because both are things the caller
+// can act on: nothing matched (the reference is wrong) or several matched (the
+// reference is ambiguous, and the candidates are listed).
+async function resolveEntityRef(
+    entity: Entity, input: string,
+    query: (stmt: spanner.Statement) => Promise<string[][]>):
+    Promise<{ref: EntityRef}|{error: string}> {
+  const warnings: string[] = [];
+  const table =
+      spannerTable(entity.dataSource, warnings, `entity '${entity.name}'`);
+  if (warnings.length) {
+    return {error: `Cannot resolve a ${entity.name}: ${warnings.join('; ')}.`};
+  }
+
+  const keyColumns: string[] = [];
+  for (const key of entity.keys) {
+    const field = entity.fields.find(f => f.name === key);
+    const expr = (field?.expression ?? '').trim();
+    if (!expr || !/^[A-Za-z_]\w*$/.test(expr)) {
+      return {
+        error: `Cannot resolve a ${entity.name}: its key field '${
+            key}' is not bound to a plain column.`,
+      };
+    }
+    keyColumns.push(quoteIfReserved(expr));
+  }
+  if (!keyColumns.length) {
+    return {error: `Cannot resolve a ${entity.name}: it declares no key.`};
+  }
+
+  const predicates = keyColumns.map(c => `CAST(${c} AS STRING) = @ref`);
+  const label = identifyingColumn(entity);
+  if (label) predicates.push(`CAST(${label} AS STRING) = @ref`);
+
+  // LIMIT 2 is enough to tell "one match" from "more than one", and avoids
+  // dragging back a large candidate set just to reject it.
+  const rows = await query({
+    sql: `SELECT ${keyColumns.join(', ')} FROM ${table} WHERE ${
+        predicates.join(' OR ')} LIMIT 2`,
+    params: {ref: input},
+    paramTypes: {ref: {code: 'STRING'}},
+  });
+
+  if (!rows.length) {
+    return {error: `No ${entity.name} matches '${input}'.`};
+  }
+  if (rows.length > 1) {
+    return {
+      error: `'${input}' matches more than one ${entity.name} (${
+          rows.map(r => r.join('/')).join(', ')}); use a key to disambiguate.`,
+    };
+  }
+  return {ref: {entity: entity.name, keys: rows[0], input}};
+}
+
+
+// The entity's identifying text field, if it has an obvious one: a String field
+// that is not part of the key and whose name reads as a name. Deliberately
+// conservative -- guessing wrong would make an agent's reference resolve to the
+// wrong row, which is worse than making it supply a key.
+function identifyingColumn(entity: Entity): string|null {
+  const keys = new Set(entity.keys);
+  for (const field of entity.fields) {
+    if (keys.has(field.name)) continue;
+    if (field.type !== 'String') continue;
+    if (!/^(name|full_name|fullname|title|label|display_name)$/i.test(
+            field.name)) {
+      continue;
+    }
+    const expr = (field.expression ?? '').trim();
+    if (!expr || !/^[A-Za-z_]\w*$/.test(expr)) continue;
+    return quoteIfReserved(expr);
+  }
+  return null;
+}

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -24,24 +24,29 @@
 // the caller supplies a handler that produces the statements.
 //
 // What this does NOT do yet: evaluate the model's constraints. A constraint is
-// still text nothing checks, so an action whose outcome a constraint is
-// supposed to decide is REFUSED here rather than run unchecked -- see
-// `unsafeToRunUnchecked`. Refusing is the point. A model that declares a rule
-// and a runtime that quietly ignores it is worse than no runtime at all,
-// because the model states the write is checked and nothing says otherwise.
+// still text nothing checks, so an action that NAMES one in `guards` is REFUSED
+// here rather than run unchecked -- see `unsafeToRunUnchecked`. Refusing is the
+// point. A model that declares a rule and a runtime that quietly ignores it is
+// worse than no runtime at all, because the model states the call is checked
+// and nothing says otherwise.
+//
+// A constraint no action names gates nothing here, because it gates nothing
+// anywhere: a rule takes effect where something references it, and `guards` is
+// that reference for an action (see Action.guards in ir.ts). Refusing on a
+// constraint that merely reads data the action writes would mean publishing a
+// rule silently stopped calls that succeeded the day before, which is the
+// property that reference rule exists to guarantee.
 
 import * as spanner from '../gcp/spanner';
 
 import {
   Action,
   ActionParameter,
-  Constraint,
   Entity,
   generatedKeyParam,
   SemanticModel,
 } from './ir';
 import {spannerTable} from './spanner';
-import {referencedEntityNames} from './sql_expr_utils';
 import {quoteIfReserved, referencedParameters} from './sql_identifiers';
 
 
@@ -138,7 +143,7 @@ export async function runAction(opts: RunActionOptions):
 
   // Decided BEFORE touching the store, so an action this runtime will not run
   // fails without having opened a transaction at all.
-  const unsafe = unsafeToRunUnchecked(model, action, !!opts.handler);
+  const unsafe = unsafeToRunUnchecked(model, action);
   if (unsafe) return {status: 'error', message: unsafe};
 
   // Whether a transaction was ever opened. A session that could not be
@@ -320,28 +325,19 @@ const DEFINITELY_NOT_COMMITTED = new Set([400, 401, 403, 404, 409, 412]);
 
 // Why this runtime will not run `action`, or null if it is safe to run.
 //
-// Nothing here evaluates a constraint yet, so the only honest thing to do with
-// an action a constraint is supposed to decide is refuse it. Three shapes say a
-// constraint may bear on this call:
+// One question, and it is narrower than "could some rule bear on this write":
+// does the action name a constraint that has to be checked before it runs,
+// which nothing can check yet. `guards` is what gives a constraint effect over
+// a call -- a rule no action names is a catalogued rule no call consults -- so
+// the model's own answer to "what gates this" is the list, and reading further
+// would be this module inventing an obligation the model does not state.
 //
-//   * The action NAMES one in `guards`. That is the author stating the
-//     constraint is checked before this call, which is precisely what is
-//     missing.
-//   * A constraint reads an entity the action `affects`. The author never had
-//     to link the two -- an invariant over stored data holds for every write,
-//     however the row arrived -- so the overlap is the only signal there is. It
-//     is computed from the expression's qualifiers, the same derivation the
-//     emitters use.
-//   * The model declares constraints and the action declares no `affects` at
-//     all. Then there is nothing to compare and no way to rule an overlap out,
-//     so this refuses too. Reading silence as "nothing is constrained" is the
-//     one guess that fails open, and `affects` is the fix the author can make.
-//
-// An action over entities no constraint mentions runs today, which is what
-// makes this runtime useful before the evaluator exists.
+// An action naming no guard therefore runs. That is not this module judging the
+// write safe; it is the model saying no rule gates the call. What the write
+// does is the author's, which is what `affects` describes and what the
+// evaluator will check against the statements once it exists.
 function unsafeToRunUnchecked(
-    model: SemanticModel, action: Action,
-    plannedByCaller: boolean): string|null {
+    model: SemanticModel, action: Action): string|null {
   // A guard names a constraint the author says is checked before the call.
   // One whose `onViolation` is `warn` reports rather than refuses, so an
   // evaluator would let the write through, and refusing here would make a
@@ -358,159 +354,7 @@ function unsafeToRunUnchecked(
         `apply a write the model says must be checked first, so it is ` +
         `refused rather than run unchecked.`;
   }
-
-  const constraints = gatingConstraints(model);
-  if (constraints.length && !(action.affects ?? []).length) {
-    return `Action '${action.name}' declares no 'affects', so there is no ` +
-        `way to tell whether the ${constraints.length} constraint(s) this ` +
-        `model states bear on its write, and this runtime does not evaluate ` +
-        `constraints yet. Declare what the action changes and it will run if ` +
-        `nothing constrains that data.`;
-  }
-
-  const bearing = constraintsOverAffected(model, action, plannedByCaller);
-  if (bearing.length) {
-    return `Action '${action.name}' writes data that ${quoteList(bearing)} ` +
-        `could constrain, and this runtime does not evaluate constraints ` +
-        `yet. The write could leave the store violating a rule the model ` +
-        `states, so it is refused rather than run unchecked.`;
-  }
   return null;
-}
-
-
-// The names of constraints whose expression may read a concept this action
-// affects, sorted so a message is stable.
-//
-// This is the one place the refusal rule could fail open, so it errs the other
-// way twice. A constraint's expression is a logical invariant this module does
-// not parse, and `affects` names an entity OR a relationship, so:
-//
-//   * The scan covers relationships as well as entities. Validation
-//     deliberately permits a relationship-qualified name like
-//     `OrderedAs.quantity`, and an M:N `create` writes exactly the junction
-//     table such a constraint is about.
-//   * A constraint matching no known concept counts as bearing on all of them.
-//     An unqualified expression (`amount > 0`) names nothing this can compare,
-//     and "it mentions no entity, so it constrains none" is the reading that
-//     runs an unchecked write.
-//
-// The cost of both is refusing an action that would have been fine, which the
-// evaluator will then let through. That is the direction to be wrong in.
-// The constraints that could REFUSE a write. `onViolation: warn` says a
-// violation is reported rather than rejected, so such a rule cannot decide
-// whether an action may run -- and gating on it would make a model that states
-// advisory rules permanently unrunnable, with nothing the author could change.
-// An absent `onViolation` carries no default (see VIOLATION_EFFECTS), so it is
-// NOT read as advisory here: only the explicit `warn` stands down.
-function gatingConstraints(model: SemanticModel): Constraint[] {
-  return (model.constraints ?? []).filter(c => c.onViolation !== 'warn');
-}
-
-
-// The concepts an action's own statements write, or null for "cannot tell".
-//
-// Only a `sql` executor has statements to read. For any other kind this
-// returns an empty set, which leaves the declared `affects` as the only
-// evidence there is -- the write lives in a system this cannot see. Null is
-// different and stronger: a statement names a table this cannot attribute to a
-// concept, so nothing here supports the claim that some constraint does not
-// bear on the write, and the caller must read it as every concept rather than
-// as none.
-//
-// The statements are validated to be one DML verb each with no `;`
-// (sqlExecutorErrors), so the target is the identifier after the verb.
-function conceptsWrittenBy(
-    model: SemanticModel, action: Action,
-    plannedByCaller: boolean): Set<string>|null {
-  // A handler supplies the plan, so the model's statements are not what runs
-  // and reading them would widen the blast radius by dead text. That leaves
-  // `affects` as the only account of the write -- the same position every
-  // non-`sql` executor is already in, since those name a system that performs
-  // it and put no statements in the model at all.
-  if (plannedByCaller || action.executor.kind !== 'sql') return new Set();
-  const statements = action.executor.sql?.statements ?? [];
-
-  // An action's statements address a table by its final name segment -- the
-  // same reading `spannerTable` produces for the resolver -- so the map is
-  // keyed that way, and case-insensitively, because SQL identifiers are.
-  //
-  // A collision is possible, and resolving it by guessing is the one thing
-  // this must not do. Two entities bound to `...dsA/tables/orders` and
-  // `...dsB/tables/orders` both read as `orders`; taking the last one written
-  // would answer "this statement writes ArchivedOrders" for a statement over
-  // Orders, and a constraint stated over Orders would then find no overlap and
-  // stand down. So a second concept on the same table marks it unanswerable
-  // rather than overwriting the first.
-  const ignored: string[] = [];
-  const byTable = new Map<string, string|null>();
-  const add = (source: string|undefined, concept: string) => {
-    if (!source) return;
-    const table =
-        spannerTable(source, ignored, concept).replace(/`/g, '').toLowerCase();
-    if (!table) return;
-    const seen = byTable.get(table);
-    byTable.set(table, seen === undefined || seen === concept ? concept : null);
-  };
-  for (const entity of model.entities ?? []) add(entity.dataSource, entity.name);
-  for (const rel of model.relationships ?? []) {
-    add(rel.association?.dataSource, rel.name);
-  }
-
-  const written = new Set<string>();
-  for (const sql of statements) {
-    const target =
-        /\b(?:insert\s+into|update|delete\s+from)\s+(`[^`]+`|[\w$]+)/i.exec(sql);
-    if (!target) return null;
-    const concept = byTable.get(target[1].replace(/`/g, '').toLowerCase());
-    // A table no concept binds -- or one that several bind, which names no
-    // single concept -- is not something this can vouch for, and what it would
-    // be vouching for is running the write unchecked.
-    if (!concept) return null;
-    written.add(concept);
-  }
-  return written;
-}
-
-
-function constraintsOverAffected(
-    model: SemanticModel, action: Action, plannedByCaller: boolean): string[] {
-  const constraints = gatingConstraints(model);
-  if (!constraints.length) return [];
-
-  // What the author DECLARED, widened by what the statements actually write.
-  // `affects` is a declaration, and an action declaring `affects: [Transfer
-  // create]` whose second statement is `UPDATE Account SET ...` would
-  // otherwise pass a test that never read the write it is about to run. For a
-  // `sql` executor the statements are in hand, so the blast radius is checked
-  // rather than taken on trust.
-  const affected = new Set((action.affects ?? []).map(a => a.concept));
-  const written = conceptsWrittenBy(model, action, plannedByCaller);
-  if (!written) return constraints.map(c => c.name).sort();
-  for (const name of written) affected.add(name);
-  if (!affected.size) return [];
-
-  const conceptNames = [
-    ...(model.entities ?? []).map(e => e.name),
-    ...(model.relationships ?? []).map(r => r.name),
-  ];
-  const names: string[] = [];
-  for (const c of constraints) {
-    // A judged constraint states its rule in prose for a language model to
-    // settle, so it declares no expression and there are no qualifiers to read
-    // a coverage set out of. What it covers is therefore unknown, and unknown
-    // counts against every action -- the same answer this gives an expression
-    // that names no concept it recognizes.
-    if (c.expression === undefined) {
-      names.push(c.name);
-      continue;
-    }
-    const read = referencedEntityNames(c.expression, conceptNames);
-    if (!read.length || read.some(name => affected.has(name))) {
-      names.push(c.name);
-    }
-  }
-  return names.sort();
 }
 
 

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -179,7 +179,21 @@ export async function runAction(opts: RunActionOptions):
       opened = true;
 
       const run = async (stmt: spanner.Statement) => {
-        const res = await client.executeSql(sessionName, transactionId, stmt);
+        // A refusal arrives as a non-2xx response; a dropped socket, a DNS
+        // failure or a TLS error arrives as a thrown fetch error instead.
+        // Both are the store not answering, and neither is this process being
+        // wrong -- so both have to leave here as a StoreError. Without this
+        // the thrown one reaches the outer catch as a plain Error and is
+        // reported as a failure inside the runtime, which sends the reader to
+        // look for a bug in the code instead of retrying a transient fault.
+        let res;
+        try {
+          res = await client.executeSql(sessionName, transactionId, stmt);
+        } catch (err) {
+          throw new StoreError(`${
+              err instanceof Error ? err.message :
+                                     String(err)} (while running: ${stmt.sql})`);
+        }
         if (res.status < 200 || res.status >= 300) {
           throw new StoreError(
               `${res.message ?? 'request failed'} (while running: ${stmt.sql})`);
@@ -433,6 +447,25 @@ function bindReference(
 // One scalar argument as a Spanner value. The declared ontology type picks the
 // store type, so a `Decimal` amount is compared as a number rather than as text
 // -- which is the difference between "9" being less than "10" and not.
+// What Spanner accepts for a DATE and a TIMESTAMP parameter. The zone is
+// required rather than defaulted, because a timestamp written without one
+// means a different instant to every reader who supplies the missing part.
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const RFC3339_TIMESTAMP =
+    /^\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[-+]\d{2}:?\d{2})$/;
+
+
+// Whether `text` is a day that exists, written the one way Spanner reads.
+// `Date.parse` answers neither question: it accepts '03/04/2026', and it reads
+// '2026-02-30' as the second of March rather than rejecting it. A round trip
+// answers both, because a day that rolled over comes back written differently.
+function isCalendarDay(text: string): boolean {
+  if (!ISO_DATE.test(text)) return false;
+  const utc = new Date(`${text}T00:00:00Z`);
+  return !Number.isNaN(utc.getTime()) && utc.toISOString().startsWith(text);
+}
+
+
 function bindScalar(param: ActionParameter, raw: unknown):
     {value: unknown; code: string}|{error: string} {
   // An empty String IS a value: `--arg memo=` is the caller saying the memo is
@@ -472,9 +505,26 @@ function bindScalar(param: ActionParameter, raw: unknown):
       }
       return {value: /^true$/i.test(text), code: 'BOOL'};
     case 'Date':
+      // Spanner reads a DATE as YYYY-MM-DD and nothing else. '03/04/2026' is
+      // the fourth of March to one reader and the third of April to another,
+      // so the shape is checked -- and then the calendar, because a shape is
+      // not a day.
+      if (!isCalendarDay(text)) {
+        return {
+          error: `'${param.name}' is a Date, but '${
+              text}' is not one. Dates are written YYYY-MM-DD.`,
+        };
+      }
       return {value: text, code: 'DATE'};
     case 'DateTime':
     case 'DateTimeTz':
+      if (!RFC3339_TIMESTAMP.test(text) || !isCalendarDay(text.slice(0, 10))) {
+        return {
+          error: `'${param.name}' is a ${param.type}, but '${
+              text}' is not a timestamp. Timestamps are written like ` +
+              `2026-03-04T10:00:00Z, with the zone.`,
+        };
+      }
       return {value: text, code: 'TIMESTAMP'};
     default:
       // `raw`, not `text`. The trim above exists to parse a number or a date

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -130,11 +130,26 @@ export async function runAction(opts: RunActionOptions):
       message: `Model '${model.name}' declares no action '${opts.actionName}'.`,
     };
   }
-  if (!opts.handler && action.executor.kind !== 'sql') {
+  // No executor at all is a binding outcome, not a broken model: the executor
+  // is a physical facet, so an action can be declared here and performable
+  // only somewhere else. Say which it is, because the fix is in the profile
+  // rather than in the action.
+  const executor = action.executor;
+  if (!executor) {
+    return {
+      status: 'error',
+      message: `Action '${action.name}' has no executor under this binding, ` +
+          `so there is nothing to run. An executor is a physical binding: a ` +
+          `profile supplies one, and a profile that writes 'executor: null' ` +
+          `withdraws it. The action is still declared and still published; ` +
+          `it is only not performable here.`,
+    };
+  }
+  if (!opts.handler && executor.kind !== 'sql') {
     return {
       status: 'error',
       message: `Action '${action.name}' is executed by ${
-          action.executor.kind.toUpperCase()}, which runs outside this ` +
+          executor.kind.toUpperCase()}, which runs outside this ` +
           `transaction and could not be rolled back if the commit failed. ` +
           `Supply a handler that performs the write as DML, or declare the ` +
           `action with a 'sql' executor.`,
@@ -522,7 +537,8 @@ function unusableGeneratedKey(
 function planFromExecutor(
     model: SemanticModel, action: Action, bound: Bindings,
     generated: Record<string, string>): ActionPlan|{error: string} {
-  if (action.executor.kind !== 'sql') {
+  const executor = action.executor;
+  if (executor?.kind !== 'sql') {
     return {error: `Action '${action.name}' has no 'sql' executor.`};
   }
   // Null-prototype maps throughout. Parameter names come from the model, and
@@ -541,7 +557,7 @@ function planFromExecutor(
   }
 
   const statements: spanner.Statement[] = [];
-  for (const sql of action.executor.sql.statements) {
+  for (const sql of executor.sql.statements) {
     const params: Record<string, unknown> = {};
     const paramTypes: Record<string, {code: string}> = {};
     for (const name of referencedParameters(sql)) {

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -138,7 +138,7 @@ export async function runAction(opts: RunActionOptions):
 
   // Decided BEFORE touching the store, so an action this runtime will not run
   // fails without having opened a transaction at all.
-  const unsafe = unsafeToRunUnchecked(model, action);
+  const unsafe = unsafeToRunUnchecked(model, action, !!opts.handler);
   if (unsafe) return {status: 'error', message: unsafe};
 
   // Whether a transaction was ever opened. A session that could not be
@@ -225,13 +225,21 @@ export async function runAction(opts: RunActionOptions):
               `response -- so read the affected data before retrying.`,
         });
 
-        // A commit fails in two shapes, and they mean the same thing here. It
-        // can RETURN a non-2xx, or it can REJECT outright: the request throws
-        // on a socket hang-up, a DNS failure or an abort, and reading the
-        // response body can throw too. That second shape is precisely what a
-        // commit deadline looks like from the client -- so letting it fall
-        // through to the catch below, which rolls back and says so, would
-        // state the exact opposite of what this branch exists to say.
+        // A commit fails in three shapes, and only two of them are unknowable.
+        // It can REJECT outright -- the request throws on a socket hang-up, a
+        // DNS failure or an abort -- which is precisely what a commit deadline
+        // looks like from the client. It can RETURN a 5xx or a timeout, which
+        // Spanner sends just as readily for a commit that landed and lost its
+        // response as for one that did not. Both are indeterminate, and
+        // letting either fall through to the catch below, which rolls back and
+        // says so, would state the opposite of what is known.
+        //
+        // But a commit can also be REFUSED, definitively, and the commonest
+        // refusal is routine: `409 ABORTED` is what Spanner returns under lock
+        // contention, and it guarantees the transaction applied nothing. The
+        // right response to it is to run the action again. Telling that caller
+        // the write may have landed and the data must be read before retrying
+        // would turn every lock conflict into an investigation.
         let committed;
         try {
           committed = await client.commit(sessionName, transactionId);
@@ -239,7 +247,21 @@ export async function runAction(opts: RunActionOptions):
           return indeterminate(err instanceof Error ? err.message : `${err}`);
         }
         if (committed.status < 200 || committed.status >= 300) {
-          return indeterminate(`${committed.message ?? committed.status}`);
+          const reason = `${committed.message ?? committed.status}`;
+          if (!DEFINITELY_NOT_COMMITTED.has(committed.status)) {
+            return indeterminate(reason);
+          }
+          // Rolled back on the way out. An ABORTED transaction is already
+          // gone, so this is a no-op for the commonest case, but a refusal on
+          // other grounds can leave one open, and it costs a request either
+          // way.
+          return await rollback({
+            status: 'error',
+            message: `Action '${action.name}' was not committed on ${
+                client.database}: ${reason}. The store refused the commit ` +
+                `outright, so nothing was written and the action can be run ` +
+                `again.`,
+          });
         }
         return {
           status: 'committed',
@@ -256,12 +278,26 @@ export async function runAction(opts: RunActionOptions):
     });
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
+    if (!opened) {
+      return {
+        status: 'error',
+        message:
+            `Action '${action.name}' could not start on ${client.database}: ${
+                reason}`,
+      };
+    }
+    // A statement the store rejected and a bug in a handler both arrive here,
+    // and they are not the same news. The first is the action failing on its
+    // own terms, and the message is about the write. The second is this
+    // process being wrong, and reporting it as a rejected write sends the
+    // reader to the data to look for a problem that is in the code.
     return {
       status: 'error',
-      message: opened ?
+      message: err instanceof StoreError ?
           `Action '${action.name}' failed and was rolled back: ${reason}` :
-          `Action '${action.name}' could not start on ${client.database}: ${
-              reason}`,
+          `Action '${action.name}' failed and was rolled back, but not on ` +
+              `the store's account: ${reason}. That is a failure inside the ` +
+              `runtime or its caller rather than a rejected write.`,
     };
   }
 }
@@ -270,6 +306,16 @@ export async function runAction(opts: RunActionOptions):
 // A store-level failure, distinguished from a programming error so the message
 // surfaced to the caller stays about the store.
 class StoreError extends Error {}
+
+
+// Commit statuses that mean the transaction applied NOTHING, as against
+// leaving its fate unknown. A Spanner `409 ABORTED` -- the routine outcome of
+// lock contention -- guarantees it, and so do a rejected request, a denied
+// permission, and a transaction the server no longer has. Everything else,
+// every 5xx and every timeout included, is a commit that may have landed:
+// unlisted is the safe default, because the cost of wrongly reporting "nothing
+// was written" is a retry that writes twice.
+const DEFINITELY_NOT_COMMITTED = new Set([400, 401, 403, 404, 409, 412]);
 
 
 // Why this runtime will not run `action`, or null if it is safe to run.
@@ -294,7 +340,8 @@ class StoreError extends Error {}
 // An action over entities no constraint mentions runs today, which is what
 // makes this runtime useful before the evaluator exists.
 function unsafeToRunUnchecked(
-    model: SemanticModel, action: Action): string|null {
+    model: SemanticModel, action: Action,
+    plannedByCaller: boolean): string|null {
   // A guard names a constraint the author says is checked before the call.
   // One whose `onViolation` is `warn` reports rather than refuses, so an
   // evaluator would let the write through, and refusing here would make a
@@ -321,7 +368,7 @@ function unsafeToRunUnchecked(
         `nothing constrains that data.`;
   }
 
-  const bearing = constraintsOverAffected(model, action);
+  const bearing = constraintsOverAffected(model, action, plannedByCaller);
   if (bearing.length) {
     return `Action '${action.name}' writes data that ${quoteList(bearing)} ` +
         `could constrain, and this runtime does not evaluate constraints ` +
@@ -374,20 +421,36 @@ function gatingConstraints(model: SemanticModel): Constraint[] {
 // The statements are validated to be one DML verb each with no `;`
 // (sqlExecutorErrors), so the target is the identifier after the verb.
 function conceptsWrittenBy(
-    model: SemanticModel, action: Action): Set<string>|null {
-  if (action.executor.kind !== 'sql') return new Set();
+    model: SemanticModel, action: Action,
+    plannedByCaller: boolean): Set<string>|null {
+  // A handler supplies the plan, so the model's statements are not what runs
+  // and reading them would widen the blast radius by dead text. That leaves
+  // `affects` as the only account of the write -- the same position every
+  // non-`sql` executor is already in, since those name a system that performs
+  // it and put no statements in the model at all.
+  if (plannedByCaller || action.executor.kind !== 'sql') return new Set();
   const statements = action.executor.sql?.statements ?? [];
 
   // An action's statements address a table by its final name segment -- the
   // same reading `spannerTable` produces for the resolver -- so the map is
   // keyed that way, and case-insensitively, because SQL identifiers are.
+  //
+  // A collision is possible, and resolving it by guessing is the one thing
+  // this must not do. Two entities bound to `...dsA/tables/orders` and
+  // `...dsB/tables/orders` both read as `orders`; taking the last one written
+  // would answer "this statement writes ArchivedOrders" for a statement over
+  // Orders, and a constraint stated over Orders would then find no overlap and
+  // stand down. So a second concept on the same table marks it unanswerable
+  // rather than overwriting the first.
   const ignored: string[] = [];
-  const byTable = new Map<string, string>();
+  const byTable = new Map<string, string|null>();
   const add = (source: string|undefined, concept: string) => {
     if (!source) return;
     const table =
         spannerTable(source, ignored, concept).replace(/`/g, '').toLowerCase();
-    if (table) byTable.set(table, concept);
+    if (!table) return;
+    const seen = byTable.get(table);
+    byTable.set(table, seen === undefined || seen === concept ? concept : null);
   };
   for (const entity of model.entities ?? []) add(entity.dataSource, entity.name);
   for (const rel of model.relationships ?? []) {
@@ -400,9 +463,9 @@ function conceptsWrittenBy(
         /\b(?:insert\s+into|update|delete\s+from)\s+(`[^`]+`|[\w$]+)/i.exec(sql);
     if (!target) return null;
     const concept = byTable.get(target[1].replace(/`/g, '').toLowerCase());
-    // A table no concept binds is not something a constraint can be stated
-    // over -- but it is also not something this can vouch for, and what it
-    // would be vouching for is running the write unchecked.
+    // A table no concept binds -- or one that several bind, which names no
+    // single concept -- is not something this can vouch for, and what it would
+    // be vouching for is running the write unchecked.
     if (!concept) return null;
     written.add(concept);
   }
@@ -411,7 +474,7 @@ function conceptsWrittenBy(
 
 
 function constraintsOverAffected(
-    model: SemanticModel, action: Action): string[] {
+    model: SemanticModel, action: Action, plannedByCaller: boolean): string[] {
   const constraints = gatingConstraints(model);
   if (!constraints.length) return [];
 
@@ -422,7 +485,7 @@ function constraintsOverAffected(
   // `sql` executor the statements are in hand, so the blast radius is checked
   // rather than taken on trust.
   const affected = new Set((action.affects ?? []).map(a => a.concept));
-  const written = conceptsWrittenBy(model, action);
+  const written = conceptsWrittenBy(model, action, plannedByCaller);
   if (!written) return constraints.map(c => c.name).sort();
   for (const name of written) affected.add(name);
   if (!affected.size) return [];
@@ -546,7 +609,12 @@ function bindScalar(param: ActionParameter, raw: unknown):
     case 'DateTimeTz':
       return {value: text, code: 'TIMESTAMP'};
     default:
-      return {value: text, code: 'STRING'};
+      // `raw`, not `text`. The trim above exists to parse a number or a date
+      // off a command line; a String parameter is not parsed, it IS the value.
+      // Trimming here would store `see ticket` for `--arg memo=" see ticket "`
+      // -- the caller's text altered on the way to the store, by a rule
+      // nothing states.
+      return {value: `${raw}`, code: 'STRING'};
   }
 }
 

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -11,8 +11,11 @@
 //   2. BIND. Every argument becomes a query parameter of the store type its
 //      declared ontology type implies. Nothing is interpolated into SQL.
 //   3. APPLY. A read-write transaction is opened, the action's writes are run
-//      inside it, and it is committed. Any failure rolls back, so no partial
-//      write survives.
+//      inside it, and it is committed. Any failure before the commit rolls
+//      back, so no partial write survives. A failure OF the commit is the one
+//      case nothing here can resolve -- the store may have applied it and lost
+//      the response -- and it is reported as the unknown it is rather than as
+//      a rollback.
 //
 // Where the write comes from. An action with a `sql` executor carries its own
 // DML, and the runtime runs those statements itself. An action with an `mcp`,
@@ -84,8 +87,15 @@ export type ActionOutcome = {
   status: 'error';
   // A failure that stopped the write: an argument that resolved to nothing, an
   // action this runtime will not run unchecked, a store-level error. The
-  // transaction is rolled back in every case, so no partial write survives.
+  // transaction is rolled back, so no partial write survives -- except in the
+  // one case `indeterminate` marks.
   message: string;
+  // Set when the write may in fact have landed: the statements ran and the
+  // COMMIT itself failed. Spanner reports a deadline or a 5xx on commit for a
+  // commit that succeeded as well as for one that did not, and nothing can
+  // undo it from here. A caller must not read this as "nothing happened" and
+  // retry.
+  indeterminate?: boolean;
 };
 
 
@@ -156,8 +166,14 @@ export async function runAction(opts: RunActionOptions):
       // Everything from here on is inside the transaction, so any failure must
       // roll back rather than leave it open.
       try {
+        // A rollback that itself fails must not replace the reason the action
+        // stopped -- that reason is what the caller acts on, and the server
+        // aborts an abandoned transaction on its own.
         const rollback = async (outcome: ActionOutcome) => {
-          await client.rollback(sessionName, transactionId);
+          try {
+            await client.rollback(sessionName, transactionId);
+          } catch {
+          }
           return outcome;
         };
 
@@ -167,14 +183,20 @@ export async function runAction(opts: RunActionOptions):
         }
         const refs = resolved.refs;
 
-        const bound = bindArguments(model, action, args, refs);
-        if ('error' in bound) {
-          return await rollback({status: 'error', message: bound.error});
+        // The bindings exist to fill the model's OWN statements, so they are
+        // built only when the model is what supplies them. A handler is given
+        // `refs` whole and may write a composite key, which this pass refuses
+        // because a single statement parameter cannot carry one.
+        let plan: ActionPlan|{error: string};
+        if (opts.handler) {
+          plan = await opts.handler({model, action, args, refs, query});
+        } else {
+          const bound = bindArguments(model, action, args, refs);
+          if ('error' in bound) {
+            return await rollback({status: 'error', message: bound.error});
+          }
+          plan = planFromExecutor(model, action, bound, generatedKeys(action));
         }
-
-        const plan = opts.handler ?
-            await opts.handler({model, action, args, refs, query}) :
-            planFromExecutor(action, bound, generatedKeys(action));
         if ('error' in plan) {
           return await rollback({status: 'error', message: plan.error});
         }
@@ -184,10 +206,20 @@ export async function runAction(opts: RunActionOptions):
 
         const committed = await client.commit(sessionName, transactionId);
         if (committed.status < 200 || committed.status >= 300) {
+          // Deliberately NOT rolled back. Once commit has been called the
+          // transaction's fate is the server's, and a deadline or a 5xx is
+          // exactly the shape of failure Spanner returns for a commit that
+          // landed and lost its response. Reporting "rolled back" here would
+          // be a guess, and the caller acting on it would retry a write that
+          // already happened.
           return {
             status: 'error',
-            message: `The write ran but the commit failed: ${
-                committed.message ?? committed.status}.`,
+            indeterminate: true,
+            message: `Action '${action.name}' ran, but committing it failed ` +
+                `on ${client.database}: ${
+                    committed.message ?? committed.status}. Whether the write ` +
+                `landed is unknown -- the store may have applied it and lost ` +
+                `the response -- so read the affected data before retrying.`,
           } as ActionOutcome;
         }
         return {
@@ -196,7 +228,10 @@ export async function runAction(opts: RunActionOptions):
           refs,
         } as ActionOutcome;
       } catch (err) {
-        await client.rollback(sessionName, transactionId);
+        try {
+          await client.rollback(sessionName, transactionId);
+        } catch {
+        }
         throw err;
       }
     });
@@ -258,27 +293,48 @@ function unsafeToRunUnchecked(
   const bearing = constraintsOverAffected(model, action);
   if (bearing.length) {
     return `Action '${action.name}' writes data that ${quoteList(bearing)} ` +
-        `constrains, and this runtime does not evaluate constraints yet. The ` +
-        `write could leave the store violating a rule the model states, so ` +
-        `it is refused rather than run unchecked.`;
+        `could constrain, and this runtime does not evaluate constraints ` +
+        `yet. The write could leave the store violating a rule the model ` +
+        `states, so it is refused rather than run unchecked.`;
   }
   return null;
 }
 
 
-// The names of constraints whose expression reads an entity this action
+// The names of constraints whose expression may read a concept this action
 // affects, sorted so a message is stable.
+//
+// This is the one place the refusal rule could fail open, so it errs the other
+// way twice. A constraint's expression is a logical invariant this module does
+// not parse, and `affects` names an entity OR a relationship, so:
+//
+//   * The scan covers relationships as well as entities. Validation
+//     deliberately permits a relationship-qualified name like
+//     `OrderedAs.quantity`, and an M:N `create` writes exactly the junction
+//     table such a constraint is about.
+//   * A constraint matching no known concept counts as bearing on all of them.
+//     An unqualified expression (`amount > 0`) names nothing this can compare,
+//     and "it mentions no entity, so it constrains none" is the reading that
+//     runs an unchecked write.
+//
+// The cost of both is refusing an action that would have been fine, which the
+// evaluator will then let through. That is the direction to be wrong in.
 function constraintsOverAffected(
     model: SemanticModel, action: Action): string[] {
   const constraints = model.constraints ?? [];
   const affected = new Set((action.affects ?? []).map(a => a.concept));
   if (!constraints.length || !affected.size) return [];
 
-  const entityNames = (model.entities ?? []).map(e => e.name);
+  const conceptNames = [
+    ...(model.entities ?? []).map(e => e.name),
+    ...(model.relationships ?? []).map(r => r.name),
+  ];
   const names: string[] = [];
   for (const c of constraints) {
-    const read = referencedEntityNames(c.expression, entityNames);
-    if (read.some(name => affected.has(name))) names.push(c.name);
+    const read = referencedEntityNames(c.expression, conceptNames);
+    if (!read.length || read.some(name => affected.has(name))) {
+      names.push(c.name);
+    }
   }
   return names.sort();
 }
@@ -392,6 +448,10 @@ function bindScalar(param: ActionParameter, raw: unknown):
 // A key for every concept the action creates, named as the DML expects it. The
 // model's own statements bind `@new<Concept>Key`, so the value has to exist
 // before the statement runs -- which rules out letting the store assign it.
+//
+// The value is a UUID, so the key it fills has to be text. Whether that fits
+// is `unusableGeneratedKey`'s question, asked where a statement actually binds
+// one.
 function generatedKeys(action: Action): Record<string, string> {
   const keys: Record<string, string> = {};
   for (const affected of action.affects ?? []) {
@@ -402,20 +462,55 @@ function generatedKeys(action: Action): Record<string, string> {
 }
 
 
+// Why a UUID cannot fill the key the action's DML asks for, or null if it can.
+// The store would reject an INT64 key bound as text, but it reports that as a
+// rejected statement -- naming neither the entity nor the reason -- so this
+// answers first, from the model.
+function unusableGeneratedKey(
+    model: SemanticModel, action: Action, concept: string): string|null {
+  const entity = (model.entities ?? []).find(e => e.name === concept);
+  if (!entity) return null;
+  const declared = entity.keys ?? [];
+  if (declared.length > 1) {
+    return `Action '${action.name}' binds a generated key for the ${
+        concept} it creates, but ${concept}'s key has ${
+        declared.length} parts. A composite key has to be written by the ` +
+        `statement itself.`;
+  }
+  const keyField = entity.fields.find(f => f.name === declared[0]);
+  const type = keyField?.type ?? 'String';
+  if (type !== 'String') {
+    return `Action '${action.name}' binds a generated key for the ${
+        concept} it creates, but ${concept}'s key '${declared[0]}' has type ${
+        type}, and the runtime generates a UUID -- which is text. Key ${
+        concept} by a String, or have the statement supply the key itself.`;
+  }
+  return null;
+}
+
+
 // Builds the plan from the action's own DML. Every `@name` in a statement is
 // either a declared parameter or a key this call generates; validate.ts refuses
 // a model where it is neither, so an unbound reference cannot reach here.
 function planFromExecutor(
-    action: Action, bound: Bindings,
+    model: SemanticModel, action: Action, bound: Bindings,
     generated: Record<string, string>): ActionPlan|{error: string} {
   if (action.executor.kind !== 'sql') {
     return {error: `Action '${action.name}' has no 'sql' executor.`};
   }
-  const values: Record<string, unknown> = {...bound.params};
-  const types: Record<string, {code: string}> = {...bound.types};
+  // Null-prototype maps throughout. Parameter names come from the model, and
+  // `'toString' in {}` is true, so a plain object would let `@toString` pass
+  // the "declared or generated" check below and reach the store bound to
+  // Object.prototype's own member.
+  const values: Record<string, unknown> =
+      Object.assign(Object.create(null), bound.params);
+  const types: Record<string, {code: string}> =
+      Object.assign(Object.create(null), bound.types);
+  const conceptOfKey: Record<string, string> = Object.create(null);
   for (const [concept, key] of Object.entries(generated)) {
     values[generatedKeyParam(concept)] = key;
     types[generatedKeyParam(concept)] = {code: 'STRING'};
+    conceptOfKey[generatedKeyParam(concept)] = concept;
   }
 
   const statements: spanner.Statement[] = [];
@@ -423,11 +518,18 @@ function planFromExecutor(
     const params: Record<string, unknown> = {};
     const paramTypes: Record<string, {code: string}> = {};
     for (const name of referencedParameters(sql)) {
-      if (!(name in values)) {
+      if (!Object.hasOwn(values, name)) {
         return {
           error: `Action '${action.name}' binds '@${name}', which is neither ` +
               `a parameter it declares nor a key it generates.`,
         };
+      }
+      // Asked only where a statement actually binds a generated key: an
+      // INT64-keyed entity whose DML supplies its own key must not be refused
+      // over a value it never uses.
+      if (Object.hasOwn(conceptOfKey, name)) {
+        const unusable = unusableGeneratedKey(model, action, conceptOfKey[name]);
+        if (unusable) return {error: unusable};
       }
       params[name] = values[name];
       paramTypes[name] = types[name];
@@ -488,6 +590,7 @@ async function resolveEntityRef(
   }
 
   const keyColumns: string[] = [];
+  const keyTypes: string[] = [];
   for (const key of entity.keys) {
     const field = entity.fields.find(f => f.name === key);
     const expr = (field?.expression ?? '').trim();
@@ -498,22 +601,50 @@ async function resolveEntityRef(
       };
     }
     keyColumns.push(quoteIfReserved(expr));
+    keyTypes.push(field?.type ?? 'String');
   }
   if (!keyColumns.length) {
     return {error: `Cannot resolve a ${entity.name}: it declares no key.`};
   }
 
-  const predicates = keyColumns.map(c => `CAST(${c} AS STRING) = @ref`);
+  // Each column is compared as ITSELF, against the input parsed to the type
+  // that column's field declares. Casting them all to STRING would let one
+  // predicate shape serve every key type, but no index can answer it -- and
+  // this SELECT runs inside the action's read-write transaction, so a scan
+  // would hold read locks over the whole table for the length of the write.
+  // Input that is not a value of a key's type cannot name that key, so its
+  // predicate is dropped rather than made to match by casting.
+  const predicates: string[] = [];
+  const params: Record<string, unknown> = {};
+  const paramTypes: Record<string, {code: string}> = {};
+  keyColumns.forEach((column, i) => {
+    const bound = bindScalar({name: 'ref', type: keyTypes[i]}, input);
+    if ('error' in bound) return;
+    predicates.push(`${column} = @ref${i}`);
+    params[`ref${i}`] = bound.value;
+    paramTypes[`ref${i}`] = {code: bound.code};
+  });
+  // An identifying column is a String field by construction, so the input is
+  // already a value of its type.
   const label = identifyingColumn(entity);
-  if (label) predicates.push(`CAST(${label} AS STRING) = @ref`);
+  if (label) {
+    predicates.push(`${label} = @ref`);
+    params['ref'] = input;
+    paramTypes['ref'] = {code: 'STRING'};
+  }
+  if (!predicates.length) {
+    // The input is not a value of any key's type and there is no text field to
+    // match it against, so no row in the table can be the one meant.
+    return {error: `No ${entity.name} matches '${input}'.`};
+  }
 
   // LIMIT 2 is enough to tell "one match" from "more than one", and avoids
   // dragging back a large candidate set just to reject it.
   const rows = await query({
     sql: `SELECT ${keyColumns.join(', ')} FROM ${table} WHERE ${
         predicates.join(' OR ')} LIMIT 2`,
-    params: {ref: input},
-    paramTypes: {ref: {code: 'STRING'}},
+    params,
+    paramTypes,
   });
 
   if (!rows.length) {

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -496,6 +496,15 @@ function constraintsOverAffected(
   ];
   const names: string[] = [];
   for (const c of constraints) {
+    // A judged constraint states its rule in prose for a language model to
+    // settle, so it declares no expression and there are no qualifiers to read
+    // a coverage set out of. What it covers is therefore unknown, and unknown
+    // counts against every action -- the same answer this gives an expression
+    // that names no concept it recognizes.
+    if (c.expression === undefined) {
+      names.push(c.name);
+      continue;
+    }
     const read = referencedEntityNames(c.expression, conceptNames);
     if (!read.length || read.some(name => affected.has(name))) {
       names.push(c.name);

--- a/toolbox/mdcode/src/libts/semantic/runtime.ts
+++ b/toolbox/mdcode/src/libts/semantic/runtime.ts
@@ -35,6 +35,7 @@ import * as spanner from '../gcp/spanner';
 import {
   Action,
   ActionParameter,
+  Constraint,
   Entity,
   generatedKeyParam,
   SemanticModel,
@@ -140,6 +141,10 @@ export async function runAction(opts: RunActionOptions):
   const unsafe = unsafeToRunUnchecked(model, action);
   if (unsafe) return {status: 'error', message: unsafe};
 
+  // Whether a transaction was ever opened. A session that could not be
+  // created, or a `beginReadWrite` that threw, fails with nothing to roll
+  // back -- and the outer catch must not claim it rolled one back.
+  let opened = false;
   try {
     return await client.withSession(async sessionName => {
       const begun = await client.beginReadWrite(sessionName);
@@ -151,6 +156,7 @@ export async function runAction(opts: RunActionOptions):
               begun.status}${begun.message ? `: ${begun.message}` : ''}).`,
         } as ActionOutcome;
       }
+      opened = true;
 
       const run = async (stmt: spanner.Statement) => {
         const res = await client.executeSql(sessionName, transactionId, stmt);
@@ -204,23 +210,36 @@ export async function runAction(opts: RunActionOptions):
           await run(stmt);
         }
 
-        const committed = await client.commit(sessionName, transactionId);
+        // Deliberately NOT rolled back. Once commit has been called the
+        // transaction's fate is the server's, and a deadline or a 5xx is
+        // exactly the shape of failure Spanner returns for a commit that
+        // landed and lost its response. Reporting "rolled back" here would be
+        // a guess, and the caller acting on it would retry a write that
+        // already happened.
+        const indeterminate = (reason: string): ActionOutcome => ({
+          status: 'error',
+          indeterminate: true,
+          message: `Action '${action.name}' ran, but committing it failed ` +
+              `on ${client.database}: ${reason}. Whether the write landed is ` +
+              `unknown -- the store may have applied it and lost the ` +
+              `response -- so read the affected data before retrying.`,
+        });
+
+        // A commit fails in two shapes, and they mean the same thing here. It
+        // can RETURN a non-2xx, or it can REJECT outright: the request throws
+        // on a socket hang-up, a DNS failure or an abort, and reading the
+        // response body can throw too. That second shape is precisely what a
+        // commit deadline looks like from the client -- so letting it fall
+        // through to the catch below, which rolls back and says so, would
+        // state the exact opposite of what this branch exists to say.
+        let committed;
+        try {
+          committed = await client.commit(sessionName, transactionId);
+        } catch (err) {
+          return indeterminate(err instanceof Error ? err.message : `${err}`);
+        }
         if (committed.status < 200 || committed.status >= 300) {
-          // Deliberately NOT rolled back. Once commit has been called the
-          // transaction's fate is the server's, and a deadline or a 5xx is
-          // exactly the shape of failure Spanner returns for a commit that
-          // landed and lost its response. Reporting "rolled back" here would
-          // be a guess, and the caller acting on it would retry a write that
-          // already happened.
-          return {
-            status: 'error',
-            indeterminate: true,
-            message: `Action '${action.name}' ran, but committing it failed ` +
-                `on ${client.database}: ${
-                    committed.message ?? committed.status}. Whether the write ` +
-                `landed is unknown -- the store may have applied it and lost ` +
-                `the response -- so read the affected data before retrying.`,
-          } as ActionOutcome;
+          return indeterminate(`${committed.message ?? committed.status}`);
         }
         return {
           status: 'committed',
@@ -236,10 +255,13 @@ export async function runAction(opts: RunActionOptions):
       }
     });
   } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
     return {
       status: 'error',
-      message: `Action '${action.name}' failed and was rolled back: ${
-          err instanceof Error ? err.message : String(err)}`,
+      message: opened ?
+          `Action '${action.name}' failed and was rolled back: ${reason}` :
+          `Action '${action.name}' could not start on ${client.database}: ${
+              reason}`,
     };
   }
 }
@@ -273,7 +295,16 @@ class StoreError extends Error {}
 // makes this runtime useful before the evaluator exists.
 function unsafeToRunUnchecked(
     model: SemanticModel, action: Action): string|null {
-  const guards = action.guards ?? [];
+  // A guard names a constraint the author says is checked before the call.
+  // One whose `onViolation` is `warn` reports rather than refuses, so an
+  // evaluator would let the write through, and refusing here would make a
+  // model that states advisory rules permanently unrunnable. Only a name the
+  // model declares AS advisory stands down -- a guard naming nothing this
+  // model declares still refuses, because it is not something to guess about.
+  const advisory = new Set((model.constraints ?? [])
+                               .filter(c => c.onViolation === 'warn')
+                               .map(c => c.name));
+  const guards = (action.guards ?? []).filter(g => !advisory.has(g));
   if (guards.length) {
     return `Action '${action.name}' is guarded by ${quoteList(guards)}, and ` +
         `this runtime does not evaluate constraints yet. Running it would ` +
@@ -281,7 +312,7 @@ function unsafeToRunUnchecked(
         `refused rather than run unchecked.`;
   }
 
-  const constraints = model.constraints ?? [];
+  const constraints = gatingConstraints(model);
   if (constraints.length && !(action.affects ?? []).length) {
     return `Action '${action.name}' declares no 'affects', so there is no ` +
         `way to tell whether the ${constraints.length} constraint(s) this ` +
@@ -319,11 +350,82 @@ function unsafeToRunUnchecked(
 //
 // The cost of both is refusing an action that would have been fine, which the
 // evaluator will then let through. That is the direction to be wrong in.
+// The constraints that could REFUSE a write. `onViolation: warn` says a
+// violation is reported rather than rejected, so such a rule cannot decide
+// whether an action may run -- and gating on it would make a model that states
+// advisory rules permanently unrunnable, with nothing the author could change.
+// An absent `onViolation` carries no default (see VIOLATION_EFFECTS), so it is
+// NOT read as advisory here: only the explicit `warn` stands down.
+function gatingConstraints(model: SemanticModel): Constraint[] {
+  return (model.constraints ?? []).filter(c => c.onViolation !== 'warn');
+}
+
+
+// The concepts an action's own statements write, or null for "cannot tell".
+//
+// Only a `sql` executor has statements to read. For any other kind this
+// returns an empty set, which leaves the declared `affects` as the only
+// evidence there is -- the write lives in a system this cannot see. Null is
+// different and stronger: a statement names a table this cannot attribute to a
+// concept, so nothing here supports the claim that some constraint does not
+// bear on the write, and the caller must read it as every concept rather than
+// as none.
+//
+// The statements are validated to be one DML verb each with no `;`
+// (sqlExecutorErrors), so the target is the identifier after the verb.
+function conceptsWrittenBy(
+    model: SemanticModel, action: Action): Set<string>|null {
+  if (action.executor.kind !== 'sql') return new Set();
+  const statements = action.executor.sql?.statements ?? [];
+
+  // An action's statements address a table by its final name segment -- the
+  // same reading `spannerTable` produces for the resolver -- so the map is
+  // keyed that way, and case-insensitively, because SQL identifiers are.
+  const ignored: string[] = [];
+  const byTable = new Map<string, string>();
+  const add = (source: string|undefined, concept: string) => {
+    if (!source) return;
+    const table =
+        spannerTable(source, ignored, concept).replace(/`/g, '').toLowerCase();
+    if (table) byTable.set(table, concept);
+  };
+  for (const entity of model.entities ?? []) add(entity.dataSource, entity.name);
+  for (const rel of model.relationships ?? []) {
+    add(rel.association?.dataSource, rel.name);
+  }
+
+  const written = new Set<string>();
+  for (const sql of statements) {
+    const target =
+        /\b(?:insert\s+into|update|delete\s+from)\s+(`[^`]+`|[\w$]+)/i.exec(sql);
+    if (!target) return null;
+    const concept = byTable.get(target[1].replace(/`/g, '').toLowerCase());
+    // A table no concept binds is not something a constraint can be stated
+    // over -- but it is also not something this can vouch for, and what it
+    // would be vouching for is running the write unchecked.
+    if (!concept) return null;
+    written.add(concept);
+  }
+  return written;
+}
+
+
 function constraintsOverAffected(
     model: SemanticModel, action: Action): string[] {
-  const constraints = model.constraints ?? [];
+  const constraints = gatingConstraints(model);
+  if (!constraints.length) return [];
+
+  // What the author DECLARED, widened by what the statements actually write.
+  // `affects` is a declaration, and an action declaring `affects: [Transfer
+  // create]` whose second statement is `UPDATE Account SET ...` would
+  // otherwise pass a test that never read the write it is about to run. For a
+  // `sql` executor the statements are in hand, so the blast radius is checked
+  // rather than taken on trust.
   const affected = new Set((action.affects ?? []).map(a => a.concept));
-  if (!constraints.length || !affected.size) return [];
+  const written = conceptsWrittenBy(model, action);
+  if (!written) return constraints.map(c => c.name).sort();
+  for (const name of written) affected.add(name);
+  if (!affected.size) return [];
 
   const conceptNames = [
     ...(model.entities ?? []).map(e => e.name),
@@ -402,7 +504,11 @@ function bindReference(
 // -- which is the difference between "9" being less than "10" and not.
 function bindScalar(param: ActionParameter, raw: unknown):
     {value: unknown; code: string}|{error: string} {
-  if (raw === undefined || raw === null || `${raw}`.trim() === '') {
+  // An empty String IS a value: `--arg memo=` is the caller saying the memo is
+  // blank, which is a different statement from not passing one. For every
+  // other type there is no value empty text could be, so it stays an error.
+  if (raw === undefined || raw === null ||
+      (`${raw}`.trim() === '' && param.type !== 'String')) {
     return {
       error: `Action parameter '${param.name}' (${param.type}) was not given ` +
           `a value.`,
@@ -614,16 +720,24 @@ async function resolveEntityRef(
   // would hold read locks over the whole table for the length of the write.
   // Input that is not a value of a key's type cannot name that key, so its
   // predicate is dropped rather than made to match by casting.
+  //
+  // Only a SINGLE-column key is matched this way. One input value cannot name
+  // a composite key, and `k1 = @ref OR k2 = @ref` would accept a row matching
+  // one PART of the key as though it were the row meant -- worse, it can match
+  // several rows that agree on that part and differ in the rest. A
+  // composite-keyed entity is reachable here only through its identifying
+  // text column.
   const predicates: string[] = [];
   const params: Record<string, unknown> = {};
   const paramTypes: Record<string, {code: string}> = {};
-  keyColumns.forEach((column, i) => {
-    const bound = bindScalar({name: 'ref', type: keyTypes[i]}, input);
-    if ('error' in bound) return;
-    predicates.push(`${column} = @ref${i}`);
-    params[`ref${i}`] = bound.value;
-    paramTypes[`ref${i}`] = {code: bound.code};
-  });
+  if (keyColumns.length === 1) {
+    const bound = bindScalar({name: 'ref', type: keyTypes[0]}, input);
+    if (!('error' in bound)) {
+      predicates.push(`${keyColumns[0]} = @ref0`);
+      params['ref0'] = bound.value;
+      paramTypes['ref0'] = {code: bound.code};
+    }
+  }
   // An identifying column is a String field by construction, so the input is
   // already a value of its type.
   const label = identifyingColumn(entity);
@@ -633,7 +747,14 @@ async function resolveEntityRef(
     paramTypes['ref'] = {code: 'STRING'};
   }
   if (!predicates.length) {
-    // The input is not a value of any key's type and there is no text field to
+    if (keyColumns.length > 1) {
+      return {
+        error: `Cannot resolve a ${entity.name} from a single value: its key ` +
+            `has ${keyColumns.length} columns, and it declares no ` +
+            `identifying text field to match instead.`,
+      };
+    }
+    // The input is not a value of the key's type and there is no text field to
     // match it against, so no row in the table can be the one meant.
     return {error: `No ${entity.name} matches '${input}'.`};
   }

--- a/toolbox/mdcode/src/libts/semantic/spanner.ts
+++ b/toolbox/mdcode/src/libts/semantic/spanner.ts
@@ -431,7 +431,7 @@ function physicalColumns(
 // path locates the store, not the table. A verbatim query (contains whitespace)
 // cannot back a graph element table, so it is passed through parenthesized with
 // a warning.
-function spannerTable(
+export function spannerTable(
     dataSource: string, warnings: string[], context: string): string {
   const trimmed = (dataSource ?? '').trim();
   if (!trimmed) {

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -153,23 +153,6 @@ export function validatePushRequirements(
   return errors;
 }
 
-// Static, target-independent checks for a model's actions. Returns one message
-// per violation. What can be statically wrong once the model has parsed:
-//   - a parameter's type resolves to neither a known entity nor a scalar
-//     datatype (the loader left isEntityRef unset and only warned) -- an
-//     unresolvable type is a malformed action, promoted to a hard error here;
-//   - an executor is missing a coordinate a runtime needs to dispatch it (an
-//     empty server/tool, endpoint/method, or service/method) -- the schema
-//     accepts empty strings, so this is caught here rather than at parse;
-//   - a guard names a constraint the model does not declare;
-//   - an `affects` entry names a concept the model does not declare, names
-//     fields on a 'delete' (which takes the whole instance), or names a field
-//     the concept does not have.
-//
-// Every `affects` check is a hard error for the reason the guard check is: an
-// entry that names nothing real leaves a reader believing the blast radius is
-// described when it is not, and a consumer routing on it would route on a
-// concept that does not exist.
 // The subset of the push checks that bear on RUNNING an action rather than on
 // deploying a model. `kcmd action run` skips the deployment checks on purpose
 // -- it deploys nothing -- but it must not skip these, because the runtime's
@@ -191,6 +174,23 @@ export function validateRunnable(models: LoadedModel[]): string[] {
 }
 
 
+// Static, target-independent checks for a model's actions. Returns one message
+// per violation. What can be statically wrong once the model has parsed:
+//   - a parameter's type resolves to neither a known entity nor a scalar
+//     datatype (the loader left isEntityRef unset and only warned) -- an
+//     unresolvable type is a malformed action, promoted to a hard error here;
+//   - an executor is missing a coordinate a runtime needs to dispatch it (an
+//     empty server/tool, endpoint/method, or service/method) -- the schema
+//     accepts empty strings, so this is caught here rather than at parse;
+//   - a guard names a constraint the model does not declare;
+//   - an `affects` entry names a concept the model does not declare, names
+//     fields on a 'delete' (which takes the whole instance), or names a field
+//     the concept does not have.
+//
+// Every `affects` check is a hard error for the reason the guard check is: an
+// entry that names nothing real leaves a reader believing the blast radius is
+// described when it is not, and a consumer routing on it would route on a
+// concept that does not exist.
 function validateActions(
     model: SemanticModel, document: string, fieldsPruned: boolean): string[] {
   const errors: string[] = [];

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -170,6 +170,27 @@ export function validatePushRequirements(
 // entry that names nothing real leaves a reader believing the blast radius is
 // described when it is not, and a consumer routing on it would route on a
 // concept that does not exist.
+// The subset of the push checks that bear on RUNNING an action rather than on
+// deploying a model. `kcmd action run` skips the deployment checks on purpose
+// -- it deploys nothing -- but it must not skip these, because the runtime's
+// refusal gate reads exactly what they verify.
+//
+// The `affects` check is the one that matters most. An entry naming a concept
+// the model does not declare is a hard error on push; at run time it would
+// instead make the overlap test find no constraint over that name, and the
+// gate would quietly turn off -- which is the single failure the gate exists
+// to prevent. Nothing has pruned fields on this path, so the field checks that
+// stand down for a profile push apply in full.
+export function validateRunnable(models: LoadedModel[]): string[] {
+  const errors: string[] = [];
+  for (const {document, model} of models) {
+    errors.push(...validateActions(model, document, false));
+    errors.push(...validateConstraints(model, document, false));
+  }
+  return errors;
+}
+
+
 function validateActions(
     model: SemanticModel, document: string, fieldsPruned: boolean): string[] {
   const errors: string[] = [];

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -155,15 +155,17 @@ export function validatePushRequirements(
 
 // The subset of the push checks that bear on RUNNING an action rather than on
 // deploying a model. `kcmd action run` skips the deployment checks on purpose
-// -- it deploys nothing -- but it must not skip these, because the runtime's
-// refusal gate reads exactly what they verify.
+// -- it deploys nothing -- but it must not skip these, because the runtime acts
+// on exactly what they verify.
 //
 // The `affects` check is the one that matters most. An entry naming a concept
 // the model does not declare is a hard error on push; at run time it would
-// instead make the overlap test find no constraint over that name, and the
-// gate would quietly turn off -- which is the single failure the gate exists
-// to prevent. Nothing has pruned fields on this path, so the field checks that
-// stand down for a profile push apply in full.
+// instead reach the binder, which turns an entry whose operation is `create`
+// into a generated key parameter. The key would be minted for a concept that
+// has no table, and the statement binding it would fail at the store reading
+// like a fault in the statement rather than a typo three lines up. Nothing has
+// pruned fields on this path, so the field checks that stand down for a profile
+// push apply in full.
 export function validateRunnable(models: LoadedModel[]): string[] {
   const errors: string[] = [];
   for (const {document, model} of models) {

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -8,16 +8,19 @@ import * as kcmd from '../libts';
 import {BigQueryClient} from '../libts/gcp/bigquery';
 import * as context from '../libts/gcp/context';
 import * as dataplex from '../libts/gcp/dataplex';
+import {SpannerDataClient} from '../libts/gcp/spanner';
 import {SemanticModelLayout} from '../libts/layouts/semantic-model';
 import {convertOwlToOsi} from '../libts/semantic/converters/owl/convert';
 import * as deploy from '../libts/semantic/deploy_bigquery';
 import * as kc from '../libts/semantic/deploy_knowledge_catalog';
 import * as deploySpannerLeg from '../libts/semantic/deploy_spanner';
 import {googleDeploymentTargets} from '../libts/semantic/deployment_target';
+import {Action, ActionParameter, SemanticModel} from '../libts/semantic/ir';
 import {provisionCustomTypes} from '../libts/semantic/kc_custom_types';
 import {LoadedModel, loadSemanticModels} from '../libts/semantic/loader';
 import {serializeModel} from '../libts/semantic/osi_converter';
 import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
+import {runAction} from '../libts/semantic/runtime';
 import {transpileModels} from '../libts/semantic/transpile';
 import {validateBigQueryDataSources, validatePushRequirements} from '../libts/semantic/validate';
 import {
@@ -1179,4 +1182,300 @@ export function catalogOnlyWarning(
   return `model '${model}' declares ${declared}, which deploy only to ` +
       `Knowledge Catalog; --no-kc excludes that leg, so they will not be ` +
       `deployed. Drop --no-kc to deploy them.`;
+}
+
+
+export interface ActionOptions {
+  // `--arg <name>=<value>`, repeatable. cac hands back a bare string for one
+  // occurrence and an array for several.
+  arg?: string|string[];
+  profile?: string;
+}
+
+
+// Lists or runs a semantic model's actions.
+//
+//   kcmd action list
+//   kcmd action run <name> --arg <name>=<value> ...
+//
+// `list` answers "what can I run, and how": each action's parameters, executor,
+// guards and blast radius, ending with the command line that runs it. `run`
+// executes one against the store the model's deployment target names -- the
+// command line never says where to write, the same rule push follows, so
+// changing stores is changing profiles rather than remembering a flag.
+//
+// Returns a process exit code (0 on success).
+export async function action(
+    command: string, name: string|undefined,
+    options: ActionOptions = {}): Promise<number> {
+  if (command !== 'list' && command !== 'run') {
+    console.error(
+        `Error: unknown action command '${command}'; expected 'list' or 'run'.`);
+    return 1;
+  }
+
+  const ctx = context.ApiContext.default();
+  const snapshot = await kcmd.CatalogSnapshot.fromPath('.', ctx);
+  if (snapshot.manifest.source.type !== Sources.SEMANTIC_MODEL) {
+    console.error(
+        'Error: `kcmd action` applies only to a semantic-model scope.');
+    return 1;
+  }
+  const layout = snapshot.layout as SemanticModelLayout;
+  const source = snapshot.manifest.source as SemanticModelSource;
+  const profile =
+      options.profile ?? snapshot.manifest.defaultProfile ?? DEFAULT_PROFILE;
+
+  const loaded = loadForProfile(layout, source, ctx, profile);
+  if ('error' in loaded) {
+    console.error(`Error: ${loaded.error}`);
+    return 1;
+  }
+
+  return command === 'list' ?
+      listActions(loaded.models, source.entryGroup, profile) :
+      await runOneAction(loaded.models, ctx, name, options);
+}
+
+
+// Loads every model document in the scope under one binding profile. A lighter
+// path than push's: nothing is transpiled, pruned or validated for deployment,
+// because running an action needs the model as authored rather than the subset
+// a deployed graph can answer. Bindings stay optional so `list` works on a
+// purely logical model; a `run` that needs a source the model does not bind
+// fails in the runtime, which names the entity.
+function loadForProfile(
+    layout: SemanticModelLayout, source: SemanticModelSource,
+    ctx: context.ApiContext,
+    profile: string): {models: LoadedModel[]}|{error: string} {
+  const docs = layout.modelDocuments();
+  if (!docs.length) return {error: 'no semantic model documents found.'};
+
+  const merged: Array<{name: string; text: string}> = [];
+  for (const doc of docs) {
+    if (profile === DEFAULT_PROFILE) {
+      merged.push({name: doc.name, text: doc.text});
+      continue;
+    }
+    const available = layout.profileDocuments(doc.name);
+    const chosen = available.find(p => p.name === profile);
+    if (!chosen) {
+      const names = available.map(p => p.name);
+      return {
+        error: `unknown binding profile '${profile}' for model '${doc.name}'; ` +
+            (names.length ? `defined profiles: ${names.join(', ')}.` :
+                            `no profiles are defined for this model.`),
+      };
+    }
+    const res = mergeProfileOntoDoc(doc.text, chosen.text, profile);
+    if ('error' in res) return {error: `[${doc.name}] ${res.error}`};
+    for (const w of res.warnings) console.warn(`Warning: [${doc.name}] ${w}`);
+    merged.push({name: doc.name, text: res.text});
+  }
+
+  const loaded = loadSemanticModels(
+      merged,
+      {defaultProject: source.project ?? ctx.project, bindingOptional: true});
+  if (loaded.error) return {error: loaded.error};
+  for (const w of loaded.warnings) console.warn(`Warning: ${w}`);
+  return {models: loaded.models};
+}
+
+
+// Prints what each model declares as runnable. The last line of every entry is
+// the command that runs it, filled in with the declared parameters, so reading
+// the listing is enough to make the call without going back to the YAML.
+function listActions(
+    models: LoadedModel[], entryGroup: string, profile: string): number {
+  for (const {model} of models) {
+    console.log(`Model '${model.name}' (${entryGroup}), profile '${profile}':`);
+    const actions = model.actions ?? [];
+    if (!actions.length) {
+      console.log('  declares no actions.');
+      continue;
+    }
+    for (const a of actions) {
+      console.log(`  ${a.name}${a.description ? `: ${a.description}` : ''}`);
+      console.log(`    parameters: ${
+          a.parameters.length ? a.parameters.map(describeParameter).join(', ') :
+                                '(none)'}`);
+      console.log(`    executor:   ${a.executor.kind}`);
+      if (a.guards?.length) {
+        console.log(`    guards:     ${a.guards.join(', ')}`);
+      }
+      if (a.affects?.length) {
+        console.log(`    affects:    ${
+            a.affects
+                .map(f => f.operation ? `${f.concept} (${f.operation})` :
+                                        f.concept)
+                .join(', ')}`);
+      }
+      console.log(`    run:        ${runLine(a)}`);
+    }
+  }
+  return 0;
+}
+
+
+// One parameter as `name (Type)`, marking an object reference as such: that is
+// the difference between passing a value and passing something the runtime has
+// to look up first.
+function describeParameter(p: ActionParameter): string {
+  return `${p.name} (${p.type}${p.isEntityRef ? ', reference' : ''})`;
+}
+
+
+// The command line that runs an action, with a placeholder per parameter.
+function runLine(a: Action): string {
+  const args = a.parameters.map(p => ` --arg ${p.name}=<${p.type}>`).join('');
+  return `kcmd action run ${a.name}${args}`;
+}
+
+
+// Runs one action against the store its model's deployment target names.
+async function runOneAction(
+    models: LoadedModel[], ctx: context.ApiContext, name: string|undefined,
+    options: ActionOptions): Promise<number> {
+  if (!name) {
+    console.error(
+        'Error: `kcmd action run` needs an action name; `kcmd action list` ' +
+        'shows what this scope declares.');
+    return 1;
+  }
+
+  const declaring =
+      models.filter(m => (m.model.actions ?? []).some(a => a.name === name));
+  if (!declaring.length) {
+    const known =
+        models.flatMap(m => (m.model.actions ?? []).map(a => a.name)).sort();
+    console.error(
+        `Error: no model in this scope declares an action '${name}'` +
+        (known.length ? `; declared: ${known.join(', ')}.` : '.'));
+    return 1;
+  }
+  if (declaring.length > 1) {
+    console.error(
+        `Error: '${name}' is declared by ${declaring.length} models (${
+            declaring.map(m => m.model.name).join(', ')}), so which one to ` +
+        `run is ambiguous.`);
+    return 1;
+  }
+  const model = declaring[0].model;
+
+  const parsed = parseActionArgs(options.arg);
+  if ('error' in parsed) {
+    console.error(`Error: ${parsed.error}`);
+    return 1;
+  }
+
+  const store = spannerClientFor(model, ctx);
+  if ('error' in store) {
+    console.error(`Error: ${store.error}`);
+    return 1;
+  }
+
+  console.log(`Running '${name}' on ${store.client.database}...`);
+  const outcome = await runAction(
+      {model, actionName: name, args: parsed.args, client: store.client});
+  if (outcome.status === 'error') {
+    console.error(`Error: ${outcome.message}`);
+    return 1;
+  }
+  // What each reference turned out to be. An agent said "Alice"; this is the
+  // row it wrote to, which is the part worth reading back.
+  for (const [param, ref] of Object.entries(outcome.refs)) {
+    console.log(
+        `  ${param}: '${ref.input}' -> ${ref.entity} ${ref.keys.join('/')}`);
+  }
+  console.log(`Committed${
+      outcome.commitTimestamp ? ` at ${outcome.commitTimestamp}` : ''}.`);
+  return 0;
+}
+
+
+// `--arg <name>=<value>` pairs. Values are kept as text: the runtime parses
+// every argument from text against its declared ontology type, so the command
+// line does not have to guess whether `30` is a number, an amount, or a string.
+function parseActionArgs(raw: string|string[]|undefined):
+    {args: Record<string, unknown>}|{error: string} {
+  const pairs = raw === undefined ? [] : (Array.isArray(raw) ? raw : [raw]);
+  const args: Record<string, unknown> = {};
+  for (const pair of pairs) {
+    const eq = pair.indexOf('=');
+    // An `=` at position 0 is a nameless argument, and none at all is a bare
+    // word; neither names a parameter.
+    if (eq <= 0) {
+      return {error: `--arg expects <name>=<value>, but got '${pair}'.`};
+    }
+    const name = pair.slice(0, eq).trim();
+    if (name in args) return {error: `--arg ${name} was given twice.`};
+    args[name] = pair.slice(eq + 1);
+  }
+  return {args};
+}
+
+
+// A Spanner table an entity is bound to.
+const SPANNER_TABLE_SOURCE =
+    /^\/\/spanner\.googleapis\.com\/projects\/([A-Za-z0-9_-]+)\/instances\/([A-Za-z0-9_-]+)\/databases\/([A-Za-z0-9_-]+)\/tables\/.+$/;
+
+
+// The store an action runs against: the Spanner database this profile's
+// deployment target names. The command line never names it, so pointing a run
+// at another store is selecting another profile.
+//
+// Checking that the entity bindings agree with the target matters more here
+// than in any other leg. An action's statements address a table by its NAME,
+// with the project/instance/database qualifier dropped, so an entity bound to
+// another database still produces a statement that runs -- against whatever
+// table of that name the target database happens to hold. Nothing later would
+// report it.
+function spannerClientFor(model: SemanticModel, ctx: context.ApiContext):
+    {client: SpannerDataClient}|{error: string} {
+  const {spanner, bigQuery} = googleDeploymentTargets(model);
+  if (spanner.length > 1) {
+    return {
+      error: `Model '${model.name}' declares ${spanner.length} Spanner ` +
+          `deployment targets under this profile, so which database the ` +
+          `action writes to is ambiguous. Give each its own profile.`,
+    };
+  }
+  if (!spanner.length) {
+    return {
+      error: `Model '${model.name}' declares no Spanner deployment target ` +
+          `under this profile, and an action runs against Spanner` +
+          (bigQuery.length ?
+               ` (this profile deploys to BigQuery, which it cannot write to)` :
+               '') +
+          `. Select a profile whose deployment target is a Spanner database.`,
+    };
+  }
+
+  const target = spanner[0];
+  const database = `projects/${target.project}/instances/${
+      target.instance}/databases/${target.database}`;
+  const strays: string[] = [];
+  for (const entity of model.entities ?? []) {
+    const bound = (entity.dataSource ?? '').trim().match(SPANNER_TABLE_SOURCE);
+    if (!bound) continue;
+    const boundDatabase =
+        `projects/${bound[1]}/instances/${bound[2]}/databases/${bound[3]}`;
+    if (boundDatabase !== database) {
+      strays.push(`'${entity.name}' to ${boundDatabase}`);
+    }
+  }
+  if (strays.length) {
+    return {
+      error: `Model '${model.name}' binds ${strays.join(', ')}, but its ` +
+          `deployment target is ${database}. An action's statements address a ` +
+          `table by name alone, so the write would land in the target ` +
+          `database's table of that name rather than in the bound one. Bind ` +
+          `both to the same database.`,
+    };
+  }
+
+  return {
+    client: new SpannerDataClient(
+        ctx, target.project, target.instance, target.database),
+  };
 }

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -20,6 +20,7 @@ import {provisionCustomTypes} from '../libts/semantic/kc_custom_types';
 import {LoadedModel, loadSemanticModels} from '../libts/semantic/loader';
 import {serializeModel} from '../libts/semantic/osi_converter';
 import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
+import {resolveInheritance} from '../libts/semantic/resolve_inheritance';
 import {runAction} from '../libts/semantic/runtime';
 import {transpileModels} from '../libts/semantic/transpile';
 import {validateBigQueryDataSources, validatePushRequirements, validateRunnable} from '../libts/semantic/validate';
@@ -1299,7 +1300,21 @@ function loadForProfile(
       {defaultProject: source.project ?? ctx.project, bindingOptional: true});
   if (loaded.error) return {error: loaded.error};
   for (const w of loaded.warnings) console.warn(`Warning: ${w}`);
-  return {models: loaded.models};
+
+  // Inheritance is resolved for the same reason both push legs resolve it: an
+  // inherited field is a field, and every reader downstream reads
+  // `entity.fields`. The runtime is the reader where skipping it is unsafe
+  // rather than merely incomplete. It would not see a subtype's inherited
+  // `name`, so resolving a reference by name would report a row missing that
+  // is there; and it would not see an inherited key's TYPE, so the check that
+  // refuses a generated UUID for an Integer key would read the key as a
+  // String, pass, and let the store take the mismatch instead.
+  const models = loaded.models.map(m => {
+    const resolved = resolveInheritance(m.model);
+    for (const w of resolved.warnings) console.warn(`Warning: ${w}`);
+    return {...m, model: resolved.model};
+  });
+  return {models};
 }
 
 
@@ -1417,14 +1432,20 @@ async function runOneAction(
 // `--arg <name>=<value>` pairs. Values are kept as text: the runtime parses
 // every argument from text against its declared ontology type, so the command
 // line does not have to guess whether `30` is a number, an amount, or a string.
-function parseActionArgs(raw: string|string[]|undefined):
+function parseActionArgs(raw: unknown):
     {args: Record<string, unknown>}|{error: string} {
-  const pairs = raw === undefined ? [] : (Array.isArray(raw) ? raw : [raw]);
+  const pairs: unknown[] =
+      raw === undefined ? [] : (Array.isArray(raw) ? raw : [raw]);
   // Null-prototype, because these names come off the command line: on a plain
   // object `--arg toString=x` would report itself as given twice, and
   // `--arg __proto__=x` would set the prototype instead of an argument.
   const args: Record<string, unknown> = Object.create(null);
-  for (const pair of pairs) {
+  for (const given of pairs) {
+    // cac does not hand back a string for every `--arg`. It coerces a bare
+    // numeric value, so the likeliest typo of all -- `--arg amount 30`, or
+    // `--arg=5` -- arrives as the NUMBER 30, and calling a string method on it
+    // would throw a TypeError past this function instead of the message below.
+    const pair = String(given);
     const eq = pair.indexOf('=');
     // An `=` at position 0 is a nameless argument, and none at all is a bare
     // word; neither names a parameter.

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -22,7 +22,7 @@ import {serializeModel} from '../libts/semantic/osi_converter';
 import {pullKnowledgeCatalog} from '../libts/semantic/pull_kc';
 import {runAction} from '../libts/semantic/runtime';
 import {transpileModels} from '../libts/semantic/transpile';
-import {validateBigQueryDataSources, validatePushRequirements} from '../libts/semantic/validate';
+import {validateBigQueryDataSources, validatePushRequirements, validateRunnable} from '../libts/semantic/validate';
 import {
   AvailabilityReport,
   DEFAULT_PROFILE,
@@ -1237,6 +1237,20 @@ export async function action(
   if ('error' in loaded) {
     console.error(`Error: ${loaded.error}`);
     return 1;
+  }
+
+  // `list` reads the model as authored and is happy with whatever it finds.
+  // `run` executes it, and the runtime's refusal gate trusts what validation
+  // checks: a push would reject an `affects` entry naming an undeclared
+  // concept, and running one would find no constraint over that name and go
+  // ahead unchecked. Only the run-relevant checks, not the deployment ones --
+  // an action needs no deployed graph.
+  if (command === 'run') {
+    const errors = validateRunnable(loaded.models);
+    if (errors.length) {
+      for (const e of errors) console.error(`Error: ${e}`);
+      return 1;
+    }
   }
 
   return command === 'list' ?

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -1240,20 +1240,6 @@ export async function action(
     return 1;
   }
 
-  // `list` reads the model as authored and is happy with whatever it finds.
-  // `run` executes it, and the runtime's refusal gate trusts what validation
-  // checks: a push would reject an `affects` entry naming an undeclared
-  // concept, and running one would find no constraint over that name and go
-  // ahead unchecked. Only the run-relevant checks, not the deployment ones --
-  // an action needs no deployed graph.
-  if (command === 'run') {
-    const errors = validateRunnable(loaded.models);
-    if (errors.length) {
-      for (const e of errors) console.error(`Error: ${e}`);
-      return 1;
-    }
-  }
-
   return command === 'list' ?
       listActions(loaded.models, source.entryGroup, profile) :
       await runOneAction(loaded.models, ctx, name, options);
@@ -1405,6 +1391,22 @@ async function runOneAction(
   }
   const model = declaring[0].model;
 
+  // `list` reads the model as authored and is happy with whatever it finds.
+  // `run` executes it, and the runtime's refusal gate trusts what validation
+  // checks: a push would reject an `affects` entry naming an undeclared
+  // concept, and running one would find no constraint over that name and go
+  // ahead unchecked. Only the run-relevant checks, not the deployment ones --
+  // an action needs no deployed graph.
+  //
+  // Only the model being run. A scope holds many documents, and a typo in one
+  // the run will not touch is a real error to fix but not a reason to refuse
+  // this call -- refusing on it would report a model the reader did not name.
+  const invalid = validateRunnable([declaring[0]]);
+  if (invalid.length) {
+    for (const e of invalid) console.error(`Error: ${e}`);
+    return 1;
+  }
+
   const parsed = parseActionArgs(options.arg);
   if ('error' in parsed) {
     console.error(`Error: ${parsed.error}`);
@@ -1525,8 +1527,21 @@ function spannerClientFor(model: SemanticModel, ctx: context.ApiContext):
 
   const strays: string[] = [];
   for (const binding of bindings) {
-    const bound = binding.source.trim().match(SPANNER_TABLE_SOURCE);
-    if (!bound) continue;
+    const source = binding.source.trim();
+    // Nothing bound is not a mis-binding: the entity is declared and this
+    // profile supplies it no table, which the statements will report on their
+    // own terms when they name a table that is not there.
+    if (!source) continue;
+    const bound = source.match(SPANNER_TABLE_SOURCE);
+    // A source that is not a Spanner table at all -- a BigQuery URI, say --
+    // is the same hazard and a likelier one: the statements would still run,
+    // against whatever table of that name the target database holds, and the
+    // data the model describes would sit untouched in the other system.
+    if (!bound) {
+      strays.push(`'${binding.name}' to ${source}, which is not a table in ` +
+                  `this database`);
+      continue;
+    }
     const boundDatabase =
         `projects/${bound[1]}/instances/${bound[2]}/databases/${bound[3]}`;
     if (boundDatabase !== database) {

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -1189,7 +1189,9 @@ export interface ActionOptions {
   // `--arg <name>=<value>`, repeatable. cac hands back a bare string for one
   // occurrence and an array for several.
   arg?: string|string[];
-  profile?: string;
+  // `string|boolean` for the same reason push's is: cac yields `true` for a
+  // bare `--profile` and `false` for `--no-profile`.
+  profile?: string|boolean;
 }
 
 
@@ -1223,8 +1225,13 @@ export async function action(
   }
   const layout = snapshot.layout as SemanticModelLayout;
   const source = snapshot.manifest.source as SemanticModelSource;
+  // cac hands back `true` for a bare `--profile` and mri `false` for
+  // `--no-profile`; neither names a profile, and `??` would let both through
+  // to be looked up as one. Same guard push uses.
+  const named =
+      typeof options.profile === 'string' ? options.profile : undefined;
   const profile =
-      options.profile ?? snapshot.manifest.defaultProfile ?? DEFAULT_PROFILE;
+      named ?? snapshot.manifest.defaultProfile ?? DEFAULT_PROFILE;
 
   const loaded = loadForProfile(layout, source, ctx, profile);
   if ('error' in loaded) {
@@ -1399,7 +1406,10 @@ async function runOneAction(
 function parseActionArgs(raw: string|string[]|undefined):
     {args: Record<string, unknown>}|{error: string} {
   const pairs = raw === undefined ? [] : (Array.isArray(raw) ? raw : [raw]);
-  const args: Record<string, unknown> = {};
+  // Null-prototype, because these names come off the command line: on a plain
+  // object `--arg toString=x` would report itself as given twice, and
+  // `--arg __proto__=x` would set the prototype instead of an argument.
+  const args: Record<string, unknown> = Object.create(null);
   for (const pair of pairs) {
     const eq = pair.indexOf('=');
     // An `=` at position 0 is a nameless argument, and none at all is a bare
@@ -1408,7 +1418,9 @@ function parseActionArgs(raw: string|string[]|undefined):
       return {error: `--arg expects <name>=<value>, but got '${pair}'.`};
     }
     const name = pair.slice(0, eq).trim();
-    if (name in args) return {error: `--arg ${name} was given twice.`};
+    if (Object.hasOwn(args, name)) {
+      return {error: `--arg ${name} was given twice.`};
+    }
     args[name] = pair.slice(eq + 1);
   }
   return {args};
@@ -1454,14 +1466,29 @@ function spannerClientFor(model: SemanticModel, ctx: context.ApiContext):
   const target = spanner[0];
   const database = `projects/${target.project}/instances/${
       target.instance}/databases/${target.database}`;
-  const strays: string[] = [];
+  // Every table the model binds, not just its entities: a many-to-many
+  // relationship is backed by a junction table of its own, and an action that
+  // creates the edge writes to exactly that one. No loader produces an
+  // association yet, so this leg is dormant -- but the day one does, the
+  // failure it prevents is a write landing in a different database silently,
+  // which is not the kind of thing to notice afterwards.
+  const bindings: Array<{name: string; source: string}> = [];
   for (const entity of model.entities ?? []) {
-    const bound = (entity.dataSource ?? '').trim().match(SPANNER_TABLE_SOURCE);
+    bindings.push({name: entity.name, source: entity.dataSource ?? ''});
+  }
+  for (const relationship of model.relationships ?? []) {
+    const source = relationship.association?.dataSource;
+    if (source) bindings.push({name: relationship.name, source});
+  }
+
+  const strays: string[] = [];
+  for (const binding of bindings) {
+    const bound = binding.source.trim().match(SPANNER_TABLE_SOURCE);
     if (!bound) continue;
     const boundDatabase =
         `projects/${bound[1]}/instances/${bound[2]}/databases/${bound[3]}`;
     if (boundDatabase !== database) {
-      strays.push(`'${entity.name}' to ${boundDatabase}`);
+      strays.push(`'${binding.name}' to ${boundDatabase}`);
     }
   }
   if (strays.length) {

--- a/toolbox/mdcode/src/tool/commands.ts
+++ b/toolbox/mdcode/src/tool/commands.ts
@@ -1335,7 +1335,9 @@ function listActions(
       console.log(`    parameters: ${
           a.parameters.length ? a.parameters.map(describeParameter).join(', ') :
                                 '(none)'}`);
-      console.log(`    executor:   ${a.executor.kind}`);
+      console.log(`    executor:   ${
+          a.executor ? a.executor.kind :
+                       '(none under this profile -- declared, not runnable)'}`);
       if (a.guards?.length) {
         console.log(`    guards:     ${a.guards.join(', ')}`);
       }
@@ -1346,7 +1348,12 @@ function listActions(
                                         f.concept)
                 .join(', ')}`);
       }
-      console.log(`    run:        ${runLine(a)}`);
+      if (a.executor) {
+        console.log(`    run:        ${runLine(a)}`);
+      } else {
+        console.log(
+            `    run:        bind an executor in a profile to run this.`);
+      }
     }
   }
   return 0;

--- a/toolbox/mdcode/src/tool/main.ts
+++ b/toolbox/mdcode/src/tool/main.ts
@@ -132,6 +132,28 @@ cli.command(
     });
 
 
+cli.command(
+       'action <command> [name]',
+       'Semantic model actions (command: `list` what the model declares, or `run` one against its store)')
+    .option(
+        '--arg <name=value...>',
+        'Bind one action parameter; repeat the flag for each one (`run` only)')
+    .option(
+        '--profile [name]',
+        'Read the model under this binding profile; its deployment target names the database the action runs against; defaults to default_profile, else the inline bindings')
+    .action(async (command, name, options) => {
+      let exitCode = 1;
+      try {
+        exitCode = await commands.action(command, name, options);
+      } catch (err: any) {
+        console.error('Error:', err.message || err);
+        exitCode = 1;
+      }
+
+      process.exit(exitCode);
+    });
+
+
 cli.command('mcp', 'Run the Model Context Protocol (MCP) server')
     .option('--path <path>', 'Path to the catalog snapshot root directory')
     .action(async (options) => {

--- a/toolbox/mdcode/tests/libts/gcp/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/gcp/spanner.test.ts
@@ -1,0 +1,153 @@
+// Behavior spec for the Spanner data client's transaction surface. Spies on the
+// low-level _post so it pins the exact request bodies without a live Spanner.
+//
+// The seqno is the reason this file exists. Spanner requires a monotonically
+// increasing per-transaction sequence number on DML, and reuses it to recognize
+// a retried statement; getting it wrong does not fail at compile time or in a
+// single-statement test -- it fails on the SECOND statement of a transaction,
+// against the real service, with "Previously received a different request with
+// this seqno". That is exactly the kind of thing a client should handle once so
+// no caller ever meets it.
+//
+
+import {describe, expect, spyOn, test} from 'bun:test';
+
+import {ApiContext} from '../../../src/libts/gcp/context';
+import {SpannerDataClient} from '../../../src/libts/gcp/spanner';
+
+const CTX = new ApiContext('test-project', 'us', 'test-token');
+const SESSION =
+    'projects/test-project/instances/i/databases/d/sessions/s1';
+
+function client() {
+  const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+  const posts: Array<{path: string; body: any}> = [];
+  const spy = spyOn(c, '_post').mockImplementation(
+      async (path: string, body: any) => {
+        posts.push({path, body});
+        return {status: 200, result: {name: SESSION, id: 'txn-1'}} as never;
+      });
+  return {c, posts, spy};
+}
+
+
+describe('SpannerDataClient addressing', () => {
+  test('scopes every call to one database', () => {
+    const c = new SpannerDataClient(CTX, 'proj', 'inst', 'db');
+    expect(c.database).toBe('projects/proj/instances/inst/databases/db');
+  });
+
+  test('creates a session under the database', async () => {
+    const {c, posts} = client();
+    await c.createSession();
+    expect(posts[0].path).toBe(
+        'projects/test-project/instances/i/databases/d/sessions');
+  });
+
+  test('begins a READ-WRITE transaction, not a read-only one', async () => {
+    const {c, posts} = client();
+    await c.beginReadWrite(SESSION);
+    expect(posts[0].path).toBe(`${SESSION}:beginTransaction`);
+    expect(posts[0].body).toEqual({options: {readWrite: {}}});
+  });
+});
+
+
+describe('the per-transaction statement sequence number', () => {
+  test('starts at 1 and increases with each statement', async () => {
+    const {c, posts} = client();
+    await c.executeSql(SESSION, 'txn-1', {sql: 'DELETE FROM T WHERE TRUE'});
+    await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (1)'});
+    await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (2)'});
+    expect(posts.map(p => p.body.seqno)).toEqual(['1', '2', '3']);
+  });
+
+  test('is tracked per transaction, so two transactions do not share a counter',
+       async () => {
+         const {c, posts} = client();
+         await c.executeSql(SESSION, 'txn-a', {sql: 'INSERT INTO T (a) VALUES (1)'});
+         await c.executeSql(SESSION, 'txn-b', {sql: 'INSERT INTO T (a) VALUES (2)'});
+         await c.executeSql(SESSION, 'txn-a', {sql: 'INSERT INTO T (a) VALUES (3)'});
+         expect(posts.map(p => p.body.seqno)).toEqual(['1', '1', '2']);
+       });
+
+  test('restarts after a commit, since the next transaction is a new one',
+       async () => {
+         const {c, posts} = client();
+         await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (1)'});
+         await c.commit(SESSION, 'txn-1');
+         await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (2)'});
+         expect(posts.filter(p => p.body.seqno).map(p => p.body.seqno))
+           .toEqual(['1', '1']);
+       });
+
+  test('restarts after a rollback too', async () => {
+    const {c, posts} = client();
+    await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (1)'});
+    await c.rollback(SESSION, 'txn-1');
+    await c.executeSql(SESSION, 'txn-1', {sql: 'INSERT INTO T (a) VALUES (2)'});
+    expect(posts.filter(p => p.body.seqno).map(p => p.body.seqno))
+      .toEqual(['1', '1']);
+  });
+});
+
+
+describe('executeSql request shape', () => {
+  test('carries the transaction id, the SQL, and its parameters', async () => {
+    const {c, posts} = client();
+    await c.executeSql(SESSION, 'txn-1', {
+      sql: 'SELECT x FROM T WHERE k = @k',
+      params: {k: 'abc'},
+      paramTypes: {k: {code: 'STRING'}},
+    });
+    expect(posts[0].path).toBe(`${SESSION}:executeSql`);
+    expect(posts[0].body).toEqual({
+      transaction: {id: 'txn-1'},
+      sql: 'SELECT x FROM T WHERE k = @k',
+      params: {k: 'abc'},
+      paramTypes: {k: {code: 'STRING'}},
+      seqno: '1',
+    });
+  });
+});
+
+
+describe('withSession', () => {
+  test('deletes the session it created', async () => {
+    const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+    spyOn(c, '_post').mockImplementation(
+        async () => ({status: 200, result: {name: SESSION}}) as never);
+    const deleted: string[] = [];
+    spyOn(c, '_delete').mockImplementation(async (path: string) => {
+      deleted.push(path);
+      return {status: 200, result: {}} as never;
+    });
+    await c.withSession(async name => name);
+    expect(deleted).toEqual([SESSION]);
+  });
+
+  test('deletes the session even when the body throws, so none is leaked',
+       async () => {
+         const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+         spyOn(c, '_post').mockImplementation(
+             async () => ({status: 200, result: {name: SESSION}}) as never);
+         const deleted: string[] = [];
+         spyOn(c, '_delete').mockImplementation(async (path: string) => {
+           deleted.push(path);
+           return {status: 200, result: {}} as never;
+         });
+         await expect(c.withSession(async () => {
+           throw new Error('boom');
+         })).rejects.toThrow('boom');
+         expect(deleted).toEqual([SESSION]);
+       });
+
+  test('reports a session that could not be created, naming the database',
+       async () => {
+         const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+         spyOn(c, '_post').mockImplementation(
+             async () => ({status: 403, message: 'denied'}) as never);
+         await expect(c.withSession(async () => 1))
+           .rejects.toThrow(/could not create a session on projects\/test-project/);
+       });
+});

--- a/toolbox/mdcode/tests/libts/gcp/spanner.test.ts
+++ b/toolbox/mdcode/tests/libts/gcp/spanner.test.ts
@@ -142,6 +142,31 @@ describe('withSession', () => {
          expect(deleted).toEqual([SESSION]);
        });
 
+  test('a delete that fails does not become the caller\'s result', async () => {
+    // The session delete runs after the body has already decided the outcome,
+    // including after a commit. If its failure escaped, a caller reading the
+    // rejection as "the write did not happen" would apply it a second time.
+    const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+    spyOn(c, '_post').mockImplementation(
+        async () => ({status: 200, result: {name: SESSION}}) as never);
+    spyOn(c, '_delete').mockImplementation(async () => {
+      throw new Error('network reset');
+    });
+    expect(await c.withSession(async () => 'committed')).toBe('committed');
+  });
+
+  test('a delete that fails does not hide why the body threw', async () => {
+    const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');
+    spyOn(c, '_post').mockImplementation(
+        async () => ({status: 200, result: {name: SESSION}}) as never);
+    spyOn(c, '_delete').mockImplementation(async () => {
+      throw new Error('network reset');
+    });
+    await expect(c.withSession(async () => {
+      throw new Error('boom');
+    })).rejects.toThrow('boom');
+  });
+
   test('reports a session that could not be created, naming the database',
        async () => {
          const c = new SpannerDataClient(CTX, 'test-project', 'i', 'd');

--- a/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
@@ -38,6 +38,9 @@ class FakeSpanner {
   // error rather than as a response, which is what makes them interesting.
   commitThrows = false;
   sessionFails = false;
+  // A commit the store REFUSES, by status. Spanner's routine one is 409
+  // ABORTED under lock contention, which guarantees nothing was applied.
+  commitRefused = 0;
   // Statements whose SQL contains one of these fragments fail, so a store-level
   // error can be provoked at a chosen point.
   failOn: string[] = [];
@@ -74,6 +77,9 @@ class FakeSpanner {
   async commit() {
     // What a socket hang-up, a DNS failure or an abort looks like from here.
     if (this.commitThrows) throw new TypeError('fetch failed');
+    if (this.commitRefused) {
+      return {status: this.commitRefused, message: 'Transaction was aborted'};
+    }
     if (this.commitFails) return {status: 500, message: 'commit failed'};
     this.committed = true;
     return {status: 200, result: {commitTimestamp: '2026-09-06T00:00:00Z'}};
@@ -297,6 +303,7 @@ describe('failures that stop the write', () => {
     const outcome = await run(fake);
     if (outcome.status !== 'error') throw new Error('expected an error');
     expect(outcome.message).toContain('statement rejected');
+    expect(outcome.message).toContain('failed and was rolled back');
     expect(fake.rolledBack).toBe(true);
     expect(fake.committed).toBe(false);
   });
@@ -310,6 +317,21 @@ describe('failures that stop the write', () => {
     });
     if (outcome.status !== 'error') throw new Error('expected an error');
     expect(outcome.message).toContain('handler blew up');
+    expect(fake.rolledBack).toBe(true);
+  });
+
+  test('a bug in a handler is not reported as a rejected write', async () => {
+    // A statement the store refused and a TypeError out of the caller's own
+    // code both land in the same catch. Reporting the second as a rejected
+    // write sends the reader to the data to look for a problem in the code.
+    const fake = resolvingFake();
+    const outcome = await run(fake, {
+      handler: async () => {
+        throw new TypeError('x.map is not a function');
+      },
+    });
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('not on the store\'s account');
     expect(fake.rolledBack).toBe(true);
   });
 
@@ -739,6 +761,34 @@ describe('an action whose write comes from a handler', () => {
     expect(outcome.refs.source.keys).toEqual(['eu', '1']);
   });
 
+  test('is gated on what it declares, not on statements that will not run',
+       async () => {
+         // The model's statements write Account, and a rule reads Account --
+         // but a handler supplies the plan, so those statements are text that
+         // never runs. Gating on them refuses the call over a write nobody is
+         // making. `affects` is the only account of what a handler does, which
+         // is the position every non-`sql` executor is already in.
+         const fake = resolvingFake();
+         const outcome = await runAction({
+           model: creditModel({
+             actions: [{
+               ...credit,
+               affects: [{concept: 'Entry', operation: 'create'}],
+             }],
+             constraints: [{
+               name: 'NonNegativeBalance',
+               expression: 'Account.balance >= 0',
+               description: 'An account cannot go negative.',
+             }],
+           }),
+           actionName: 'Credit',
+           args: {account: 'A1', amount: 100},
+           client: fake.client,
+           handler: debitAndCredit,
+         });
+         if (outcome.status !== 'committed') throw new Error(outcome.message);
+       });
+
   test('a composite key is still refused when the MODEL supplies the write',
        async () => {
          // Here the key has to become one statement parameter, and one value
@@ -1041,6 +1091,114 @@ describe('the blast radius read off the statements', () => {
 });
 
 
+describe('a commit the store refuses outright', () => {
+  test('is a rollback, not an unknown outcome', async () => {
+    // `409 ABORTED` is what Spanner returns under lock contention, and it
+    // guarantees the transaction applied nothing. Reporting it as
+    // indeterminate -- "the write may have landed, read the data before
+    // retrying" -- would turn the commonest routine failure there is into an
+    // investigation, every time two writers meet.
+    const fake = resolvingFake();
+    fake.commitRefused = 409;
+    const outcome = await runCredit(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.indeterminate).toBeUndefined();
+    expect(outcome.message).toContain('nothing was written');
+    expect(outcome.message).toContain('can be run again');
+    expect(fake.committed).toBe(false);
+  });
+
+  test('but a 5xx is still unknown, because that one may have landed',
+       async () => {
+         // The distinction is the whole point: a definite refusal is definite,
+         // and everything else is not.
+         const fake = resolvingFake();
+         fake.commitRefused = 503;
+         const outcome = await runCredit(fake);
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.indeterminate).toBe(true);
+         expect(outcome.message).toContain('Whether the write landed is unknown');
+         expect(fake.rolledBack).toBe(false);
+       });
+});
+
+
+describe('two concepts bound to the same table name', () => {
+  // A constraint over a concept this action does not touch. It is what makes
+  // the control case run, so the refusal below is attributable to the
+  // collision and to nothing else.
+  const widgetRule: Constraint = {
+    name: 'WidgetsAreSized',
+    expression: 'Widget.size >= 0',
+    description: 'A widget has a non-negative size.',
+  };
+
+  const widget = {
+    name: 'Widget',
+    dataSource: 'demo.payments.Widget',
+    keys: ['widgetId'],
+    fields: [
+      {name: 'widgetId', expression: 'widget_id'},
+      {name: 'size', expression: 'size'},
+    ],
+  };
+
+  // Bound to a DIFFERENT database, and reading as the same table: an action's
+  // statements address a table by its final name segment, so `Account` names
+  // both of these.
+  const archived = {
+    name: 'ArchivedAccount',
+    dataSource: 'demo.archive.Account',
+    keys: ['accountId'],
+    fields: [{name: 'accountId', expression: 'account_id'}],
+  };
+
+  const debit: Action = {
+    ...credit,
+    executor: {
+      kind: 'sql',
+      sql: {
+        statements: [
+          'UPDATE Account SET balance = balance - @amount ' +
+              'WHERE account_id = @account',
+        ],
+      },
+    },
+    affects: [{concept: 'Account', operation: 'modify', fields: ['balance']}],
+  };
+
+  function runDebit(entities: SemanticModel['entities']) {
+    const base = creditModel();
+    return runAction({
+      model: {
+        ...base,
+        entities: [...base.entities, ...entities],
+        actions: [debit],
+        constraints: [widgetRule],
+      },
+      actionName: 'Credit',
+      args: {account: 'A1', amount: 100},
+      client: resolvingFake().client,
+    });
+  }
+
+  test('runs when the table it writes names one concept', async () => {
+    const outcome = await runDebit([widget]);
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+  });
+
+  test('is refused when the table it writes names two', async () => {
+    // Keeping the last one written would answer "this statement writes
+    // ArchivedAccount" for a statement over Account, and a rule stated over
+    // Account would then find no overlap and stand down -- the gate failing
+    // open, which is the one direction it must never fail.
+    const outcome = await runDebit([widget, archived]);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('\'WidgetsAreSized\' could constrain');
+  });
+});
+
+
 describe('an entity whose key has more than one column', () => {
   test('is not resolved by matching one part of the key', async () => {
     // `region = @ref OR account_id = @ref` accepts a row matching one PART of
@@ -1104,6 +1262,44 @@ describe('an argument given as empty text', () => {
     });
     if (outcome.status !== 'committed') throw new Error(outcome.message);
   });
+
+  test('keeps the caller\'s spacing, because a String is not parsed',
+       async () => {
+         // The trim on the way in exists to read a number or a date off a
+         // command line. A String parameter is not being parsed -- it IS the
+         // value -- so trimming it would store text the caller did not write.
+         const fake = resolvingFake();
+         const outcome = await runAction({
+           model: creditModel({
+             actions: [{
+               ...credit,
+               executor: {
+                 kind: 'sql',
+                 sql: {
+                   statements: [
+                     'UPDATE Account SET memo = @memo WHERE account_id = @account',
+                   ],
+                 },
+               },
+               parameters: [
+                 {name: 'account', type: 'Account', isEntityRef: true},
+                 {name: 'memo', type: 'String', isEntityRef: false},
+               ],
+               affects: [{
+                 concept: 'Account',
+                 operation: 'modify',
+                 fields: ['balance'],
+               }],
+             }],
+           }),
+           actionName: 'Credit',
+           args: {account: 'A1', memo: '  see ticket 42  '},
+           client: fake.client,
+         });
+         if (outcome.status !== 'committed') throw new Error(outcome.message);
+         const write = fake.statements.find(s => s.sql.includes('SET memo'));
+         expect(write?.params?.['memo']).toBe('  see ticket 42  ');
+       });
 
   test('is still not a value for a numeric one', async () => {
     // There is no Float that empty text could be.

--- a/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
@@ -33,6 +33,11 @@ class FakeSpanner {
   sessionsOpened = 0;
   beginFails = false;
   commitFails = false;
+  // A commit that REJECTS rather than returning a status, and a session that
+  // cannot be created: the two failures that reach the runtime as a thrown
+  // error rather than as a response, which is what makes them interesting.
+  commitThrows = false;
+  sessionFails = false;
   // Statements whose SQL contains one of these fragments fail, so a store-level
   // error can be provoked at a chosen point.
   failOn: string[] = [];
@@ -40,6 +45,9 @@ class FakeSpanner {
   constructor(private readonly answers: Answer[] = []) {}
 
   async withSession<T>(fn: (s: string) => Promise<T>): Promise<T> {
+    if (this.sessionFails) {
+      throw new Error('Spanner: could not create a session on d (503).');
+    }
     this.sessionsOpen++;
     this.sessionsOpened++;
     try {
@@ -64,6 +72,8 @@ class FakeSpanner {
   }
 
   async commit() {
+    // What a socket hang-up, a DNS failure or an abort looks like from here.
+    if (this.commitThrows) throw new TypeError('fetch failed');
     if (this.commitFails) return {status: 500, message: 'commit failed'};
     this.committed = true;
     return {status: 200, result: {commitTimestamp: '2026-09-06T00:00:00Z'}};
@@ -706,6 +716,10 @@ describe('an action whose write comes from a handler', () => {
     // The bindings exist to fill the model's OWN statements. A handler is
     // handed the resolved refs whole, so a two-part key it can write perfectly
     // well must not be refused on the way in.
+    //
+    // The entity carries an identifying column because that is the only way a
+    // composite-keyed row can be named by one value at all -- see the
+    // resolution tests below.
     const fake = new FakeSpanner([{match: 'FROM Account', rows: [['eu', '1']]}]);
     const outcome = await run(fake, {
       model: model({
@@ -716,6 +730,7 @@ describe('an action whose write comes from a handler', () => {
           fields: [
             {name: 'region', expression: 'region', type: 'String'},
             {name: 'accountId', expression: 'account_id', type: 'String'},
+            {name: 'name', expression: 'name', type: 'String'},
           ],
         }],
       }),
@@ -740,6 +755,7 @@ describe('an action whose write comes from a handler', () => {
                  fields: [
                    {name: 'region', expression: 'region', type: 'String'},
                    {name: 'accountId', expression: 'account_id', type: 'String'},
+                   {name: 'name', expression: 'name', type: 'String'},
                  ],
                },
                {
@@ -825,5 +841,275 @@ describe('the key generated for a created row', () => {
     if (outcome.status !== 'committed') throw new Error(outcome.message);
     const insert = fake.statements.find(s => s.sql.startsWith('INSERT'));
     expect(insert?.paramTypes?.newEntryKey).toEqual({code: 'STRING'});
+  });
+});
+
+
+// A commit is the one step whose failure cannot be undone from here, so what
+// the runtime SAYS about it is the whole of what a caller has to go on.
+describe('a commit whose outcome the runtime cannot know', () => {
+  test('a commit that rejects is indeterminate, not a rollback', async () => {
+    // The request throws rather than returning a status -- a socket hang-up, a
+    // DNS failure, an abort. That is exactly the shape a commit deadline takes
+    // from the client, and the case where the write is likeliest to have
+    // landed anyway. Reporting a rollback would invite the retry that applies
+    // it twice.
+    const fake = resolvingFake();
+    fake.commitThrows = true;
+    const outcome = await runCredit(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.indeterminate).toBe(true);
+    expect(outcome.message).toContain('Whether the write landed is unknown');
+    expect(outcome.message).not.toContain('rolled back');
+    expect(fake.rolledBack).toBe(false);
+  });
+});
+
+
+describe('a failure before any transaction exists', () => {
+  test('is not reported as a rollback', async () => {
+    // Nothing was opened, so nothing was rolled back. Saying otherwise tells
+    // the caller a transaction was undone that never began.
+    const fake = resolvingFake();
+    fake.sessionFails = true;
+    const outcome = await runCredit(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('could not start');
+    expect(outcome.message).not.toContain('rolled back');
+  });
+});
+
+
+// `onViolation` says what a violation DOES. A rule that only reports one can
+// never refuse a write, so it cannot be the reason a write is refused.
+describe('a constraint that only warns', () => {
+  const advisory: Constraint = {
+    name: 'BalanceIsLow',
+    expression: 'Account.balance >= 0',
+    description: 'Flag an account that has gone negative.',
+    onViolation: 'warn',
+  };
+
+  test(
+      'does not gate the action, because it could never refuse it',
+      async () => {
+        // Gating on it would leave a model that states advisory rules
+        // permanently unrunnable, with nothing the author could change short
+        // of deleting the rule.
+        const outcome = await runAction({
+          model: creditModel({constraints: [advisory]}),
+          actionName: 'Credit',
+          args: {account: 'A1', amount: 100},
+          client: resolvingFake().client,
+        });
+        if (outcome.status !== 'committed') throw new Error(outcome.message);
+      });
+
+  test('does not gate it as a guard either', async () => {
+    const outcome = await runAction({
+      model: creditModel({
+        actions: [{...credit, guards: ['BalanceIsLow']}],
+        constraints: [advisory],
+      }),
+      actionName: 'Credit',
+      args: {account: 'A1', amount: 100},
+      client: resolvingFake().client,
+    });
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+  });
+
+  test(
+      'but a guard naming nothing the model declares still refuses',
+      async () => {
+        // Validation makes that a hard error and `kcmd action run` now runs
+        // validation -- but a library caller reaching runAction directly gets
+        // no such pass, and a guard this cannot account for is not something
+        // to wave through on the grounds that it was not found.
+        const outcome = await runAction({
+          model: creditModel({
+            actions: [{...credit, guards: ['NoSuchRule']}],
+            constraints: [advisory],
+          }),
+          actionName: 'Credit',
+          args: {account: 'A1', amount: 100},
+          client: resolvingFake().client,
+        });
+        if (outcome.status !== 'error') throw new Error('expected an error');
+        expect(outcome.message).toContain('\'NoSuchRule\'');
+      });
+});
+
+
+// For a `sql` executor the write is in the model, so what it touches is a fact
+// to be read rather than a claim to be believed.
+describe('the blast radius read off the statements', () => {
+  const nonNegative: Constraint = {
+    name: 'NonNegativeBalance',
+    expression: 'Account.balance >= 0',
+    description: 'An account cannot go negative.',
+  };
+
+  test(
+      'an action that writes more than it declares is still caught',
+      async () => {
+        // This `affects` omits Account, whose balance the second statement
+        // changes, and the constraint reads exactly that. Trusting the
+        // declaration would run the write with the rule unevaluated -- and an
+        // author who under-declares is the likeliest one to have missed it.
+        const outcome = await runAction({
+          model: creditModel({
+            actions: [{
+              ...credit,
+              affects: [{concept: 'Entry', operation: 'create'}],
+            }],
+            constraints: [nonNegative],
+          }),
+          actionName: 'Credit',
+          args: {account: 'A1', amount: 100},
+          client: resolvingFake().client,
+        });
+        if (outcome.status !== 'error') throw new Error('expected an error');
+        expect(outcome.message)
+            .toContain('\'NonNegativeBalance\' could constrain');
+      });
+
+  test(
+      'a statement writing a table no concept binds is not vouched for',
+      async () => {
+        // An audit table is not something a constraint can be stated over,
+        // but it is also not something this can attribute to a concept -- and
+        // what it would be vouching for is running the write unchecked.
+        const outcome = await runAction({
+          model: creditModel({
+            actions: [{
+              ...credit,
+              executor: {
+                kind: 'sql',
+                sql: {
+                  statements: ['INSERT INTO audit_log (note) VALUES (@amount)'],
+                },
+              },
+              affects: [{concept: 'Entry', operation: 'create'}],
+            }],
+            constraints: [nonNegative],
+          }),
+          actionName: 'Credit',
+          args: {account: 'A1', amount: 100},
+          client: resolvingFake().client,
+        });
+        if (outcome.status !== 'error') throw new Error('expected an error');
+        expect(outcome.message).toContain('could constrain');
+      });
+
+  test(
+      'an action whose statements stay inside what it declares runs',
+      async () => {
+        // The point of reading the statements is to catch the one that
+        // reaches further, not to refuse everything.
+        const fake = resolvingFake();
+        const outcome = await runAction({
+          model: creditModel({
+            constraints: [{
+              name: 'EntryHasAmount',
+              expression: 'Entry.amount >= 0',
+              description: 'A ledger entry records an amount.',
+            }],
+            actions: [{
+              ...credit,
+              executor: {
+                kind: 'sql',
+                sql: {
+                  statements: [
+                    'UPDATE Account SET balance = balance - @amount ' +
+                        'WHERE account_id = @account',
+                  ],
+                },
+              },
+              affects: [{
+                concept: 'Account',
+                operation: 'modify',
+                fields: ['balance'],
+              }],
+            }],
+          }),
+          actionName: 'Credit',
+          args: {account: 'A1', amount: 100},
+          client: fake.client,
+        });
+        if (outcome.status !== 'committed') throw new Error(outcome.message);
+      });
+});
+
+
+describe('an entity whose key has more than one column', () => {
+  test('is not resolved by matching one part of the key', async () => {
+    // `region = @ref OR account_id = @ref` accepts a row matching one PART of
+    // the key as though it were the row meant, and can match several rows that
+    // agree on that part and differ in the rest. One value cannot name a
+    // two-column key, and guessing which column it names is not resolution.
+    const fake =
+        new FakeSpanner([{match: 'FROM Account', rows: [['eu', '1']]}]);
+    const outcome = await run(fake, {
+      model: model({
+        entities: [{
+          name: 'Account',
+          dataSource: 'demo.payments.Account',
+          keys: ['region', 'accountId'],
+          fields: [
+            {name: 'region', expression: 'region', type: 'String'},
+            {name: 'accountId', expression: 'account_id', type: 'String'},
+          ],
+        }],
+      }),
+    });
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('its key has 2 columns');
+    // Nothing was asked of the store: there was no question to ask.
+    expect(fake.statements).toEqual([]);
+  });
+});
+
+
+describe('an argument given as empty text', () => {
+  test('is a value for a String parameter', async () => {
+    // `--arg memo=` says the memo is blank, which is a different statement
+    // from not passing one.
+    const fake = resolvingFake();
+    const outcome = await runAction({
+      model: creditModel({
+        actions: [{
+          ...credit,
+          executor: {
+            kind: 'sql',
+            sql: {
+              statements: [
+                'UPDATE Account SET memo = @memo WHERE account_id = @account',
+              ],
+            },
+          },
+          parameters: [
+            {name: 'account', type: 'Account', isEntityRef: true},
+            {name: 'memo', type: 'String', isEntityRef: false},
+          ],
+          affects: [{
+            concept: 'Account',
+            operation: 'modify',
+            fields: ['balance'],
+          }],
+        }],
+      }),
+      actionName: 'Credit',
+      args: {account: 'A1', memo: ''},
+      client: fake.client,
+    });
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+  });
+
+  test('is still not a value for a numeric one', async () => {
+    // There is no Float that empty text could be.
+    const outcome =
+        await runCredit(resolvingFake(), {args: {account: 'A1', amount: ''}});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('was not given a value');
   });
 });

--- a/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
@@ -135,7 +135,7 @@ const debitAndCredit = async (): Promise<ActionPlan> => ({
 function resolvingFake(extra: Answer[] = []) {
   return new FakeSpanner([
     {
-      match: 'FROM Account WHERE CAST(account_id AS STRING) = @ref',
+      match: 'FROM Account WHERE account_id = @ref0',
       rows: [['1']],
     },
     ...extra,
@@ -172,8 +172,63 @@ describe('resolving an entity-typed argument', () => {
     const fake = resolvingFake();
     await run(fake);
     const lookup = fake.statements[0];
-    expect(lookup.sql).toContain('CAST(account_id AS STRING) = @ref');
-    expect(lookup.sql).toContain('CAST(name AS STRING) = @ref');
+    expect(lookup.sql).toContain('account_id = @ref0');
+    expect(lookup.sql).toContain('name = @ref');
+  });
+
+  test('compares each column as itself, so an index can answer the lookup',
+       async () => {
+         // This SELECT runs inside the action's read-write transaction. Casting
+         // the columns to STRING would make one predicate shape fit every key
+         // type, at the price of a scan holding read locks over the whole table
+         // for the length of the write.
+         const fake = resolvingFake();
+         await run(fake);
+         expect(fake.statements[0].sql).not.toContain('CAST');
+       });
+
+  test('drops a key predicate the input cannot possibly match', async () => {
+    // 'A1' is not an Integer, so no INT64 key equals it. Comparing anyway
+    // would mean casting the column, which is the scan this avoids.
+    const fake = new FakeSpanner([{match: 'FROM Account', rows: [['1']]}]);
+    await run(fake, {
+      model: model({
+        entities: [{
+          name: 'Account',
+          dataSource: 'demo.payments.Account',
+          keys: ['accountId'],
+          fields: [
+            {name: 'accountId', expression: 'account_id', type: 'Integer'},
+            {name: 'name', expression: 'name', type: 'String'},
+          ],
+        }],
+      }),
+    });
+    // The key column is still SELECTed -- it is what a match returns -- but
+    // nothing compares it.
+    expect(fake.statements[0].sql).toContain('WHERE name = @ref LIMIT');
+    expect(fake.statements[0].sql).not.toContain('account_id =');
+  });
+
+  test('does not query at all when nothing could match the input', async () => {
+    // An Integer key, no identifying text field, and a reference that is not a
+    // number: there is no row this could denote, and no predicate left to ask.
+    const fake = new FakeSpanner([]);
+    const outcome = await run(fake, {
+      model: model({
+        entities: [{
+          name: 'Account',
+          dataSource: 'demo.payments.Account',
+          keys: ['accountId'],
+          fields: [
+            {name: 'accountId', expression: 'account_id', type: 'Integer'},
+          ],
+        }],
+      }),
+    });
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toBe("No Account matches 'A1'.");
+    expect(fake.statements).toHaveLength(0);
   });
 
   test('rejects a reference that matches nothing', async () => {
@@ -186,7 +241,7 @@ describe('resolving an entity-typed argument', () => {
 
   test('rejects an ambiguous reference and lists the candidates', async () => {
     const fake =
-        new FakeSpanner([{match: 'FROM Account WHERE CAST', rows: [['1'], ['2']]}]);
+        new FakeSpanner([{match: 'FROM Account WHERE', rows: [['1'], ['2']]}]);
     const outcome = await run(fake);
     if (outcome.status !== 'error') throw new Error('expected an error');
     expect(outcome.message).toContain('matches more than one Account (1, 2)');
@@ -253,9 +308,50 @@ describe('failures that stop the write', () => {
     fake.commitFails = true;
     const outcome = await run(fake);
     if (outcome.status !== 'error') throw new Error('expected an error');
-    expect(outcome.message).toContain('the commit failed');
+    expect(outcome.message).toContain('committing it failed');
     expect(fake.committed).toBe(false);
   });
+
+  test('a commit that fails is reported as an UNKNOWN outcome, not a rollback',
+       async () => {
+         // The one failure this runtime cannot call: Spanner returns a deadline
+         // or a 5xx on commit for a commit that landed as readily as for one
+         // that did not, and nothing can undo it from here. Saying "rolled
+         // back" would be a guess, and a caller acting on it would apply the
+         // write twice.
+         const fake = resolvingFake();
+         fake.commitFails = true;
+         const outcome = await run(fake);
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.indeterminate).toBe(true);
+         expect(outcome.message).toContain('Whether the write landed is unknown');
+         expect(fake.rolledBack).toBe(false);
+       });
+
+  test('a rollback that fails does not replace the reason the action stopped',
+       async () => {
+         // The reason is what the caller acts on. An abandoned transaction is
+         // aborted by the server on its own.
+         const fake = new FakeSpanner([]);
+         fake.rollback = async () => {
+           throw new Error('rollback unreachable');
+         };
+         const outcome = await run(fake);
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toBe("No Account matches 'A1'.");
+       });
+
+  test('a rollback that fails after a thrown statement keeps the store error',
+       async () => {
+         const fake = resolvingFake();
+         fake.failOn = ['UPDATE Account'];
+         fake.rollback = async () => {
+           throw new Error('rollback unreachable');
+         };
+         const outcome = await run(fake);
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain('statement rejected');
+       });
 
   test('the session is closed even when the action fails', async () => {
     const fake = resolvingFake();
@@ -460,7 +556,8 @@ describe('an action a constraint may decide is refused, not run unchecked', () =
          // write -- so the overlap is the only signal there is.
          const outcome = await runWith({constraints: [balance]});
          if (outcome.status !== 'error') throw new Error('expected an error');
-         expect(outcome.message).toContain("'NonNegativeBalance' constrains");
+         expect(outcome.message)
+             .toContain("'NonNegativeBalance' could constrain");
        });
 
   test('an action writing data no constraint reads runs', async () => {
@@ -550,4 +647,183 @@ describe('an action a constraint may decide is refused, not run unchecked', () =
          if (outcome.status !== 'error') throw new Error('expected an error');
          expect(outcome.message).toContain("'AEntry' and 'ZBalance'");
        });
+});
+
+
+// The overlap test is the one place the refusal rule could fail open: it is
+// what decides that no constraint bears on a write, and it decides it by
+// reading expressions this module does not parse. So it is wrong on purpose,
+// in the direction that refuses.
+describe('constraints the overlap test cannot rule out', () => {
+  const runWith = (over: Partial<SemanticModel>) => runAction({
+    model: creditModel(over),
+    actionName: 'Credit',
+    args: {account: 'A1', amount: 100},
+    client: resolvingFake().client,
+  });
+
+  test('a constraint qualified by a RELATIONSHIP the action affects is found',
+       async () => {
+         // `affects` names an entity OR a relationship, and validation
+         // deliberately permits a relationship-qualified expression. Scanning
+         // entity names alone would find no overlap, and -- because `affects`
+         // is non-empty -- the "declares no affects" rule would not catch it
+         // either, so the write would run unchecked.
+         const outcome = await runWith({
+           actions: [{
+             ...credit,
+             affects: [{concept: 'PostedTo', operation: 'create'}],
+           }],
+           relationships: [{
+             name: 'PostedTo',
+             source: {entity: 'Entry', columns: ['entry_id']},
+             destination: {entity: 'Account', columns: ['account_id']},
+           }],
+           constraints: [
+             {name: 'OnePosting', expression: 'PostedTo.postings <= 1'},
+           ],
+         });
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain("'OnePosting' could constrain");
+       });
+
+  test('a constraint that names no known concept bears on every action',
+       async () => {
+         // `amount > 0` is about whatever the author had in mind. Nothing here
+         // can tell which concept that is, and reading "it mentions no entity"
+         // as "it constrains none" is the guess that runs an unchecked write.
+         const outcome = await runWith({
+           constraints: [{name: 'PositiveAmount', expression: 'amount > 0'}],
+         });
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain("'PositiveAmount' could constrain");
+       });
+});
+
+
+describe('an action whose write comes from a handler', () => {
+  test('is not held to a binding pass its plan never uses', async () => {
+    // The bindings exist to fill the model's OWN statements. A handler is
+    // handed the resolved refs whole, so a two-part key it can write perfectly
+    // well must not be refused on the way in.
+    const fake = new FakeSpanner([{match: 'FROM Account', rows: [['eu', '1']]}]);
+    const outcome = await run(fake, {
+      model: model({
+        entities: [{
+          name: 'Account',
+          dataSource: 'demo.payments.Account',
+          keys: ['region', 'accountId'],
+          fields: [
+            {name: 'region', expression: 'region', type: 'String'},
+            {name: 'accountId', expression: 'account_id', type: 'String'},
+          ],
+        }],
+      }),
+    });
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+    expect(outcome.refs.source.keys).toEqual(['eu', '1']);
+  });
+
+  test('a composite key is still refused when the MODEL supplies the write',
+       async () => {
+         // Here the key has to become one statement parameter, and one value
+         // cannot carry two columns.
+         const fake =
+             new FakeSpanner([{match: 'FROM Account', rows: [['eu', '1']]}]);
+         const outcome = await runCredit(fake, {
+           model: creditModel({
+             entities: [
+               {
+                 name: 'Account',
+                 dataSource: 'demo.payments.Account',
+                 keys: ['region', 'accountId'],
+                 fields: [
+                   {name: 'region', expression: 'region', type: 'String'},
+                   {name: 'accountId', expression: 'account_id', type: 'String'},
+                 ],
+               },
+               {
+                 name: 'Entry',
+                 dataSource: 'demo.payments.Entry',
+                 keys: ['entryId'],
+                 fields: [{name: 'entryId', expression: 'entry_id'}],
+               },
+             ],
+           }),
+         });
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain('a composite key cannot be passed');
+       });
+});
+
+
+describe('the key generated for a created row', () => {
+  // Every model here keys Entry by something a UUID is not.
+  function entryKeyed(type: 'Integer'|'String', statements: string[]) {
+    return creditModel({
+      actions: [{...credit, executor: {kind: 'sql', sql: {statements}}}],
+      entities: [
+        ...model().entities,
+        {
+          name: 'Entry',
+          dataSource: 'demo.payments.Entry',
+          keys: ['entryId'],
+          fields: [
+            {name: 'entryId', expression: 'entry_id', type},
+            {name: 'amount', expression: 'amount'},
+          ],
+        },
+      ],
+    });
+  }
+
+  test('is refused by name when the entity is not keyed by a String',
+       async () => {
+         // The store would reject the INSERT too, but as "statement rejected"
+         // -- naming neither the entity, nor the key, nor the reason.
+         const fake = resolvingFake();
+         const outcome = await runCredit(fake, {
+           model: entryKeyed(
+               'Integer',
+               [
+                 'INSERT INTO Entry (entry_id, amount) ' +
+                     'VALUES (@newEntryKey, @amount)',
+               ]),
+         });
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain("Entry's key 'entryId' has type Integer");
+         expect(fake.sql.some(s => s.startsWith('INSERT'))).toBe(false);
+       });
+
+  test('does not refuse an entity whose statement supplies its own key',
+       async () => {
+         // An INT64 key is nobody's problem as long as the DML never asks the
+         // runtime for one. Refusing over a value the action does not bind
+         // would be a false alarm on a model that works.
+         const fake = resolvingFake();
+         const outcome = await runCredit(fake, {
+           model: entryKeyed(
+               'Integer',
+               [
+                 'INSERT INTO Entry (entry_id, amount) ' +
+                     'SELECT MAX(entry_id) + 1, @amount FROM Entry',
+               ]),
+         });
+         if (outcome.status !== 'committed') throw new Error(outcome.message);
+       });
+
+  test('fills a String key, which is what a UUID is', async () => {
+    const fake = resolvingFake();
+    const outcome = await runCredit(fake, {
+      model: entryKeyed(
+          'String',
+          [
+            'INSERT INTO Entry (entry_id, amount) ' +
+                'VALUES (@newEntryKey, @amount)',
+          ]),
+    });
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+    const insert = fake.statements.find(s => s.sql.startsWith('INSERT'));
+    expect(insert?.paramTypes?.newEntryKey).toEqual({code: 'STRING'});
+  });
 });

--- a/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
@@ -414,6 +414,52 @@ describe('an executor the runtime cannot roll back', () => {
 });
 
 
+// An executor is a physical binding, so an action can reach the runtime with
+// none at all -- a profile that never mentioned it, or one that withdrew it
+// with `executor: null`. That is a legitimate state, not a malformed model,
+// and it is the binding that has to change to fix it.
+describe('an action with no executor under this binding', () => {
+  const unbound: Action = {
+    name: 'Transfer',
+    parameters: [
+      {name: 'source', type: 'Account', isEntityRef: true},
+      {name: 'target', type: 'Account', isEntityRef: true},
+      {name: 'amount', type: 'Float', isEntityRef: false},
+    ],
+  };
+
+  test('is refused without touching the store', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(
+        fake, {model: model({actions: [unbound]}), handler: undefined});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('no executor under this binding');
+    expect(fake.statements).toHaveLength(0);
+  });
+
+  test('points at the profile rather than at the action', async () => {
+    // The action itself is fine. Saying "declare a sql executor" would send
+    // the author to change a logical declaration that was never the problem.
+    const fake = resolvingFake();
+    const outcome = await run(
+        fake, {model: model({actions: [unbound]}), handler: undefined});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('profile');
+    expect(outcome.message).toContain('still declared');
+  });
+
+  test('is refused even when a handler is supplied', async () => {
+    // A handler substitutes for a remote executor's write. It does not
+    // substitute for the binding deciding this action runs here at all.
+    const fake = resolvingFake();
+    const outcome = await run(fake, {model: model({actions: [unbound]})});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('no executor under this binding');
+    expect(fake.statements).toHaveLength(0);
+  });
+});
+
+
 // A second model, for the half of the runtime the payments model cannot reach:
 // an action whose write is declared in the model rather than performed by a
 // handler.

--- a/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
@@ -538,10 +538,10 @@ describe('an action whose write is declared in the model', () => {
 });
 
 
-// Nothing evaluates a constraint yet. The runtime therefore has to tell an
-// action a constraint might decide from one no constraint touches, and refuse
-// the first rather than apply a write the model says must be checked.
-describe('an action a constraint may decide is refused, not run unchecked', () => {
+// Nothing evaluates a constraint yet, so an action that says it is checked
+// before it runs must not run. `guards` is what says that, and it is the only
+// thing that does: a constraint takes effect where something references it.
+describe('a guarded action is refused, not run unchecked', () => {
   const balance: Constraint = {
     name: 'NonNegativeBalance',
     expression: 'Account.balance >= 0',
@@ -581,62 +581,24 @@ describe('an action a constraint may decide is refused, not run unchecked', () =
     expect(fake.rolledBack).toBe(false);
   });
 
-  test('an action writing data a constraint reads is refused, and says which',
+  test('an action writing data a constraint reads runs, if it names no guard',
        async () => {
-         // Credit affects Account; NonNegativeBalance reads Account.balance.
-         // Nothing links them in the model -- an invariant holds for every
-         // write -- so the overlap is the only signal there is.
+         // Credit affects Account and NonNegativeBalance reads Account.balance.
+         // That overlap is not what gives the rule effect over this call, and
+         // refusing on it would mean publishing a rule silently stopped calls
+         // that worked the day before -- the thing a constraint's reference
+         // rule exists to prevent.
          const outcome = await runWith({constraints: [balance]});
-         if (outcome.status !== 'error') throw new Error('expected an error');
-         expect(outcome.message)
-             .toContain("'NonNegativeBalance' could constrain");
+         if (outcome.status !== 'committed') throw new Error(outcome.message);
        });
 
-  test('an action writing data no constraint reads runs', async () => {
-    // The same constraint, over an entity Credit does not touch. This is what
-    // makes the runtime useful before the evaluator exists.
-    const outcome = await runWith({
-      constraints: [{
-        name: 'NamedAccount',
-        expression: 'Ledger.name IS NOT NULL',
-        description: 'Every ledger is named.',
-      }],
-      entities: [
-        ...creditModel().entities,
-        {
-          name: 'Ledger',
-          dataSource: 'demo.payments.Ledger',
-          keys: ['ledgerId'],
-          fields: [
-            {name: 'ledgerId', expression: 'ledger_id'},
-            {name: 'name', expression: 'name', type: 'String'},
-          ],
-        },
-      ],
-    });
-    expect(outcome.status).toBe('committed');
-  });
-
-  test('an action that declares no affects is refused when the model has ' +
-           'constraints',
+  test('an action that declares no affects runs, constraints or not',
        async () => {
-         // Silence is not a statement that nothing is constrained, and reading
-         // it as one is the single guess here that fails open.
-         const outcome = await runWith({
-           actions: [{...credit, affects: undefined}],
-           constraints: [balance],
-         });
-         if (outcome.status !== 'error') throw new Error('expected an error');
-         expect(outcome.message).toContain("declares no 'affects'");
-       });
-
-  test('an action that declares no affects runs when the model has no ' +
-           'constraints',
-       async () => {
-         // Nothing to be unsure about, so there is nothing to refuse. The DML
-         // is the UPDATE alone: dropping `affects` drops the `create` that
+         // `affects` describes the blast radius; it is not a switch that turns
+         // checking on, and its absence is not a reason to refuse. The DML is
+         // the UPDATE alone: dropping `affects` drops the `create` that
          // generates `@newEntryKey`, so an INSERT binding it would fail for an
-         // unrelated reason and prove nothing about the refusal rules.
+         // unrelated reason.
          const outcome = await runWith({
            actions: [{
              ...credit,
@@ -651,8 +613,9 @@ describe('an action a constraint may decide is refused, not run unchecked', () =
                },
              },
            }],
+           constraints: [balance],
          });
-         expect(outcome.status).toBe('committed');
+         if (outcome.status !== 'committed') throw new Error(outcome.message);
        });
 
   test('a guard is refused even when the model states no such constraint',
@@ -668,68 +631,17 @@ describe('an action a constraint may decide is refused, not run unchecked', () =
          expect(outcome.message).toContain("guarded by 'NoSuchRule'");
        });
 
-  test('several bearing constraints are all named, in a stable order',
-       async () => {
-         const outcome = await runWith({
-           constraints: [
-             {name: 'ZBalance', expression: 'Account.balance >= 0'},
-             {name: 'AEntry', expression: 'Entry.amount > 0'},
-           ],
-         });
-         if (outcome.status !== 'error') throw new Error('expected an error');
-         expect(outcome.message).toContain("'AEntry' and 'ZBalance'");
-       });
-});
-
-
-// The overlap test is the one place the refusal rule could fail open: it is
-// what decides that no constraint bears on a write, and it decides it by
-// reading expressions this module does not parse. So it is wrong on purpose,
-// in the direction that refuses.
-describe('constraints the overlap test cannot rule out', () => {
-  const runWith = (over: Partial<SemanticModel>) => runAction({
-    model: creditModel(over),
-    actionName: 'Credit',
-    args: {account: 'A1', amount: 100},
-    client: resolvingFake().client,
+  test('several guards are all named', async () => {
+    const outcome = await runWith({
+      actions: [{...credit, guards: ['ZBalance', 'AEntry']}],
+      constraints: [
+        {name: 'ZBalance', expression: 'Account.balance >= 0'},
+        {name: 'AEntry', expression: 'Entry.amount > 0'},
+      ],
+    });
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain("'ZBalance' and 'AEntry'");
   });
-
-  test('a constraint qualified by a RELATIONSHIP the action affects is found',
-       async () => {
-         // `affects` names an entity OR a relationship, and validation
-         // deliberately permits a relationship-qualified expression. Scanning
-         // entity names alone would find no overlap, and -- because `affects`
-         // is non-empty -- the "declares no affects" rule would not catch it
-         // either, so the write would run unchecked.
-         const outcome = await runWith({
-           actions: [{
-             ...credit,
-             affects: [{concept: 'PostedTo', operation: 'create'}],
-           }],
-           relationships: [{
-             name: 'PostedTo',
-             source: {entity: 'Entry', columns: ['entry_id']},
-             destination: {entity: 'Account', columns: ['account_id']},
-           }],
-           constraints: [
-             {name: 'OnePosting', expression: 'PostedTo.postings <= 1'},
-           ],
-         });
-         if (outcome.status !== 'error') throw new Error('expected an error');
-         expect(outcome.message).toContain("'OnePosting' could constrain");
-       });
-
-  test('a constraint that names no known concept bears on every action',
-       async () => {
-         // `amount > 0` is about whatever the author had in mind. Nothing here
-         // can tell which concept that is, and reading "it mentions no entity"
-         // as "it constrains none" is the guess that runs an unchecked write.
-         const outcome = await runWith({
-           constraints: [{name: 'PositiveAmount', expression: 'amount > 0'}],
-         });
-         if (outcome.status !== 'error') throw new Error('expected an error');
-         expect(outcome.message).toContain("'PositiveAmount' could constrain");
-       });
 });
 
 
@@ -760,34 +672,6 @@ describe('an action whose write comes from a handler', () => {
     if (outcome.status !== 'committed') throw new Error(outcome.message);
     expect(outcome.refs.source.keys).toEqual(['eu', '1']);
   });
-
-  test('is gated on what it declares, not on statements that will not run',
-       async () => {
-         // The model's statements write Account, and a rule reads Account --
-         // but a handler supplies the plan, so those statements are text that
-         // never runs. Gating on them refuses the call over a write nobody is
-         // making. `affects` is the only account of what a handler does, which
-         // is the position every non-`sql` executor is already in.
-         const fake = resolvingFake();
-         const outcome = await runAction({
-           model: creditModel({
-             actions: [{
-               ...credit,
-               affects: [{concept: 'Entry', operation: 'create'}],
-             }],
-             constraints: [{
-               name: 'NonNegativeBalance',
-               expression: 'Account.balance >= 0',
-               description: 'An account cannot go negative.',
-             }],
-           }),
-           actionName: 'Credit',
-           args: {account: 'A1', amount: 100},
-           client: fake.client,
-           handler: debitAndCredit,
-         });
-         if (outcome.status !== 'committed') throw new Error(outcome.message);
-       });
 
   test('a composite key is still refused when the MODEL supplies the write',
        async () => {
@@ -940,22 +824,7 @@ describe('a constraint that only warns', () => {
     onViolation: 'warn',
   };
 
-  test(
-      'does not gate the action, because it could never refuse it',
-      async () => {
-        // Gating on it would leave a model that states advisory rules
-        // permanently unrunnable, with nothing the author could change short
-        // of deleting the rule.
-        const outcome = await runAction({
-          model: creditModel({constraints: [advisory]}),
-          actionName: 'Credit',
-          args: {account: 'A1', amount: 100},
-          client: resolvingFake().client,
-        });
-        if (outcome.status !== 'committed') throw new Error(outcome.message);
-      });
-
-  test('does not gate it as a guard either', async () => {
+  test('does not gate the action that guards it', async () => {
     const outcome = await runAction({
       model: creditModel({
         actions: [{...credit, guards: ['BalanceIsLow']}],
@@ -990,107 +859,6 @@ describe('a constraint that only warns', () => {
 });
 
 
-// For a `sql` executor the write is in the model, so what it touches is a fact
-// to be read rather than a claim to be believed.
-describe('the blast radius read off the statements', () => {
-  const nonNegative: Constraint = {
-    name: 'NonNegativeBalance',
-    expression: 'Account.balance >= 0',
-    description: 'An account cannot go negative.',
-  };
-
-  test(
-      'an action that writes more than it declares is still caught',
-      async () => {
-        // This `affects` omits Account, whose balance the second statement
-        // changes, and the constraint reads exactly that. Trusting the
-        // declaration would run the write with the rule unevaluated -- and an
-        // author who under-declares is the likeliest one to have missed it.
-        const outcome = await runAction({
-          model: creditModel({
-            actions: [{
-              ...credit,
-              affects: [{concept: 'Entry', operation: 'create'}],
-            }],
-            constraints: [nonNegative],
-          }),
-          actionName: 'Credit',
-          args: {account: 'A1', amount: 100},
-          client: resolvingFake().client,
-        });
-        if (outcome.status !== 'error') throw new Error('expected an error');
-        expect(outcome.message)
-            .toContain('\'NonNegativeBalance\' could constrain');
-      });
-
-  test(
-      'a statement writing a table no concept binds is not vouched for',
-      async () => {
-        // An audit table is not something a constraint can be stated over,
-        // but it is also not something this can attribute to a concept -- and
-        // what it would be vouching for is running the write unchecked.
-        const outcome = await runAction({
-          model: creditModel({
-            actions: [{
-              ...credit,
-              executor: {
-                kind: 'sql',
-                sql: {
-                  statements: ['INSERT INTO audit_log (note) VALUES (@amount)'],
-                },
-              },
-              affects: [{concept: 'Entry', operation: 'create'}],
-            }],
-            constraints: [nonNegative],
-          }),
-          actionName: 'Credit',
-          args: {account: 'A1', amount: 100},
-          client: resolvingFake().client,
-        });
-        if (outcome.status !== 'error') throw new Error('expected an error');
-        expect(outcome.message).toContain('could constrain');
-      });
-
-  test(
-      'an action whose statements stay inside what it declares runs',
-      async () => {
-        // The point of reading the statements is to catch the one that
-        // reaches further, not to refuse everything.
-        const fake = resolvingFake();
-        const outcome = await runAction({
-          model: creditModel({
-            constraints: [{
-              name: 'EntryHasAmount',
-              expression: 'Entry.amount >= 0',
-              description: 'A ledger entry records an amount.',
-            }],
-            actions: [{
-              ...credit,
-              executor: {
-                kind: 'sql',
-                sql: {
-                  statements: [
-                    'UPDATE Account SET balance = balance - @amount ' +
-                        'WHERE account_id = @account',
-                  ],
-                },
-              },
-              affects: [{
-                concept: 'Account',
-                operation: 'modify',
-                fields: ['balance'],
-              }],
-            }],
-          }),
-          actionName: 'Credit',
-          args: {account: 'A1', amount: 100},
-          client: fake.client,
-        });
-        if (outcome.status !== 'committed') throw new Error(outcome.message);
-      });
-});
-
-
 describe('a commit the store refuses outright', () => {
   test('is a rollback, not an unknown outcome', async () => {
     // `409 ABORTED` is what Spanner returns under lock contention, and it
@@ -1120,82 +888,6 @@ describe('a commit the store refuses outright', () => {
          expect(outcome.message).toContain('Whether the write landed is unknown');
          expect(fake.rolledBack).toBe(false);
        });
-});
-
-
-describe('two concepts bound to the same table name', () => {
-  // A constraint over a concept this action does not touch. It is what makes
-  // the control case run, so the refusal below is attributable to the
-  // collision and to nothing else.
-  const widgetRule: Constraint = {
-    name: 'WidgetsAreSized',
-    expression: 'Widget.size >= 0',
-    description: 'A widget has a non-negative size.',
-  };
-
-  const widget = {
-    name: 'Widget',
-    dataSource: 'demo.payments.Widget',
-    keys: ['widgetId'],
-    fields: [
-      {name: 'widgetId', expression: 'widget_id'},
-      {name: 'size', expression: 'size'},
-    ],
-  };
-
-  // Bound to a DIFFERENT database, and reading as the same table: an action's
-  // statements address a table by its final name segment, so `Account` names
-  // both of these.
-  const archived = {
-    name: 'ArchivedAccount',
-    dataSource: 'demo.archive.Account',
-    keys: ['accountId'],
-    fields: [{name: 'accountId', expression: 'account_id'}],
-  };
-
-  const debit: Action = {
-    ...credit,
-    executor: {
-      kind: 'sql',
-      sql: {
-        statements: [
-          'UPDATE Account SET balance = balance - @amount ' +
-              'WHERE account_id = @account',
-        ],
-      },
-    },
-    affects: [{concept: 'Account', operation: 'modify', fields: ['balance']}],
-  };
-
-  function runDebit(entities: SemanticModel['entities']) {
-    const base = creditModel();
-    return runAction({
-      model: {
-        ...base,
-        entities: [...base.entities, ...entities],
-        actions: [debit],
-        constraints: [widgetRule],
-      },
-      actionName: 'Credit',
-      args: {account: 'A1', amount: 100},
-      client: resolvingFake().client,
-    });
-  }
-
-  test('runs when the table it writes names one concept', async () => {
-    const outcome = await runDebit([widget]);
-    if (outcome.status !== 'committed') throw new Error(outcome.message);
-  });
-
-  test('is refused when the table it writes names two', async () => {
-    // Keeping the last one written would answer "this statement writes
-    // ArchivedAccount" for a statement over Account, and a rule stated over
-    // Account would then find no overlap and stand down -- the gate failing
-    // open, which is the one direction it must never fail.
-    const outcome = await runDebit([widget, archived]);
-    if (outcome.status !== 'error') throw new Error('expected an error');
-    expect(outcome.message).toContain('\'WidgetsAreSized\' could constrain');
-  });
 });
 
 

--- a/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
@@ -1,0 +1,553 @@
+// Running an action against a store.
+//
+// The store is faked here rather than mocked at the HTTP layer: the fake
+// records the statements it is given, answers queries from a programmable
+// table, and tracks whether the transaction ended in a commit or a rollback.
+// That is exactly the surface the runtime's guarantees are stated in -- "a
+// failed statement rolls back", "a refused action never opens a transaction"
+// -- so the assertions can be about those guarantees rather than about wire
+// format.
+//
+
+import {describe, expect, test} from 'bun:test';
+
+import * as spanner from '../../../src/libts/gcp/spanner';
+import {Action, Constraint, SemanticModel} from '../../../src/libts/semantic/ir';
+import {ActionPlan, runAction} from '../../../src/libts/semantic/runtime';
+
+
+// A query the fake knows how to answer: rows returned when `match` is found in
+// the statement's SQL.
+interface Answer {
+  match: string;
+  rows: string[][];
+}
+
+
+class FakeSpanner {
+  readonly database = 'projects/p/instances/i/databases/d';
+  readonly statements: spanner.Statement[] = [];
+  committed = false;
+  rolledBack = false;
+  sessionsOpen = 0;
+  sessionsOpened = 0;
+  beginFails = false;
+  commitFails = false;
+  // Statements whose SQL contains one of these fragments fail, so a store-level
+  // error can be provoked at a chosen point.
+  failOn: string[] = [];
+
+  constructor(private readonly answers: Answer[] = []) {}
+
+  async withSession<T>(fn: (s: string) => Promise<T>): Promise<T> {
+    this.sessionsOpen++;
+    this.sessionsOpened++;
+    try {
+      return await fn('sessions/1');
+    } finally {
+      this.sessionsOpen--;
+    }
+  }
+
+  async beginReadWrite() {
+    return this.beginFails ? {status: 400, message: 'nope'} :
+                             {status: 200, result: {id: 'txn-1'}};
+  }
+
+  async executeSql(_s: string, _t: string, stmt: spanner.Statement) {
+    this.statements.push(stmt);
+    if (this.failOn.some(f => stmt.sql.includes(f))) {
+      return {status: 400, message: 'statement rejected'};
+    }
+    const answer = this.answers.find(a => stmt.sql.includes(a.match));
+    return {status: 200, result: {rows: answer?.rows ?? []}};
+  }
+
+  async commit() {
+    if (this.commitFails) return {status: 500, message: 'commit failed'};
+    this.committed = true;
+    return {status: 200, result: {commitTimestamp: '2026-09-06T00:00:00Z'}};
+  }
+
+  async rollback() {
+    this.rolledBack = true;
+    return {status: 200, result: {}};
+  }
+
+  get client(): spanner.SpannerDataClient {
+    return this as unknown as spanner.SpannerDataClient;
+  }
+
+  // The SQL of every statement run, for asserting what did and did not happen.
+  get sql(): string[] {
+    return this.statements.map(s => s.sql);
+  }
+}
+
+
+const transfer: Action = {
+  name: 'Transfer',
+  description: 'Move funds between two accounts.',
+  executor: {
+    kind: 'mcp',
+    mcp: {server: '//example/servers/payments', tool: 'transfer'},
+  },
+  parameters: [
+    {name: 'source', type: 'Account', isEntityRef: true},
+    {name: 'target', type: 'Account', isEntityRef: true},
+    {name: 'amount', type: 'Float', isEntityRef: false},
+  ],
+};
+
+// The base model states no constraint, so every action in it is safe to run
+// unchecked and the tests below are about the write itself. The refusal rules
+// get their own model further down.
+function model(overrides: Partial<SemanticModel> = {}): SemanticModel {
+  return {
+    name: 'payments',
+    entities: [
+      {
+        name: 'Account',
+        dataSource: 'demo.payments.Account',
+        keys: ['accountId'],
+        fields: [
+          {name: 'accountId', expression: 'account_id'},
+          {name: 'balance', expression: 'balance'},
+          {name: 'name', expression: 'name', type: 'String'},
+        ],
+      },
+    ],
+    relationships: [],
+    metrics: [],
+    actions: [transfer],
+    ...overrides,
+  };
+}
+
+
+const debitAndCredit = async (): Promise<ActionPlan> => ({
+  statements: [{
+    sql: 'UPDATE Account SET balance = balance - 100 WHERE account_id = 1',
+  }],
+});
+
+// Answers that resolve 'A1' and 'A2' to account 1.
+function resolvingFake(extra: Answer[] = []) {
+  return new FakeSpanner([
+    {
+      match: 'FROM Account WHERE CAST(account_id AS STRING) = @ref',
+      rows: [['1']],
+    },
+    ...extra,
+  ]);
+}
+
+function run(
+    fake: FakeSpanner, over: Partial<Parameters<typeof runAction>[0]> = {}) {
+  return runAction({
+    model: model(),
+    actionName: 'Transfer',
+    args: {source: 'A1', target: 'A2', amount: 100},
+    client: fake.client,
+    handler: debitAndCredit,
+    ...over,
+  });
+}
+
+
+describe('resolving an entity-typed argument', () => {
+  test('matches on the key', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(fake);
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+    expect(outcome.refs.source).toEqual({
+      entity: 'Account',
+      keys: ['1'],
+      input: 'A1',
+    });
+  });
+
+  test('also matches on an identifying name column', async () => {
+    // An agent saying "Alice" should reach the same row as one saying "7".
+    const fake = resolvingFake();
+    await run(fake);
+    const lookup = fake.statements[0];
+    expect(lookup.sql).toContain('CAST(account_id AS STRING) = @ref');
+    expect(lookup.sql).toContain('CAST(name AS STRING) = @ref');
+  });
+
+  test('rejects a reference that matches nothing', async () => {
+    const fake = new FakeSpanner([]);
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toBe("No Account matches 'A1'.");
+    expect(fake.rolledBack).toBe(true);
+  });
+
+  test('rejects an ambiguous reference and lists the candidates', async () => {
+    const fake =
+        new FakeSpanner([{match: 'FROM Account WHERE CAST', rows: [['1'], ['2']]}]);
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('matches more than one Account (1, 2)');
+  });
+
+  test('rejects a missing required reference', async () => {
+    const outcome =
+        await run(resolvingFake(), {args: {target: 'A2', amount: 100}});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message)
+        .toContain("requires 'source', a reference to a Account");
+  });
+
+  test('leaves scalar arguments alone', async () => {
+    const outcome = await run(resolvingFake());
+    if (outcome.status !== 'committed') throw new Error(outcome.message);
+    expect(Object.keys(outcome.refs)).toEqual(['source', 'target']);
+  });
+});
+
+
+describe('failures that stop the write', () => {
+  test('an unknown action is refused before any store call', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(fake, {actionName: 'Refund'});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain("declares no action 'Refund'");
+    expect(fake.statements).toHaveLength(0);
+  });
+
+  test('a transaction that will not begin is reported, not retried',
+       async () => {
+         const fake = resolvingFake();
+         fake.beginFails = true;
+         const outcome = await run(fake);
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain('Could not begin a transaction');
+       });
+
+  test('a rejected statement rolls the transaction back', async () => {
+    const fake = resolvingFake();
+    fake.failOn = ['UPDATE Account'];
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('statement rejected');
+    expect(fake.rolledBack).toBe(true);
+    expect(fake.committed).toBe(false);
+  });
+
+  test('a handler that throws rolls the transaction back', async () => {
+    const fake = resolvingFake();
+    const outcome = await run(fake, {
+      handler: async () => {
+        throw new Error('handler blew up');
+      },
+    });
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('handler blew up');
+    expect(fake.rolledBack).toBe(true);
+  });
+
+  test('a commit that fails is reported as a commit failure', async () => {
+    const fake = resolvingFake();
+    fake.commitFails = true;
+    const outcome = await run(fake);
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('the commit failed');
+    expect(fake.committed).toBe(false);
+  });
+
+  test('the session is closed even when the action fails', async () => {
+    const fake = resolvingFake();
+    fake.failOn = ['UPDATE Account'];
+    await run(fake);
+    expect(fake.sessionsOpen).toBe(0);
+  });
+
+  test('the session is closed on the happy path too', async () => {
+    const fake = resolvingFake();
+    await run(fake);
+    expect(fake.sessionsOpen).toBe(0);
+    expect(fake.sessionsOpened).toBe(1);
+  });
+});
+
+
+describe('an executor the runtime cannot roll back', () => {
+  test('is refused when the caller supplies no handler', async () => {
+    // An MCP tool commits inside a system this transaction does not control,
+    // so a rollback here would leave the two out of step.
+    const fake = resolvingFake();
+    const outcome = await run(fake, {handler: undefined});
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain('could not be rolled back');
+    expect(fake.statements).toHaveLength(0);
+  });
+});
+
+
+// A second model, for the half of the runtime the payments model cannot reach:
+// an action whose write is declared in the model rather than performed by a
+// handler.
+const credit: Action = {
+  name: 'Credit',
+  description: 'Credit an account and record the entry.',
+  executor: {
+    kind: 'sql',
+    sql: {
+      statements: [
+        'INSERT INTO Entry (entry_id, account_id, amount) ' +
+            'VALUES (@newEntryKey, @account, @amount)',
+        'UPDATE Account SET balance = balance - @amount ' +
+            'WHERE account_id = @account',
+      ],
+    },
+  },
+  parameters: [
+    {name: 'account', type: 'Account', isEntityRef: true},
+    {name: 'amount', type: 'Float', isEntityRef: false},
+  ],
+  affects: [
+    {concept: 'Entry', operation: 'create', fields: ['amount']},
+    {concept: 'Account', operation: 'modify', fields: ['balance']},
+  ],
+};
+
+function creditModel(overrides: Partial<SemanticModel> = {}): SemanticModel {
+  const base = model();
+  return {
+    ...base,
+    entities: [
+      ...base.entities,
+      {
+        name: 'Entry',
+        dataSource: 'demo.payments.Entry',
+        keys: ['entryId'],
+        fields: [
+          {name: 'entryId', expression: 'entry_id'},
+          {name: 'amount', expression: 'amount'},
+        ],
+      },
+    ],
+    actions: [credit],
+    ...overrides,
+  };
+}
+
+function runCredit(
+    fake: FakeSpanner, over: Partial<Parameters<typeof runAction>[0]> = {}) {
+  return runAction({
+    model: creditModel(),
+    actionName: 'Credit',
+    args: {account: 'A1', amount: 100},
+    client: fake.client,
+    ...over,
+  });
+}
+
+
+describe('an action whose write is declared in the model', () => {
+  test('runs the executor statements in order, with no handler involved',
+       async () => {
+         const fake = resolvingFake();
+         const outcome = await runCredit(fake);
+         if (outcome.status !== 'committed') throw new Error(outcome.message);
+         expect(fake.sql.filter(s => s.startsWith('INSERT'))).toHaveLength(1);
+         expect(fake.sql.filter(s => s.startsWith('UPDATE'))).toHaveLength(1);
+         expect(fake.sql.indexOf('INSERT INTO Entry (entry_id, account_id, ' +
+                                 'amount) VALUES (@newEntryKey, @account, ' +
+                                 '@amount)'))
+             .toBeLessThan(fake.sql.findIndex(s => s.startsWith('UPDATE')));
+       });
+
+  test('binds every caller value as a parameter, interpolating nothing',
+       async () => {
+         const fake = resolvingFake();
+         await runCredit(fake);
+         const insert = fake.statements.find(s => s.sql.startsWith('INSERT'))!;
+         expect(insert.sql).not.toContain('100');
+         expect(insert.params?.amount).toBe(100);
+         expect(insert.paramTypes?.amount).toEqual({code: 'FLOAT64'});
+       });
+
+  test('binds only the parameters a given statement mentions', async () => {
+    // The UPDATE names both; a statement naming one would carry one.
+    const fake = resolvingFake();
+    await runCredit(fake);
+    const update = fake.statements.find(s => s.sql.startsWith('UPDATE'))!;
+    expect(Object.keys(update.params ?? {}).sort()).toEqual([
+      'account',
+      'amount',
+    ]);
+    expect(update.params?.newEntryKey).toBeUndefined();
+  });
+
+  test('generates the key of a created row rather than taking the caller\'s',
+       async () => {
+         // An agent that picks its own primary key can overwrite a row that
+         // already has that key.
+         const fake = resolvingFake();
+         await runCredit(fake);
+         const insert = fake.statements.find(s => s.sql.startsWith('INSERT'))!;
+         expect(typeof insert.params?.newEntryKey).toBe('string');
+         expect(insert.params?.newEntryKey as string).not.toBe('');
+       });
+
+  test('resolves an entity-typed argument to its key before binding it',
+       async () => {
+         const fake = resolvingFake();
+         await runCredit(fake);
+         const update = fake.statements.find(s => s.sql.startsWith('UPDATE'))!;
+         expect(update.params?.account).toBe('1');
+       });
+
+  test('commits once every statement has run', async () => {
+    const fake = resolvingFake();
+    await runCredit(fake);
+    expect(fake.committed).toBe(true);
+    expect(fake.rolledBack).toBe(false);
+  });
+});
+
+
+// Nothing evaluates a constraint yet. The runtime therefore has to tell an
+// action a constraint might decide from one no constraint touches, and refuse
+// the first rather than apply a write the model says must be checked.
+describe('an action a constraint may decide is refused, not run unchecked', () => {
+  const balance: Constraint = {
+    name: 'NonNegativeBalance',
+    expression: 'Account.balance >= 0',
+    description: 'An account cannot go negative.',
+  };
+
+  const runWith = (over: Partial<SemanticModel>, fake = resolvingFake()) =>
+      runAction({
+        model: creditModel(over),
+        actionName: 'Credit',
+        args: {account: 'A1', amount: 100},
+        client: fake.client,
+      });
+
+  test('an action that names a guard is refused', async () => {
+    const outcome = await runWith({
+      actions: [{...credit, guards: ['NonNegativeBalance']}],
+      constraints: [balance],
+    });
+    if (outcome.status !== 'error') throw new Error('expected an error');
+    expect(outcome.message).toContain("guarded by 'NonNegativeBalance'");
+    expect(outcome.message).toContain('does not evaluate constraints yet');
+  });
+
+  test('a refused action never opens a transaction', async () => {
+    // The point of deciding before the store is touched: there is nothing to
+    // roll back, and no session to leak.
+    const fake = resolvingFake();
+    await runWith(
+        {
+          actions: [{...credit, guards: ['NonNegativeBalance']}],
+          constraints: [balance],
+        },
+        fake);
+    expect(fake.statements).toHaveLength(0);
+    expect(fake.sessionsOpened).toBe(0);
+    expect(fake.rolledBack).toBe(false);
+  });
+
+  test('an action writing data a constraint reads is refused, and says which',
+       async () => {
+         // Credit affects Account; NonNegativeBalance reads Account.balance.
+         // Nothing links them in the model -- an invariant holds for every
+         // write -- so the overlap is the only signal there is.
+         const outcome = await runWith({constraints: [balance]});
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain("'NonNegativeBalance' constrains");
+       });
+
+  test('an action writing data no constraint reads runs', async () => {
+    // The same constraint, over an entity Credit does not touch. This is what
+    // makes the runtime useful before the evaluator exists.
+    const outcome = await runWith({
+      constraints: [{
+        name: 'NamedAccount',
+        expression: 'Ledger.name IS NOT NULL',
+        description: 'Every ledger is named.',
+      }],
+      entities: [
+        ...creditModel().entities,
+        {
+          name: 'Ledger',
+          dataSource: 'demo.payments.Ledger',
+          keys: ['ledgerId'],
+          fields: [
+            {name: 'ledgerId', expression: 'ledger_id'},
+            {name: 'name', expression: 'name', type: 'String'},
+          ],
+        },
+      ],
+    });
+    expect(outcome.status).toBe('committed');
+  });
+
+  test('an action that declares no affects is refused when the model has ' +
+           'constraints',
+       async () => {
+         // Silence is not a statement that nothing is constrained, and reading
+         // it as one is the single guess here that fails open.
+         const outcome = await runWith({
+           actions: [{...credit, affects: undefined}],
+           constraints: [balance],
+         });
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain("declares no 'affects'");
+       });
+
+  test('an action that declares no affects runs when the model has no ' +
+           'constraints',
+       async () => {
+         // Nothing to be unsure about, so there is nothing to refuse. The DML
+         // is the UPDATE alone: dropping `affects` drops the `create` that
+         // generates `@newEntryKey`, so an INSERT binding it would fail for an
+         // unrelated reason and prove nothing about the refusal rules.
+         const outcome = await runWith({
+           actions: [{
+             ...credit,
+             affects: undefined,
+             executor: {
+               kind: 'sql',
+               sql: {
+                 statements: [
+                   'UPDATE Account SET balance = balance - @amount ' +
+                       'WHERE account_id = @account',
+                 ],
+               },
+             },
+           }],
+         });
+         expect(outcome.status).toBe('committed');
+       });
+
+  test('a guard is refused even when the model states no such constraint',
+       async () => {
+         // An unresolved guard fails the push, so this model should not exist.
+         // If one reaches the runtime anyway, the action still claims to be
+         // checked, and running it would still be running it unchecked.
+         const outcome = await runWith({
+           actions: [{...credit, guards: ['NoSuchRule']}],
+           constraints: [],
+         });
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain("guarded by 'NoSuchRule'");
+       });
+
+  test('several bearing constraints are all named, in a stable order',
+       async () => {
+         const outcome = await runWith({
+           constraints: [
+             {name: 'ZBalance', expression: 'Account.balance >= 0'},
+             {name: 'AEntry', expression: 'Entry.amount > 0'},
+           ],
+         });
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain("'AEntry' and 'ZBalance'");
+       });
+});

--- a/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/runtime.test.ts
@@ -44,6 +44,10 @@ class FakeSpanner {
   // Statements whose SQL contains one of these fragments fail, so a store-level
   // error can be provoked at a chosen point.
   failOn: string[] = [];
+  // Statements whose SQL contains one of these never get an answer at all:
+  // the request itself throws, the way a dropped socket or a DNS failure
+  // reaches the runtime. A refusal and a silence are different news.
+  throwOn: string[] = [];
 
   constructor(private readonly answers: Answer[] = []) {}
 
@@ -67,6 +71,9 @@ class FakeSpanner {
 
   async executeSql(_s: string, _t: string, stmt: spanner.Statement) {
     this.statements.push(stmt);
+    if (this.throwOn.some(f => stmt.sql.includes(f))) {
+      throw new TypeError('fetch failed');
+    }
     if (this.failOn.some(f => stmt.sql.includes(f))) {
       return {status: 400, message: 'statement rejected'};
     }
@@ -307,6 +314,24 @@ describe('failures that stop the write', () => {
     expect(fake.rolledBack).toBe(true);
     expect(fake.committed).toBe(false);
   });
+
+  test('a store that stops answering is the store failing, not this code',
+       async () => {
+         // A statement the store REFUSES comes back as a status; a dropped
+         // socket, a DNS failure or a TLS error throws instead. Both are the
+         // store, and reporting the second as a fault inside the runtime
+         // sends the reader to look for a bug where there is only a network
+         // worth retrying.
+         const fake = resolvingFake();
+         fake.throwOn = ['UPDATE Account'];
+         const outcome = await run(fake);
+         if (outcome.status !== 'error') throw new Error('expected an error');
+         expect(outcome.message).toContain('fetch failed');
+         expect(outcome.message).toContain('failed and was rolled back');
+         expect(outcome.message).not.toContain('inside the runtime');
+         expect(fake.rolledBack).toBe(true);
+         expect(fake.committed).toBe(false);
+       });
 
   test('a handler that throws rolls the transaction back', async () => {
     const fake = resolvingFake();
@@ -934,6 +959,94 @@ describe('a commit the store refuses outright', () => {
          expect(outcome.message).toContain('Whether the write landed is unknown');
          expect(fake.rolledBack).toBe(false);
        });
+});
+
+
+// A temporal argument is checked from the model like every other scalar. The
+// alternative is that the store checks it -- after a transaction is open and
+// the reference lookups have run -- and answers with a parse error that names
+// neither the parameter nor the type it was declared as.
+describe('a date or a timestamp argument', () => {
+  const schedule: Action = {
+    name: 'Schedule',
+    executor: {
+      kind: 'sql',
+      sql: {
+        statements: [
+          'UPDATE Account SET review_on = @day, seen_at = @at ' +
+              'WHERE account_id = @account',
+        ],
+      },
+    },
+    parameters: [
+      {name: 'account', type: 'Account', isEntityRef: true},
+      {name: 'day', type: 'Date', isEntityRef: false},
+      {name: 'at', type: 'DateTimeTz', isEntityRef: false},
+    ],
+  };
+
+  function scheduling(over: Record<string, unknown> = {}) {
+    const fake = resolvingFake();
+    return {
+      fake,
+      outcome: runAction({
+        model: model({actions: [schedule]}),
+        actionName: 'Schedule',
+        args: {
+          account: 'A1',
+          day: '2026-03-04',
+          at: '2026-03-04T10:00:00Z',
+          ...over,
+        },
+        client: fake.client,
+      }),
+    };
+  }
+
+  test('a well-formed pair binds as DATE and TIMESTAMP', async () => {
+    const {fake, outcome} = scheduling();
+    const result = await outcome;
+    if (result.status !== 'committed') throw new Error(result.message);
+    const write = fake.statements[fake.statements.length - 1];
+    expect(write.paramTypes!['day']).toEqual({code: 'DATE'});
+    expect(write.paramTypes!['at']).toEqual({code: 'TIMESTAMP'});
+    expect(write.params!['day']).toBe('2026-03-04');
+  });
+
+  test('a date in some other order is refused, naming the parameter',
+       async () => {
+         // '03/04/2026' is the fourth of March to one reader and the third of
+         // April to another, so it is not a date this can accept.
+         const {fake, outcome} = scheduling({day: '03/04/2026'});
+         const result = await outcome;
+         if (result.status !== 'error') throw new Error('expected an error');
+         expect(result.message).toContain("'day' is a Date");
+         expect(result.message).toContain('YYYY-MM-DD');
+         expect(fake.committed).toBe(false);
+       });
+
+  test('a date with the right shape and no such day is refused', async () => {
+    const {outcome} = scheduling({day: '2026-02-30'});
+    const result = await outcome;
+    if (result.status !== 'error') throw new Error('expected an error');
+    expect(result.message).toContain("'day' is a Date");
+  });
+
+  test('a timestamp with no zone is refused rather than assumed', async () => {
+    // Filling in the missing zone would write a different instant for every
+    // caller, and each of them would be sure it was the one they meant.
+    const {outcome} = scheduling({at: '2026-03-04T10:00:00'});
+    const result = await outcome;
+    if (result.status !== 'error') throw new Error('expected an error');
+    expect(result.message).toContain("'at' is a DateTimeTz");
+    expect(result.message).toContain('with the zone');
+  });
+
+  test('an offset counts as a zone', async () => {
+    const {outcome} = scheduling({at: '2026-03-04T10:00:00-07:00'});
+    const result = await outcome;
+    expect(result.status).toBe('committed');
+  });
 });
 
 

--- a/toolbox/mdcode/tests/tool/action.test.ts
+++ b/toolbox/mdcode/tests/tool/action.test.ts
@@ -151,6 +151,54 @@ semantic_model:
 `;
 
 
+// A binding that points the model at Spanner and leaves its entities in
+// BigQuery. The statements would still run -- they name a table, not a
+// database -- so the write would land in whatever Spanner table shares the
+// name while the data the model describes sat untouched in the other system.
+const CROSSBOUND = `version: "0.2.0.dev0/google"
+semantic_model:
+  - name: commerce
+    deployment_target: ${SPANNER}/databases/commerce/propertyGraphs/commerce
+    entities:
+      - name: Order
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
+        fields:
+          - { name: key, expression: order_id }
+          - { name: total, expression: total }
+      - name: Entry
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/ledger
+        fields:
+          - { name: key, expression: entry_id }
+          - { name: amount, expression: amount }
+`;
+
+
+// A second document in the same scope, whose action names a concept the model
+// does not declare. Running an action in ANOTHER document must not be blocked
+// by it.
+const WAREHOUSE = `version: "0.2.0.dev0/google"
+semantic_model:
+  - name: warehouse
+    deployment_target: ${SPANNER}/databases/commerce/propertyGraphs/warehouse
+    entities:
+      - name: Bin
+        source: ${SPANNER}/databases/commerce/tables/Bins
+        primary_key: [key]
+        fields:
+          - { name: key, expression: BinId }
+    actions:
+      - name: Restock
+        executor:
+          sql:
+            statements:
+              - UPDATE Bins SET Held = Held + 1 WHERE BinId = @bin
+        parameters:
+          - {name: bin, type: Bin}
+        affects:
+          - {concept: Pallet, operation: modify}
+`;
+
+
 // A subtype whose identifying field is its supertype's. Nothing else here has
 // inheritance, and the run path is the one reader for which not resolving it
 // is unsafe rather than merely incomplete.
@@ -202,6 +250,8 @@ function writeWorkspace(modelText = MODEL): void {
       path.join(eg, 'commerce.profiles', 'mismatched.yaml'), MISMATCHED);
   fs.writeFileSync(
       path.join(eg, 'commerce.profiles', 'readonly.yaml'), READONLY);
+  fs.writeFileSync(
+      path.join(eg, 'commerce.profiles', 'crossbound.yaml'), CROSSBOUND);
 }
 
 beforeEach(() => {
@@ -414,6 +464,62 @@ describe('kcmd action run: where the write would go', () => {
          expect(out).toContain(
              'deployment target is projects/acme-ops/instances/prod/databases/archive');
          expect(out).toContain('address a table by name alone');
+       });
+
+  test('refuses a binding that leaves its entities in another system',
+       async () => {
+         // The same hazard as a wrong database and a likelier one: the
+         // statements name a table, so they would run against whatever
+         // Spanner table shares the name while the data the model describes
+         // sat in BigQuery, untouched and unmentioned.
+         writeWorkspace();
+         const code = await action(
+             'run', 'IssueCredit',
+             {profile: 'crossbound', arg: ['order=12345', 'amount=30']});
+         expect(code).toBe(1);
+         const out = logs.join('\n');
+         expect(out).toContain("binds 'Order' to acme-analytics.sales.orders");
+         expect(out).toContain('not a table in this database');
+       });
+});
+
+
+// A scope holds every document under the entry group, and `run` touches one of
+// them. An error in a document this call will not read is a real error to fix,
+// and refusing on it would report a model the reader did not name.
+describe('kcmd action run: which model has to be valid', () => {
+  function withWarehouse(): void {
+    writeWorkspace();
+    fs.writeFileSync(
+        path.join(
+            dir, 'catalog', 'EntryGroups', 'commerce_eg', 'warehouse.yaml'),
+        WAREHOUSE);
+  }
+
+  test('a broken document elsewhere in the scope does not block the run',
+       async () => {
+         withWarehouse();
+         const code = await action(
+             'run', 'IssueCredit', {arg: ['order=12345', 'amount=30']});
+         // Still refused -- IssueCredit is guarded and nothing evaluates a
+         // guard yet -- but refused on its OWN terms.
+         expect(code).toBe(1);
+         // The broken document is still WARNED about -- it is a real problem,
+         // reported where it is. What must not happen is it becoming the
+         // reason this call failed.
+         const errors = logs.filter(l => l.startsWith('Error:')).join('\n');
+         expect(errors).toContain("is guarded by 'CreditIsPositive'");
+         expect(errors).not.toContain('Pallet');
+         expect(errors).not.toContain('warehouse');
+       });
+
+  test('the broken document is still refused when it is the one being run',
+       async () => {
+         withWarehouse();
+         const code = await action('run', 'Restock', {arg: ['bin=B1']});
+         expect(code).toBe(1);
+         const errors = logs.filter(l => l.startsWith('Error:')).join('\n');
+         expect(errors).toContain('Pallet');
        });
 });
 

--- a/toolbox/mdcode/tests/tool/action.test.ts
+++ b/toolbox/mdcode/tests/tool/action.test.ts
@@ -1,8 +1,10 @@
 // Tests for `kcmd action` (src/tool/commands.ts, action()) -- the command in
 // front of the semantic runtime.
 //
-// Nothing here reaches a store, and that is not a compromise: `list` never
-// opens one, and every `run` covered fails before the first request. The
+// Almost nothing here reaches a store, and that is not a compromise: `list`
+// never opens one, and every `run` covered but the last fails before the first
+// request. The exception fakes the Spanner client's own surface, because what
+// it checks is the QUESTION the runtime asks the store. The
 // argument parse, the choice of database, and the runtime's own refusal to run
 // an action a constraint is supposed to decide all happen before a session
 // exists. What is under test is the wiring -- that the command finds the model,
@@ -17,6 +19,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import {ApiContext} from '../../src/libts/gcp/context';
+import {SpannerDataClient} from '../../src/libts/gcp/spanner';
 import {action} from '../../src/tool/commands';
 
 const CTX = new ApiContext('test-project', 'us', 'test-token');
@@ -122,6 +125,41 @@ semantic_model:
         fields:
           - { name: key, expression: EntryId }
           - { name: amount, expression: Amount }
+`;
+
+
+// A subtype whose identifying field is its supertype's. Nothing else here has
+// inheritance, and the run path is the one reader for which not resolving it
+// is unsafe rather than merely incomplete.
+const INHERITS = `version: "0.2.0.dev0/google"
+semantic_model:
+  - name: commerce
+    deployment_target: ${SPANNER}/databases/commerce/propertyGraphs/commerce
+    entities:
+      - name: Party
+        source: ${SPANNER}/databases/commerce/tables/Parties
+        primary_key: [key]
+        fields:
+          - { name: key, expression: PartyId }
+          - { name: name, expression: FullName, datatype: String }
+      - name: Customer
+        extends: [Party]
+        source: ${SPANNER}/databases/commerce/tables/Customers
+        primary_key: [key]
+        fields:
+          - { name: key, expression: CustomerId }
+    actions:
+      - name: Touch
+        executor:
+          sql:
+            statements:
+              - >-
+                UPDATE Customers SET LastSeen = CURRENT_TIMESTAMP()
+                WHERE CustomerId = @who
+        parameters:
+          - {name: who, type: Customer}
+        affects:
+          - {concept: Customer, operation: modify, fields: [key]}
 `;
 
 let dir = '';
@@ -379,6 +417,51 @@ describe('kcmd action: what the command line can actually contain', () => {
 
 // `run` skips the deployment checks on purpose -- it deploys nothing -- but
 // not the ones the runtime's refusal gate depends on.
+describe('kcmd action run: --arg has to be a pair', () => {
+  test('a bare value is reported rather than crashing the parse', async () => {
+    // cac does not hand back a string for every `--arg`: it coerces a bare
+    // numeric value, so `--arg amount 30` arrives here as the NUMBER 30. Left
+    // as it came, `pair.indexOf` threw a TypeError past the parser and the
+    // message written for exactly this typo was unreachable.
+    writeWorkspace();
+    expect(await action('run', 'IssueCredit', {arg: 30 as any})).toBe(1);
+    expect(logs.join('\n')).toContain('--arg expects <name>=<value>');
+  });
+});
+
+
+describe('kcmd action run: a subtype inherits its fields', () => {
+  test('resolves a reference by an inherited identifying column', async () => {
+    // Both push legs resolve inheritance and this path did not, so a subtype
+    // arrived at the runtime with only the fields it declares itself.
+    // Customer's identifying field is Party's `name`; without it the lookup
+    // drops silently to key-only and reports a row missing that is there.
+    writeWorkspace(INHERITS);
+    const asked: string[] = [];
+    const ok = (result: unknown) =>
+        Promise.resolve({status: 200, result} as any);
+    spyOn(SpannerDataClient.prototype, 'createSession')
+        .mockImplementation(() => ok({name: 'sessions/1'}));
+    spyOn(SpannerDataClient.prototype, 'deleteSession')
+        .mockImplementation(() => ok({}));
+    spyOn(SpannerDataClient.prototype, 'beginReadWrite')
+        .mockImplementation(() => ok({id: 'txn-1'}));
+    spyOn(SpannerDataClient.prototype, 'rollback')
+        .mockImplementation(() => ok({}));
+    spyOn(SpannerDataClient.prototype, 'executeSql')
+        .mockImplementation((_s: any, _t: any, stmt: any) => {
+          asked.push(stmt.sql);
+          return ok({rows: []});
+        });
+
+    // No row comes back, so the run fails -- but it fails having asked the
+    // right question, which is what is under test.
+    expect(await action('run', 'Touch', {arg: 'who=Alice'})).toBe(1);
+    expect(asked[0]).toContain('FullName = @ref');
+  });
+});
+
+
 describe('kcmd action run: the model has to be valid to run', () => {
   const TYPO = MODEL.replace(
       '- {concept: Entry, operation: create}',

--- a/toolbox/mdcode/tests/tool/action.test.ts
+++ b/toolbox/mdcode/tests/tool/action.test.ts
@@ -322,3 +322,56 @@ describe('kcmd action run: where the write would go', () => {
          expect(out).toContain('address a table by name alone');
        });
 });
+
+
+// cac and mri hand back values a flag's name does not suggest, and the shell
+// hands back names an object literal already has. Both look like a nuisance
+// and both change which model runs, or whether the run happens at all.
+describe('kcmd action: what the command line can actually contain', () => {
+  test('a bare --profile falls back to the default rather than looking up ' +
+           "a profile called 'true'",
+       async () => {
+         // cac yields `true` for `--profile` with no value. Reading it as a
+         // name would fail the command with a profile the user never typed.
+         writeWorkspace();
+         const code = await action('list', undefined, {profile: true});
+         expect(code).toBe(0);
+         expect(logs.join('\n')).toContain("profile 'default'");
+       });
+
+  test('--no-profile does not become a profile name either', async () => {
+    // mri yields `false`, which `??` would pass straight through.
+    writeWorkspace();
+    const code = await action('list', undefined, {profile: false});
+    expect(code).toBe(0);
+    expect(logs.join('\n')).toContain("profile 'default'");
+  });
+
+  test('a named profile still selects that profile', async () => {
+    writeWorkspace();
+    await action('list', undefined, {profile: 'analytical'});
+    expect(logs.join('\n')).toContain("profile 'analytical'");
+  });
+
+  test('an argument named after an Object member is an ordinary argument',
+       async () => {
+         // On a plain object `'toString' in args` is true before anything is
+         // parsed, so this would report a duplicate the caller never gave.
+         writeWorkspace();
+         await action(
+             'run', 'IssueCredit',
+             {arg: ['toString=x', 'order=1', 'amount=5']});
+         const out = logs.join('\n');
+         expect(out).not.toContain('given twice');
+         // It gets as far as the refusal, which is where this model stops.
+         expect(out).toContain('CreditIsPositive');
+       });
+
+  test('a genuinely repeated argument is still reported', async () => {
+    writeWorkspace();
+    const code = await action(
+        'run', 'IssueCredit', {arg: ['order=1', 'order=2', 'amount=5']});
+    expect(code).toBe(1);
+    expect(logs.join('\n')).toContain('--arg order was given twice');
+  });
+});

--- a/toolbox/mdcode/tests/tool/action.test.ts
+++ b/toolbox/mdcode/tests/tool/action.test.ts
@@ -375,3 +375,32 @@ describe('kcmd action: what the command line can actually contain', () => {
     expect(logs.join('\n')).toContain('--arg order was given twice');
   });
 });
+
+
+// `run` skips the deployment checks on purpose -- it deploys nothing -- but
+// not the ones the runtime's refusal gate depends on.
+describe('kcmd action run: the model has to be valid to run', () => {
+  const TYPO = MODEL.replace(
+      '- {concept: Entry, operation: create}',
+      '- {concept: Etnry, operation: create}');
+
+  test(
+      'an affects entry naming a concept the model does not declare is ' +
+          'refused rather than run',
+      async () => {
+        // A push rejects this outright. Left to run, the overlap test would
+        // look for constraints over 'Etnry', find none, and the gate that
+        // exists to stop an unchecked write would quietly turn off -- the one
+        // failure it is there to prevent, arriving as a typo.
+        writeWorkspace(TYPO);
+        const code =
+            await action('run', 'IssueCredit', {arg: ['order=A1', 'amount=5']});
+        expect(code).toBe(1);
+        expect(logs.join('\n')).toContain('\'Etnry\'');
+      });
+
+  test('but listing it still works, because listing runs nothing', async () => {
+    writeWorkspace(TYPO);
+    expect(await action('list', undefined)).toBe(0);
+  });
+});

--- a/toolbox/mdcode/tests/tool/action.test.ts
+++ b/toolbox/mdcode/tests/tool/action.test.ts
@@ -1,0 +1,324 @@
+// Tests for `kcmd action` (src/tool/commands.ts, action()) -- the command in
+// front of the semantic runtime.
+//
+// Nothing here reaches a store, and that is not a compromise: `list` never
+// opens one, and every `run` covered fails before the first request. The
+// argument parse, the choice of database, and the runtime's own refusal to run
+// an action a constraint is supposed to decide all happen before a session
+// exists. What is under test is the wiring -- that the command finds the model,
+// merges the profile, parses the arguments, picks the database from the
+// deployment target rather than from a flag, and hands the runtime's answer
+// back as an exit code. It runs in a temp working directory with a pinned
+// context, mirroring profiles.test.ts.
+
+import {afterEach, beforeEach, describe, expect, mock, spyOn, test} from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {ApiContext} from '../../src/libts/gcp/context';
+import {action} from '../../src/tool/commands';
+
+const CTX = new ApiContext('test-project', 'us', 'test-token');
+
+const SPANNER = '//spanner.googleapis.com/projects/acme-ops/instances/prod';
+
+// The model as authored: bound to Spanner, with one action the runtime could
+// run and one it could not, plus the two constraint shapes -- an invariant over
+// stored data and a guard over an argument.
+const MODEL = `version: "0.2.0.dev0/google"
+semantic_model:
+  - name: commerce
+    deployment_target: ${SPANNER}/databases/commerce/propertyGraphs/commerce
+    entities:
+      - name: Order
+        source: ${SPANNER}/databases/commerce/tables/Orders
+        primary_key: [key]
+        fields:
+          - { name: key, expression: OrderId }
+          - { name: total, expression: Total }
+      - name: Entry
+        source: ${SPANNER}/databases/commerce/tables/LedgerEntry
+        primary_key: [key]
+        fields:
+          - { name: key, expression: EntryId }
+          - { name: amount, expression: Amount }
+    actions:
+      - name: IssueCredit
+        description: Credit an order
+        executor:
+          sql:
+            statements:
+              - >-
+                INSERT INTO LedgerEntry (EntryId, OrderId, Amount)
+                VALUES (@newEntryKey, @order, @amount)
+        parameters:
+          - {name: order, type: Order}
+          - {name: amount, type: Decimal}
+        guards: [CreditIsPositive]
+        affects:
+          - {concept: Entry, operation: create}
+      - name: NotifyCustomer
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/commerce
+            tool: notify
+        parameters:
+          - {name: order, type: Order}
+    constraints:
+      - name: TotalStaysPositive
+        expression: Order.total >= 0
+        description: An order total never goes negative.
+      - name: CreditIsPositive
+        expression: amount > 0
+        description: A credit must be for a positive amount.
+`;
+
+// The same model with nothing to run.
+const NO_ACTIONS = `version: "0.2.0.dev0/google"
+semantic_model:
+  - name: commerce
+    deployment_target: ${SPANNER}/databases/commerce/propertyGraphs/commerce
+    entities:
+      - name: Order
+        source: ${SPANNER}/databases/commerce/tables/Orders
+        primary_key: [key]
+        fields:
+          - { name: key, expression: OrderId }
+`;
+
+// An analytical binding: the same concepts, deployed to BigQuery.
+const ANALYTICAL = `version: "0.2.0.dev0/google"
+semantic_model:
+  - name: commerce
+    deployment_target: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/propertyGraphs/commerce
+    entities:
+      - name: Order
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/orders
+        fields:
+          - { name: key, expression: order_id }
+          - { name: total, expression: total }
+      - name: Entry
+        source: //bigquery.googleapis.com/projects/acme-analytics/datasets/sales/tables/ledger
+        fields:
+          - { name: key, expression: entry_id }
+          - { name: amount, expression: amount }
+`;
+
+// A binding whose deployment target and entity sources disagree about which
+// database they mean.
+const MISMATCHED = `version: "0.2.0.dev0/google"
+semantic_model:
+  - name: commerce
+    deployment_target: ${SPANNER}/databases/archive/propertyGraphs/commerce
+    entities:
+      - name: Order
+        source: ${SPANNER}/databases/commerce/tables/Orders
+        fields:
+          - { name: key, expression: OrderId }
+          - { name: total, expression: Total }
+      - name: Entry
+        source: ${SPANNER}/databases/commerce/tables/LedgerEntry
+        fields:
+          - { name: key, expression: EntryId }
+          - { name: amount, expression: Amount }
+`;
+
+let dir = '';
+let cwd = '';
+let logs: string[] = [];
+
+function writeWorkspace(modelText = MODEL): void {
+  fs.writeFileSync(
+      path.join(dir, 'catalog.yaml'),
+      'scope: semantic-model.test-project.us.commerce_eg\n');
+  const eg = path.join(dir, 'catalog', 'EntryGroups', 'commerce_eg');
+  fs.mkdirSync(path.join(eg, 'commerce.profiles'), {recursive: true});
+  fs.writeFileSync(path.join(eg, 'commerce.yaml'), modelText);
+  fs.writeFileSync(
+      path.join(eg, 'commerce.profiles', 'analytical.yaml'), ANALYTICAL);
+  fs.writeFileSync(
+      path.join(eg, 'commerce.profiles', 'mismatched.yaml'), MISMATCHED);
+}
+
+beforeEach(() => {
+  cwd = process.cwd();
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kcmd-action-'));
+  process.chdir(dir);
+  logs = [];
+  spyOn(ApiContext, 'default').mockReturnValue(CTX);
+  for (const channel of ['log', 'warn', 'error'] as const) {
+    spyOn(console, channel).mockImplementation((...a: any[]) => {
+      logs.push(a.join(' '));
+    });
+  }
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  if (dir) fs.rmSync(dir, {recursive: true, force: true});
+  dir = '';
+  mock.restore();
+});
+
+
+describe('kcmd action list', () => {
+  test('prints each action with what it takes, what it touches, and the ' +
+           'command line that runs it',
+       async () => {
+         writeWorkspace();
+         const code = await action('list', undefined);
+         expect(code).toBe(0);
+         const out = logs.join('\n');
+
+         expect(out).toContain("Model 'commerce' (commerce_eg), profile 'default'");
+         expect(out).toContain('IssueCredit: Credit an order');
+
+         // An entity-typed parameter is marked as a reference: the caller
+         // passes something to look up, not a value.
+         expect(out).toContain('parameters: order (Order, reference), amount (Decimal)');
+         expect(out).toContain('executor:   sql');
+         expect(out).toContain('guards:     CreditIsPositive');
+         expect(out).toContain('affects:    Entry (create)');
+
+         // The point of the listing: the reader can copy this and run it.
+         expect(out).toContain(
+             'run:        kcmd action run IssueCredit --arg order=<Order> ' +
+             '--arg amount=<Decimal>');
+
+         // An action with no description, guards or blast radius shows only
+         // what it declares.
+         expect(out).toContain('NotifyCustomer');
+         expect(out).toContain('executor:   mcp');
+         expect(out).toContain('run:        kcmd action run NotifyCustomer --arg order=<Order>');
+       });
+
+  test('says so when a model declares no actions', async () => {
+    writeWorkspace(NO_ACTIONS);
+    const code = await action('list', undefined);
+    expect(code).toBe(0);
+    expect(logs.join('\n')).toContain('declares no actions.');
+  });
+
+  test('reads the model under a named profile', async () => {
+    writeWorkspace();
+    const code = await action('list', undefined, {profile: 'analytical'});
+    expect(code).toBe(0);
+    expect(logs.join('\n')).toContain("profile 'analytical'");
+  });
+
+  test('names the profiles that exist when given one that does not',
+       async () => {
+         writeWorkspace();
+         const code = await action('list', undefined, {profile: 'nope'});
+         expect(code).toBe(1);
+         const out = logs.join('\n');
+         expect(out).toContain("unknown binding profile 'nope'");
+         expect(out).toContain('analytical');
+       });
+
+  test('rejects a subcommand that is neither list nor run', async () => {
+    writeWorkspace();
+    const code = await action('explain', 'IssueCredit');
+    expect(code).toBe(1);
+    expect(logs.join('\n')).toContain("expected 'list' or 'run'");
+  });
+});
+
+
+describe('kcmd action run: what it will not send to a store', () => {
+  test('needs an action name', async () => {
+    writeWorkspace();
+    const code = await action('run', undefined);
+    expect(code).toBe(1);
+    expect(logs.join('\n')).toContain('needs an action name');
+  });
+
+  test('names the declared actions when asked for one that is not there',
+       async () => {
+         writeWorkspace();
+         const code = await action('run', 'IssueRefund');
+         expect(code).toBe(1);
+         const out = logs.join('\n');
+         expect(out).toContain("declares an action 'IssueRefund'");
+         expect(out).toContain('declared: IssueCredit, NotifyCustomer.');
+       });
+
+  test('rejects an --arg that does not name a parameter', async () => {
+    writeWorkspace();
+    const code = await action(
+        'run', 'IssueCredit', {arg: ['order=12345', 'amount']});
+    expect(code).toBe(1);
+    expect(logs.join('\n')).toContain("--arg expects <name>=<value>, but got 'amount'");
+  });
+
+  test('rejects the same parameter given twice', async () => {
+    writeWorkspace();
+    const code =
+        await action('run', 'IssueCredit', {arg: ['amount=30', 'amount=40']});
+    expect(code).toBe(1);
+    expect(logs.join('\n')).toContain('--arg amount was given twice.');
+  });
+
+  test('takes a single --arg, which cac hands over as a bare string',
+       async () => {
+         writeWorkspace();
+         // Reaches the runtime rather than the argument parser: the refusal
+         // below is about the guard, which is proof the parse succeeded.
+         const code = await action('run', 'IssueCredit', {arg: 'amount=30'});
+         expect(code).toBe(1);
+         expect(logs.join('\n')).toContain('does not evaluate constraints yet');
+       });
+
+  test('refuses an action whose executor runs outside the transaction',
+       async () => {
+         writeWorkspace();
+         const code = await action('run', 'NotifyCustomer', {arg: 'order=1'});
+         expect(code).toBe(1);
+         expect(logs.join('\n')).toContain('which runs outside this transaction');
+       });
+
+  test('refuses a guarded action while nothing evaluates the guard',
+       async () => {
+         writeWorkspace();
+         const code = await action(
+             'run', 'IssueCredit', {arg: ['order=12345', 'amount=30']});
+         expect(code).toBe(1);
+         const out = logs.join('\n');
+         expect(out).toContain("is guarded by 'CreditIsPositive'");
+         // It got as far as choosing a database, so the refusal is the
+         // runtime's and not a wiring failure earlier on.
+         expect(out).toContain(
+             "Running 'IssueCredit' on projects/acme-ops/instances/prod/databases/commerce");
+       });
+});
+
+
+describe('kcmd action run: where the write would go', () => {
+  test('refuses a profile that deploys to BigQuery', async () => {
+    writeWorkspace();
+    const code = await action(
+        'run', 'IssueCredit',
+        {profile: 'analytical', arg: ['order=12345', 'amount=30']});
+    expect(code).toBe(1);
+    const out = logs.join('\n');
+    expect(out).toContain('declares no Spanner deployment target');
+    expect(out).toContain('this profile deploys to BigQuery');
+  });
+
+  test('refuses a binding whose sources sit in a different database than ' +
+           'its deployment target',
+       async () => {
+         writeWorkspace();
+         const code = await action(
+             'run', 'IssueCredit',
+             {profile: 'mismatched', arg: ['order=12345', 'amount=30']});
+         expect(code).toBe(1);
+         const out = logs.join('\n');
+         expect(out).toContain(
+             "binds 'Order' to projects/acme-ops/instances/prod/databases/commerce");
+         expect(out).toContain(
+             'deployment target is projects/acme-ops/instances/prod/databases/archive');
+         expect(out).toContain('address a table by name alone');
+       });
+});

--- a/toolbox/mdcode/tests/tool/action.test.ts
+++ b/toolbox/mdcode/tests/tool/action.test.ts
@@ -108,6 +108,29 @@ semantic_model:
           - { name: amount, expression: amount }
 `;
 
+// A read-only binding of the same store. An executor is a physical facet, so
+// a profile can withdraw one with `executor: null` -- the action stays
+// declared and published, and simply cannot be performed here.
+const READONLY = `version: "0.2.0.dev0/google"
+semantic_model:
+  - name: commerce
+    deployment_target: ${SPANNER}/databases/commerce/propertyGraphs/commerce
+    entities:
+      - name: Order
+        source: ${SPANNER}/databases/commerce/tables/Orders
+        fields:
+          - { name: key, expression: OrderId }
+          - { name: total, expression: Total }
+      - name: Entry
+        source: ${SPANNER}/databases/commerce/tables/LedgerEntry
+        fields:
+          - { name: key, expression: EntryId }
+          - { name: amount, expression: Amount }
+    actions:
+      - name: IssueCredit
+        executor: null
+`;
+
 // A binding whose deployment target and entity sources disagree about which
 // database they mean.
 const MISMATCHED = `version: "0.2.0.dev0/google"
@@ -177,6 +200,8 @@ function writeWorkspace(modelText = MODEL): void {
       path.join(eg, 'commerce.profiles', 'analytical.yaml'), ANALYTICAL);
   fs.writeFileSync(
       path.join(eg, 'commerce.profiles', 'mismatched.yaml'), MISMATCHED);
+  fs.writeFileSync(
+      path.join(eg, 'commerce.profiles', 'readonly.yaml'), READONLY);
 }
 
 beforeEach(() => {
@@ -229,6 +254,21 @@ describe('kcmd action list', () => {
          expect(out).toContain('NotifyCustomer');
          expect(out).toContain('executor:   mcp');
          expect(out).toContain('run:        kcmd action run NotifyCustomer --arg order=<Order>');
+       });
+
+  test('shows an action the profile withdrew as declared but not runnable',
+       async () => {
+         // The listing answers "what can this model do HERE". Printing a run
+         // line for a write this binding cannot perform would send the reader
+         // to a refusal, so it prints the fix instead.
+         writeWorkspace();
+         const code = await action('list', undefined, {profile: 'readonly'});
+         expect(code).toBe(0);
+         const out = logs.join('\n');
+         expect(out).toContain('IssueCredit');
+         expect(out).toContain('executor:   (none under this profile');
+         expect(out).toContain('bind an executor in a profile to run this');
+         expect(out).not.toContain('kcmd action run IssueCredit');
        });
 
   test('says so when a model declares no actions', async () => {
@@ -329,6 +369,22 @@ describe('kcmd action run: what it will not send to a store', () => {
          expect(out).toContain(
              "Running 'IssueCredit' on projects/acme-ops/instances/prod/databases/commerce");
        });
+});
+
+
+describe('kcmd action run: an action this binding cannot perform', () => {
+  test('refuses an action whose executor the profile withdrew', async () => {
+    // Nothing is wrong with the action. The binding is what says no, so the
+    // message has to send the reader to the profile rather than to the model.
+    writeWorkspace();
+    const code = await action(
+        'run', 'IssueCredit',
+        {profile: 'readonly', arg: ['order=1', 'amount=5']});
+    expect(code).toBe(1);
+    const out = logs.join('\n');
+    expect(out).toContain('no executor under this binding');
+    expect(out).toContain('profile');
+  });
 });
 
 

--- a/toolbox/mdcode/tests/tool/action.test.ts
+++ b/toolbox/mdcode/tests/tool/action.test.ts
@@ -471,10 +471,11 @@ describe('kcmd action run: the model has to be valid to run', () => {
       'an affects entry naming a concept the model does not declare is ' +
           'refused rather than run',
       async () => {
-        // A push rejects this outright. Left to run, the overlap test would
-        // look for constraints over 'Etnry', find none, and the gate that
-        // exists to stop an unchecked write would quietly turn off -- the one
-        // failure it is there to prevent, arriving as a typo.
+        // A push rejects this outright. Left to run, the typo would reach
+        // the binder, which turns an `affects` entry whose operation is
+        // `create` into a generated key: the key would be minted for a concept
+        // that has no table, and the statement binding it would fail at the
+        // store reading like a fault in the SQL rather than a typo.
         writeWorkspace(TYPO);
         const code =
             await action('run', 'IssueCredit', {arg: ['order=A1', 'amount=5']});


### PR DESCRIPTION
An action has been a description of what can be DONE that nothing could do.
This runs one: resolve the entity-typed arguments to rows, bind every argument
as a typed query parameter, open a read-write transaction, run the action's DML
inside it, commit or roll back — with `kcmd action` in front of it.

**Constraint evaluation is not here.** That is the larger half and it lands
next. What *is* here is the part that makes deferring it safe: an action the
model says is checked before it runs is **refused** rather than run unchecked. A
model that declares a rule and a runtime that quietly ignores it is worse than
no runtime, because the model states the call is checked and nothing says
otherwise.

What says that is `guards`, and only `guards` — the rule #414 landed. A
constraint takes effect where something references it, so a constraint no action
names is catalogued rather than applied, and this runtime does not go looking
for one: an overlap between what a constraint reads and what an action writes
gates nothing here. A guard whose constraint declares `warn` stands down, since
such a rule reports a violation rather than rejecting one and an evaluator would
let the write through. A guard naming nothing the model declares still refuses.

An action that names no guard runs today, which is what makes the runtime useful
before the evaluator exists. Every refusal is decided before a session is opened,
so a refused action leaves no transaction to roll back.

### `kcmd action`

A runtime with no entry point is something a reviewer has to imagine a caller
for. Two subcommands, in the positional shape `kcmd owl` uses.

`kcmd action list` answers "what can I run, and how" — and ends each entry with
the command line that runs it, so reading the listing is enough to make the
call:

```
Model 'commerce' (commerce_eg), profile 'default':
  IssueCredit: Credit an order
    parameters: order (Order, reference), amount (Decimal)
    executor:   sql
    guards:     CreditIsPositive
    affects:    Entry (create)
    run:        kcmd action run IssueCredit --arg order=<Order> --arg amount=<Decimal>
```

`kcmd action run <name> --arg <name>=<value> …` collects the pairs and hands
them to `runAction`. Values stay text: the runtime parses each against its
declared ontology type, so the command line does not have to guess whether `30`
is a number, an amount, or a string.

Where the write goes is the model's Spanner deployment target under the selected
profile. **The command line never names a database** — changing stores is
`--profile`, the same rule push follows. Two things are settled before a client
is built:

- a profile with no Spanner target cannot be run against, and one that deploys
  to BigQuery is told so by name;
- an entity bound to a *different* database than the target is refused. That
  matters more here than in any other leg: an action's statements address a
  table by NAME, with the project/instance/database qualifier dropped, so the
  write would otherwise land in whatever table of that name the target database
  happens to hold, and nothing later would report it.

### The Spanner data surface

A second client alongside the existing Database Admin one: sessions, read-write
transactions, and explicit commit/rollback rather than a callback wrapper,
because the caller has to keep the decision to commit.

It tracks the per-transaction `seqno` itself. Spanner requires a monotonically
increasing one on every DML statement in a read-write transaction — it is how
the server recognizes a retry it has already applied. Sending a repeated seqno
with a *different* statement fails with "Previously received a different request
with this seqno", which is what makes a hand-rolled client fail on its **second**
statement rather than its first.

`spannerTable` in `semantic/spanner.ts` is exported so the resolver can address
an entity's table the same way the push leg does.

### Tests

Three files. The store is faked at the client surface rather than over HTTP, so
the runtime's assertions are about the guarantees it states — a failed statement
rolls back, a refused action opens nothing, no argument reaches the store as
anything but a bound parameter — rather than about wire format.

The command's tests reach no store at all, and not by mocking one away: `list`
opens none, and every `run` covered fails before the first request. The argument
parse, the choice of database, and the runtime's own refusal all happen before a
session exists.

### Docs

Having a command is what makes the guide possible. `actions.md` gains
"7. Run it" — resolve/bind/apply, the executor kinds that do not run and why,
and the refusal rule. Two claims it could not make before are corrected: the
runtime no longer "lands separately", and a guard no longer "blocks no call",
since it now refuses the call outright. "What is not modeled yet" says what is
actually missing. `reference.md` gains the flags.

### What review changed

Two of these are the runtime claiming to know something it did not.

**The overlap test failed open.** *(Removed on rebase — see "After the rebase".)*
It was what decided that *no* constraint bears on a write — the one judgment
that runs an unchecked write if it is wrong — and it scanned entity names only.
`affects` names an entity *or a relationship*, and validation deliberately
permits a relationship-qualified expression, so an action affecting a
many-to-many with a rule stated over it found no overlap and ran; its `affects`
was non-empty, so the "declares no affects" fallback did not catch it either. An
expression naming no concept at all (`amount > 0`) missed the same way.

**A failed commit is not a rollback.** The branch said "the write ran but the
commit failed", claimed a rollback in the type's own doc, and performed none.
Spanner returns a deadline or a 5xx on commit for a commit that *landed* as
readily as for one that did not, so the old message told the caller the write
did not happen in exactly the case where it may have, and invited the retry
that applies it twice. It now returns an `indeterminate` outcome saying the
fate is unknown and to read the data before retrying — and still no rollback,
because once commit is called the transaction is the server's.

Two more ways an error could be replaced by a worse one: `withSession` deleted
its session in a `finally` with the rejection unguarded, so a blip on cleanup
*after* a successful commit became the caller's result; and a rollback that
itself failed discarded the reason the action stopped. Also: an `mcp` handler
is no longer held to a binding pass its plan never uses; a generated UUID key
for a non-String-keyed entity is refused by name rather than by the store, and
only where a statement actually binds one; reference resolution compares each
column as itself instead of `CAST(col AS STRING)`, which no index can serve and
which held read locks over the whole table inside the write; a bare
`--profile` is no longer looked up as a profile called `true`; and parameter
maps have a null prototype, so `--arg toString=x` is an argument rather than a
duplicate.

### What the second review changed

**A commit that rejects is the case the first round was about.** That round
added an `indeterminate` outcome for a commit that *returns* a non-2xx. But a
commit can also reject outright — the request throws on a socket hang-up, a DNS
failure or an abort — and that is the more common shape of a commit deadline. It
fell through to the catch, which rolled back and reported "failed and was rolled
back": the exact sentence the new branch exists to avoid, in the exact case it
was written for. Both shapes return the same outcome now.

**`kcmd action run` ran models `kcmd push` would reject.** The load path skips
validation on purpose, but it skipped the checks that bear on *running* too. An
`affects` entry naming an undeclared concept is a hard error on push; at run
time it reached the binder, which mints a generated key for an entry whose
operation is `create` — so a typo produced a key for a concept with no table and
failed at the store reading like a fault in the SQL. The run-relevant checks run
first now, and only those.

**The blast radius is read, not believed.** *(Removed on rebase — see "After the
rebase".)* The overlap test had trusted `affects` even for a `sql` executor
whose statements were sitting right there, so an action declaring `affects:
[Transfer create]` whose second statement was `UPDATE Account SET …` ran while a
constraint over `Account` went unevaluated.

Also: a `warn` constraint no longer gates anything (it reports rather than
rejects, so gating on it made a model stating advisory rules permanently
unrunnable); a composite key is no longer resolved by matching one *part* of it,
which the previous round's per-column predicates did by ORing them; a failure
before any transaction existed no longer claims a rollback; and `--arg memo=`
passes an empty string, which is a different statement from passing nothing.

### Run against a real store

None of this had ever been run end to end, so it was — against a scratch Spanner
database, since a runtime nothing has executed is a claim rather than a result.

Both resolution paths (by key, and by an identifying name column), the ambiguous
and no-match errors, a committed write confirmed by reading the row back, and
every refusal the branch then had: mcp executor, generated key on an
`Integer`-keyed entity, guard, constraint overlap, and database mismatch. The
overlap refusal is the one of those that is gone.

It also settled a question by experiment. Two actions doing the same write, one
in database names and one in model names:

- `UPDATE Orders SET Total = Total + @amount WHERE OrderId = @order` — committed.
- `UPDATE Order SET total = total + @amount WHERE key = @order` — `Syntax error:
  Unexpected keyword ORDER [at 1:8]`.

Action statements are not translated; they reach the store verbatim. **Every SQL
example in the guide was written in model names** and would have failed exactly
that way — legibly only by accident, since here the entity name happened to be a
reserved word. They are corrected, and a section now says the rule outright.

"7. Run it" also gains **"How a row is identified"**, because the old one-line
answer did not answer it. It separates the two mechanisms that were running
together: *resolving an argument*, where the runtime finds exactly one row using
the declared `primary_key` and an identifying text field, and *targeting the
write*, where the statement's own `WHERE` decides how many rows are written and
nothing constrains it — `affects` declares the blast radius, it does not limit
it. And the page's headline example could not succeed, because the action it ran
is the one the page later shows being refused; it says so where it is shown.

### What the third review changed

**A commit Spanner refuses is not a commit whose fate is unknown.** The two
rounds above went to some trouble to stop reporting a rollback for a commit that
may have landed — and then applied that answer to every non-2xx. `409 ABORTED`
is what Spanner returns under ordinary lock contention, and it guarantees the
transaction applied nothing. Telling that caller the write may have landed and
the data must be read before retrying turns the commonest routine failure there
is into an investigation, on every conflict, when the answer is simply to run
the action again. A definite refusal now reports a rollback; a 5xx, a timeout
and a rejected request are still unknown, which is the default for anything
unlisted.

**The run path did not resolve inheritance.** Both push legs do. An inherited
field is a field, and the runtime reads `entity.fields` twice for things it must
not get wrong: it could not see a subtype's inherited `name`, so a reference by
name reported a row missing that is there, and it could not see an inherited
key's type, so the check that refuses a generated UUID for an `Integer` key read
the absent field as a String and passed.

Also: `--arg 30` reports the message written for it instead of throwing a
TypeError past the parser (cac hands back the *number* `30`); a String argument
is no longer trimmed; a bug in a handler no longer reports itself as a rejected
write; `executeQuery` is dropped until the read-only path it was written for
lands; and `validateRunnable` no longer sits between `validateActions` and its
doc comment.

*(That round also fixed a table-name collision in the overlap test, and stopped
gating a handler's action on statements that never run. Both are gone with the
overlap test itself.)*

### After the rebase

Main now carries judged constraints (#414), which settles a question this branch
had answered for itself: **a constraint is inert until something references it.**
`guards` is that reference for an action.

The gate here predated that and read two further signals — a constraint whose
expression touched a concept the action writes, and a model with constraints
whose action declared no `affects` at all. Both refused calls the model never
said were checked, and the second read silence as suspicion. Keeping them would
have made publishing a rule a breaking change: add a constraint over `Account`,
and every action writing an account stops running, having been told nothing
about it. That is the exact failure an explicit reference exists to prevent, so
the overlap test goes rather than the rule. −461 lines, in its own commit.

What is left is the one question the model answers directly: does the action
name a constraint that must be checked before it runs, which nothing can check
yet.

One integration fix came with the rebase: a judged constraint declares no
`expression`, so the code reading one had to stop assuming there is one. That
commit is now moot and stays only because it is what made the rebase green.

Verified: `npx tsc --noEmit` clean, `npx bun test` 861 pass / 0 fail across 37
files (up from 738 across 34). Each behavioural fix above fails its test without
the fix.
