### PR TITLE
feat(mdcode): a constraint may state its rule as a judgment

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -132,15 +132,19 @@ declared or it is unknown. Knowledge Catalog is the only system an action
 reaches, and the only place it is governed. See
 [Modeling write operations](actions.md).
 
-A model can also state **constraints**: named boolean invariants over the
-ontology that hold for every instance, whatever writes to the model. A
-constraint is part of what the model asserts, written in the same expression
-language as a metric, and `Account.balance >= 0` is as much a fact about an
-account as the fields beside it. A constraint that reads an action's parameters
+A model can also state **constraints**: named invariants over the ontology that
+hold for every instance, whatever writes to the model. A constraint is part of
+what the model asserts, and `Account.balance >= 0` is as much a fact about an
+account as the fields beside it. Most are boolean expressions in the same
+language as a metric. A rule no expression decides — whether a discount is
+justified by the reason given — is stated in words instead, under `judgment`,
+with the field names it mentions written model-qualified so they are checked
+like any other reference. A constraint that reads an action's parameters
 describes one call rather than the stored data. It can be checked only before
 that call runs, so the action names it in `guards`. A constraint reaches
 Knowledge Catalog only: it is validated, published there, and read back by
-`pull`. No component checks one against live data yet.
+`pull`. No component checks one against live data or asks a model to settle a
+judgment yet.
 
 This model names no table and no store, so it is complete enough to govern in
 Knowledge Catalog as-is (step 2). Where each entity reads from — the store and the

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -210,6 +210,20 @@ constraints that have no other moment to run. Naming an invariant over stored
 data as a guard is still useful. It states that the call must not proceed on
 data that is already broken, and it puts that check before the call.
 
+The two kinds are settled at different moments, and what each rule reads decides
+which. A constraint that reads an action's parameters can be settled before
+anything is written, from the arguments and the data as it stands. A constraint
+over stored data states a condition on the state the write produces, so it is
+settled against the proposed result, inside the write, and a breach stops the
+commit. A rule meant to report rather than block is one that declares `warn`,
+checked at the same moment and let through.
+
+Not every rule can be handed to the store to check. A condition on a single row
+lowers to a store-level `CHECK`. A condition that aggregates across a child
+table, such as an order total matching the sum of its line items, lowers to
+neither Spanner nor BigQuery, so enforcing it before the commit falls to
+whatever performs the write.
+
 The reference lives on the action rather than on the constraint, because the
 same rule may gate `TransferFunds` and leave `CloseAccount` alone.
 
@@ -373,7 +387,9 @@ for every write from every source, whether or not an action mentions it, so it
 is declared and left unguarded. It is also the only rule here that nobody in the
 business may approve: an order whose total disagrees with its line items is
 broken rather than unusual. When a rule tempts you toward `reject`, check first
-whether it is really an invariant, which belongs outside `guards`.
+whether it is really an invariant. One is in force without being listed, and
+naming it in `guards` would add an early check rather than switch enforcement
+on.
 
 **Rules 4 and 5 are why the second body exists.** Neither reduces to arithmetic
 over `Order` and `LineItem`, and before `judgment` they had nowhere to go but a

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -164,12 +164,12 @@ which lands separately.
 
 ## 2. Gate it with a constraint
 
-A **constraint** is a named invariant a model states over its ontology. An
-action needs none; declare one when a rule decides whether a call may proceed at
-all. Where a constraint applies depends on what its rule reads.
+A **constraint** is a named rule a model states over its ontology. Declaring one
+adds it to the catalog and changes nothing by itself. A constraint takes effect
+where something references it and nowhere else, so publishing a rule cannot
+silently start refusing calls that succeeded yesterday.
 
-An expression over stored data holds for every write, whatever performed that
-write. No action has to name such a constraint:
+An expression over stored data states a condition the data must satisfy:
 
 ```yaml
     constraints:
@@ -179,9 +179,12 @@ write. No action has to name such a constraint:
           An account cannot be taken below its minimum balance.
 ```
 
+On its own that is a catalogued rule and no more. Nothing consults it, and no
+write is refused for breaking it. It acquires effect when an action names it.
+
 An expression that reads an action's **parameters** describes one call rather
 than the stored data. The only moment it can be checked is before that call
-runs, so the action names it in `guards`:
+runs:
 
 ```yaml
     constraints:
@@ -203,26 +206,29 @@ runs, so the action names it in `guards`:
         guards: [AmountIsPositive]
 ```
 
-`guards` holds the names of constraints the same model declares. Naming one adds
-an earlier check; it does not switch enforcement on. An invariant over stored
-data is in force whether or not an action names it, so `guards` exists for the
-constraints that have no other moment to run. Naming an invariant over stored
-data as a guard is still useful. It states that the call must not proceed on
-data that is already broken, and it puts that check before the call.
+`guards` holds the names of constraints the same model declares, and it is how a
+constraint acquires effect over an action. Both kinds of rule belong there. One
+that reads the action's parameters has no other moment to run. One over stored
+data, named as a guard, states that the call must not proceed on data that is
+already broken.
 
-The two kinds are settled at different moments, and what each rule reads decides
-which. A constraint that reads an action's parameters can be settled before
-anything is written, from the arguments and the data as it stands. A constraint
-over stored data states a condition on the state the write produces, so it is
-settled against the proposed result, inside the write, and a breach stops the
-commit. A rule meant to report rather than block is one that declares `warn`,
-checked at the same moment and let through.
+Every guard is checked before the call, with the arguments bound. What each rule
+reads decides how much that moment can tell you. A rule over the parameters is
+settled completely there, since the arguments are the whole of what it reads. A
+rule over stored data is a condition on the state a write produces, and checking
+it before the call reports only that the call is not starting from a broken
+state. It does not report that the call leaves a sound one. Nothing in the model
+binds a rule to the result of a write, which is the gap between what a data rule
+says and what a guard can enforce.
 
-Not every rule can be handed to the store to check. A condition on a single row
-lowers to a store-level `CHECK`. A condition that aggregates across a child
-table, such as an order total matching the sum of its line items, lowers to
-neither Spanner nor BigQuery, so enforcing it before the commit falls to
-whatever performs the write.
+A rule meant to report rather than block is one that declares `warn`, checked at
+the same moment and let through.
+
+Whatever dispatches the call is what checks its guards. Handing a rule to the
+store instead works only for some rules. A condition on a single row lowers to a
+store-level `CHECK`. One that aggregates across a child table, such as an order
+total matching the sum of its line items, lowers to neither Spanner nor
+BigQuery.
 
 The reference lives on the action rather than on the constraint, because the
 same rule may gate `TransferFunds` and leave `CloseAccount` alone.
@@ -373,6 +379,7 @@ becomes one constraint, carrying its own outcome in its own `on_violation`:
         guards:
           - CreditWithinOrderTotal
           - CreditUnderSelfServiceLimit
+          - OrderTotalMatchesLineItems
           - CreditMemoNamesAServiceFailure
           - CreditIsNotSplitToAvoidReview
 ```
@@ -380,16 +387,18 @@ becomes one constraint, carrying its own outcome in its own `on_violation`:
 Reading down the `on_violation` column gives the branching that the policy
 describes in prose, in a column a search can read.
 
-**Rule 3 is not a guard, and that is what `reject` means.** The other four rules
-are about one proposed call, so they can be checked only before that call and
-the action names them in `guards`. Rule 3 quantifies over stored data. It holds
-for every write from every source, whether or not an action mentions it, so it
-is declared and left unguarded. It is also the only rule here that nobody in the
-business may approve: an order whose total disagrees with its line items is
-broken rather than unusual. When a rule tempts you toward `reject`, check first
-whether it is really an invariant. One is in force without being listed, and
-naming it in `guards` would add an early check rather than switch enforcement
-on.
+**Rule 3 is named like the rest, because an unnamed rule does nothing.** It is
+the one rule here that nobody in the business may approve: an order whose total
+disagrees with its line items is broken rather than unusual, which is why it
+says `reject`. That word buys nothing until an action names the rule. Left out
+of every `guards` list it would be a rule the catalog records and no call
+consults, and the strongest word in the policy would be the one with the least
+effect.
+
+Naming it makes `IssueCredit` refuse to run against an order whose books already
+disagree. Catching the credit that *breaks* the agreement is a different check,
+against the state the write produces, and the model cannot bind one yet. Rule 3
+is the rule in this policy whose enforcement is furthest from what it says.
 
 **Rules 4 and 5 are why the second body exists.** Neither reduces to arithmetic
 over `Order` and `LineItem`, and before `judgment` they had nowhere to go but a
@@ -417,11 +426,12 @@ IssueCredit(order=12345, amount=30.00,
             memo="refund of the shipping charge applied in error during the Labor Day sale")
 ```
 
-Rule 1 holds, since 30 is within the order. Rule 2 is violated, since 30 is over
-the self-service limit, and its word is `escalate`. Rules 4 and 5 hold: the memo
-names a specific failure, and a single credit is not a split one. One violation,
-so the call is held for a supervisor, who reviews it as a credit against an
-order rather than as a SQL diff.
+Rules 1 and 3 hold: 30 is within the order, and the order's total agrees with
+its line items. Rule 2 is violated, since 30 is over the self-service limit, and
+its word is `escalate`. Rules 4 and 5 hold: the memo names a specific failure,
+and a single credit is not a split one. One violation, so the call is held for a
+supervisor, who reviews it as a credit against an order rather than as a SQL
+diff.
 
 Now three 9-dollar credits raised against the same order within the hour, each
 memo reading some version of "customer asked":
@@ -430,8 +440,8 @@ memo reading some version of "customer asked":
 IssueCredit(order=12345, amount=9.00, memo="customer asked")
 ```
 
-Rules 1 and 2 both hold — 9 is inside the order and inside the limit — so every
-gate a query can compute lets this through. Rule 4 is violated and warns. Rule 5
+Rules 1, 2 and 3 all hold — 9 is inside the order, inside the limit, and the
+order's books agree — so every gate a query can compute lets this through. Rule 4 is violated and warns. Rule 5
 is violated and rejects. This is the case the judged rules were added for: the
 policy is being evaded precisely by staying inside the arithmetic.
 
@@ -448,7 +458,7 @@ Open Policy Agent, so a policy written this way lowers into either.
 
 An action whose guards are *all* judged loads with a warning. Every gate then
 costs a model call, none can lower to a store-level check, and each may decide
-two identical calls differently. `IssueCredit` is clear of it: two of its four
+two identical calls differently. `IssueCredit` is clear of it: three of its five
 guards are expressions.
 
 **Status: nothing calls a judge.** `kcmd` parses `judgment`, validates it,

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -223,22 +223,23 @@ block on still gets checked at the moment of the call and reported back.
 
 ### When no expression decides it
 
-Some rules a business enforces cannot be written as a boolean. Whether a
-discount is justified by the reason given, whether a refund note explains the
-exception it claims — a query can read the text but cannot settle the question.
+Some rules a business enforces cannot be written as a boolean. Whether a credit
+memo explains the failure it claims to refund, whether a discount is justified
+by the reason given — a query can read the text and cannot settle the question.
 Such a rule goes in `judgment` instead of `expression`:
 
 ```yaml
     constraints:
-      - name: DiscountIsJustified
+      - name: CreditMemoNamesAServiceFailure
         judgment: >-
-          A discount over 30% must be justified by the reason given in
-          Order.discount_reason. A reason that only restates the discount, such
-          as "competitive pricing", is not a justification.
+          LineItem.memo must name a specific, verifiable service failure on the
+          order: a late delivery, a damaged item, a shipping charge applied in
+          error. A memo that states only that the customer requested a credit
+          does not satisfy this rule.
         description: >-
-          Say what makes this discount necessary, then resubmit for approval.
-        on_violation: escalate
-        severity: high
+          Say what went wrong with the order in the credit memo.
+        on_violation: warn
+        severity: low
 ```
 
 A constraint declares one body or the other, never both and never neither. A
@@ -251,131 +252,196 @@ rejects, and that is too strong a consequence to inherit by silence.
 A language model reads the sentence at review time with the proposed write in
 front of it. Five habits make that reading consistent.
 
-**State what must be true of the data.** Write the condition — *the reason must
-name a specific problem with the order* — rather than the procedure — *check
-whether the reason is specific*. The sentence describes a clean write, and
-everything about handling a breach lives elsewhere.
+**State what must be true of the data.** Write the condition — *the memo must
+name a specific service failure* — rather than the procedure — *check whether
+the memo is specific*. The sentence describes a clean write, and everything
+about handling a breach lives elsewhere.
 
-**Name fields model-qualified.** Write `Order.discount_reason` rather than "the
-reason". `kcmd` resolves every `Entity.field` token in the text against the
-model and fails the push when the entity declares no such field, so a rename
-cannot leave the sentence pointing at nothing. The qualified name also tells the
-judge exactly which value to read.
+**Name fields model-qualified.** Write `LineItem.memo` rather than "the memo".
+`kcmd` resolves every `Entity.field` token in the text against the model and
+fails the push when the entity declares no such field, so a rename cannot leave
+the sentence pointing at nothing. The qualified name also tells the judge
+exactly which value to read.
 
 **Say what does not count.** A rule with no negative example is graded against
-whatever the model guesses the author had in mind. "A reason that only restates
-the discount, such as 'competitive pricing', is not a justification" buys more
-consistency than any further description of what a good reason is.
+whatever the model guesses the author had in mind. "A memo that states only that
+the customer requested a credit does not satisfy this rule" buys more
+consistency than any further description of what a good memo is.
 
 **Leave the consequence out of the prose.** What happens on a breach is
-`on_violation`. A judgment ending "…otherwise escalate to a director" states a
+`on_violation`. A judgment ending "…otherwise escalate to a supervisor" states a
 routing nothing reads, and the engine routes by the field regardless.
 
 **Keep it to one condition.** When the sentence needs "and also", the second
 half is a second constraint. One `on_violation` cannot carry two consequences,
 so two conditions that end differently cannot share a constraint.
 
-### A policy whose branches end differently
+### A policy whose rules end differently
 
-Written policies branch, and the branches rarely end the same way. A refund
-policy might say: a refund over $10,000 needs a director's approval; the stated
-reason has to be a real problem with the order; and a refund that looks like a
-larger one split into pieces is refused outright. Three conditions, three
-different outcomes.
+Real policies have several rules, and the rules rarely end the same way. Take
+the policy governing a customer-service credit, stated the way a business states
+it:
 
-Each condition becomes its own constraint, carrying its own outcome in its own
-`on_violation`:
+1. a credit may not exceed the total of the order it credits;
+2. a credit over 25 dollars needs a supervisor's decision;
+3. an order's total always equals the sum of its line items;
+4. the memo on a credit must name a specific service failure;
+5. a credit must not be one larger credit split up to stay under the 25-dollar
+   limit.
+
+Five rules, three different outcomes, and two of them that no query settles. The
+model has an `Order` with a `total`, a `LineItem` with an `amount` and a `memo`,
+and an `IssueCredit` action taking the order, the amount and the memo. Each rule
+becomes one constraint, carrying its own outcome in its own `on_violation`:
 
 ```yaml
     constraints:
-      - name: LargeRefundHasDirectorApproval
-        expression: >-
-          Refund.amount <= 10000 OR Refund.director_approval IS NOT NULL
+      # Rules a query can compute.
+      - name: CreditWithinOrderTotal              # rule 1
+        expression: amount <= Order.total
         description: >-
-          Refunds over $10,000 need a director's approval. Attach one and
-          resubmit.
+          A credit cannot exceed the total of the order it credits. Lower the
+          amount, or split it across the orders it actually covers.
         on_violation: escalate
         severity: high
 
-      - name: RefundReasonIsSpecific
-        judgment: >-
-          Refund.reason must name a specific, verifiable problem with the order
-          — a late delivery, a damaged item, an incorrect charge. A reason that
-          only restates that the customer asked for a refund does not satisfy
-          this rule.
+      - name: CreditUnderSelfServiceLimit         # rule 2
+        expression: amount <= 25
         description: >-
-          Say what went wrong with the order in the refund reason.
+          A credit over 25 dollars is above the self-service limit. A
+          supervisor decides it.
+        on_violation: escalate
+        severity: medium
+
+      - name: OrderTotalMatchesLineItems          # rule 3
+        expression: Order.total == SUM(LineItem.amount)
+        description: >-
+          An order's total must equal the sum of its line items, with credits
+          subtracted.
+        on_violation: reject
+        severity: critical
+
+      # Rules no query can compute.
+      - name: CreditMemoNamesAServiceFailure      # rule 4
+        judgment: >-
+          LineItem.memo must name a specific, verifiable service failure on the
+          order: a late delivery, a damaged item, a shipping charge applied in
+          error. A memo that states only that the customer requested a credit
+          does not satisfy this rule.
+        description: >-
+          Say what went wrong with the order in the credit memo.
         on_violation: warn
         severity: low
 
-      - name: RefundIsNotStructured
+      - name: CreditIsNotSplitToAvoidReview       # rule 5
         judgment: >-
-          A refund must not appear to be one larger refund split into parts to
-          stay under an approval limit. Read Refund.amount together with the
-          other refunds on the same Order in the same week: several near-limit
-          refunds for related reasons are structuring, whatever each one says
-          on its own.
+          A credit must not appear to be one larger credit divided into parts
+          that each stay under the 25-dollar self-service limit. Read the
+          proposed amount together with the other credits already on the same
+          Order: several near-limit credits raised close together for related
+          reasons are one credit, whatever each memo says on its own.
         description: >-
-          Issue this as a single refund at its full amount and route it for
-          approval.
+          Raise this as a single credit for the full amount and send it for
+          supervisor review.
         on_violation: reject
         severity: critical
 
     actions:
-      - name: IssueRefund
+      - name: IssueCredit
+        executor:
+          mcp:
+            server: //agentregistry.googleapis.com/projects/acme-ops/locations/us-central1/mcpServers/commerce
+            tool: issue_credit
         parameters:
-          - { name: order, type: Order }
-          - { name: amount, type: Float }
+          - { name: order,  type: Order }
+          - { name: amount, type: Decimal }
+          - { name: memo,   type: String }
         guards:
-          - LargeRefundHasDirectorApproval
-          - RefundReasonIsSpecific
-          - RefundIsNotStructured
+          - CreditWithinOrderTotal
+          - CreditUnderSelfServiceLimit
+          - CreditMemoNamesAServiceFailure
+          - CreditIsNotSplitToAvoidReview
 ```
 
 Reading down the `on_violation` column gives the branching that the policy
-describes in prose. A structured refund is refused. A large refund with no
-director's approval is held until one arrives. A vague reason is reported and
-the refund proceeds.
+describes in prose, in a column a search can read.
 
-Three properties come from writing it this way. The words stay in fields, so a
-search for the rules that can stop a refund finds them without reading prose.
-The first condition stays an expression, so a query settles it and no model call
-is spent on arithmetic. And each branch has its own name, owner and history, so
-raising the approval limit is an edit to one constraint rather than to a
-paragraph that also governs two other things.
+**Rule 3 is not a guard, and that is what `reject` means.** The other four rules
+are about one proposed call, so they can be checked only before that call and
+the action names them in `guards`. Rule 3 quantifies over stored data. It holds
+for every write from every source, whether or not an action mentions it, so it
+is declared and left unguarded. It is also the only rule here that nobody in the
+business may approve: an order whose total disagrees with its line items is
+broken rather than unusual. When a rule tempts you toward `reject`, check first
+whether it is really an invariant, which belongs outside `guards`.
 
-A judgment may declare `reject`, as `RefundIsNotStructured` does. Structuring is
-a rule an organization means as unappealable, and no expression detects it, so
-the alternative to representing the pairing is leaving the rule out of the model
-entirely. What the pairing costs is real: a language model can decide two
-identical refunds differently, and `reject` leaves nobody to appeal to. It is
-made visible rather than forbidden. Every published constraint carries a derived
-`evaluation` field, so "unappealable rules settled by a model" is one query
-against the catalog.
+**Rules 4 and 5 are why the second body exists.** Neither reduces to arithmetic
+over `Order` and `LineItem`, and before `judgment` they had nowhere to go but a
+policy document nothing links to. Note what stays computable alongside them: the
+threshold in rule 2 is arithmetic, so it remains an expression a query settles
+and no model call is spent on. Folding rules 2, 4 and 5 into one paragraph of
+prose, on the grounds that a model could read all three, would throw that away.
 
-### When several guards fire at once
+**Rule 5 is a judgment that declares `reject`.** Splitting a credit to evade
+review is a rule the business means as unappealable, and no expression detects
+it, so the alternative to writing it this way is leaving it out of the model.
+The pairing carries a real cost, because a language model can decide two
+identical credits differently and `reject` leaves nobody to appeal to. It is
+published rather than forbidden, and made findable: every constraint carries a
+derived `evaluation` field, which reads `judged` here, so an auditor asking
+which unappealable rules a model settles gets an answer from one query.
 
-An action's `guards` names all the constraints checked before the call, and more
-than one can be violated by the same write. The strictest outcome wins: any
+### Two calls through that policy
+
+A 30-dollar credit for a shipping charge billed in error, against an order
+totalling 142 dollars:
+
+```
+IssueCredit(order=12345, amount=30.00,
+            memo="refund of the shipping charge applied in error during the Labor Day sale")
+```
+
+Rule 1 holds, since 30 is within the order. Rule 2 is violated, since 30 is over
+the self-service limit, and its word is `escalate`. Rules 4 and 5 hold: the memo
+names a specific failure, and a single credit is not a split one. One violation,
+so the call is held for a supervisor, who reviews it as a credit against an
+order rather than as a SQL diff.
+
+Now three 9-dollar credits raised against the same order within the hour, each
+memo reading some version of "customer asked":
+
+```
+IssueCredit(order=12345, amount=9.00, memo="customer asked")
+```
+
+Rules 1 and 2 both hold — 9 is inside the order and inside the limit — so every
+gate a query can compute lets this through. Rule 4 is violated and warns. Rule 5
+is violated and rejects. This is the case the judged rules were added for: the
+policy is being evaded precisely by staying inside the arithmetic.
+
+When one call violates several guards, the strictest outcome applies: any
 `reject` refuses the call; failing that, any `escalate` holds it; failing that,
-any `warn` lets it through with the violations reported. A refund that is both
-vaguely justified and structured is refused.
+any `warn` lets it through with the violations reported. So the first call is
+held, and the second is refused with the memo warning reported alongside the
+refusal.
 
-That rule is fixed, and no part of the model states it. It is why an action can
-name any number of guards without the author writing how to combine them. It is
-also how `forbid` overrides `permit` in Cedar and how a deny wins in Open Policy
-Agent, so a model written this way lowers into either.
+That combination is fixed, and no part of the model states it. It is why an
+action can name any number of guards without the author writing how to combine
+them. It is also how `forbid` overrides `permit` in Cedar and how a deny wins in
+Open Policy Agent, so a policy written this way lowers into either.
 
 An action whose guards are *all* judged loads with a warning. Every gate then
 costs a model call, none can lower to a store-level check, and each may decide
-two identical calls differently. One expression guard among them settles it.
+two identical calls differently. `IssueCredit` is clear of it: two of its four
+guards are expressions.
 
 **Status: nothing calls a judge.** `kcmd` parses `judgment`, validates it,
 publishes it and reads it back, and publishes a derived `evaluation` field
 saying whether the rule is `deterministic` or `judged` so a consumer can select
 on it. No component asks a model to settle a judgment, and nothing combines
-guard outcomes. The rule above says what an engine is expected to do, and `kcmd`
-publishes the fields it needs to do it.
+guard outcomes. The two calls above are what the published policy says should
+happen, and `kcmd` publishes the fields an engine needs in order to make it
+happen.
 
 `kcmd` reports a mismatch from either side. A guard that names no constraint
 fails the push. A constraint over parameters that no action names loads with a

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -215,9 +215,9 @@ same rule may gate `TransferFunds` and leave `CloseAccount` alone.
 
 `guards` and `on_violation` answer different questions, and both can be set. A
 guard says *when* the constraint is checked — before the write, with the
-arguments bound. `on_violation` says the strongest thing a breach may do:
-`reject` refuses the call, `escalate` holds it for an approver, `warn` reports
-it and lets the write proceed. So guarding a constraint that declares `warn` is a real shape rather
+arguments bound. `on_violation` says what a breach does: `reject` refuses the
+call, `escalate` holds it for an approver, `warn` reports it and lets the write
+proceed. So guarding a constraint that declares `warn` is a real shape rather
 than a contradiction: it is how a rule the organization is not yet ready to
 block on still gets checked at the moment of the call and reported back.
 
@@ -241,40 +241,141 @@ Such a rule goes in `judgment` instead of `expression`:
         severity: high
 ```
 
-A constraint declares one body or the other, never both and never neither. Field
-names inside a judgment are written model-qualified — `Order.discount_reason`
-rather than "the reason" — so `kcmd` resolves the reference against the model
-and a rename cannot leave the sentence pointing at nothing.
+A constraint declares one body or the other, never both and never neither. A
+judgment must state `on_violation`, and it may state any of the three words.
+Leaving the key out is the one thing it may not do: an unmarked constraint
+rejects, and that is too strong a consequence to inherit by silence.
 
-A judgment must state `on_violation`, and it may not be `reject`. What settles a
-judged rule is a language model, which can decide two identical proposals
-differently. It may hold a write for a person to approve; it may not be the last
-word refusing a write nobody can appeal. A condition that must refuse outright
-belongs in its own constraint, written as an expression.
+### Writing a judgment
 
-One judgment states one condition. A written policy usually has several — over
-one amount a director approves, under another a manager does, and separately the
-stated reason must be specific — and it becomes several constraints, each named,
-each with its own `on_violation` and `severity`, which `guards` on the action
-then regroups into the policy the business wrote:
+A language model reads the sentence at review time with the proposed write in
+front of it. Five habits make that reading consistent.
+
+**State what must be true of the data.** Write the condition — *the reason must
+name a specific problem with the order* — rather than the procedure — *check
+whether the reason is specific*. The sentence describes a clean write, and
+everything about handling a breach lives elsewhere.
+
+**Name fields model-qualified.** Write `Order.discount_reason` rather than "the
+reason". `kcmd` resolves every `Entity.field` token in the text against the
+model and fails the push when the entity declares no such field, so a rename
+cannot leave the sentence pointing at nothing. The qualified name also tells the
+judge exactly which value to read.
+
+**Say what does not count.** A rule with no negative example is graded against
+whatever the model guesses the author had in mind. "A reason that only restates
+the discount, such as 'competitive pricing', is not a justification" buys more
+consistency than any further description of what a good reason is.
+
+**Leave the consequence out of the prose.** What happens on a breach is
+`on_violation`. A judgment ending "…otherwise escalate to a director" states a
+routing nothing reads, and the engine routes by the field regardless.
+
+**Keep it to one condition.** When the sentence needs "and also", the second
+half is a second constraint. One `on_violation` cannot carry two consequences,
+so two conditions that end differently cannot share a constraint.
+
+### A policy whose branches end differently
+
+Written policies branch, and the branches rarely end the same way. A refund
+policy might say: a refund over $10,000 needs a director's approval; the stated
+reason has to be a real problem with the order; and a refund that looks like a
+larger one split into pieces is refused outright. Three conditions, three
+different outcomes.
+
+Each condition becomes its own constraint, carrying its own outcome in its own
+`on_violation`:
 
 ```yaml
-        guards: [DiscountWithinDirectorLimit, DiscountIsJustified]
+    constraints:
+      - name: LargeRefundHasDirectorApproval
+        expression: >-
+          Refund.amount <= 10000 OR Refund.director_approval IS NOT NULL
+        description: >-
+          Refunds over $10,000 need a director's approval. Attach one and
+          resubmit.
+        on_violation: escalate
+        severity: high
+
+      - name: RefundReasonIsSpecific
+        judgment: >-
+          Refund.reason must name a specific, verifiable problem with the order
+          — a late delivery, a damaged item, an incorrect charge. A reason that
+          only restates that the customer asked for a refund does not satisfy
+          this rule.
+        description: >-
+          Say what went wrong with the order in the refund reason.
+        on_violation: warn
+        severity: low
+
+      - name: RefundIsNotStructured
+        judgment: >-
+          A refund must not appear to be one larger refund split into parts to
+          stay under an approval limit. Read Refund.amount together with the
+          other refunds on the same Order in the same week: several near-limit
+          refunds for related reasons are structuring, whatever each one says
+          on its own.
+        description: >-
+          Issue this as a single refund at its full amount and route it for
+          approval.
+        on_violation: reject
+        severity: critical
+
+    actions:
+      - name: IssueRefund
+        parameters:
+          - { name: order, type: Order }
+          - { name: amount, type: Float }
+        guards:
+          - LargeRefundHasDirectorApproval
+          - RefundReasonIsSpecific
+          - RefundIsNotStructured
 ```
 
-Folding those branches into one judgment would be the wrong trade. The branches
-an expression can decide stop being searchable, revisable and separately owned,
-and the line between what a query settles and what a reader settles — the reason
-the second body exists — disappears into prose.
+Reading down the `on_violation` column gives the branching that the policy
+describes in prose. A structured refund is refused. A large refund with no
+director's approval is held until one arrives. A vague reason is reported and
+the refund proceeds.
 
-An action whose guards are *all* judged loads with a warning. It has no gate a
-query can decide, so every call costs a model decision and none of its rules can
-lower to a store-level check. One expression guard among them settles it.
+Three properties come from writing it this way. The words stay in fields, so a
+search for the rules that can stop a refund finds them without reading prose.
+The first condition stays an expression, so a query settles it and no model call
+is spent on arithmetic. And each branch has its own name, owner and history, so
+raising the approval limit is an edit to one constraint rather than to a
+paragraph that also governs two other things.
+
+A judgment may declare `reject`, as `RefundIsNotStructured` does. Structuring is
+a rule an organization means as unappealable, and no expression detects it, so
+the alternative to representing the pairing is leaving the rule out of the model
+entirely. What the pairing costs is real: a language model can decide two
+identical refunds differently, and `reject` leaves nobody to appeal to. It is
+made visible rather than forbidden. Every published constraint carries a derived
+`evaluation` field, so "unappealable rules settled by a model" is one query
+against the catalog.
+
+### When several guards fire at once
+
+An action's `guards` names all the constraints checked before the call, and more
+than one can be violated by the same write. The strictest outcome wins: any
+`reject` refuses the call; failing that, any `escalate` holds it; failing that,
+any `warn` lets it through with the violations reported. A refund that is both
+vaguely justified and structured is refused.
+
+That rule is fixed, and no part of the model states it. It is why an action can
+name any number of guards without the author writing how to combine them. It is
+also how `forbid` overrides `permit` in Cedar and how a deny wins in Open Policy
+Agent, so a model written this way lowers into either.
+
+An action whose guards are *all* judged loads with a warning. Every gate then
+costs a model call, none can lower to a store-level check, and each may decide
+two identical calls differently. One expression guard among them settles it.
 
 **Status: nothing calls a judge.** `kcmd` parses `judgment`, validates it,
 publishes it and reads it back, and publishes a derived `evaluation` field
 saying whether the rule is `deterministic` or `judged` so a consumer can select
-on it. No component asks a model to settle one.
+on it. No component asks a model to settle a judgment, and nothing combines
+guard outcomes. The rule above says what an engine is expected to do, and `kcmd`
+publishes the fields it needs to do it.
 
 `kcmd` reports a mismatch from either side. A guard that names no constraint
 fails the push. A constraint over parameters that no action names loads with a

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -164,9 +164,9 @@ which lands separately.
 
 ## 2. Gate it with a constraint
 
-A **constraint** is a named boolean invariant a model states over its ontology.
-An action needs none; declare one when a rule decides whether a call may proceed
-at all. Where a constraint applies depends on what its expression reads.
+A **constraint** is a named invariant a model states over its ontology. An
+action needs none; declare one when a rule decides whether a call may proceed at
+all. Where a constraint applies depends on what its rule reads.
 
 An expression over stored data holds for every write, whatever performed that
 write. No action has to name such a constraint:
@@ -215,15 +215,72 @@ same rule may gate `TransferFunds` and leave `CloseAccount` alone.
 
 `guards` and `on_violation` answer different questions, and both can be set. A
 guard says *when* the constraint is checked — before the write, with the
-arguments bound. `on_violation` says what a breach does: `reject` refuses the
-call, `escalate` holds it for an approver, `warn` reports it and lets the write
-proceed. So guarding a constraint that declares `warn` is a real shape rather
+arguments bound. `on_violation` says the strongest thing a breach may do:
+`reject` refuses the call, `escalate` holds it for an approver, `warn` reports
+it and lets the write proceed. So guarding a constraint that declares `warn` is a real shape rather
 than a contradiction: it is how a rule the organization is not yet ready to
 block on still gets checked at the moment of the call and reported back.
 
+### When no expression decides it
+
+Some rules a business enforces cannot be written as a boolean. Whether a
+discount is justified by the reason given, whether a refund note explains the
+exception it claims — a query can read the text but cannot settle the question.
+Such a rule goes in `judgment` instead of `expression`:
+
+```yaml
+    constraints:
+      - name: DiscountIsJustified
+        judgment: >-
+          A discount over 30% must be justified by the reason given in
+          Order.discount_reason. A reason that only restates the discount, such
+          as "competitive pricing", is not a justification.
+        description: >-
+          Say what makes this discount necessary, then resubmit for approval.
+        on_violation: escalate
+        severity: high
+```
+
+A constraint declares one body or the other, never both and never neither. Field
+names inside a judgment are written model-qualified — `Order.discount_reason`
+rather than "the reason" — so `kcmd` resolves the reference against the model
+and a rename cannot leave the sentence pointing at nothing.
+
+A judgment must state `on_violation`, and it may not be `reject`. What settles a
+judged rule is a language model, which can decide two identical proposals
+differently. It may hold a write for a person to approve; it may not be the last
+word refusing a write nobody can appeal. A condition that must refuse outright
+belongs in its own constraint, written as an expression.
+
+One judgment states one condition. A written policy usually has several — over
+one amount a director approves, under another a manager does, and separately the
+stated reason must be specific — and it becomes several constraints, each named,
+each with its own `on_violation` and `severity`, which `guards` on the action
+then regroups into the policy the business wrote:
+
+```yaml
+        guards: [DiscountWithinDirectorLimit, DiscountIsJustified]
+```
+
+Folding those branches into one judgment would be the wrong trade. The branches
+an expression can decide stop being searchable, revisable and separately owned,
+and the line between what a query settles and what a reader settles — the reason
+the second body exists — disappears into prose.
+
+An action whose guards are *all* judged loads with a warning. It has no gate a
+query can decide, so every call costs a model decision and none of its rules can
+lower to a store-level check. One expression guard among them settles it.
+
+**Status: nothing calls a judge.** `kcmd` parses `judgment`, validates it,
+publishes it and reads it back, and publishes a derived `evaluation` field
+saying whether the rule is `deterministic` or `judged` so a consumer can select
+on it. No component asks a model to settle one.
+
 `kcmd` reports a mismatch from either side. A guard that names no constraint
 fails the push. A constraint over parameters that no action names loads with a
-warning, because nothing will ever evaluate it.
+warning, because nothing will ever evaluate it. That scan reads expressions
+only: a judgment is prose, in which a word matching a parameter name is not a
+read of that parameter.
 
 **Status: nothing evaluates a guard yet.** `kcmd` parses `guards`, resolves each
 name, publishes the list, and reads it back. No component checks a guard against

--- a/toolbox/mdcode/docs/semantic-model/fidelity.md
+++ b/toolbox/mdcode/docs/semantic-model/fidelity.md
@@ -173,12 +173,19 @@ foreign-key edges only, so a concept naming an M:N edge would look unresolvable
 on a model that is perfectly well-formed. It comes back untouched instead.
 
 **Constraints** publish the same way: each becomes a `semantic-constraint` entry
-under the model entry, with the expression and any `instructions` in a
+under the model entry, with the rule and any `instructions` in a
 `semantic-constraint` aspect and the `description` as the entry's own summary.
-Name, expression, description, `on_violation`, `severity`, and instructions
-round-trip losslessly through `pull`. A constraint that declares neither routing
-word comes back without them rather than with a default filled in. That entry
-type is custom too, and a model that declares no constraint never needs it.
+Name, description, `on_violation`, `severity`, instructions, and whichever body
+states the rule — `expression` or `judgment` — round-trip losslessly through
+`pull`. A constraint that declares neither routing word comes back without them
+rather than with a default filled in. The aspect also carries a derived
+`evaluation` field, `deterministic` or `judged`, which a pull recomputes from
+the body rather than reading, so it can never come back disagreeing with the
+rule beside it; it is not written into the authored document, because a derived
+value in an authored file is a value that can go stale. An entry that states
+both bodies, or neither, is skipped with a warning rather than pulled into a
+model that would then fail its own push. That entry type is custom too, and a
+model that declares no constraint never needs it.
 
 ¹⁰ What you author is the `expression.dialects[]` list; the graph builds from the canonical (BigQuery/ANSI) variant. `importedExpression` / `importedDialect` are not authored keys — the loader *derives* them from a non-canonical dialect entry (e.g. the MAQL or Snowflake form a metric was imported from) and uses that verbatim as the fallback when no canonical variant exists. See [Model spec §2.5](model_spec.md#25-expressions).
 

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -503,9 +503,9 @@ reads the document ([§6](#6-the-extension-mechanism)).
   branch, each with its own name, `on_violation` and `severity`, which `guards`
   on the action lists together. That keeps each branch independently searchable,
   revisable and owned, and it keeps the branches an expression *can* decide out
-  of prose that no query can read. [Actions → A policy whose branches end
-  differently](actions.md#a-policy-whose-branches-end-differently) works one
-  through.
+  of prose that no query can read. [Actions → A policy whose rules end
+  differently](actions.md#a-policy-whose-rules-end-differently) works a
+  five-rule credit policy through end to end.
 
   A constraint that quantifies over stored data applies to every write without
   being referenced anywhere. A constraint that reads an action's parameters can

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -484,24 +484,62 @@ reads the document ([§6](#6-the-extension-mechanism)).
   whose `operation` is `create`. Those rules are what let every value be bound
   rather than interpolated, so an argument cannot reach the store as SQL.
 
-- **`constraints` (extended profile only).** Model-level named boolean
-  invariants over the ontology, written in the same expression language as a
-  metric — `Account.balance >= 0`. Accepted only under `0.2.0.dev0/google`.
+- **`constraints` (extended profile only).** Model-level named invariants over
+  the ontology, accepted only under `0.2.0.dev0/google`. Each states exactly one
+  condition, in exactly one of two bodies.
+
+  **`expression`** is a boolean written in the same expression language as a
+  metric — `Account.balance >= 0`. **`judgment`** is the rule in words, for a
+  condition no expression decides: whether a discount is justified by the reason
+  given, whether a refund note explains the exception it claims. Field names in
+  a judgment are written model-qualified (`Order.discount_reason` rather than
+  "the reason"), so the reference is checked against the model and lives in the
+  sentence that uses it. A constraint declaring both bodies, or neither, is a
+  load error.
+
+  A judgment states one condition. A written policy usually has several — over
+  one amount a director approves, under another a manager does, and separately
+  the stated reason must be specific — and it becomes several constraints, one
+  per condition, each with its own name, `on_violation` and `severity`, which
+  `guards` on the action then regroups into the policy the business wrote. That
+  keeps each branch independently searchable, revisable and owned, and it keeps
+  the branches an expression *can* decide out of prose that no query can read.
+
   A constraint that quantifies over stored data applies to every write without
   being referenced anywhere. A constraint that reads an action's parameters can
   be checked only before that call, so it applies only where an action names it
-  in `guards`; one that no action names at all draws a load warning. Status:
-  authored, validated and published; no component evaluates a constraint, so
-  nothing today rejects a write that would break one. Rules in
-  [Reference → Validation](reference.md#validation).
+  in `guards`; one that no action names at all draws a load warning. An action
+  whose every guard is judged draws one too: it has no gate a query can decide.
+  Status: authored, validated and published; no component evaluates a
+  constraint, so nothing today rejects a write that would break one, and nothing
+  calls a judge. Rules in [Reference → Validation](reference.md#validation).
 
   A constraint MAY say two things about a violation, under two separate keys.
-  **`on_violation`** is what the engine does to the write that tripped it:
-  `reject` refuses it outright and nobody may approve it, `escalate` holds it
-  for a human decision, `warn` lets it proceed and reports it. Absent means
-  `reject`, the safe reading of an author who did not say. **`severity`** is how
-  grave the violation is — `critical`, `high`, `medium` or `low` — for ranking
-  and reporting. It carries no default, and nothing ranks or routes on it yet.
+  **`on_violation`** is the strongest thing a violation may do to the write that
+  tripped it: `reject` refuses it outright and nobody may approve it, `escalate`
+  holds it for a human decision, `warn` lets it proceed and reports it. On an
+  `expression` it defaults to `reject`, the safe reading of an author who did
+  not say. **`severity`** is the gravest a violation is — `critical`, `high`,
+  `medium` or `low` — for ranking and reporting. It carries no default, and
+  nothing ranks or routes on it yet.
+
+  The three words are ordered by how much they let through: `reject` permits
+  nothing, `escalate` permits the write with a person's approval, `warn` permits
+  it outright. Reading `on_violation` as a ceiling rather than a fixed outcome
+  lets a judge grading one condition settle on a word that permits at least as
+  much as the declared one — a thin justification warned about where a
+  pretextual one escalates — while the enforceable bound stays a word the loader
+  can read. It bounds the grading of a single condition; a policy that branches
+  is encoded as several constraints instead.
+
+  A `judgment` MUST state `on_violation`, and it may not be `reject`. A judged
+  rule is settled by a language model that can decide two identical proposals
+  differently, so it may hold a write for a person but may not be the last word
+  refusing one nobody can appeal. The bound is not checked against the prose,
+  because the prose is prose: a judgment whose wording implies a harsher
+  response than its declared word still routes by the word, so the routing stays
+  safe while the published text is wrong. That is a real cost, and the reason
+  the ceiling reading is kept narrow.
 
   They are two keys because they answer different questions, and neither one
   implies the other. A `low` rule can still be an absolute refusal, and a

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -497,13 +497,15 @@ reads the document ([§6](#6-the-extension-mechanism)).
   sentence that uses it. A constraint declaring both bodies, or neither, is a
   load error.
 
-  A judgment states one condition. A written policy usually has several — over
-  one amount a director approves, under another a manager does, and separately
-  the stated reason must be specific — and it becomes several constraints, one
-  per condition, each with its own name, `on_violation` and `severity`, which
-  `guards` on the action then regroups into the policy the business wrote. That
-  keeps each branch independently searchable, revisable and owned, and it keeps
-  the branches an expression *can* decide out of prose that no query can read.
+  A judgment states one condition, the same as an expression does. A written
+  policy that branches — a large refund is held for a director, a disguised one
+  is refused, a vague reason is only reported — becomes one constraint per
+  branch, each with its own name, `on_violation` and `severity`, which `guards`
+  on the action lists together. That keeps each branch independently searchable,
+  revisable and owned, and it keeps the branches an expression *can* decide out
+  of prose that no query can read. [Actions → A policy whose branches end
+  differently](actions.md#a-policy-whose-branches-end-differently) works one
+  through.
 
   A constraint that quantifies over stored data applies to every write without
   being referenced anywhere. A constraint that reads an action's parameters can
@@ -515,31 +517,29 @@ reads the document ([§6](#6-the-extension-mechanism)).
   calls a judge. Rules in [Reference → Validation](reference.md#validation).
 
   A constraint MAY say two things about a violation, under two separate keys.
-  **`on_violation`** is the strongest thing a violation may do to the write that
-  tripped it: `reject` refuses it outright and nobody may approve it, `escalate`
-  holds it for a human decision, `warn` lets it proceed and reports it. On an
+  **`on_violation`** is what a violation does to the write that tripped it:
+  `reject` refuses it outright and nobody may approve it, `escalate` holds it
+  for a human decision, `warn` lets it proceed and reports it. On an
   `expression` it defaults to `reject`, the safe reading of an author who did
-  not say. **`severity`** is the gravest a violation is — `critical`, `high`,
+  not say. **`severity`** is how grave a violation is — `critical`, `high`,
   `medium` or `low` — for ranking and reporting. It carries no default, and
   nothing ranks or routes on it yet.
 
-  The three words are ordered by how much they let through: `reject` permits
-  nothing, `escalate` permits the write with a person's approval, `warn` permits
-  it outright. Reading `on_violation` as a ceiling rather than a fixed outcome
-  lets a judge grading one condition settle on a word that permits at least as
-  much as the declared one — a thin justification warned about where a
-  pretextual one escalates — while the enforceable bound stays a word the loader
-  can read. It bounds the grading of a single condition; a policy that branches
-  is encoded as several constraints instead.
+  When an action's `guards` names several constraints and a write violates more
+  than one, the strictest outcome among them applies: any `reject` refuses the
+  call, failing that any `escalate` holds it, failing that any `warn` lets it
+  through with the violations reported. That combination is fixed and no part of
+  the model states it, which is why an action can name any number of guards
+  without saying how to add them up.
 
-  A `judgment` MUST state `on_violation`, and it may not be `reject`. A judged
-  rule is settled by a language model that can decide two identical proposals
-  differently, so it may hold a write for a person but may not be the last word
-  refusing one nobody can appeal. The bound is not checked against the prose,
-  because the prose is prose: a judgment whose wording implies a harsher
-  response than its declared word still routes by the word, so the routing stays
-  safe while the published text is wrong. That is a real cost, and the reason
-  the ceiling reading is kept narrow.
+  A `judgment` MUST state `on_violation`, and it MAY be any of the three words.
+  Omitting the key is the only error: an unmarked constraint rejects, and that
+  is too strong a consequence for an author of a judged rule to inherit by
+  silence. Pairing `judgment` with `reject` is the riskiest thing the format can
+  express, because a language model can decide two identical proposals
+  differently and `reject` leaves no appeal. It is published rather than
+  refused, and made findable: the derived `evaluation` field carries `judged`
+  beside the word, so unappealable rules settled by a model are one query.
 
   They are two keys because they answer different questions, and neither one
   implies the other. A `low` rule can still be an absolute refusal, and a

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -507,11 +507,15 @@ reads the document ([§6](#6-the-extension-mechanism)).
   differently](actions.md#a-policy-whose-rules-end-differently) works a
   five-rule credit policy through end to end.
 
-  A constraint that quantifies over stored data applies to every write without
-  being referenced anywhere. A constraint that reads an action's parameters can
-  be checked only before that call, so it applies only where an action names it
-  in `guards`; one that no action names at all draws a load warning. An action
-  whose every guard is judged draws one too: it has no gate a query can decide.
+  A constraint takes effect only where something references it. Declaring one
+  adds a rule to the catalog and refuses nothing, so publishing a rule cannot
+  change what an already-working call does. `guards` on an action is the only
+  reference the model defines, and rules of both kinds belong in it: one over an
+  action's parameters has no other moment to run, and one over stored data
+  checks that the call does not start from a broken state. A parameter-reading
+  constraint that no action names draws a load warning, since it can never run.
+  An action whose every guard is judged draws one too: it has no gate a query
+  can decide.
   Status: authored, validated and published; no component evaluates a
   constraint, so nothing today rejects a write that would break one, and nothing
   calls a judge. Rules in [Reference → Validation](reference.md#validation).

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -420,16 +420,14 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   `OrderedAs.quantity`, a metric reference, or compound logic — is left alone
   rather than guessed at, so a valid constraint is never falsely rejected.
   *(static)*
-* **Every judged constraint says what a violation may do, and may not refuse
-  outright.** The `judgment` must be non-empty, and `on_violation` is required
-  on it rather than defaulting: `escalate` or `warn`, never `reject`. A judged
-  rule is settled by a language model, which can decide two identical proposals
-  differently, so it may hold a write for a person but may not be the last word
-  refusing one nobody can appeal. A condition that must refuse outright belongs
-  in its own constraint, stated as an expression. Every `Entity.field` token in
-  the prose is resolved against the model the same way an expression's leading
-  qualifier is, so a field name that has been renamed out from under the
-  sentence is caught. *(static)*
+* **Every judged constraint says what a violation does.** The `judgment` must
+  be non-empty, and `on_violation` is required on it rather than defaulting. Any
+  of the three words is allowed, `reject` included; leaving the key out is the
+  error, because an unmarked constraint rejects and that is too strong a
+  consequence to inherit by silence. Every `Entity.field` token in the prose is
+  resolved against the model the same way an expression's leading qualifier is,
+  so a field name that has been renamed out from under the sentence is caught.
+  *(static)*
 * Like an action, a constraint of either kind reaches Knowledge Catalog only,
   and a `--no-kc` push warns that it will not be deployed. Two rules are
   enforced at parse time: `on_violation` and `severity` are each a closed

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -413,20 +413,21 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   it neither way; declaring neither states no rule at all. Either error names
   the constraint. *(static)*
 * **Every expression constraint is checkable.** The `expression` must be
-  non-empty. When it opens with an `<Entity>.<field>` qualifier naming a
-  **known** entity, that entity must declare the field; this catches a typo that
-  would otherwise surface only when something tries to check the rule. A leading
-  qualifier that is not a known entity — a relationship-qualified name like
-  `OrderedAs.quantity`, a metric reference, or compound logic — is left alone
-  rather than guessed at, so a valid constraint is never falsely rejected.
+  non-empty. Every `<Entity>.<field>` token in it that names a **known** entity
+  must name a field that entity declares, wherever in the expression it appears;
+  this catches a typo that would otherwise surface only when something tries to
+  check the rule. A qualifier that is not a known entity — a
+  relationship-qualified name like `OrderedAs.quantity`, a metric reference, or
+  compound logic — is left alone rather than guessed at, so a valid constraint
+  is never falsely rejected. A quoted literal is data, so it is not scanned.
   *(static)*
 * **Every judged constraint says what a violation does.** The `judgment` must
   be non-empty, and `on_violation` is required on it rather than defaulting. Any
   of the three words is allowed, `reject` included; leaving the key out is the
   error, because an unmarked constraint rejects and that is too strong a
   consequence to inherit by silence. Every `Entity.field` token in the prose is
-  resolved against the model the same way an expression's leading qualifier is,
-  so a field name that has been renamed out from under the sentence is caught.
+  resolved against the model by the same scan an expression gets, so a field
+  name that has been renamed out from under the sentence is caught.
   *(static)*
 * Like an action, a constraint of either kind reaches Knowledge Catalog only,
   and a `--no-kc` push warns that it will not be deployed. Two rules are

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -419,11 +419,15 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   check the rule. A qualifier that is not a known entity — a
   relationship-qualified name like `OrderedAs.quantity`, a metric reference, or
   compound logic — is left alone rather than guessed at, so a valid constraint
-  is never falsely rejected. So is an entity that declares no fields, since
-  fields are optional and a logical model may declare none; an empty list is no
-  evidence that a field is missing. So is a token carrying a third dotted
+  is never falsely rejected. So is a token whose **tail** names something the
+  model declares that is not a field of the head: `Customer.Order` and
+  `LineItem.BelongsTo` are traversals, and `Order.total_revenue` names a metric,
+  none of which the check can settle. So is an entity that declares no fields,
+  since fields are optional and a logical model may declare none; an empty list
+  is no evidence that a field is missing. So is a token carrying a third dotted
   segment, which is a path rather than a field. A quoted literal is data, so it
-  is not scanned.
+  is not scanned. What is left is the case the check exists for: a tail the
+  model declares under no kind at all, next to an entity it does declare.
   *(static)*
 * **Every judged constraint says what a violation does.** The `judgment` must
   be non-empty, and `on_violation` is required on it rather than defaulting. Any

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -427,7 +427,10 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   error, because an unmarked constraint rejects and that is too strong a
   consequence to inherit by silence. Every `Entity.field` token in the prose is
   resolved against the model by the same scan an expression gets, so a field
-  name that has been renamed out from under the sentence is caught.
+  name that has been renamed out from under the sentence is caught. Quoted text
+  is scanned here, unlike in an expression, where quotes delimit a string
+  literal. In prose they more often set off a field name for emphasis, and
+  skipping those would hide the renames this check exists to catch.
   *(static)*
 * Like an action, a constraint of either kind reaches Knowledge Catalog only,
   and a `--no-kc` push warns that it will not be deployed. Two rules are

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -419,7 +419,11 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   check the rule. A qualifier that is not a known entity — a
   relationship-qualified name like `OrderedAs.quantity`, a metric reference, or
   compound logic — is left alone rather than guessed at, so a valid constraint
-  is never falsely rejected. A quoted literal is data, so it is not scanned.
+  is never falsely rejected. So is an entity that declares no fields, since
+  fields are optional and a logical model may declare none; an empty list is no
+  evidence that a field is missing. So is a token carrying a third dotted
+  segment, which is a path rather than a field. A quoted literal is data, so it
+  is not scanned.
   *(static)*
 * **Every judged constraint says what a violation does.** The `judgment` must
   be non-empty, and `on_violation` is required on it rather than defaulting. Any

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -298,8 +298,15 @@ ships, the entries move to it and their shape does not change. (This is the
 prototype scope — an action's `precondition` is not modeled yet, and nothing
 consumes its `affects`.)
 
-A **constraint** entry carries its expression in a `semantic-constraint`
-aspect, together with the whole of any `ai_context` declared on it. The
+A **constraint** entry carries its rule in a `semantic-constraint`
+aspect, together with the whole of any `ai_context` declared on it. The rule
+sits in whichever of the two bodies states it — `expression` for a condition a
+query can compute, `judgment` for one stated in words because no expression
+decides it. The aspect adds a third field, `evaluation`, that no author writes:
+it restates which body was used, as `deterministic` or `judged`, so a consumer
+picking rules to lower into SQL and a consumer picking rules to hand to a
+language-model judge each select on one field. A pull recomputes it from the
+body that came back rather than reading it, so the two cannot drift apart. The
 constraint's `description` is the entry's own summary, because that sentence is
 what a caller refused by the rule reads. Its type is provisioned alongside the action pair and
 for the same reason. All three parts of `ai_context` survive, unlike an element
@@ -400,19 +407,41 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   deploy **only** through the Knowledge Catalog leg — a
   graph-only `--no-kc` push validates them but has nowhere to put them, and
   warns that they will not be deployed. *(static)*
-* **Every constraint is checkable.** A constraint's `expression` must be
-  non-empty. When the expression opens with an `<Entity>.<field>` qualifier
-  naming a **known** entity, that entity must declare the field; this catches a
-  typo that would otherwise surface only when something tries to check the rule.
-  A leading qualifier that is not a known entity — a relationship-qualified name
-  like `OrderedAs.quantity`, a metric reference, or compound logic — is left
-  alone rather than guessed at, so a valid constraint is never falsely rejected.
-  Like an action, a constraint reaches Knowledge Catalog only, and a `--no-kc`
-  push warns that it will not be deployed. Two rules are enforced at parse time:
-  `on_violation` and `severity` are each a closed vocabulary — `reject` /
-  `escalate` / `warn` and `critical` / `high` / `medium` / `low` — so an
-  unrecognized word is a hard load error rather than a value that publishes and
-  means nothing. *(static)*
+* **Every constraint states exactly one rule.** A constraint declares an
+  `expression` or a `judgment`, never both and never neither. Declaring both
+  answers the "can this be computed?" question two ways at once, which answers
+  it neither way; declaring neither states no rule at all. Either error names
+  the constraint. *(static)*
+* **Every expression constraint is checkable.** The `expression` must be
+  non-empty. When it opens with an `<Entity>.<field>` qualifier naming a
+  **known** entity, that entity must declare the field; this catches a typo that
+  would otherwise surface only when something tries to check the rule. A leading
+  qualifier that is not a known entity — a relationship-qualified name like
+  `OrderedAs.quantity`, a metric reference, or compound logic — is left alone
+  rather than guessed at, so a valid constraint is never falsely rejected.
+  *(static)*
+* **Every judged constraint says what a violation may do, and may not refuse
+  outright.** The `judgment` must be non-empty, and `on_violation` is required
+  on it rather than defaulting: `escalate` or `warn`, never `reject`. A judged
+  rule is settled by a language model, which can decide two identical proposals
+  differently, so it may hold a write for a person but may not be the last word
+  refusing one nobody can appeal. A condition that must refuse outright belongs
+  in its own constraint, stated as an expression. Every `Entity.field` token in
+  the prose is resolved against the model the same way an expression's leading
+  qualifier is, so a field name that has been renamed out from under the
+  sentence is caught. *(static)*
+* Like an action, a constraint of either kind reaches Knowledge Catalog only,
+  and a `--no-kc` push warns that it will not be deployed. Two rules are
+  enforced at parse time: `on_violation` and `severity` are each a closed
+  vocabulary — `reject` / `escalate` / `warn` and `critical` / `high` /
+  `medium` / `low` — so an unrecognized word is a hard load error rather than a
+  value that publishes and means nothing. *(static)*
+* **An action keeps at least one deterministic gate.** When every constraint an
+  action names in `guards` is judged, the model loads with a warning: the action
+  has nothing gating it that a query can decide, so each of its guards costs a
+  model call that may decide two identical calls differently, and none of them
+  can lower to a store-level check. One expression guard among them silences it.
+  *(warning, at load)*
 * **A constraint over an action's parameters is guarded.** A constraint whose
   expression reads a bare name that is a parameter of some action describes that
   call rather than the stored data, so it can be checked only before the call
@@ -425,7 +454,8 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
   matches identifiers, and an expression may use a bare name that merely
   coincides with a parameter name. Neither a qualified name
   (`OrderedAs.quantity`) nor a quoted literal (`status = 'quantity'`) counts as
-  a parameter read.
+  a parameter read. The scan reads expressions only: a judgment is prose, in
+  which a word matching a parameter name is not a read of that parameter.
   *(warning, at load)*
 * **Every entity's source table is reachable.** For a **BigQuery-targeting**
   model, each `source` is probed with a dry-run query, so BigQuery resolves it

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -64,11 +64,12 @@ export interface SemanticModel {
   // absent on models authored before actions existed, so consumers read it as
   // `actions ?? []`. See Action.
   actions?: Action[];
-  // Named invariants over the ontology: a boolean `expression` that must hold
-  // for every instance (e.g. `Customer.accountBalance >= 0`). Model-level, like
-  // metrics and actions. Optional, and absent on models authored before
-  // constraints existed, so consumers read it as `constraints ?? []`. See
-  // Constraint.
+  // Named invariants over the ontology, each stating one condition that must
+  // hold for every instance -- as a boolean `expression` a query can compute
+  // (`Customer.accountBalance >= 0`), or as a `judgment` in words for a rule no
+  // expression decides. Model-level, like metrics and actions. Optional, and
+  // absent on models authored before constraints existed, so consumers read it
+  // as `constraints ?? []`. See Constraint.
   constraints?: Constraint[];
   // Vendor extension blocks carried verbatim (round-trip fidelity), including the
   // model-level GOOGLE block. A typed deployment-target view is derived by the
@@ -473,7 +474,8 @@ export interface GrpcExecutor {
 }
 
 /**
- * What a violated constraint does to the write that tripped it.
+ * The strongest thing a violated constraint may do to the write that tripped
+ * it.
  *
  *   - `reject`   the write is refused. Nobody is allowed to approve it, which
  *                is what makes the rule an invariant rather than a policy.
@@ -485,6 +487,14 @@ export interface GrpcExecutor {
  * rule publishes with the same shape, and a $30 credit that needs a supervisor
  * is indistinguishable from one that is simply forbidden.
  *
+ * The three words are ordered by how much they let through: `reject` permits
+ * nothing, `escalate` permits the write once a person approves it, `warn`
+ * permits it outright. The declared word is a ceiling on that scale, so an
+ * evaluation may settle on a word that permits at least as much and never on
+ * one that permits less. A constraint with a single condition reaches its
+ * ceiling whenever it is violated at all, which is why an expression's declared
+ * word and its outcome are always the same word.
+ *
  * This is a disposition, not a magnitude, and the two are deliberately separate
  * keys. `escalate` is not "between" reject and warn on a scale of badness: it is
  * a different control flow, and what it really states is that an approver
@@ -494,6 +504,63 @@ export interface GrpcExecutor {
  *
  * `escalate` names that an approver exists. It does not name who: an approver
  * role is not modeled yet.
+ *
+ * A judged constraint may not declare `reject`, and must declare one of the
+ * other two. `reject` is what makes a rule an invariant: nobody in the
+ * organization may approve the write. That authority should not rest on an
+ * evaluation that can decide two identical proposals differently, with no
+ * person in the loop. `escalate` stops the write just as firmly and adds
+ * someone who can be held responsible for releasing it. The word is required
+ * rather than defaulted there, because the default for an unmarked constraint
+ * is `reject` and a rule whose safe default is unavailable should say what it
+ * wants instead of inheriting a different one by body kind.
+ *
+ * The ceiling exists for one narrow case: grading a single judged condition. A
+ * thin discount justification may warrant a warning where an obviously
+ * pretextual one warrants escalation, and the two cannot be written as separate
+ * constraints without asking a judge the same question twice and depending on
+ * the answers agreeing. The ceiling lets one condition carry both responses
+ * while the enforceable bound stays a word load can read.
+ *
+ * IT IS NOT A PLACE TO PUT A POLICY THAT BRANCHES. A written policy usually has
+ * several conditions -- over one amount a director approves, under another a
+ * missing receipt needs a manager, and separately the stated reason must be
+ * plausible -- and the first two of those are expressions. Each condition
+ * becomes its own constraint, with its own name, `onViolation` and `severity`,
+ * and `guards` on the action regroups them into the policy the business wrote.
+ * That keeps each branch independently searchable, revisable and owned, and it
+ * keeps the computable branches computable. Folding the set into one judgment
+ * because the prose can express the routing produces a judged rule where the
+ * model should hold three deterministic ones and a judged one, which discards
+ * the distinction the second body was added to draw.
+ *
+ * The ceiling is not checked against the judgment, and it cannot be: the prose
+ * is prose. A judgment naming a response above its declared word is enforced at
+ * the declared word, so the routing stays safe, but the published rule then
+ * says something the engine will not do. That is a real cost of the reading and
+ * the reason its scope is narrow.
+ *
+ * Three things need the declared word without running the judge, which is why
+ * the routing stays a field even though a sentence can carry its own
+ * consequence. The restriction above is one: load can refuse `reject` only
+ * while `reject` is a value it can see, and a check that asks a model whether a
+ * sentence means refusal is no guardrail at all. An unrunnable judge is the
+ * second: no judge, a failed call or a timeout still has to route the breach it
+ * could not evaluate. Translation is the third: a policy DSL states its effect
+ * in the rule head, so a rule whose consequence is only implied by its wording
+ * cannot be lowered into one.
+ *
+ * What the ceiling costs in search is precision. Rules that can escalate
+ * include ones that in practice usually only warn. The reverse error would be
+ * worse, a search for warnings that missed rules able to stop a write, so the
+ * overstatement runs in the safe direction.
+ *
+ * STATUS of the ceiling: the declared word is the enforced word, and that is
+ * the whole of what is implemented. Nothing evaluates a judgment, so no verdict
+ * has ever been graded beneath the bound. When a verdict format arrives this is
+ * what it is checked against; until then the reading is a bound with one
+ * possible value, and the paragraphs above describe what it is for rather than
+ * what runs.
  */
 export const VIOLATION_EFFECTS = ['reject', 'escalate', 'warn'] as const;
 
@@ -513,6 +580,10 @@ export type ViolationEffect = (typeof VIOLATION_EFFECTS)[number];
  * a severity called `warning` sitting beside an effect called `warn` would read
  * as the same statement made twice.
  *
+ * Like `onViolation`, this is the gravest a violation of the rule can be rather
+ * than the gravity of every violation of it, so a judged condition graded
+ * across a range publishes the top of that range.
+ *
  * STATUS: authored, published and read back. Nothing ranks or routes on it yet.
  */
 export const CONSTRAINT_SEVERITIES =
@@ -521,11 +592,57 @@ export const CONSTRAINT_SEVERITIES =
 export type ConstraintSeverity = (typeof CONSTRAINT_SEVERITIES)[number];
 
 /**
- * A constraint: a model-level, named invariant over the ontology -- a boolean
- * `expression` that must hold for every instance. It is written in the same
- * expression language as a metric (`Customer.accountBalance >= 0`,
+ * How a constraint is checked, derived from which body it declares.
+ *
+ *   - `deterministic` an `expression`. Computable, reproducible, and the only
+ *                     kind that can lower to a store-level `CHECK` or inform a
+ *                     query plan.
+ *   - `judged`        a `judgment`. Settled by a language model reading the
+ *                     proposed change, because no expression over the ontology
+ *                     decides it.
+ *
+ * Published on the aspect so a consumer can select without knowing which key
+ * the author populated. A pass that lowers constraints to SQL takes the
+ * deterministic ones; a judge takes the judged ones.
+ */
+export const CONSTRAINT_EVALUATIONS = ['deterministic', 'judged'] as const;
+
+export type ConstraintEvaluation = (typeof CONSTRAINT_EVALUATIONS)[number];
+
+/**
+ * How a constraint is checked. Derived rather than authored: a constraint
+ * declares exactly one body, and that choice is the whole of the distinction.
+ */
+export function constraintEvaluation(c: Constraint): ConstraintEvaluation {
+  return c.judgment !== undefined ? 'judged' : 'deterministic';
+}
+
+/**
+ * A constraint: a model-level, named invariant over the ontology. It declares
+ * exactly one body, and the body says how the rule is checked.
+ *
+ * An `expression` is a boolean that must hold for every instance, written in
+ * the same expression language as a metric (`Customer.accountBalance >= 0`,
  * `OrderedAs.quantity > 0`), and may reference a metric by name when the rule
  * needs an aggregate.
+ *
+ * A `judgment` is the same kind of rule stated in words, for the rules that no
+ * expression decides: *the credit memo must name a specific service failure*
+ * is a real requirement with a real owner, and no arithmetic settles it.
+ * Without this body such a rule has nowhere to go but `description`, where
+ * nothing distinguishes it from the message explaining a different rule.
+ *
+ * One judgment states one condition. A policy with several conditions becomes
+ * several constraints, and `guards` on the action regroups them -- see
+ * VIOLATION_EFFECTS for why folding them into one judgment is the wrong trade,
+ * and for the narrow grading the single condition still permits.
+ *
+ * What the catalog offers a judged rule is identity and governance, never
+ * determinism: one name, one owner, one version, one ceiling, and the same text
+ * for every caller instead of prose re-improvised per call. A language model
+ * can still decide two identical proposals differently, and no schema changes
+ * that. The mitigation is `onViolation`, which a judged constraint must state
+ * and may not set to `reject` -- see VIOLATION_EFFECTS.
  *
  * STATUS: authored, validated and published; not yet enforced. kcmd carries a
  * constraint to Knowledge Catalog, where an agent can read the rules a model
@@ -540,15 +657,29 @@ export type ConstraintSeverity = (typeof CONSTRAINT_SEVERITIES)[number];
  */
 export interface Constraint {
   name: string;
-  expression: string;     // boolean invariant in the model's expression language
-  description?: string;   // human-readable summary; also the violation error
-  // What the engine does when this constraint does not hold. Defaults to
-  // `reject`: an unmarked rule refuses the write, which is the safe reading of
-  // an author who did not say. See VIOLATION_EFFECTS.
+  // Exactly one of `expression` and `judgment`. Declaring neither, or both, is
+  // a hard load error: the pair is what tells a consumer whether the rule can
+  // be computed, and a constraint that answers both ways answers neither.
+  expression?: string;  // boolean invariant in the model's expression language
+  // The rule in words, for a rule no expression decides. Write field names
+  // model-qualified (`LineItem.memo` rather than "the memo"): validate resolves
+  // every `Entity.field` token in the text, so the reference is checked, and it
+  // lives in the sentence that uses it rather than in a second list that drifts
+  // from the prose beside it. States one condition: a policy with several goes
+  // in several constraints, regrouped by `guards` on the action. The one
+  // condition may still warrant a graded response, bounded by `onViolation`.
+  judgment?: string;
+  description?: string;  // human-readable summary; also the violation error
+  // The strongest thing a violation of this constraint may do to the write. On
+  // an `expression` it defaults to `reject`: an unmarked rule refuses the
+  // write, which is the safe reading of an author who did not say, and a
+  // single-condition rule reaches its ceiling whenever it is violated. On a
+  // `judgment` it is required, and `reject` is refused. See VIOLATION_EFFECTS.
   onViolation?: ViolationEffect;
-  // How grave a violation is, for ranking and reporting. Orthogonal to
-  // `onViolation` and carries no default -- an author who did not say has not
-  // said, and nothing reads it yet. See CONSTRAINT_SEVERITIES.
+  // The gravest a violation is, for ranking and reporting. Orthogonal to
+  // `onViolation`, read as a ceiling for the same reason, and carries no
+  // default -- an author who did not say has not said, and nothing reads it
+  // yet. See CONSTRAINT_SEVERITIES.
   severity?: ConstraintSeverity;
   aiContext?: AiContext;
   // No `customExtensions`. Every other IR object has one because vanilla Ossie

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -474,26 +474,17 @@ export interface GrpcExecutor {
 }
 
 /**
- * The strongest thing a violated constraint may do to the write that tripped
- * it.
+ * What a violated constraint does to the write that tripped it.
  *
  *   - `reject`   the write is refused. Nobody is allowed to approve it, which
  *                is what makes the rule an invariant rather than a policy.
- *   - `escalate` the write is held and a human decides. The rule is a business
+ *   - `escalate` the write is held and a person decides. The rule is a business
  *                threshold, so somebody is allowed to say yes.
  *   - `warn`     the write proceeds and the violation is reported.
  *
  * An engine reading the catalog needs this in order to route. Without it every
  * rule publishes with the same shape, and a $30 credit that needs a supervisor
  * is indistinguishable from one that is simply forbidden.
- *
- * The three words are ordered by how much they let through: `reject` permits
- * nothing, `escalate` permits the write once a person approves it, `warn`
- * permits it outright. The declared word is a ceiling on that scale, so an
- * evaluation may settle on a word that permits at least as much and never on
- * one that permits less. A constraint with a single condition reaches its
- * ceiling whenever it is violated at all, which is why an expression's declared
- * word and its outcome are always the same word.
  *
  * This is a disposition, not a magnitude, and the two are deliberately separate
  * keys. `escalate` is not "between" reject and warn on a scale of badness: it is
@@ -505,62 +496,32 @@ export interface GrpcExecutor {
  * `escalate` names that an approver exists. It does not name who: an approver
  * role is not modeled yet.
  *
- * A judged constraint may not declare `reject`, and must declare one of the
- * other two. `reject` is what makes a rule an invariant: nobody in the
- * organization may approve the write. That authority should not rest on an
- * evaluation that can decide two identical proposals differently, with no
- * person in the loop. `escalate` stops the write just as firmly and adds
- * someone who can be held responsible for releasing it. The word is required
- * rather than defaulted there, because the default for an unmarked constraint
- * is `reject` and a rule whose safe default is unavailable should say what it
- * wants instead of inheriting a different one by body kind.
+ * The consequence is a field rather than something a `judgment` states in its
+ * own prose, because three things need it without running a judge. An
+ * unrunnable judge -- none configured, a failed call, a timeout -- still has to
+ * route the breach it could not evaluate. A search for the rules that can stop
+ * a write cannot read prose. And a policy DSL states its effect in the rule
+ * head, so a rule whose consequence is only implied by its wording cannot be
+ * lowered into OPA or Cedar.
  *
- * The ceiling exists for one narrow case: grading a single judged condition. A
- * thin discount justification may warrant a warning where an obviously
- * pretextual one warrants escalation, and the two cannot be written as separate
- * constraints without asking a judge the same question twice and depending on
- * the answers agreeing. The ceiling lets one condition carry both responses
- * while the enforceable bound stays a word load can read.
+ * A judgment may declare any of the three, `reject` included. What settles a
+ * judgment can decide two identical proposals differently, and `reject` leaves
+ * no appeal, so that pairing is the riskiest thing this model can express. It
+ * is still a bet an organization is entitled to place, and refusing to
+ * represent it would move the policy out of the catalog rather than prevent it.
+ * It is made auditable instead: `evaluation` publishes `judged` beside the
+ * word, so "unappealable rules settled by a model" is one query. `onViolation`
+ * is required on a judgment rather than defaulted, because a forgotten word
+ * would produce exactly that pairing silently.
  *
- * IT IS NOT A PLACE TO PUT A POLICY THAT BRANCHES. A written policy usually has
- * several conditions -- over one amount a director approves, under another a
- * missing receipt needs a manager, and separately the stated reason must be
- * plausible -- and the first two of those are expressions. Each condition
- * becomes its own constraint, with its own name, `onViolation` and `severity`,
- * and `guards` on the action regroups them into the policy the business wrote.
- * That keeps each branch independently searchable, revisable and owned, and it
- * keeps the computable branches computable. Folding the set into one judgment
- * because the prose can express the routing produces a judged rule where the
- * model should hold three deterministic ones and a judged one, which discards
- * the distinction the second body was added to draw.
+ * A constraint's word is the consequence of the one condition it states. A
+ * policy whose conditions carry different consequences is written as several
+ * constraints, which `guards` on an action lists together; the strictest
+ * consequence among the violated ones is what the action does. See
+ * docs/semantic-model/constraints.md for a worked policy.
  *
- * The ceiling is not checked against the judgment, and it cannot be: the prose
- * is prose. A judgment naming a response above its declared word is enforced at
- * the declared word, so the routing stays safe, but the published rule then
- * says something the engine will not do. That is a real cost of the reading and
- * the reason its scope is narrow.
- *
- * Three things need the declared word without running the judge, which is why
- * the routing stays a field even though a sentence can carry its own
- * consequence. The restriction above is one: load can refuse `reject` only
- * while `reject` is a value it can see, and a check that asks a model whether a
- * sentence means refusal is no guardrail at all. An unrunnable judge is the
- * second: no judge, a failed call or a timeout still has to route the breach it
- * could not evaluate. Translation is the third: a policy DSL states its effect
- * in the rule head, so a rule whose consequence is only implied by its wording
- * cannot be lowered into one.
- *
- * What the ceiling costs in search is precision. Rules that can escalate
- * include ones that in practice usually only warn. The reverse error would be
- * worse, a search for warnings that missed rules able to stop a write, so the
- * overstatement runs in the safe direction.
- *
- * STATUS of the ceiling: the declared word is the enforced word, and that is
- * the whole of what is implemented. Nothing evaluates a judgment, so no verdict
- * has ever been graded beneath the bound. When a verdict format arrives this is
- * what it is checked against; until then the reading is a bound with one
- * possible value, and the paragraphs above describe what it is for rather than
- * what runs.
+ * STATUS: the declared word is published and read back. Nothing evaluates a
+ * constraint, so nothing routes on it yet.
  */
 export const VIOLATION_EFFECTS = ['reject', 'escalate', 'warn'] as const;
 
@@ -579,10 +540,6 @@ export type ViolationEffect = (typeof VIOLATION_EFFECTS)[number];
  * The scale is the ordinary four-point one, and it avoids `warning` on purpose:
  * a severity called `warning` sitting beside an effect called `warn` would read
  * as the same statement made twice.
- *
- * Like `onViolation`, this is the gravest a violation of the rule can be rather
- * than the gravity of every violation of it, so a judged condition graded
- * across a range publishes the top of that range.
  *
  * STATUS: authored, published and read back. Nothing ranks or routes on it yet.
  */
@@ -632,17 +589,20 @@ export function constraintEvaluation(c: Constraint): ConstraintEvaluation {
  * Without this body such a rule has nowhere to go but `description`, where
  * nothing distinguishes it from the message explaining a different rule.
  *
- * One judgment states one condition. A policy with several conditions becomes
- * several constraints, and `guards` on the action regroups them -- see
- * VIOLATION_EFFECTS for why folding them into one judgment is the wrong trade,
- * and for the narrow grading the single condition still permits.
+ * A judgment states one condition, the same as an expression, because the
+ * consequence is carried by `onViolation` and one word cannot route two
+ * branches. A policy whose branches end differently -- a missing approval is
+ * held for a person, a disguised transaction is refused -- is written as one
+ * constraint per branch, and `guards` on the action lists them together. That
+ * also keeps the branches an expression could decide computable, which is the
+ * distinction the second body exists to draw.
  *
  * What the catalog offers a judged rule is identity and governance, never
- * determinism: one name, one owner, one version, one ceiling, and the same text
- * for every caller instead of prose re-improvised per call. A language model
- * can still decide two identical proposals differently, and no schema changes
- * that. The mitigation is `onViolation`, which a judged constraint must state
- * and may not set to `reject` -- see VIOLATION_EFFECTS.
+ * determinism: one name, one owner, one version, one declared consequence, and
+ * the same text for every caller instead of prose re-improvised per call. A
+ * language model can still decide two identical proposals differently, and no
+ * schema changes that. `onViolation` is required on a judgment so that the
+ * consequence of that non-determinism is always stated rather than inherited.
  *
  * STATUS: authored, validated and published; not yet enforced. kcmd carries a
  * constraint to Knowledge Catalog, where an agent can read the rules a model
@@ -665,21 +625,21 @@ export interface Constraint {
   // model-qualified (`LineItem.memo` rather than "the memo"): validate resolves
   // every `Entity.field` token in the text, so the reference is checked, and it
   // lives in the sentence that uses it rather than in a second list that drifts
-  // from the prose beside it. States one condition: a policy with several goes
-  // in several constraints, regrouped by `guards` on the action. The one
-  // condition may still warrant a graded response, bounded by `onViolation`.
+  // from the prose beside it. States one condition, in the form of what must be
+  // true rather than what to do, and says what does not satisfy it: a policy
+  // with several conditions goes in several constraints, regrouped by `guards`
+  // on the action. The consequence goes in `onViolation`, not the prose.
   judgment?: string;
   description?: string;  // human-readable summary; also the violation error
-  // The strongest thing a violation of this constraint may do to the write. On
-  // an `expression` it defaults to `reject`: an unmarked rule refuses the
-  // write, which is the safe reading of an author who did not say, and a
-  // single-condition rule reaches its ceiling whenever it is violated. On a
-  // `judgment` it is required, and `reject` is refused. See VIOLATION_EFFECTS.
+  // What a violation of this constraint does to the write. On an `expression`
+  // it defaults to `reject`: an unmarked rule refuses the write, which is the
+  // safe reading of an author who did not say. On a `judgment` it is required,
+  // any of the three words, because inheriting the harshest one by silence is
+  // not a thing to do to a rule a model settles. See VIOLATION_EFFECTS.
   onViolation?: ViolationEffect;
-  // The gravest a violation is, for ranking and reporting. Orthogonal to
-  // `onViolation`, read as a ceiling for the same reason, and carries no
-  // default -- an author who did not say has not said, and nothing reads it
-  // yet. See CONSTRAINT_SEVERITIES.
+  // How grave a violation is, for ranking and reporting. Orthogonal to
+  // `onViolation`, and carries no default -- an author who did not say has not
+  // said, and nothing reads it yet. See CONSTRAINT_SEVERITIES.
   severity?: ConstraintSeverity;
   aiContext?: AiContext;
   // No `customExtensions`. Every other IR object has one because vanilla Ossie

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -518,7 +518,7 @@ export interface GrpcExecutor {
  * policy whose conditions carry different consequences is written as several
  * constraints, which `guards` on an action lists together; the strictest
  * consequence among the violated ones is what the action does. See
- * docs/semantic-model/constraints.md for a worked policy.
+ * docs/semantic-model/actions.md for a worked policy.
  *
  * STATUS: the declared word is published and read back. Nothing evaluates a
  * constraint, so nothing routes on it yet.

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -321,12 +321,15 @@ export interface Action {
   // Inputs, each typed by the ontology: an entity type is an object reference,
   // a scalar type an ordinary value. See ActionParameter.
   parameters: ActionParameter[];
-  // The constraints that gate this action, by name. A constraint reaches this
-  // list only when it has to: one that reads an action's parameters describes
-  // the call rather than the data, so the only moment it can be checked is
-  // before that call runs. A constraint over data alone holds for every write
-  // and needs no reference here. Naming a constraint adds an earlier check and
-  // does not switch its enforcement on.
+  // The constraints that gate this action, by name. This list is what gives a
+  // constraint effect over the action. A constraint no action names is a
+  // catalogued rule that no call consults, so adding one to a model cannot
+  // silently start refusing calls that succeeded before it was published.
+  //
+  // Both kinds of rule belong here. One reading the action's parameters has no
+  // other moment to run. One over stored data, guarded, says the call must not
+  // proceed from a state that is already broken -- which is less than the rule
+  // itself says, because nothing binds a check to the state a write produces.
   guards?: string[];
   // What the call changes: its blast radius, one entry per concept touched.
   // Declared rather than derived, because the executor is opaque -- nothing

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -8,16 +8,25 @@
 // the encoding that fills the aspect.
 //
 // An entry of its own is what makes the invariant governable. A search can list
-// every rule a model states. The expression is a typed field rather than prose.
-// Dropping a constraint from the model deletes its entry, so the catalog never
-// advertises a rule the model stopped requiring.
+// every rule a model states, whichever way the rule is settled. Dropping a
+// constraint from the model deletes its entry, so the catalog never advertises
+// a rule the model stopped requiring.
 //
-// The five authored fields land in two places. `expression`, `on_violation`,
-// `severity` and `ai_context` go on the aspect, the last whole --
-// aiContextField in kc_custom_types.ts says why. `description` goes on the
+// The six authored fields land in two places. `expression`, `judgment`,
+// `on_violation`, `severity` and `ai_context` go on the aspect, the last whole
+// -- aiContextField in kc_custom_types.ts says why. `description` goes on the
 // entry source, where a pull of an action already reads it, and because a
 // violation quotes that sentence back to the caller as the error, which makes
 // it the entry's summary.
+//
+// A constraint states its rule in one of those first two fields and never in
+// both: `expression` for a rule a query can compute, `judgment` for one only a
+// reader can settle. The aspect adds a seventh field, `evaluation`, which no
+// author writes -- it restates which body the constraint used, as the word
+// `deterministic` or `judged`, so a consumer picking rules to lower into SQL
+// and a consumer picking rules to hand a language-model judge each select on
+// one field instead of testing which body is populated. A pull reads the
+// bodies and recomputes the word, so the two can never disagree in the IR.
 //
 // Both routing words are on the aspect because they are machine-readable, and
 // they are two fields because they answer different questions: what the engine
@@ -39,7 +48,7 @@
 
 import {Entry} from '../gcp/dataplex';
 
-import {Constraint, CONSTRAINT_SEVERITIES, ConstraintSeverity, SemanticModel, VIOLATION_EFFECTS, ViolationEffect} from './ir';
+import {Constraint, CONSTRAINT_SEVERITIES, constraintEvaluation, ConstraintSeverity, SemanticModel, VIOLATION_EFFECTS, ViolationEffect} from './ir';
 import {aiContextAspectValue, aiContextFromAspect, CONSTRAINT_TYPE_ID, customAspectKey, customAspectTypeName, customEntryTypeName} from './kc_custom_types';
 
 // Full resource name of the constraint entry type for a destination.
@@ -135,11 +144,19 @@ export function constraintEntries(
   return entries;
 }
 
-// The aspect payload for one constraint: the invariant, what a violation of it
-// does, how grave it is, and the whole of any `ai_context` declared on it.
+// The aspect payload for one constraint: the invariant in whichever body states
+// it, the word for which body that was, what a violation of it does, how grave
+// it is, and the whole of any `ai_context` declared on it.
+//
+// `evaluation` is the one field here that is computed rather than read off the
+// model. It is safe to compute because it is a restatement: it says nothing the
+// two bodies do not already say, and the reader recomputes it instead of
+// trusting it.
 function constraintAspectData(constraint: Constraint): Record<string, any> {
   return compact({
     expression: constraint.expression,
+    judgment: constraint.judgment,
+    evaluation: constraintEvaluation(constraint),
     aiContext: aiContextAspectValue(constraint.aiContext),
     onViolation: constraint.onViolation,
     severity: constraint.severity,
@@ -170,25 +187,37 @@ export function constraintAspectTypes(entryTypeBase: string): string[] {
 /**
  * Recovers one constraint from its entry, the inverse of constraintEntries.
  *
- * Returns undefined, with a warning, for an entry whose expression is missing
- * or blank: an invariant that states nothing would be pulled into a model that
- * then fails its own push-side validation, so one bad entry degrades itself
- * rather than the pull.
+ * Returns undefined, with a warning, for an entry that states neither body, and
+ * for one that states both: an invariant that states nothing, or states its
+ * rule twice, would be pulled into a model that then fails its own push-side
+ * validation, so one bad entry degrades itself rather than the pull.
+ *
+ * `evaluation` is not read. It is derived on the way out, so recomputing it
+ * from the body that came back is the only reading that cannot go stale.
  */
 export function readConstraint(entry: Entry, warnings: string[]): Constraint|
     undefined {
   const name = entry.entrySource?.displayName || idOf(entry.name);
   const data = constraintAspectDataOf(entry);
-  const expression =
-      typeof data.expression === 'string' ? data.expression.trim() : '';
-  if (!expression) {
+  const expression = text(data.expression);
+  const judgment = text(data.judgment);
+  if (!expression && !judgment) {
     warnings.push(
         `constraint '${name}': the ${CONSTRAINT_TYPE_ID} aspect has no ` +
-        `expression; the constraint is skipped`);
+        `expression and no judgment; the constraint is skipped`);
+    return undefined;
+  }
+  if (expression && judgment) {
+    warnings.push(
+        `constraint '${name}': the ${CONSTRAINT_TYPE_ID} aspect states both ` +
+        `an expression and a judgment, and a constraint states its rule in ` +
+        `one or the other; the constraint is skipped`);
     return undefined;
   }
 
-  const constraint: Constraint = {name, expression};
+  const constraint: Constraint = {name};
+  if (expression) constraint.expression = expression;
+  if (judgment) constraint.judgment = judgment;
   const description = entry.entrySource?.description;
   if (description !== undefined && description !== '')
     constraint.description = description;
@@ -210,7 +239,10 @@ export function readConstraint(entry: Entry, warnings: string[]): Constraint|
 // push-side validation. What dropping costs differs by field and both are safe:
 // an unreadable `onViolation` falls back to `reject`, which refuses more than
 // the catalog asked for and never less, and an unreadable `severity` leaves a
-// rule unranked, which nothing reads yet.
+// rule unranked, which nothing reads yet. On a judged constraint the first of
+// those is not a fallback but a load error, because a judge may not refuse: the
+// pulled model names the constraint and says the routing word is missing, which
+// is the outcome to want when the catalog no longer says how a breach routes.
 function readEnum(
     name: string, field: string, value: unknown, allowed: readonly string[],
     warnings: string[]): string|undefined {
@@ -255,6 +287,12 @@ function constraintAspectDataOf(entry: Entry): Record<string, any> {
     }
   }
   return {};
+}
+
+// The trimmed text an aspect field states, or '' when it states none. A blank
+// or whitespace-only value reads as unset, the same reading readEnum gives.
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
 }
 
 // Entry ids allow letters, numbers, underscores, hyphens, and periods.

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -204,14 +204,16 @@ export function readConstraint(entry: Entry, warnings: string[]): Constraint|
   if (!expression && !judgment) {
     warnings.push(
         `constraint '${name}': the ${CONSTRAINT_TYPE_ID} aspect has no ` +
-        `expression and no judgment; the constraint is skipped`);
+        `expression and no judgment; the constraint is skipped, and pushing ` +
+        `this model back will delete the entry`);
     return undefined;
   }
   if (expression && judgment) {
     warnings.push(
         `constraint '${name}': the ${CONSTRAINT_TYPE_ID} aspect states both ` +
         `an expression and a judgment, and a constraint states its rule in ` +
-        `one or the other; the constraint is skipped`);
+        `one or the other; the constraint is skipped, and pushing this model ` +
+        `back will delete the entry`);
     return undefined;
   }
 

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -224,6 +224,17 @@ export function readConstraint(entry: Entry, warnings: string[]): Constraint|
   const onViolation = readEnum(
       name, 'onViolation', data.onViolation, VIOLATION_EFFECTS, warnings);
   if (onViolation) constraint.onViolation = onViolation as ViolationEffect;
+  // A judgment must say what a violation does, so a pulled one that states no
+  // routing word is a model that will not push. Saying so here names the
+  // constraint while the pull is in front of the author; the alternative is a
+  // push error about a key they never wrote.
+  if (judgment && constraint.onViolation === undefined) {
+    warnings.push(
+        `constraint '${name}': the ${CONSTRAINT_TYPE_ID} aspect states a ` +
+        `judgment but no onViolation, so the pulled constraint will not push ` +
+        `until one is added; a judged constraint must say whether a breach ` +
+        `rejects, escalates or warns`);
+  }
   const severity = readEnum(
       name, 'severity', data.severity, CONSTRAINT_SEVERITIES, warnings);
   if (severity) constraint.severity = severity as ConstraintSeverity;

--- a/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_constraints.ts
@@ -199,8 +199,8 @@ export function readConstraint(entry: Entry, warnings: string[]): Constraint|
     undefined {
   const name = entry.entrySource?.displayName || idOf(entry.name);
   const data = constraintAspectDataOf(entry);
-  const expression = text(data.expression);
-  const judgment = text(data.judgment);
+  const expression = aspectText(data.expression);
+  const judgment = aspectText(data.judgment);
   if (!expression && !judgment) {
     warnings.push(
         `constraint '${name}': the ${CONSTRAINT_TYPE_ID} aspect has no ` +
@@ -302,7 +302,7 @@ function constraintAspectDataOf(entry: Entry): Record<string, any> {
 
 // The trimmed text an aspect field states, or '' when it states none. A blank
 // or whitespace-only value reads as unset, the same reading readEnum gives.
-function text(value: unknown): string {
+function aspectText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -395,8 +395,19 @@ export const CONSTRAINT_TYPE_ID = 'semantic-constraint';
 
 // The aspect that carries a constraint's rule.
 //
-// The expression is the whole of the machine-readable content, so it is a
-// required field: a constraint entry without one states no invariant.
+// A constraint states its rule in one of two fields, and neither is required on
+// its own because either one alone is a whole rule. `expression` is a boolean
+// expression a query can compute. `judgment` is the rule in words, for a rule
+// no expression decides -- whether a discount is justified, whether a refund
+// reason is plausible -- which a language-model judge settles at review time.
+// The push refuses a constraint that states both or neither, so the pair is
+// required in the sense that matters and the template cannot say so.
+//
+// `evaluation` restates which of the two the constraint used. It is derived,
+// never authored, and a reader recomputes it from the bodies rather than
+// trusting it. It exists so a consumer selecting rules to lower into a store
+// CHECK and a consumer selecting rules to hand a judge can each filter on one
+// field.
 //
 // The other two authored fields are the ones every model element carries, and
 // they land in different places. `description` rides the entry source, the way
@@ -416,9 +427,10 @@ export const CONSTRAINT_TYPE_ID = 'semantic-constraint';
 const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
   displayName: 'Semantic Constraint',
   description:
-      'An invariant over a semantic model: a boolean expression that must ' +
-      'hold for every instance of an entity, however that instance was ' +
-      'written.',
+      'An invariant over a semantic model: a condition that must hold for ' +
+      'every instance of an entity, however that instance was written. The ' +
+      'condition is either a boolean expression a query can compute or a ' +
+      'rule stated in words for a reader to settle.',
   metadataTemplate: {
     name: CONSTRAINT_TYPE_ID,
     type: 'record',
@@ -427,12 +439,13 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
         index: 1,
         name: 'expression',
         type: 'string',
-        constraints: {required: true},
         annotations: {
           displayName: 'Expression',
           description:
               'The invariant, as a boolean expression in the model\'s ' +
-              'expression language, for example `Customer.balance >= 0`.',
+              'expression language, for example `Customer.balance >= 0`. ' +
+              'Present on a constraint a query can decide; a constraint ' +
+              'states `judgment` instead when no expression decides it.',
         },
       },
       aiContextField(2),
@@ -443,11 +456,21 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
         annotations: {
           displayName: 'On Violation',
           description:
-              'What a violation does to the write that tripped it: ' +
-              '`reject` refuses the write and nobody may approve it, ' +
-              '`escalate` holds the write for a human decision, `warn` lets ' +
-              'it proceed and reports it. Absent means `reject`. `escalate` ' +
-              'states that an approver exists, not who they are.',
+              'The strongest thing a violation may do to the write that ' +
+              'tripped it: `reject` refuses the write and nobody may approve ' +
+              'it, `escalate` holds the write for a human decision, `warn` ' +
+              'lets it proceed and reports it. Absent means `reject`. ' +
+              '`escalate` states that an approver exists, not who they are. ' +
+              'The words are ordered by how much they let through, and this ' +
+              'one is a ceiling: an evaluation may settle on a word that ' +
+              'permits at least as much and never on one that permits less, ' +
+              'which lets a single judged condition warrant a graded ' +
+              'response. A policy with several conditions is published as ' +
+              'several constraints instead, each with its own word. A ' +
+              'constraint stating `judgment` always states this field and ' +
+              'never states `reject`: an evaluation that can decide two ' +
+              'identical proposals differently may hold a write for a person ' +
+              'but may not be the last word refusing it.',
         },
       },
       {
@@ -457,10 +480,44 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
         annotations: {
           displayName: 'Severity',
           description:
-              'How grave a violation is, for ranking and reporting: ' +
+              'The gravest a violation is, for ranking and reporting: ' +
               '`critical`, `high`, `medium` or `low`. Independent of what ' +
-              'the engine does about it, which is `onViolation`. Absent ' +
-              'means the model did not say; there is no default.',
+              'the engine does about it, which is `onViolation`, and read as ' +
+              'a ceiling for the same reason: a judged condition graded ' +
+              'across a range publishes the top of that range. Absent means ' +
+              'the model did not say; there is no default.',
+        },
+      },
+      {
+        index: 5,
+        name: 'judgment',
+        type: 'string',
+        annotations: {
+          displayName: 'Judgment',
+          description:
+              'The invariant in words, for a rule no boolean expression ' +
+              'decides, for example `A discount over 30% must be justified ' +
+              'by the reason given in Order.discount_reason`. A ' +
+              'language-model judge settles it against the proposed write at ' +
+              'review time. Field names are written model-qualified so a ' +
+              'reader can resolve them. States one condition: a policy with ' +
+              'several is published as several constraints. Present instead ' +
+              'of `expression`, never alongside it.',
+        },
+      },
+      {
+        index: 6,
+        name: 'evaluation',
+        type: 'string',
+        annotations: {
+          displayName: 'Evaluation',
+          description:
+              'How the constraint is settled: `deterministic` when it ' +
+              'states an `expression`, `judged` when it states a ' +
+              '`judgment`. Derived from which of the two the constraint ' +
+              'used, so it says nothing they do not, and present so a ' +
+              'consumer can select rules by how they are decided without ' +
+              'inspecting both bodies.',
         },
       },
     ],

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -456,21 +456,18 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
         annotations: {
           displayName: 'On Violation',
           description:
-              'The strongest thing a violation may do to the write that ' +
-              'tripped it: `reject` refuses the write and nobody may approve ' +
-              'it, `escalate` holds the write for a human decision, `warn` ' +
-              'lets it proceed and reports it. Absent means `reject`. ' +
-              '`escalate` states that an approver exists, not who they are. ' +
-              'The words are ordered by how much they let through, and this ' +
-              'one is a ceiling: an evaluation may settle on a word that ' +
-              'permits at least as much and never on one that permits less, ' +
-              'which lets a single judged condition warrant a graded ' +
-              'response. A policy with several conditions is published as ' +
-              'several constraints instead, each with its own word. A ' +
-              'constraint stating `judgment` always states this field and ' +
-              'never states `reject`: an evaluation that can decide two ' +
-              'identical proposals differently may hold a write for a person ' +
-              'but may not be the last word refusing it.',
+              'What a violation does to the write that tripped it: ' +
+              '`reject` refuses the write and nobody may approve it, ' +
+              '`escalate` holds the write for a human decision, `warn` lets ' +
+              'it proceed and reports it. Absent means `reject`. `escalate` ' +
+              'states that an approver exists, not who they are. A ' +
+              'constraint states one condition and this is that ' +
+              'condition\'s consequence, so a policy whose conditions end ' +
+              'differently is published as several constraints, each with ' +
+              'its own word, listed together by an action\'s `guards`; the ' +
+              'strictest consequence among the violated ones is what the ' +
+              'action does. A constraint stating `judgment` always states ' +
+              'this field, and may state any of the three words.',
         },
       },
       {
@@ -480,12 +477,10 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
         annotations: {
           displayName: 'Severity',
           description:
-              'The gravest a violation is, for ranking and reporting: ' +
+              'How grave a violation is, for ranking and reporting: ' +
               '`critical`, `high`, `medium` or `low`. Independent of what ' +
-              'the engine does about it, which is `onViolation`, and read as ' +
-              'a ceiling for the same reason: a judged condition graded ' +
-              'across a range publishes the top of that range. Absent means ' +
-              'the model did not say; there is no default.',
+              'the engine does about it, which is `onViolation`. Absent ' +
+              'means the model did not say; there is no default.',
         },
       },
       {
@@ -500,9 +495,11 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
               'by the reason given in Order.discount_reason`. A ' +
               'language-model judge settles it against the proposed write at ' +
               'review time. Field names are written model-qualified so a ' +
-              'reader can resolve them. States one condition: a policy with ' +
-              'several is published as several constraints. Present instead ' +
-              'of `expression`, never alongside it.',
+              'reader can resolve them. States one condition, as what must ' +
+              'be true rather than what to do; the consequence is ' +
+              '`onViolation`, and a policy whose conditions end differently ' +
+              'is published as several constraints. Present instead of ' +
+              '`expression`, never alongside it.',
         },
       },
       {

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -466,8 +466,10 @@ const CONSTRAINT_ASPECT_TYPE: Omit<AspectType, 'name'> = {
               'differently is published as several constraints, each with ' +
               'its own word, listed together by an action\'s `guards`; the ' +
               'strictest consequence among the violated ones is what the ' +
-              'action does. A constraint stating `judgment` always states ' +
-              'this field, and may state any of the three words.',
+              'action does. That combination is what the model states, and ' +
+              'no component evaluates a constraint today. A constraint ' +
+              'stating `judgment` always states this field, and may state ' +
+              'any of the three words.',
         },
       },
       {

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -669,8 +669,9 @@ async function provisionOne(
     if (reason) {
       warnings.push(
           `left the existing ${aspectLabel} in project '${home.project}' ` +
-          `unchanged (${reason}); a push that needs a field it does not ` +
-          `carry will fail`);
+          `unchanged (${reason}); a push will fail wherever the two ` +
+          `templates disagree, whether it states a field this one does not ` +
+          `carry or omits one this one still requires`);
     }
   } else if (aspect.status !== 200) {
     const refused = denial(aspectLabel, aspect.status, aspect.message);

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -475,9 +475,8 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
                         expression: z.string().optional(),
                         judgment: z.string().optional(),
                         description: z.string().optional(),
-                        // The strongest thing a violation may do; absent means
-                        // `reject`, and a judgment must state it. See
-                        // VIOLATION_EFFECTS.
+                        // What a violation does; absent means `reject`, and
+                        // a judgment must state it. See VIOLATION_EFFECTS.
                         on_violation: z.enum(VIOLATION_EFFECTS).optional(),
                         // How grave it is; no default. See
                         // CONSTRAINT_SEVERITIES.
@@ -1094,10 +1093,9 @@ function warnMixedAffectsPrecision(
 // This warns rather than fails because the scan matches identifiers, and an
 // expression may use a bare name that merely coincides with a parameter name.
 // An action every one of whose guards is judged has no deterministic gate at
-// all. Each of its guards is settled by a language model that may decide two
-// identical calls differently, and none of them can lower to a store-level
-// `CHECK`, so nothing protects the write when the judge is unavailable or
-// wrong.
+// all. Every gate costs a model call, none can lower to a store-level `CHECK`,
+// and each may decide two identical calls differently, so nothing protects the
+// write when the judge is unavailable or wrong.
 //
 // This is a warning and not an error, because it may be exactly what the author
 // meant: some operations really are governed only by rules no expression
@@ -1115,9 +1113,8 @@ function warnAllGuardsJudged(
     if (!guards.length || !guards.every(g => judged.has(g))) continue;
     warnings.push(
         `model '${modelName}': every constraint action '${a.name}' names in ` +
-        `guards is judged, so the action has no deterministic gate. A judged ` +
-        `constraint cannot reject a write on its own and cannot lower to a ` +
-        `store-level check.`);
+        `guards is judged, so the action has no deterministic gate. Every ` +
+        `gate costs a model call, and none can lower to a store-level check.`);
   }
 }
 

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -1079,19 +1079,6 @@ function warnMixedAffectsPrecision(
   }
 }
 
-// A constraint that reads an action's parameter describes that call, so the
-// only moment it can be checked is before the call runs -- which happens only
-// when the action names it in `guards`. Such a constraint left unnamed by EVERY
-// action is text nothing will ever evaluate, so say so at load time.
-//
-// Being guarded anywhere is enough. An action that shares the parameter name and
-// does not name the constraint is a deliberate modeling choice, since the same
-// rule may gate one action and leave another alone; warning about it would
-// report a constraint that does run and would teach an author to ignore this
-// message.
-//
-// This warns rather than fails because the scan matches identifiers, and an
-// expression may use a bare name that merely coincides with a parameter name.
 // An action every one of whose guards is judged has no deterministic gate at
 // all. Every gate costs a model call, none can lower to a store-level `CHECK`,
 // and each may decide two identical calls differently, so nothing protects the
@@ -1118,6 +1105,20 @@ function warnAllGuardsJudged(
   }
 }
 
+// A constraint that reads an action's parameter describes that call, so the
+// only moment it can be checked is before the call runs -- which happens only
+// when the action names it in `guards`. Such a constraint left unnamed by EVERY
+// action is text nothing will ever evaluate, so say so at load time.
+//
+// Being guarded anywhere is enough. An action that shares the parameter name and
+// does not name the constraint is a deliberate modeling choice, since the same
+// rule may gate one action and leave another alone; warning about it would
+// report a constraint that does run and would teach an author to ignore this
+// message.
+//
+// This warns rather than fails because the scan matches identifiers, and an
+// expression may use a bare name that merely coincides with a parameter name.
+//
 // One message per pair, naming the first parameter that matched.
 function warnUnguardedParameterConstraints(
     actions: Action[], constraints: Constraint[], modelName: string,

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -272,14 +272,24 @@ const actionSchema = z.object({
   custom_extensions: z.array(customExtensionSchema).optional(),
 });
 
-// A constraint: a named boolean invariant over the ontology. `expression` is a
-// logical expression in the model's own language (`Customer.accountBalance >=
-// 0`) rather than a physical binding, so it stays a plain string. Whatever
-// evaluates the constraint resolves it against the ontology; the loader leaves
-// it alone.
+// A constraint: a named invariant over the ontology, in one of two bodies.
+//
+// `expression` is a logical expression in the model's own language
+// (`Customer.accountBalance >= 0`) rather than a physical binding, so it stays
+// a plain string. Whatever evaluates the constraint resolves it against the
+// ontology; the loader leaves it alone.
+//
+// `judgment` is the rule in words, for a rule no expression decides. It is a
+// plain string for the same reason, and validate resolves the `Entity.field`
+// tokens it mentions.
+//
+// Both are optional here and exactly one is required, which `validate` enforces
+// so the author gets one message naming the constraint rather than a schema
+// union error naming a position in the document.
 const constraintSchema = z.object({
   name: z.string(),
-  expression: z.string(),
+  expression: z.string().optional(),
+  judgment: z.string().optional(),
   description: z.string().optional(),
   // What the engine does; absent means `reject`. See VIOLATION_EFFECTS.
   on_violation: z.enum(VIOLATION_EFFECTS).optional(),
@@ -457,11 +467,16 @@ function buildDocumentSchema(bindingOptional: boolean, extended: boolean) {
                     ...ce,
                   }).strict();
 
+  // Both bodies are optional here because the schema cannot say "one of these
+  // two, never both". validateConstraints enforces the exclusivity, which also
+  // lets it name the constraint and say which way it went wrong.
   const constraint = z.object({
                         name: z.string(),
-                        expression: z.string(),
+                        expression: z.string().optional(),
+                        judgment: z.string().optional(),
                         description: z.string().optional(),
-                        // What the engine does; absent means `reject`. See
+                        // The strongest thing a violation may do; absent means
+                        // `reject`, and a judgment must state it. See
                         // VIOLATION_EFFECTS.
                         on_violation: z.enum(VIOLATION_EFFECTS).optional(),
                         // How grave it is; no default. See
@@ -762,6 +777,7 @@ function convertModel(
   rejectDuplicateNames(
       constraints.map(c => c.name), 'constraint name', `model '${m.name}'`);
   warnUnguardedParameterConstraints(actions, constraints, m.name, warnings);
+  warnAllGuardsJudged(actions, constraints, m.name, warnings);
 
   const description = composeDescription(m.description);
 
@@ -937,11 +953,17 @@ function convertMetric(
   return metric;
 }
 
-// Converts a constraint document to the IR. The `expression` is kept verbatim:
-// it is a logical invariant, resolved against the ontology by whatever
-// evaluates it. Description and AI context round-trip like everywhere else.
+// Converts a constraint document to the IR. Whichever body it declares is kept
+// verbatim: an expression is a logical invariant resolved against the ontology
+// by whatever evaluates it, and a judgment is the text a judge is handed.
+// Description and AI context round-trip like everywhere else.
+//
+// Both bodies are copied when a document sets both, so `validate` can name the
+// conflict against the real constraint rather than against a repaired one.
 function convertConstraint(c: ConstraintDoc): Constraint {
-  const constraint: Constraint = { name: c.name, expression: c.expression };
+  const constraint: Constraint = {name: c.name};
+  if (c.expression !== undefined) constraint.expression = c.expression;
+  if (c.judgment !== undefined) constraint.judgment = c.judgment;
   if (c.on_violation) constraint.onViolation = c.on_violation;
   if (c.severity) constraint.severity = c.severity;
   const description = composeDescription(c.description);
@@ -1071,6 +1093,34 @@ function warnMixedAffectsPrecision(
 //
 // This warns rather than fails because the scan matches identifiers, and an
 // expression may use a bare name that merely coincides with a parameter name.
+// An action every one of whose guards is judged has no deterministic gate at
+// all. Each of its guards is settled by a language model that may decide two
+// identical calls differently, and none of them can lower to a store-level
+// `CHECK`, so nothing protects the write when the judge is unavailable or
+// wrong.
+//
+// This is a warning and not an error, because it may be exactly what the author
+// meant: some operations really are governed only by rules no expression
+// decides. It exists so that state is visible in the source rather than
+// discovered from a published model.
+function warnAllGuardsJudged(
+    actions: Action[], constraints: Constraint[], modelName: string,
+    warnings: string[]): void {
+  if (!actions.length || !constraints.length) return;
+  const judged = new Set(
+      constraints.filter(c => c.judgment !== undefined).map(c => c.name));
+  if (!judged.size) return;
+  for (const a of actions) {
+    const guards = a.guards ?? [];
+    if (!guards.length || !guards.every(g => judged.has(g))) continue;
+    warnings.push(
+        `model '${modelName}': every constraint action '${a.name}' names in ` +
+        `guards is judged, so the action has no deterministic gate. A judged ` +
+        `constraint cannot reject a write on its own and cannot lower to a ` +
+        `store-level check.`);
+  }
+}
+
 // One message per pair, naming the first parameter that matched.
 function warnUnguardedParameterConstraints(
     actions: Action[], constraints: Constraint[], modelName: string,
@@ -1078,13 +1128,19 @@ function warnUnguardedParameterConstraints(
   if (!actions.length || !constraints.length) return;
   for (const c of constraints) {
     if (actions.some(a => a.guards?.includes(c.name))) continue;
+    // Judged constraints are skipped. The scan looks for a bare identifier that
+    // matches a parameter name, and a judgment is ordinary prose, so words like
+    // `amount` or `order` appear in it as English rather than as references.
+    // Running the scan there would warn on most judged rules ever written.
+    if (c.expression === undefined) continue;
     const identifiers = bareIdentifiers(c.expression);
     if (!identifiers.size) continue;
     for (const a of actions) {
       const read = a.parameters.find(p => identifiers.has(p.name));
       if (!read) continue;
       warnings.push(
-          `model '${modelName}': constraint '${c.name}' reads '${read.name}', ` +
+          `model '${modelName}': constraint '${c.name}' reads '${
+              read.name}', ` +
           `a parameter of action '${a.name}', but '${a.name}' does not list ` +
           `'${c.name}' in guards. A constraint over an action's parameters is ` +
           `checked only as a guard of that action.`);

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -318,13 +318,17 @@ function affectedConceptDoc(affected: AffectedConcept):
   });
 }
 
-// Inverts loader.convertConstraint. The expression is a logical invariant and
-// round-trips verbatim, since nothing about it is derived.
+// Inverts loader.convertConstraint. Both bodies are logical invariants and
+// round-trip verbatim, since nothing about either is derived. The `evaluation`
+// word the published aspect carries is absent here for that reason: it is
+// computed from which body the constraint states, so emitting it would put a
+// derived value in an authored document.
 function constraintDoc(constraint: Constraint): Record<string, any> {
   // No dropExtensions call: a constraint carries no custom extensions to drop.
   return compact({
     name: constraint.name,
     expression: constraint.expression,
+    judgment: constraint.judgment,
     description: constraint.description,
     on_violation: constraint.onViolation,
     severity: constraint.severity,

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -386,7 +386,22 @@ function validateConstraints(
   const errors: string[] = [];
   const constraints = model.constraints ?? [];
   if (!constraints.length) return errors;
-  const fieldsByEntity = fieldsPruned ? undefined : declaredFields(model);
+  // declaredFields resolves inheritance, and that THROWS on an `extends` naming
+  // an entity the model does not declare. The loader accepts such a model and a
+  // Knowledge-Catalog-only push reaches no graph leg to catch it, so calling
+  // this unguarded turns a bad `extends` into a stack trace out of the
+  // validation gate. Standing the field scan down is the same thing a pruned
+  // profile does: this scan catches a misspelled field, and a model whose
+  // inheritance does not resolve has a larger problem that the graph legs
+  // report where they can resolve it.
+  let fieldsByEntity: Map<string, Set<string>>|undefined;
+  if (!fieldsPruned) {
+    try {
+      fieldsByEntity = declaredFields(model);
+    } catch {
+      fieldsByEntity = undefined;
+    }
+  }
 
   for (const c of constraints) {
     const where =
@@ -467,6 +482,12 @@ function judgedConstraintErrors(
 // refusing to guess is what stops a valid rule being falsely rejected. A known
 // entity with an unknown field is the case where the author plainly meant this
 // model and got the name wrong, so that one is an error.
+
+// An entity that declares no fields at all is unknowable in the same way an
+// unrecognized name is, so the scan stands down there too. Fields are optional
+// on an entity, and a logical model bound to nothing but Knowledge Catalog
+// routinely declares none; reading an empty set as "this entity has no such
+// field" would refuse every constraint such a model can write.
 //
 // The two segments must be adjacent to the dot, which is what keeps a sentence
 // boundary ("check the memo. Every credit...") out of the scan. A decimal
@@ -481,7 +502,7 @@ function unknownFieldRefs(
   for (let m = token.exec(judgment); m; m = token.exec(judgment)) {
     const [, entity, field] = m;
     const fields = fieldsByEntity.get(entity);
-    if (!fields || fields.has(field)) continue;
+    if (!fields || !fields.size || fields.has(field)) continue;
     const ref = `${entity}.${field}`;
     if (seen.has(ref)) continue;
     seen.add(ref);

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -118,6 +118,26 @@ export function validatePushRequirements(
       }
     }
 
+    // Resolving inheritance throws on an `extends` naming an entity the model
+    // does not declare, and the two checks below stand down rather than
+    // stack-trace on one. Standing down has to mean reporting somewhere or it
+    // means publishing a broken model in silence: the loader accepts such a
+    // model, and a Knowledge-Catalog-only push reaches no graph leg that would
+    // resolve inheritance and catch it. So the failure is reported here, once
+    // per model, and the checks below stay quiet about it. A profile push that
+    // pruned fields is exempt for the same reason those checks are -- pruning
+    // can remove a supertype whole, and the dangling `extends` it leaves is the
+    // pruner's doing rather than the author's.
+    if (!opts.fieldsPruned) {
+      const failure = inheritanceFailure(model);
+      if (failure) {
+        errors.push(
+            `model '${model.name}' (${document}): ${failure} Constraint and ` +
+            `action checks that need the resolved model are skipped until ` +
+            `this is fixed.`);
+      }
+    }
+
     // An action reaches Knowledge Catalog only, so its checks are
     // target-independent: each parameter's type must resolve to something in
     // the ontology, the executor must carry the coordinates a runtime needs to
@@ -383,6 +403,12 @@ function validateConstraints(
   if (!constraints.length) return errors;
   const fieldsByEntity =
       fieldsPruned ? undefined : ifResolvable(() => declaredFields(model));
+  // Names the model declares that are not fields of any one entity, which a
+  // token's tail may legitimately carry. See unknownFieldRefs.
+  const nonFieldNames = new Set([
+    ...(model.relationships ?? []).map(r => r.name),
+    ...(model.metrics ?? []).map(m => m.name),
+  ]);
 
   for (const c of constraints) {
     const where =
@@ -405,7 +431,8 @@ function validateConstraints(
     }
 
     if (hasJudgment) {
-      errors.push(...judgedConstraintErrors(c, where, fieldsByEntity));
+      errors.push(
+        ...judgedConstraintErrors(c, where, fieldsByEntity, nonFieldNames));
       continue;
     }
 
@@ -416,7 +443,8 @@ function validateConstraints(
     // A quoted literal is data rather than a reference, so it is blanked
     // before the scan: `status = 'Order.total'` compares against a string.
     errors.push(...unknownFieldRefs(
-        c.expression!.replace(/'[^']*'|"[^"]*"/g, ' '), where, fieldsByEntity));
+        c.expression!.replace(/'[^']*'|"[^"]*"/g, ' '), where, fieldsByEntity,
+        nonFieldNames));
   }
   return errors;
 }
@@ -434,11 +462,15 @@ function validateConstraints(
 // is the whole of the static checking a judged rule can get.
 function judgedConstraintErrors(
     c: Constraint, where: string,
-    fieldsByEntity: Map<string, Set<string>>|undefined): string[] {
+    fieldsByEntity: Map<string, Set<string>>|undefined,
+    nonFieldNames: Set<string>): string[] {
   const errors: string[] = [];
-  if (!c.judgment!.trim()) {
+  // The two checks are independent, so an empty judgment does not skip the
+  // routing one. Reporting only the empty body would send the author back for a
+  // second failure over a key they were never told about.
+  const empty = !c.judgment!.trim();
+  if (empty) {
     errors.push(`${where} has an empty judgment.`);
-    return errors;
   }
   if (c.onViolation === undefined) {
     errors.push(
@@ -447,7 +479,10 @@ function judgedConstraintErrors(
         `let it through and report it. An unmarked constraint rejects, which ` +
         `is too strong a thing to inherit by leaving the key out.`);
   }
-  errors.push(...unknownFieldRefs(c.judgment!, where, fieldsByEntity));
+  if (!empty) {
+    errors.push(...unknownFieldRefs(
+        c.judgment!, where, fieldsByEntity, nonFieldNames));
+  }
   return errors;
 }
 
@@ -470,12 +505,21 @@ function judgedConstraintErrors(
 // routinely declares none; reading an empty set as "this entity has no such
 // field" would refuse every constraint such a model can write.
 //
+// A tail that names something the model declares is not a misspelled field
+// either. Traversal has no syntax in the model today, so a prose token like
+// `Customer.Order` or `LineItem.BelongsTo` reads as a field of the head and
+// would be rejected for a field the author never claimed existed; the same goes
+// for `Order.total_revenue`, where metrics are model-level and the qualifier is
+// the entity the metric hangs off. The scan therefore settles only the case it
+// can: a tail the model does not declare under any kind is the misspelling.
+//
 // The two segments must be adjacent to the dot, which is what keeps a sentence
 // boundary ("check the memo. Every credit...") out of the scan. A decimal
 // number cannot survive either, since no entity is named `30`.
 function unknownFieldRefs(
     judgment: string, where: string,
-    fieldsByEntity: Map<string, Set<string>>|undefined): string[] {
+    fieldsByEntity: Map<string, Set<string>>|undefined,
+    nonFieldNames: Set<string>): string[] {
   if (!fieldsByEntity) return [];
   const errors: string[] = [];
   const seen = new Set<string>();
@@ -494,6 +538,13 @@ function unknownFieldRefs(
     }
     const fields = fieldsByEntity.get(entity);
     if (!fields || !fields.size || fields.has(field)) continue;
+    // The tail names something the model declares that is not a field of the
+    // head: another entity, a relationship, or a metric. `Customer.Order` and
+    // `LineItem.BelongsTo` are traversals and `Order.total_revenue` is a metric
+    // reference, none of which this scan can settle, and all of which an author
+    // writing prose reaches for. Only a tail the model does not declare at all
+    // is read as the misspelling this check exists to catch.
+    if (fieldsByEntity.has(field) || nonFieldNames.has(field)) continue;
     const ref = `${entity}.${field}`;
     if (seen.has(ref)) continue;
     seen.add(ref);
@@ -514,15 +565,31 @@ function unknownFieldRefs(
 // push can create one by pruning a supertype whole. A validation gate reports;
 // it does not stack-trace, so every caller that resolves inheritance to answer
 // a question comes through here and stands its own check down when the answer
-// is unavailable. That is the same thing a pruned profile does. The checks
-// these builders feed catch a misspelled name, and a model whose inheritance
-// does not resolve has a larger problem that the graph legs report where they
-// can resolve it.
+// is unavailable. That is the same thing a pruned profile does. Standing down
+// is not silence: validatePushRequirements reports the resolution failure once
+// per model, so the larger problem is named and only the checks that depend on
+// the resolved model go quiet.
 function ifResolvable<T>(build: () => T): T|undefined {
   try {
     return build();
   } catch {
     return undefined;
+  }
+}
+
+// Why resolving the model's inheritance fails, or nothing when it succeeds.
+//
+// Reported rather than thrown, and reported once for the model rather than once
+// per check that needed it. A model declaring no inheritance cannot fail, and
+// resolving clones, so it is not asked.
+function inheritanceFailure(model: SemanticModel): string|undefined {
+  if (!(model.entities ?? []).some(e => e.extends?.length)) return undefined;
+  try {
+    resolveInheritance(model);
+    return undefined;
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return message.endsWith('.') ? message : `${message}.`;
   }
 }
 

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -157,15 +157,10 @@ function validateActions(
   if (!actions.length) return errors;
   const constraintNames =
       new Set((model.constraints ?? []).map(c => c.name));
-  // Built only when an `affects` entry will actually read it, which is not a
-  // cost argument: declaredFields resolves inheritance, and that THROWS on an
-  // `extends` naming an entity the model does not declare. The loader accepts
-  // such a model, a KC-only push reaches no graph leg to catch it, and a
-  // profile push can create one by pruning a supertype whole. Building this
-  // eagerly would turn any of those into a stack trace out of the validation
-  // gate, for a model this check has nothing to say about.
+  // Built only when an `affects` entry will actually read it, and through
+  // `ifResolvable` because declaredConcepts resolves inheritance.
   const concepts = !fieldsPruned && actions.some(a => a.affects?.length) ?
-      declaredConcepts(model) :
+      ifResolvable(() => declaredConcepts(model)) :
       undefined;
   for (const action of actions) {
     const where =
@@ -386,22 +381,8 @@ function validateConstraints(
   const errors: string[] = [];
   const constraints = model.constraints ?? [];
   if (!constraints.length) return errors;
-  // declaredFields resolves inheritance, and that THROWS on an `extends` naming
-  // an entity the model does not declare. The loader accepts such a model and a
-  // Knowledge-Catalog-only push reaches no graph leg to catch it, so calling
-  // this unguarded turns a bad `extends` into a stack trace out of the
-  // validation gate. Standing the field scan down is the same thing a pruned
-  // profile does: this scan catches a misspelled field, and a model whose
-  // inheritance does not resolve has a larger problem that the graph legs
-  // report where they can resolve it.
-  let fieldsByEntity: Map<string, Set<string>>|undefined;
-  if (!fieldsPruned) {
-    try {
-      fieldsByEntity = declaredFields(model);
-    } catch {
-      fieldsByEntity = undefined;
-    }
-  }
+  const fieldsByEntity =
+      fieldsPruned ? undefined : ifResolvable(() => declaredFields(model));
 
   for (const c of constraints) {
     const where =
@@ -501,6 +482,16 @@ function unknownFieldRefs(
   const token = /\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)/g;
   for (let m = token.exec(judgment); m; m = token.exec(judgment)) {
     const [, entity, field] = m;
+    // A token with a third segment (`Order.lineItems.amount`) is a path rather
+    // than a field of `Order`, and reading its middle segment as one would
+    // reject it for a field the author never claimed existed. Nothing in the
+    // model defines path syntax today, so the scan declines to guess in both
+    // directions: a token followed by another dotted segment is skipped, and so
+    // is one preceded by a dot, which is how the tail of a path presents.
+    const after = judgment.slice(m.index + m[0].length);
+    if (/^\.\w/.test(after) || (m.index > 0 && judgment[m.index - 1] === '.')) {
+      continue;
+    }
     const fields = fieldsByEntity.get(entity);
     if (!fields || !fields.size || fields.has(field)) continue;
     const ref = `${entity}.${field}`;
@@ -511,6 +502,28 @@ function unknownFieldRefs(
         `field '${field}'.`);
   }
   return errors;
+}
+
+// What `build` returns, or nothing when the model's inheritance does not
+// resolve.
+//
+// `declaredFields` and `declaredConcepts` both resolve inheritance, and
+// resolving THROWS on an `extends` naming an entity the model does not declare
+// rather than reporting it. The loader accepts such a model, a
+// Knowledge-Catalog-only push reaches no graph leg to catch it, and a profile
+// push can create one by pruning a supertype whole. A validation gate reports;
+// it does not stack-trace, so every caller that resolves inheritance to answer
+// a question comes through here and stands its own check down when the answer
+// is unavailable. That is the same thing a pruned profile does. The checks
+// these builders feed catch a misspelled name, and a model whose inheritance
+// does not resolve has a larger problem that the graph legs report where they
+// can resolve it.
+function ifResolvable<T>(build: () => T): T|undefined {
+  try {
+    return build();
+  } catch {
+    return undefined;
+  }
 }
 
 // Every field each entity has, inherited ones included. Inheritance is resolved

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -355,11 +355,15 @@ function declaredConcepts(model: SemanticModel): Map<string, DeclaredConcept> {
 //
 // An `expression` then gets two checks:
 //   - the expression must be non-empty;
-//   - when it opens with a `<Entity>.<field>` qualifier naming a KNOWN entity,
-//     that entity must declare the field. This catches a typo that would
-//     otherwise surface only inside an agent's rejected action.
-// A `judgment` gets the field-reference check over every qualified token in the
-// prose, plus the one routing rule in judgedConstraintErrors.
+//   - every `<Entity>.<field>` token naming a KNOWN entity must name a field
+//     that entity declares. This catches a typo that would otherwise surface
+//     only inside an agent's rejected action.
+// A `judgment` gets the same field-reference check over the qualified tokens in
+// its prose, plus the one routing rule in judgedConstraintErrors.
+//
+// Both bodies are scanned the same way, because a rule is as easy to misspell
+// in `amount <= Order.totl` as in a sentence, and an expression that names a
+// field no entity has can never be computed.
 //
 // Everything else is left alone. The expression is a logical invariant, and
 // whatever evaluates it resolves it against the ontology. So a leading
@@ -413,14 +417,10 @@ function validateConstraints(
       errors.push(`${where} has an empty expression.`);
       continue;
     }
-    if (!fieldsByEntity) continue;
-    const ref = leadingFieldRef(c.expression!);
-    if (!ref) continue;
-    const fields = fieldsByEntity.get(ref.entity);
-    if (fields && !fields.has(ref.field)) {
-      errors.push(`${where} references '${ref.entity}.${ref.field}', but ` +
-          `entity '${ref.entity}' declares no field '${ref.field}'.`);
-    }
+    // A quoted literal is data rather than a reference, so it is blanked
+    // before the scan: `status = 'Order.total'` compares against a string.
+    errors.push(...unknownFieldRefs(
+        c.expression!.replace(/'[^']*'|"[^"]*"/g, ' '), where, fieldsByEntity));
   }
   return errors;
 }
@@ -462,8 +462,8 @@ function judgedConstraintErrors(
 // spelling heuristic is needed and none is used: entity names here are as often
 // lowercase (`customer`, `orders`) as capitalized, and a rule keyed on the
 // capital would check some models and quietly skip others. An unrecognized
-// leading name is left alone on the principle that keeps leadingFieldRef
-// conservative -- a judgment may name a concept from another system, and
+// entity name is left alone on the principle that keeps this scan
+// conservative -- a rule may name a concept from another system, and
 // refusing to guess is what stops a valid rule being falsely rejected. A known
 // entity with an unknown field is the case where the author plainly meant this
 // model and got the name wrong, so that one is an error.
@@ -502,13 +502,6 @@ function declaredFields(model: SemanticModel): Map<string, Set<string>> {
       (inherits ? resolveInheritance(model).model : model).entities ?? [];
   return new Map(
       entities.map(e => [e.name, new Set((e.fields ?? []).map(f => f.name))]));
-}
-
-// The leading `<name>.<field>` qualifier of a constraint expression, or null
-// when it does not open with one.
-function leadingFieldRef(expr: string): {entity: string; field: string}|null {
-  const m = expr.trim().match(/^([A-Za-z_]\w*)\.([A-Za-z_]\w*)/);
-  return m ? {entity: m[1], field: m[2]} : null;
 }
 
 // The executor coordinate fields that are absent or blank. An executor with no

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -359,7 +359,7 @@ function declaredConcepts(model: SemanticModel): Map<string, DeclaredConcept> {
 //     that entity must declare the field. This catches a typo that would
 //     otherwise surface only inside an agent's rejected action.
 // A `judgment` gets the field-reference check over every qualified token in the
-// prose, plus the two routing rules in judgedConstraintErrors.
+// prose, plus the one routing rule in judgedConstraintErrors.
 //
 // Everything else is left alone. The expression is a logical invariant, and
 // whatever evaluates it resolves it against the ontology. So a leading
@@ -427,20 +427,15 @@ function validateConstraints(
 
 // What a judged constraint must satisfy, beyond stating a body at all.
 //
-// Two of the three checks are about what a violation may do. A judged rule is
-// settled by a language model, which can decide two identical proposals
-// differently, so it may not be the last word on a refusal nobody may appeal.
-// Requiring the word rather than defaulting to `escalate` keeps one rule for
-// readers of the published aspect: absent means `reject`, whatever the body.
+// It must say what a violation does. Any of the three words is allowed,
+// `reject` included, but silence is not: an unmarked constraint rejects, and
+// inheriting the harshest consequence by omission is the one outcome an author
+// of a judged rule is least likely to have meant. Nothing here reads the prose
+// to check the word against it -- the prose is prose, and a check that asked a
+// model whether a sentence means refusal would be no guardrail at all.
 //
-// `on_violation` bounds a judgment rather than fixing its outcome, and neither
-// check looks into the prose to confirm the bound holds -- the prose is prose.
-// A judgment naming a harsher response than its declared word is enforced at
-// the declared word, so the routing is safe and the published text is wrong;
-// VIOLATION_EFFECTS says why that cost is accepted and kept small.
-//
-// The third resolves the `Entity.field` tokens the prose mentions, which is the
-// whole of the static checking a judged rule can get.
+// The other check resolves the `Entity.field` tokens the prose mentions, which
+// is the whole of the static checking a judged rule can get.
 function judgedConstraintErrors(
     c: Constraint, where: string,
     fieldsByEntity: Map<string, Set<string>>|undefined): string[] {
@@ -451,16 +446,10 @@ function judgedConstraintErrors(
   }
   if (c.onViolation === undefined) {
     errors.push(
-        `${where} is judged, so it must state on_violation as 'escalate' or ` +
-        `'warn'. An unmarked constraint rejects the write, and a judged rule ` +
-        `may not do that.`);
-  } else if (c.onViolation === 'reject') {
-    errors.push(
-        `${where} is judged, so on_violation may not be 'reject'. Nobody may ` +
-        `approve a rejected write, and that authority cannot rest on a ` +
-        `judgment. Use 'escalate' to stop the write and let a human release ` +
-        `it, or 'warn' to report it. A condition that must refuse outright ` +
-        `belongs in its own constraint, stated as an expression.`);
+        `${where} is judged, so it must state on_violation: 'reject' to ` +
+        `refuse the write, 'escalate' to hold it for a person, or 'warn' to ` +
+        `let it through and report it. An unmarked constraint rejects, which ` +
+        `is too strong a thing to inherit by leaving the key out.`);
   }
   errors.push(...unknownFieldRefs(c.judgment!, where, fieldsByEntity));
   return errors;

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -11,7 +11,7 @@
 import {BigQueryClient} from '../gcp/bigquery';
 
 import {googleDeploymentTargets} from './deploy_bigquery';
-import {Action, Executor, generatedKeyParam, SemanticModel, SQL_EXECUTOR_VERBS} from './ir';
+import {Action, Constraint, Executor, generatedKeyParam, SemanticModel, SQL_EXECUTOR_VERBS} from './ir';
 import {LoadedModel} from './loader';
 import {resolveInheritance} from './resolve_inheritance';
 import {referencedParameters} from './sql_identifiers';
@@ -347,11 +347,20 @@ function declaredConcepts(model: SemanticModel): Map<string, DeclaredConcept> {
 }
 
 
-// Static, target-independent checks for a model's constraints. Two checks:
+// Static, target-independent checks for a model's constraints.
+//
+// First, every constraint must declare exactly one body. `expression` says the
+// rule can be computed and `judgment` says it cannot, so a constraint with both
+// answers neither, and one with neither states no rule at all.
+//
+// An `expression` then gets two checks:
 //   - the expression must be non-empty;
 //   - when it opens with a `<Entity>.<field>` qualifier naming a KNOWN entity,
 //     that entity must declare the field. This catches a typo that would
 //     otherwise surface only inside an agent's rejected action.
+// A `judgment` gets the field-reference check over every qualified token in the
+// prose, plus the two routing rules in judgedConstraintErrors.
+//
 // Everything else is left alone. The expression is a logical invariant, and
 // whatever evaluates it resolves it against the ontology. So a leading
 // qualifier that is not a known entity is not guessed at here: a
@@ -378,18 +387,118 @@ function validateConstraints(
   for (const c of constraints) {
     const where =
         `constraint '${c.name}' in model '${model.name}' (${document})`;
-    if (!c.expression.trim()) {
+    const hasExpression = c.expression !== undefined;
+    const hasJudgment = c.judgment !== undefined;
+    if (hasExpression && hasJudgment) {
+      errors.push(
+          `${where} declares both an expression and a judgment. A constraint ` +
+          `states one rule in one body: use 'expression' when the rule can be ` +
+          `computed, 'judgment' when it cannot.`);
+      continue;
+    }
+    if (!hasExpression && !hasJudgment) {
+      errors.push(
+          `${where} declares neither an expression nor a judgment. Give it ` +
+          `one: 'expression' when the rule can be computed, 'judgment' when ` +
+          `it cannot.`);
+      continue;
+    }
+
+    if (hasJudgment) {
+      errors.push(...judgedConstraintErrors(c, where, fieldsByEntity));
+      continue;
+    }
+
+    if (!c.expression!.trim()) {
       errors.push(`${where} has an empty expression.`);
       continue;
     }
     if (!fieldsByEntity) continue;
-    const ref = leadingFieldRef(c.expression);
+    const ref = leadingFieldRef(c.expression!);
     if (!ref) continue;
     const fields = fieldsByEntity.get(ref.entity);
     if (fields && !fields.has(ref.field)) {
       errors.push(`${where} references '${ref.entity}.${ref.field}', but ` +
           `entity '${ref.entity}' declares no field '${ref.field}'.`);
     }
+  }
+  return errors;
+}
+
+// What a judged constraint must satisfy, beyond stating a body at all.
+//
+// Two of the three checks are about what a violation may do. A judged rule is
+// settled by a language model, which can decide two identical proposals
+// differently, so it may not be the last word on a refusal nobody may appeal.
+// Requiring the word rather than defaulting to `escalate` keeps one rule for
+// readers of the published aspect: absent means `reject`, whatever the body.
+//
+// `on_violation` bounds a judgment rather than fixing its outcome, and neither
+// check looks into the prose to confirm the bound holds -- the prose is prose.
+// A judgment naming a harsher response than its declared word is enforced at
+// the declared word, so the routing is safe and the published text is wrong;
+// VIOLATION_EFFECTS says why that cost is accepted and kept small.
+//
+// The third resolves the `Entity.field` tokens the prose mentions, which is the
+// whole of the static checking a judged rule can get.
+function judgedConstraintErrors(
+    c: Constraint, where: string,
+    fieldsByEntity: Map<string, Set<string>>|undefined): string[] {
+  const errors: string[] = [];
+  if (!c.judgment!.trim()) {
+    errors.push(`${where} has an empty judgment.`);
+    return errors;
+  }
+  if (c.onViolation === undefined) {
+    errors.push(
+        `${where} is judged, so it must state on_violation as 'escalate' or ` +
+        `'warn'. An unmarked constraint rejects the write, and a judged rule ` +
+        `may not do that.`);
+  } else if (c.onViolation === 'reject') {
+    errors.push(
+        `${where} is judged, so on_violation may not be 'reject'. Nobody may ` +
+        `approve a rejected write, and that authority cannot rest on a ` +
+        `judgment. Use 'escalate' to stop the write and let a human release ` +
+        `it, or 'warn' to report it. A condition that must refuse outright ` +
+        `belongs in its own constraint, stated as an expression.`);
+  }
+  errors.push(...unknownFieldRefs(c.judgment!, where, fieldsByEntity));
+  return errors;
+}
+
+// Every `Entity.field` token in a judgment whose entity the model declares and
+// whose field it does not.
+//
+// What makes a token a reference is that the model declares the entity, so no
+// spelling heuristic is needed and none is used: entity names here are as often
+// lowercase (`customer`, `orders`) as capitalized, and a rule keyed on the
+// capital would check some models and quietly skip others. An unrecognized
+// leading name is left alone on the principle that keeps leadingFieldRef
+// conservative -- a judgment may name a concept from another system, and
+// refusing to guess is what stops a valid rule being falsely rejected. A known
+// entity with an unknown field is the case where the author plainly meant this
+// model and got the name wrong, so that one is an error.
+//
+// The two segments must be adjacent to the dot, which is what keeps a sentence
+// boundary ("check the memo. Every credit...") out of the scan. A decimal
+// number cannot survive either, since no entity is named `30`.
+function unknownFieldRefs(
+    judgment: string, where: string,
+    fieldsByEntity: Map<string, Set<string>>|undefined): string[] {
+  if (!fieldsByEntity) return [];
+  const errors: string[] = [];
+  const seen = new Set<string>();
+  const token = /\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)/g;
+  for (let m = token.exec(judgment); m; m = token.exec(judgment)) {
+    const [, entity, field] = m;
+    const fields = fieldsByEntity.get(entity);
+    if (!fields || fields.has(field)) continue;
+    const ref = `${entity}.${field}`;
+    if (seen.has(ref)) continue;
+    seen.add(ref);
+    errors.push(
+        `${where} references '${ref}', but entity '${entity}' declares no ` +
+        `field '${field}'.`);
   }
   return errors;
 }

--- a/toolbox/mdcode/tests/libts/semantic/action_affects.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/action_affects.test.ts
@@ -435,9 +435,13 @@ describe('validatePushRequirements checks every affected concept', () => {
     return m;
   }
 
-  test('a dangling extends does not crash a model with no affects', () => {
-    // Nothing here reads the ontology, so nothing may resolve inheritance.
-    expect(validatePushRequirements([withDanglingSupertype([])])).toEqual([]);
+  test('a dangling extends is reported, not crashed on or ignored', () => {
+    // Nothing here reads the ontology, so nothing may resolve inheritance to
+    // answer a question. The model is still broken, and no other leg of a
+    // Knowledge-Catalog-only push would say so, so the gate reports it.
+    const errs = validatePushRequirements([withDanglingSupertype([])]);
+    expect(errs.length).toBe(1);
+    expect(errs[0]).toContain('extends unknown entity');
   });
 
   test('a dangling extends does not crash a profile push', () => {

--- a/toolbox/mdcode/tests/libts/semantic/action_guards.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/action_guards.test.ts
@@ -371,3 +371,63 @@ describe('guards survive every round trip', () => {
     expect(w).toContain(`'RequestedQuantityIsPositive'`);
   });
 });
+
+
+// A judged constraint states its rule as prose a language model settles. It
+// links to an action the way an expression does, and the two places the loader
+// treats it differently are both about what a warning can conclude.
+describe('judged constraints as guards', () => {
+  const judged = (name: string) => ({
+    name,
+    judgment: 'The request must be defensible.',
+    on_violation: 'escalate',
+  });
+
+  test('a judged constraint can guard an action', () => {
+    const {models, warnings} =
+        withGuards(['Defensible'], [judged('Defensible')]);
+    expect(models[0].actions![0].guards).toEqual(['Defensible']);
+    expect(warnings.some(w => w.includes('no constraint of that name')))
+        .toBe(false);
+  });
+
+  test('an action guarded only by judged constraints is warned about', () => {
+    // Nothing deterministic gates the write: no guard can lower to a store
+    // check, and none can refuse on its own.
+    const {warnings} = withGuards(['Defensible'], [judged('Defensible')]);
+    const w = warnings.find(x => x.includes('no deterministic gate'));
+    expect(w).toBeDefined();
+    expect(w).toContain(`action 'PlaceOrder'`);
+  });
+
+  test('one deterministic guard among them is enough to stay quiet', () => {
+    const {warnings} = withGuards(['Defensible', 'PositiveQuantity'], [
+      judged('Defensible'),
+      {name: 'PositiveQuantity', expression: 'quantity > 0'}
+    ]);
+    expect(warnings.some(w => w.includes('no deterministic gate'))).toBe(false);
+  });
+
+  test('an action naming no guards is not warned about', () => {
+    // The message is about the guards an action chose. An action that chose
+    // none raises a different question, which this does not answer.
+    const {warnings} = withGuards(undefined, [judged('Defensible')]);
+    expect(warnings.some(w => w.includes('no deterministic gate'))).toBe(false);
+  });
+
+  test(
+      'a judged constraint naming a parameter is not reported as unguarded',
+      () => {
+        // The unguarded-parameter scan looks for a bare identifier matching a
+        // parameter name. A judgment is prose, so `quantity` in it is as
+        // likely to be an ordinary noun as a reference, and concluding
+        // anything from the match would report rules that are well guarded.
+        const {warnings} =
+            withGuards(undefined, [{
+                         name: 'Defensible',
+                         judgment: 'The requested quantity must be defensible.',
+                         on_violation: 'warn',
+                       }]);
+        expect(warnings.some(w => w.includes(`'Defensible'`))).toBe(false);
+      });
+});

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -221,6 +221,22 @@ describe('validatePushRequirements gates constraints', () => {
     expect(errs).toEqual([]);
   });
 
+  test('a bad reference anywhere in an expression is a hard error', () => {
+    // The scan does not stop at the leading qualifier. A guard reads its
+    // action's parameters first, so the field it misspells is usually not the
+    // token the expression opens with.
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'amount <= customer.blance'}])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain('customer.blance');
+  });
+
+  test('a quoted literal in an expression is not a field reference', () => {
+    const errs = validatePushRequirements([loaded(
+        [{name: 'C', expression: "customer.balance = 'customer.blance'"}])]);
+    expect(errs).toEqual([]);
+  });
+
   // The field check reads a field list, and by the time this gate runs the
   // model's field lists are no longer what the author wrote. Both directions
   // of that gap rejected a valid constraint.
@@ -340,8 +356,8 @@ describe('validatePushRequirements gates constraints', () => {
     }
   });
 
-  // A judgment gets its `Entity.field` tokens resolved, which is stricter than
-  // an expression gets: leadingFieldRef checks only the leading qualifier.
+  // A judgment gets its `Entity.field` tokens resolved by the same scan an
+  // expression gets, so the two bodies are checked alike.
 
   test(
       'an unknown field on a KNOWN entity in a judgment is a hard error',

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -250,6 +250,30 @@ describe('validatePushRequirements gates constraints', () => {
     expect(() => validatePushRequirements([m])).not.toThrow();
   });
 
+  test('a bad extends does not throw through the affects check either', () => {
+    // The action check resolves inheritance by a second path. Standing one
+    // caller down and not the other leaves the stack trace exactly where a
+    // model is most likely to reach it.
+    const m = loaded([{name: 'C', expression: 'customer.balance >= 0'}]);
+    (m.model.entities[0] as any).extends = ['MissingParent'];
+    m.model.actions = [{
+      name: 'Touch',
+      description: 'd',
+      executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+      parameters: [],
+      affects: [{concept: 'customer', operation: 'modify'}],
+    }] as any;
+    expect(() => validatePushRequirements([m])).not.toThrow();
+  });
+
+  test('a dotted path is not read as a field of its first segment', () => {
+    // `customer.orders.total` is a path. Reading `orders` as a field of
+    // `customer` rejects it for a field the author never claimed existed.
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', expression: 'customer.orders.total > 0'}])]);
+    expect(errs).toEqual([]);
+  });
+
   test('a quoted literal in an expression is not a field reference', () => {
     const errs = validatePushRequirements([loaded(
         [{name: 'C', expression: "customer.balance = 'customer.blance'"}])]);

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -92,13 +92,41 @@ describe('loader parses constraints', () => {
   test('the expression is kept verbatim, not parsed', () => {
     // A compound expression the loader has no business interpreting: it belongs
     // to the evaluator, so it must survive character for character.
-    const expr = 'customer.balance >= 0 AND (total_revenue > 100 OR NOT flagged)';
+    const expr =
+        'customer.balance >= 0 AND (total_revenue > 100 OR NOT flagged)';
     const {models} = withConstraints([{name: 'C', expression: expr}]);
     expect(models[0].constraints![0].expression).toBe(expr);
   });
 
-  test('a constraint with no expression is rejected at parse', () => {
-    expect(() => withConstraints([{name: 'C'}])).toThrow();
+  test('a constraint with no body parses and is caught by validation', () => {
+    // Neither body is a schema-legal document, because the schema cannot say
+    // "one of these two". The push gate is where it fails; see the
+    // validatePushRequirements suite below.
+    const {models} = withConstraints([{name: 'C'}]);
+    expect(models[0].constraints).toEqual([{name: 'C'}]);
+  });
+
+  test('reads a judgment, and it is the whole of the body', () => {
+    const {models} = withConstraints([{
+      name: 'MemoNamesAFailure',
+      judgment: 'The credit memo must name a specific service failure.',
+      on_violation: 'escalate',
+    }]);
+    expect(models[0].constraints).toEqual([{
+      name: 'MemoNamesAFailure',
+      judgment: 'The credit memo must name a specific service failure.',
+      onViolation: 'escalate',
+    }]);
+    expect(models[0].constraints![0].expression).toBeUndefined();
+  });
+
+  test('the judgment is kept verbatim, not reflowed', () => {
+    const prose =
+        'A discount over 30% must be justified by customer.balance history,\n' +
+        'not by the size of the order alone.';
+    const {models} =
+        withConstraints([{name: 'C', judgment: prose, on_violation: 'warn'}]);
+    expect(models[0].constraints![0].judgment).toBe(prose);
   });
 
   test('duplicate constraint names are rejected', () => {
@@ -226,12 +254,14 @@ describe('validatePushRequirements gates constraints', () => {
   }
 
   test('a constraint over an INHERITED field passes', () => {
-    const errs = validatePushRequirements([withInheritance('savings.balance >= 0')]);
+    const errs =
+        validatePushRequirements([withInheritance('savings.balance >= 0')]);
     expect(errs).toEqual([]);
   });
 
   test('a typo is still caught on an entity that inherits', () => {
-    const errs = validatePushRequirements([withInheritance('savings.blance >= 0')]);
+    const errs =
+        validatePushRequirements([withInheritance('savings.blance >= 0')]);
     expect(errs).toHaveLength(1);
     expect(errs[0]).toContain(`declares no field 'blance'`);
   });
@@ -255,13 +285,174 @@ describe('validatePushRequirements gates constraints', () => {
     expect(errs).toHaveLength(1);
     expect(errs[0]).toContain('empty expression');
   });
+
+  // A constraint states its rule in one body or the other. The schema cannot
+  // express that, so both halves of the exclusivity land here.
+
+  test('declaring both bodies is a hard error', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'C',
+      expression: 'customer.balance >= 0',
+      judgment: 'The balance must be defensible.',
+    }])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain('declares both an expression and a judgment');
+  });
+
+  test('declaring neither body is a hard error', () => {
+    const errs = validatePushRequirements([loaded([{name: 'C'}])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain('declares neither an expression nor a judgment');
+  });
+
+  test('an empty judgment is a hard error', () => {
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', judgment: '  ', onViolation: 'warn'}])]);
+    expect(errs.some(e => e.includes('empty judgment'))).toBe(true);
+  });
+
+  test('a well-formed judged constraint passes', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'C',
+      judgment: 'A credit must be justified by a stated service failure.',
+      onViolation: 'escalate',
+    }])]);
+    expect(errs).toEqual([]);
+  });
+
+  test('a judged constraint must state on_violation', () => {
+    // An unmarked constraint rejects, and a judged rule may not, so the safe
+    // default is unavailable and silence cannot stand in for a choice.
+    const errs = validatePushRequirements(
+        [loaded([{name: 'C', judgment: 'The memo must be specific.'}])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain(
+        `must state on_violation as 'escalate' or 'warn'`);
+  });
+
+  test('a judged constraint may not reject', () => {
+    // The one real mitigation for a non-deterministic evaluation: it can stop a
+    // write for a person to release, and it cannot be the last word refusing
+    // one.
+    const errs = validatePushRequirements([loaded([{
+      name: 'C',
+      judgment: 'The memo must be specific.',
+      onViolation: 'reject',
+    }])]);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain(`on_violation may not be 'reject'`);
+    expect(errs[0]).toContain('stated as an expression');
+  });
+
+  test('escalate and warn are both accepted', () => {
+    for (const onViolation of ['escalate', 'warn'] as const) {
+      const errs = validatePushRequirements(
+          [loaded([{name: 'C', judgment: 'Be specific.', onViolation}])]);
+      expect(errs).toEqual([]);
+    }
+  });
+
+  // A judgment gets its `Entity.field` tokens resolved, which is stricter than
+  // an expression gets: leadingFieldRef checks only the leading qualifier.
+
+  test(
+      'an unknown field on a KNOWN entity in a judgment is a hard error',
+      () => {
+        const errs = validatePushRequirements([loaded([{
+          name: 'C',
+          judgment: 'The write must be consistent with customer.blance.',
+          onViolation: 'warn',
+        }])]);
+        expect(errs).toHaveLength(1);
+        expect(errs[0]).toContain('customer.blance');
+      });
+
+  test(
+      'a field reference anywhere in the prose is checked, not just the first',
+      () => {
+        const errs = validatePushRequirements([loaded([{
+          name: 'C',
+          judgment: 'Given customer.balance, the memo must also cite ' +
+              'customer.blance and customer.nope.',
+          onViolation: 'warn',
+        }])]);
+        expect(errs).toHaveLength(2);
+        expect(errs.some(e => e.includes('customer.blance'))).toBe(true);
+        expect(errs.some(e => e.includes('customer.nope'))).toBe(true);
+      });
+
+  test('the same bad reference twice is reported once', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'C',
+      judgment: 'Cite customer.blance, and check customer.blance again.',
+      onViolation: 'warn',
+    }])]);
+    expect(errs).toHaveLength(1);
+  });
+
+  test('an unrecognized entity in a judgment is left alone', () => {
+    // A judgment may name a concept from another system, and a wrong guess
+    // here would refuse a valid rule. Only a known entity with an unknown
+    // field is plainly a typo.
+    const errs = validatePushRequirements([loaded([{
+      name: 'C',
+      judgment: 'The write must respect Salesforce.opportunity_stage.',
+      onViolation: 'warn',
+    }])]);
+    expect(errs).toEqual([]);
+  });
+
+  test('ordinary prose is not mistaken for a field reference', () => {
+    // A sentence boundary and a decimal both look like `x.y` to a careless
+    // scan. Neither survives, because the leading segment has to name a
+    // declared entity.
+    const errs = validatePushRequirements([loaded([{
+      name: 'C',
+      judgment: 'Check the memo. Every credit over 30.5% needs a reason.',
+      onViolation: 'warn',
+    }])]);
+    expect(errs).toEqual([]);
+  });
+
+  test('a lowercase entity name is checked like any other', () => {
+    // The scan keys on the model declaring the entity rather than on the name
+    // being capitalized: these models name entities `customer` and `orders`.
+    const good = validatePushRequirements([loaded([{
+      name: 'C',
+      judgment: 'Weigh customer.balance against the stated reason.',
+      onViolation: 'warn',
+    }])]);
+    expect(good).toEqual([]);
+  });
+
+  test('the field check in a judgment stands down on a pruned model', () => {
+    const errs = validatePushRequirements(
+        [loaded([{
+          name: 'C',
+          judgment: 'Consider customer.unbound before approving.',
+          onViolation: 'warn',
+        }])],
+        {fieldsPruned: true});
+    expect(errs).toEqual([]);
+  });
+
+  test('the routing checks still run on a pruned model', () => {
+    // Pruning is about fields. What a violation may do does not depend on
+    // which columns this profile binds.
+    const errs = validatePushRequirements(
+        [loaded(
+            [{name: 'C', judgment: 'Be specific.', onViolation: 'reject'}])],
+        {fieldsPruned: true});
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain(`may not be 'reject'`);
+  });
 });
 
 
 describe('OSI round trip', () => {
   test('constraints survive serialize -> reload', () => {
     const model = loadFixtureModel('actions_place_order.yaml');
-    expect(model.constraints).toHaveLength(4);
+    expect(model.constraints).toHaveLength(5);
     const {yaml} = serializeModel(model);
     expect(yaml).toContain('constraints:');
     const reloaded = loadModels(yaml).models[0];
@@ -282,53 +473,62 @@ describe('Knowledge Catalog publish/pull round trip', () => {
   const CONSTRAINT_ASPECT = 'dest.global.semantic-constraint';
 
   function constraintEntriesOf(m: SemanticModel) {
-    return generateCatalogResources(m, OPTS)
-        .entries.filter(e => e.entryType.endsWith(CONSTRAINT_ENTRY_TYPE));
+    return generateCatalogResources(m, OPTS).entries.filter(
+        e => e.entryType.endsWith(CONSTRAINT_ENTRY_TYPE));
   }
 
-  test('every constraint becomes one entry, parented to the model anchor',
-       () => {
-         const {entries, warnings} = generateCatalogResources(model, OPTS);
-         const constraints =
-             entries.filter(e => e.entryType.endsWith(CONSTRAINT_ENTRY_TYPE));
-         expect(constraints.map(e => e.name.split('/entries/')[1])).toEqual([
-           'sales.constraints.NonNegativeOrderTotal',
-           'sales.constraints.PositiveQuantity',
-           'sales.constraints.OrderWithinStandingLimit',
-           'sales.constraints.RequestedQuantityIsPositive',
-         ]);
-         for (const e of constraints) expect(e.parentEntry).toBe(entries[0].name);
-         // Author is warned constraints are catalog-only.
-         expect(warnings.some(w => w.includes('constraint(s) published')))
-             .toBe(true);
-       });
+  test(
+      'every constraint becomes one entry, parented to the model anchor',
+      () => {
+        const {entries, warnings} = generateCatalogResources(model, OPTS);
+        const constraints =
+            entries.filter(e => e.entryType.endsWith(CONSTRAINT_ENTRY_TYPE));
+        expect(constraints.map(e => e.name.split('/entries/')[1])).toEqual([
+          'sales.constraints.NonNegativeOrderTotal',
+          'sales.constraints.PositiveQuantity',
+          'sales.constraints.OrderWithinStandingLimit',
+          'sales.constraints.RequestedQuantityIsPositive',
+          'sales.constraints.LargeOrderIsJustified',
+        ]);
+        for (const e of constraints)
+          expect(e.parentEntry).toBe(entries[0].name);
+        // Author is warned constraints are catalog-only.
+        expect(warnings.some(w => w.includes('constraint(s) published')))
+            .toBe(true);
+      });
 
-  test('the entry type is custom, so it lives in the destination project',
-       () => {
-         // Every built-in type is referenced from `dataplex-types`; this one is
-         // provisioned by `kcmd init` in the project being pushed to.
-         const [first] = constraintEntriesOf(model);
-         expect(first.entryType)
-             .toBe('projects/dest/locations/global/entryTypes/' +
-                   'semantic-constraint');
-         expect(first.aspects![CONSTRAINT_ASPECT].aspectType)
-             .toBe('projects/dest/locations/global/aspectTypes/' +
-                   'semantic-constraint');
-       });
+  test(
+      'the entry type is custom, so it lives in the destination project',
+      () => {
+        // Every built-in type is referenced from `dataplex-types`; this one is
+        // provisioned by `kcmd init` in the project being pushed to.
+        const [first] = constraintEntriesOf(model);
+        expect(first.entryType)
+            .toBe(
+                'projects/dest/locations/global/entryTypes/' +
+                'semantic-constraint');
+        expect(first.aspects![CONSTRAINT_ASPECT].aspectType)
+            .toBe(
+                'projects/dest/locations/global/aspectTypes/' +
+                'semantic-constraint');
+      });
 
-  test('the aspect carries the expression and the entry source the description',
-       () => {
-         // PositiveQuantity is the fixture's constraint with no `ai_context`,
-         // so its aspect is the expression alone.
-         const positive = constraintEntriesOf(model).find(
-             e => e.entrySource!.displayName === 'PositiveQuantity')!;
-         expect(positive.aspects![CONSTRAINT_ASPECT].data)
-             .toEqual({expression: 'OrderedAs.quantity > 0'});
-         // The description is the message a violation quotes back, so it is the
-         // entry's human-readable summary rather than an aspect field.
-         expect(positive.entrySource!.description)
-             .toBe('An order line must be for at least one unit.');
-       });
+  test(
+      'the aspect carries the expression and the entry source the description',
+      () => {
+        // PositiveQuantity is the fixture's constraint with no `ai_context`,
+        // so its aspect is the expression alone.
+        const positive = constraintEntriesOf(model).find(
+            e => e.entrySource!.displayName === 'PositiveQuantity')!;
+        expect(positive.aspects![CONSTRAINT_ASPECT].data).toEqual({
+          expression: 'OrderedAs.quantity > 0',
+          evaluation: 'deterministic',
+        });
+        // The description is the message a violation quotes back, so it is the
+        // entry's human-readable summary rather than an aspect field.
+        expect(positive.entrySource!.description)
+            .toBe('An order line must be for at least one unit.');
+      });
 
   test('the whole ai_context rides the constraint\'s own aspect', () => {
     // Not `instructions` alone: the built-in guidelines aspect has a home for
@@ -338,6 +538,7 @@ describe('Knowledge Catalog publish/pull round trip', () => {
     expect(nonNegative.entrySource!.displayName).toBe('NonNegativeOrderTotal');
     expect(nonNegative.aspects![CONSTRAINT_ASPECT].data).toEqual({
       expression: 'orders.o_totalprice >= 0',
+      evaluation: 'deterministic',
       aiContext: {
         instructions:
             'Quote the shortfall in the customer\'s own currency when refusing.',
@@ -509,21 +710,128 @@ describe('Knowledge Catalog publish/pull round trip', () => {
     // A hand-edited aspect can carry a blank expression. Such a constraint
     // states no invariant, so it degrades itself rather than the pull.
     const {entries} = generateCatalogResources(model, OPTS);
-    const broken = entries.find(
-        e => e.entrySource?.displayName === 'PositiveQuantity')!;
+    const broken =
+        entries.find(e => e.entrySource?.displayName === 'PositiveQuantity')!;
     broken.aspects![CONSTRAINT_ASPECT].data!.expression = '  ';
     const {models, warnings} = modelsFromCatalogResources(entries);
     expect(models[0].constraints!.map(c => c.name)).toEqual([
       'NonNegativeOrderTotal',
       'OrderWithinStandingLimit',
       'RequestedQuantityIsPositive',
+      'LargeOrderIsJustified',
     ]);
     expect(warnings.some(
-               w => w.includes("constraint 'PositiveQuantity'") &&
-                   w.includes('no expression')))
+               w => w.includes('constraint \'PositiveQuantity\'') &&
+                   w.includes('no expression and no judgment')))
         .toBe(true);
     // The actions, published under their own type, are unaffected.
     expect(models[0].actions).toHaveLength(1);
+  });
+
+  test('an entry stating both bodies is skipped and warned', () => {
+    // The same reading as neither: a constraint that answers both ways states
+    // no single rule, and pulling it would produce a model that fails its own
+    // push-side validation.
+    const {entries} = generateCatalogResources(model, OPTS);
+    const broken =
+        entries.find(e => e.entrySource?.displayName === 'PositiveQuantity')!;
+    broken.aspects![CONSTRAINT_ASPECT].data!.judgment = 'Also be reasonable.';
+    const {models, warnings} = modelsFromCatalogResources(entries);
+    expect(models[0].constraints!.map(c => c.name))
+        .not.toContain('PositiveQuantity');
+    expect(warnings.some(
+               w => w.includes('constraint \'PositiveQuantity\'') &&
+                   w.includes('both an expression and a judgment')))
+        .toBe(true);
+  });
+});
+
+
+// A judged constraint is the second body: the rule stated in words, for rules
+// no expression decides. It travels the same pipeline as an expression, so what
+// follows checks the places the two diverge.
+describe('judged constraints', () => {
+  const judged: SemanticModel = {
+    name: 'sales',
+    entities: [{
+      name: 'credit',
+      dataSource: 'p.d.credit',
+      keys: ['id'],
+      fields: [{name: 'memo'}, {name: 'amount'}],
+    }],
+    relationships: [],
+    metrics: [],
+    constraints: [
+      {
+        name: 'MemoNamesAFailure',
+        judgment:
+            'The credit.memo must name a specific service failure rather ' +
+            'than restating the amount.',
+        description: 'Say which service failure the credit is for.',
+        onViolation: 'escalate',
+        severity: 'high',
+      },
+      {
+        name: 'NonNegativeAmount',
+        expression: 'credit.amount >= 0',
+      },
+    ],
+  };
+  const CONSTRAINT_ASPECT = 'dest.global.semantic-constraint';
+
+  function aspectOf(m: SemanticModel, name: string) {
+    return generateCatalogResources(m, OPTS)
+        .entries.find(e => e.entrySource?.displayName === name)!
+        .aspects![CONSTRAINT_ASPECT]
+        .data!;
+  }
+
+  test(
+      'the judgment rides the aspect and the description the entry source',
+      () => {
+        const {entries} = generateCatalogResources(judged, OPTS);
+        const entry = entries.find(
+            e => e.entrySource?.displayName === 'MemoNamesAFailure')!;
+        expect(entry.aspects![CONSTRAINT_ASPECT].data).toEqual({
+          judgment: 'The credit.memo must name a specific service failure ' +
+              'rather than restating the amount.',
+          evaluation: 'judged',
+          onViolation: 'escalate',
+          severity: 'high',
+        });
+        expect(entry.entrySource!.description)
+            .toBe('Say which service failure the credit is for.');
+      });
+
+  test('evaluation is derived, so each body publishes its own word', () => {
+    expect(aspectOf(judged, 'MemoNamesAFailure').evaluation).toBe('judged');
+    expect(aspectOf(judged, 'NonNegativeAmount').evaluation)
+        .toBe('deterministic');
+  });
+
+  test('a pull recovers the judgment and recomputes evaluation', () => {
+    // `evaluation` is never read back: recomputing it from the body that
+    // returned is the only reading that cannot go stale against it.
+    const {entries, entryLinks} = generateCatalogResources(judged, OPTS);
+    const {models, warnings} = modelsFromCatalogResources(entries, entryLinks);
+    expect(models[0].constraints).toEqual(judged.constraints);
+    expect(warnings.filter(w => w.includes('MemoNamesAFailure'))).toEqual([]);
+  });
+
+  test('push -> pull -> push is a fixed point', () => {
+    const first = generateCatalogResources(judged, OPTS);
+    const {models} =
+        modelsFromCatalogResources(first.entries, first.entryLinks);
+    const second = generateCatalogResources(models[0], OPTS);
+    expect(second.entries).toEqual(first.entries);
+  });
+
+  test('the judgment survives serialize -> reload', () => {
+    const {yaml} = serializeModel(judged);
+    expect(yaml).toContain('judgment:');
+    // Derived, so it has no place in an authored document.
+    expect(yaml).not.toContain('evaluation:');
+    expect(loadModels(yaml).models[0].constraints).toEqual(judged.constraints);
   });
 });
 
@@ -541,12 +849,12 @@ describe('a graph leg says what it dropped', () => {
   ] as const) {
     test(`the ${backend} leg warns about actions and constraints`, () => {
       const {warnings} = generate(model());
-      // The fixture declares one action and four constraints.
+      // The fixture declares one action and five constraints.
       expect(warnings.some(
                  w => /1 action\(s\) reach Knowledge Catalog only/.test(w)))
           .toBe(true);
       expect(warnings.some(
-                 w => /4 constraint\(s\) reach Knowledge Catalog only/.test(w)))
+                 w => /5 constraint\(s\) reach Knowledge Catalog only/.test(w)))
           .toBe(true);
       // Named the system it does reach, and the one that drops it.
       expect(warnings.some(w => w.includes(`the ${backend} push deploys none`)))

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -231,6 +231,25 @@ describe('validatePushRequirements gates constraints', () => {
     expect(errs[0]).toContain('customer.blance');
   });
 
+  test('an entity that declares no fields is not scanned', () => {
+    // Fields are optional, and a logical model bound to nothing but Knowledge
+    // Catalog routinely declares none. Reading an empty set as "this entity
+    // has no such field" would refuse every constraint such a model can write.
+    const m = loaded([{name: 'C', expression: 'orders.total >= 0'}]);
+    m.model.entities = [
+      {name: 'orders', dataSource: 'p.d.o', keys: ['id']} as any,
+    ];
+    expect(validatePushRequirements([m])).toEqual([]);
+  });
+
+  test('an extends naming an undeclared entity does not throw', () => {
+    // declaredFields resolves inheritance, and that throws on an unknown
+    // parent. A validation gate reports; it does not stack-trace.
+    const m = loaded([{name: 'C', expression: 'customer.balance >= 0'}]);
+    (m.model.entities[0] as any).extends = ['MissingParent'];
+    expect(() => validatePushRequirements([m])).not.toThrow();
+  });
+
   test('a quoted literal in an expression is not a field reference', () => {
     const errs = validatePushRequirements([loaded(
         [{name: 'C', expression: "customer.balance = 'customer.blance'"}])]);

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -321,31 +321,19 @@ describe('validatePushRequirements gates constraints', () => {
   });
 
   test('a judged constraint must state on_violation', () => {
-    // An unmarked constraint rejects, and a judged rule may not, so the safe
-    // default is unavailable and silence cannot stand in for a choice.
+    // Silence means `reject`, which is too strong a thing for an author to
+    // inherit by leaving the key out of a rule a model settles.
     const errs = validatePushRequirements(
         [loaded([{name: 'C', judgment: 'The memo must be specific.'}])]);
     expect(errs).toHaveLength(1);
-    expect(errs[0]).toContain(
-        `must state on_violation as 'escalate' or 'warn'`);
+    expect(errs[0]).toContain('is judged, so it must state on_violation');
   });
 
-  test('a judged constraint may not reject', () => {
-    // The one real mitigation for a non-deterministic evaluation: it can stop a
-    // write for a person to release, and it cannot be the last word refusing
-    // one.
-    const errs = validatePushRequirements([loaded([{
-      name: 'C',
-      judgment: 'The memo must be specific.',
-      onViolation: 'reject',
-    }])]);
-    expect(errs).toHaveLength(1);
-    expect(errs[0]).toContain(`on_violation may not be 'reject'`);
-    expect(errs[0]).toContain('stated as an expression');
-  });
-
-  test('escalate and warn are both accepted', () => {
-    for (const onViolation of ['escalate', 'warn'] as const) {
+  test('all three words are accepted on a judgment', () => {
+    // `reject` included. A rule an organization means as unappealable is
+    // representable, and publishes as `judged` beside the word so the pairing
+    // can be found.
+    for (const onViolation of ['reject', 'escalate', 'warn'] as const) {
       const errs = validatePushRequirements(
           [loaded([{name: 'C', judgment: 'Be specific.', onViolation}])]);
       expect(errs).toEqual([]);
@@ -436,15 +424,13 @@ describe('validatePushRequirements gates constraints', () => {
     expect(errs).toEqual([]);
   });
 
-  test('the routing checks still run on a pruned model', () => {
-    // Pruning is about fields. What a violation may do does not depend on
-    // which columns this profile binds.
+  test('the routing check still runs on a pruned model', () => {
+    // Pruning is about fields. Whether a violation says what it does not
+    // depend on which columns this profile binds.
     const errs = validatePushRequirements(
-        [loaded(
-            [{name: 'C', judgment: 'Be specific.', onViolation: 'reject'}])],
-        {fieldsPruned: true});
+        [loaded([{name: 'C', judgment: 'Be specific.'}])], {fieldsPruned: true});
     expect(errs).toHaveLength(1);
-    expect(errs[0]).toContain(`may not be 'reject'`);
+    expect(errs[0]).toContain('is judged, so it must state on_violation');
   });
 });
 

--- a/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/constraints.test.ts
@@ -274,6 +274,70 @@ describe('validatePushRequirements gates constraints', () => {
     expect(errs).toEqual([]);
   });
 
+  test('a tail naming a relationship is not read as a field', () => {
+    // `customer.OwnedBy` is a traversal. The model declares the name, so the
+    // scan cannot call it a misspelling.
+    const m = loaded([{
+      name: 'C',
+      judgment: 'Trace the balance through customer.OwnedBy before approving.',
+      onViolation: 'warn',
+    }]);
+    m.model.relationships = [{
+      name: 'OwnedBy',
+      source: {entity: 'customer', columns: ['id']},
+      destination: {entity: 'customer', columns: ['id']},
+    }];
+    expect(validatePushRequirements([m])).toEqual([]);
+  });
+
+  test('a tail naming a metric is not read as a field', () => {
+    // Metrics are model-level, so the qualifier is the entity the metric hangs
+    // off rather than an entity that declares it as a field.
+    const m = loaded([{name: 'C', expression: '0 <= customer.total_owed'}]);
+    m.model.metrics = [{name: 'total_owed', entity: 'customer'}];
+    expect(validatePushRequirements([m])).toEqual([]);
+  });
+
+  test('a tail naming another entity is not read as a field', () => {
+    const m = loaded([{name: 'C', expression: 'customer.account > 0'}]);
+    m.model.entities.push(
+        {name: 'account', dataSource: 'p.d.a', keys: ['id'], fields: []} as
+        any);
+    expect(validatePushRequirements([m])).toEqual([]);
+  });
+
+  test('a tail the model declares nowhere is still a misspelling', () => {
+    // The carve-outs above must not swallow the case the scan exists for.
+    const m = loaded([{name: 'C', expression: 'customer.blance > 0'}]);
+    m.model.relationships = [{
+      name: 'OwnedBy',
+      source: {entity: 'customer', columns: ['id']},
+      destination: {entity: 'customer', columns: ['id']},
+    }];
+    m.model.metrics = [{name: 'total_owed', entity: 'customer'}];
+    const errs = validatePushRequirements([m]);
+    expect(errs.some(e => e.includes("declares no field 'blance'"))).toBe(true);
+  });
+
+  test('an extends naming an undeclared entity is reported', () => {
+    // Standing the field scan down cannot mean saying nothing: nothing else on
+    // a Knowledge-Catalog-only push resolves inheritance, so silence here
+    // publishes the broken model.
+    const m = loaded([{name: 'C', expression: 'customer.balance >= 0'}]);
+    (m.model.entities[0] as any).extends = ['MissingParent'];
+    const errs = validatePushRequirements([m]);
+    expect(errs.some(e => e.includes('MissingParent'))).toBe(true);
+  });
+
+  test('an empty judgment still reports a missing on_violation', () => {
+    // The two are independent. Reporting only the empty body sends the author
+    // back for a second failure over a key they were never told about.
+    const errs =
+        validatePushRequirements([loaded([{name: 'C', judgment: '   '}])]);
+    expect(errs.some(e => e.includes('empty judgment'))).toBe(true);
+    expect(errs.some(e => e.includes('on_violation'))).toBe(true);
+  });
+
   test('a quoted literal in an expression is not a field reference', () => {
     const errs = validatePushRequirements([loaded(
         [{name: 'C', expression: "customer.balance = 'customer.blance'"}])]);

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.knowledge_catalog.golden.json
@@ -190,6 +190,7 @@
           "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
           "data": {
             "expression": "orders.o_totalprice >= 0",
+            "evaluation": "deterministic",
             "aiContext": {
               "instructions": "Quote the shortfall in the customer's own currency when refusing.",
               "synonyms": [
@@ -216,7 +217,8 @@
         "sqlgen-testing.global.semantic-constraint": {
           "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
           "data": {
-            "expression": "OrderedAs.quantity > 0"
+            "expression": "OrderedAs.quantity > 0",
+            "evaluation": "deterministic"
           }
         }
       }
@@ -234,6 +236,7 @@
           "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
           "data": {
             "expression": "orders.o_totalprice <= 100000",
+            "evaluation": "deterministic",
             "onViolation": "escalate",
             "severity": "high"
           }
@@ -252,7 +255,28 @@
         "sqlgen-testing.global.semantic-constraint": {
           "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
           "data": {
-            "expression": "quantity > 0"
+            "expression": "quantity > 0",
+            "evaluation": "deterministic"
+          }
+        }
+      }
+    },
+    {
+      "name": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales.constraints.LargeOrderIsJustified",
+      "entryType": "projects/sqlgen-testing/locations/global/entryTypes/semantic-constraint",
+      "parentEntry": "projects/sqlgen-testing/locations/us/entryGroups/semantic/entries/sales",
+      "entrySource": {
+        "displayName": "LargeOrderIsJustified",
+        "description": "Say what makes this order larger than usual, then resubmit for approval."
+      },
+      "aspects": {
+        "sqlgen-testing.global.semantic-constraint": {
+          "aspectType": "projects/sqlgen-testing/locations/global/aspectTypes/semantic-constraint",
+          "data": {
+            "judgment": "An order whose orders.o_totalprice is far above what this customer usually places must be explained by something in the request itself, such as a stated event or a contract reference. A round number alone is not an explanation.",
+            "evaluation": "judged",
+            "onViolation": "escalate",
+            "severity": "medium"
           }
         }
       }
@@ -302,7 +326,7 @@
   ],
   "warnings": [
     "model 'sales': 1 action(s) published as semantic-action entries (Knowledge Catalog is the only system an action reaches).",
-    "model 'sales': 4 constraint(s) published as semantic-constraint entries (Knowledge Catalog is the only system a constraint reaches).",
+    "model 'sales': 5 constraint(s) published as semantic-constraint entries (Knowledge Catalog is the only system a constraint reaches).",
     "relationship 'orders_to_customer': Knowledge Catalog stores the name only in the normalized link id, so a pull returns it lowercased/hyphenated (e.g. 'orders-to-customer'), not 'orders_to_customer'."
   ]
 }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.osi.golden.yaml
@@ -104,3 +104,12 @@ semantic_model:
         expression: quantity > 0
         description: A request must be for at least one unit. Ask the caller for the
           quantity again before retrying.
+      - name: LargeOrderIsJustified
+        judgment: An order whose orders.o_totalprice is far above what this customer
+          usually places must be explained by something in the request itself,
+          such as a stated event or a contract reference. A round number alone
+          is not an explanation.
+        description: Say what makes this order larger than usual, then resubmit for
+          approval.
+        on_violation: escalate
+        severity: medium

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.pull.golden.yaml
@@ -86,3 +86,12 @@ semantic_model:
         expression: quantity > 0
         description: A request must be for at least one unit. Ask the caller for the
           quantity again before retrying.
+      - name: LargeOrderIsJustified
+        judgment: An order whose orders.o_totalprice is far above what this customer
+          usually places must be explained by something in the request itself,
+          such as a stated event or a contract reference. A round number alone
+          is not an explanation.
+        description: Say what makes this order larger than usual, then resubmit for
+          approval.
+        on_violation: escalate
+        severity: medium

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -7,13 +7,17 @@
 # scalar ones. The model also names a BigQuery deployment target, so a push
 # exercises the leg that deploys neither an action nor a constraint.
 #
-# The four constraints cover every validation path. NonNegativeOrderTotal opens
-# with a KNOWN entity, so its field is checked. PositiveQuantity opens with
-# `OrderedAs`, which is no entity, so it is left to the evaluator rather than
-# falsely rejected. RequestedQuantityIsPositive reads the action's `quantity`
-# parameter, so PlaceOrder names it in `guards`. OrderWithinStandingLimit is the
-# only one to state the two routing words, so the goldens show `on_violation`
-# and `severity` making the round trip while the other three show their absence.
+# The five constraints cover every validation path. NonNegativeOrderTotal names
+# a KNOWN entity, so its field is checked; every qualified token in an
+# expression is, wherever it appears. PositiveQuantity names `OrderedAs`, which
+# is no entity, so it is left to the evaluator rather than falsely rejected.
+# RequestedQuantityIsPositive reads the action's `quantity` parameter, so
+# PlaceOrder names it in `guards`. LargeOrderIsJustified states a `judgment`
+# rather than an expression, so the goldens carry the derived `evaluation:
+# judged` and the required `on_violation` beside it. OrderWithinStandingLimit
+# and LargeOrderIsJustified are the two that state routing words, so the goldens
+# show `on_violation` and `severity` making the round trip while the other three
+# show their absence.
 #
 # PlaceOrder's `affects` covers every authored shape at once: an entry on an
 # entity narrowed to the fields it writes, an entry on a relationship, and the

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_place_order.yaml
@@ -135,3 +135,14 @@ semantic_model:
         description: >-
           A request must be for at least one unit. Ask the caller for the
           quantity again before retrying.
+      - name: LargeOrderIsJustified
+        judgment: >-
+          An order whose orders.o_totalprice is far above what this customer
+          usually places must be explained by something in the request itself,
+          such as a stated event or a contract reference. A round number alone
+          is not an explanation.
+        description: >-
+          Say what makes this order larger than usual, then resubmit for
+          approval.
+        on_violation: escalate
+        severity: medium


### PR DESCRIPTION
## What

A constraint may now state its rule as a **judgment** — the rule in words — instead of a boolean expression.

```yaml
constraints:
  - name: DiscountIsJustified
    judgment: >-
      A discount over 30% must be justified by the reason given in
      Order.discount_reason. A reason that only restates the discount, such as
      "competitive pricing", is not a justification.
    description: >-
      Say what makes this discount necessary, then resubmit for approval.
    on_violation: escalate
    severity: high
```

## Why

Every constraint today must be a boolean expression, which excludes the rules a business most wants governed. Whether a discount is justified by the reason given, whether a refund note explains the exception it claims — a query can read that text and cannot settle it. Those rules currently have nowhere to live in the model, so they live in a policy document nothing links to.

## The design

**One new authored field.** `judgment` is mutually exclusive with `expression`. Declaring both answers "can this be computed?" two ways at once, which answers it neither way; declaring neither states no rule. Both are load errors naming the constraint.

**References are checked.** Field names in a judgment are written model-qualified (`Order.discount_reason` rather than "the reason"). `validate` resolves every `Entity.field` token in the prose against the model, so the reference is checked and lives in the sentence that uses it rather than in a second list that drifts from it.

**A judgment must say what a violation does.** `on_violation` is required on a judgment, and may be any of the three words. Leaving the key out is the only error: an unmarked constraint rejects, and that is too strong a consequence for an author of a judged rule to inherit by silence. This is the sole rule specific to judgments.

**A judgment may declare `reject`.** Pairing a rule a model settles with an outcome nobody may appeal is the riskiest thing the format can express. Forbidding it does not prevent the policy, because a rule no expression decides has no expression to fall back to — the prohibition only moves the rule out of the catalog. So the pairing is published and made findable instead: the derived `evaluation` field carries `judged` beside the word, so "unappealable rules settled by a model" is one query.

**`on_violation` means what a violation does.** An earlier revision of this branch read it as a ceiling that an evaluation could settle beneath. That bought one narrow case — grading a single judged condition across a range — at the cost of a reading no loader could check against the prose it bounded. It is gone.

**A constraint takes effect only where something references it.** Declaring one adds a rule to the catalog and refuses nothing. `guards` on an action is the only reference the model defines, and rules of both kinds belong in it. One over an action's parameters has no other moment to run. One over stored data checks that the call does not start from a broken state. Adding a constraint to a published model therefore cannot make a call that worked yesterday start failing today, which is what makes it safe to write rules down before anything enforces them.

**A policy that branches is several constraints.** One `on_violation` cannot carry two consequences, so conditions that end differently are separate constraints, listed together by an action's `guards`. When more than one fires, the strictest outcome applies: any `reject` refuses, failing that any `escalate` holds, failing that any `warn` reports. That combination is fixed and nothing in the model states it, which is why an action can name any number of guards without saying how to add them up. It is also `forbid` over `permit` in Cedar and deny-wins in OPA.

**A derived `evaluation` field on the published aspect.** No author writes it. It restates which body was used, as `deterministic` or `judged`, so a consumer selecting rules to lower into SQL and one selecting rules to hand a judge each read one field instead of testing which body is populated. Pull recomputes it from the body that came back rather than reading it, and it is never emitted into an authored OSI document, so it cannot go stale.

**One new load warning.** An action whose every guard is judged has no gate a query can decide: every call costs a model decision, and none of its rules can lower to a store-level check. One expression guard among them silences it.

## The authoring guide

`docs/semantic-model/actions.md` gains two sections a reader needs before writing one of these.

*Writing a judgment* gives the five habits that make a sentence read consistently: state what must be true of the data rather than the procedure to check it; name fields model-qualified; say what does **not** count, because a rule with no negative example is graded against whatever the model guesses; leave the consequence out of the prose, since `on_violation` carries it; keep it to one condition.

*A policy whose rules end differently* works a customer-credit policy end to end: a credit may not exceed its order; a credit over 25 dollars needs a supervisor; an order's total always equals the sum of its line items; the memo must name a specific service failure; and a credit must not be one larger credit split up to stay under the limit. Five rules, three outcomes, two of them judged, all under one `IssueCredit` action.

Two things that example teaches which a flatter one cannot. The total-matches-line-items rule is the one nobody in the business may approve, which is why it says `reject`, and it is named in `guards` like the other four, because a rule no action names is a rule no call consults. That is where the guide says what `reject` means and how much of it a guard delivers. Naming the rule makes `IssueCredit` refuse to run against an order whose books already disagree. Catching the credit that *breaks* the agreement is a check against the state the write produces, and the model cannot bind one yet. And the guide walks two calls through: a 30-dollar credit with a specific memo, held for a supervisor by the threshold rule; then three 9-dollar credits memoed "customer asked", where both computable gates pass and only the judged rules catch the evasion, `warn` and `reject` combining to a refusal. That is the answer to "if this happens escalate, if that happens reject": the branching lives in the `on_violation` column, where a search can read it, rather than inside a paragraph of prose.

The model as printed was run through the loader and the validator. It loads with no warnings and no errors, and the five constraints publish with the words the walkthroughs claim. Renaming `LineItem.memo` out from under the judgment was confirmed to fail the push.

The guide also now states **when** a constraint is settled, which it never did. Every guard is checked before the call, with the arguments bound. A rule over the parameters is settled completely there, since the arguments are the whole of what it reads. A rule over stored data is a condition on the state a write produces, so checking it before the call reports only that the call does not start from a broken state. Nothing in the model binds a rule to a write's result, and the guide names that as the gap between what a data rule says and what a guard can enforce. Reporting instead of blocking is what `warn` means, checked at the same moment and let through. Recorded alongside it: a condition on a single row lowers to a store-level `CHECK`, while one that aggregates across a child table, as the order-total rule does, lowers to neither Spanner nor BigQuery.

An earlier revision of this branch said an invariant over stored data is in force whether or not an action names it, and that `guards` adds an earlier check rather than switching enforcement on. That is gone. A constraint nothing references has no effect at all, which is why the credit policy now names all five rules in `guards`. Under the old reading, publishing a rule could change what an already-working call does.

## Expression field references are checked in full

Separable from the rest of this PR, and included because the guide's own example depended on it.

An expression was checked only at its leading `Entity.field` qualifier, so `amount <= Order.totl` passed validation: the leading token is a bare parameter name and the scan stopped there. That is the ordinary shape of a guard, which reads its action's parameters first, so the check was missing on exactly the constraints most likely to carry one — including rule 1 of the credit policy above.

Expressions now route through `unknownFieldRefs`, the scan judgments already used. Both bodies are checked alike: every qualified token naming a known entity must name a field that entity declares, an unknown entity is still left alone so a relationship-qualified name is never falsely rejected, and quoted literals are blanked so a string is never read as a reference. `leadingFieldRef` is removed.

Verified: `amount <= Order.totall` in the credit model is now a hard error, and the model as printed in the guide still loads clean. This is a token sweep rather than a parser, so it still checks no types, arity, or well-formedness.

## Status

Nothing evaluates a judgment. `kcmd` parses it, validates it, publishes it, and reads it back. No component calls a judge and nothing combines guard outcomes, exactly as no component evaluates an expression constraint today.

## Deployment note for review

`kc_custom_types.ts` relaxes `expression` from `constraints: {required: true}` on the `semantic-constraint` aspect type, since either body alone is a whole rule. Appending template fields to an already-provisioned Dataplex aspect type is known to work; **relaxing a required field on one is not verified.** Worth a check against a provisioned project before this reaches an environment that already ran `kcmd init --semantic-model`.

A second item with the same root, and it is the one to check first. `constraintAspectData` always emits `evaluation`, so every constraint push now needs the updated template, including a model with no judged constraint in it. Provisioning runs at `init` and never at push, so a project whose `kcmd init` got a non-fatal `denied` on `updateAspectType` will fail every constraint push until someone re-runs it. The two failures also share a cause. If Dataplex refuses the relaxation, the patch fails as a whole, so the appended `judgment` and `evaluation` fields do not land either. That is what turns this into a break for deterministic pushes that worked before this PR.

A project provisioned before this PR may need its aspect type updated by hand, or recreated, if the patch is refused. **This needs a live check against a provisioned project, and I have not run one** — it means mutating an aspect type on a real project, which is not mine to do unasked. The alternative, if the relaxation turns out to be refused, is to emit `evaluation` and `judgment` only when the template carrying them is known to exist.

## Review fixes

A read of the branch turned up four things, all fixed in `c75bdea`.

- The rationale for the unguarded-parameter warning had been spliced above the all-guards-judged function in `loader.ts`, leaving the function it describes with a dangling one-line comment. Each function carries its own again.
- A pulled judgment stating no `onViolation` now warns. Such a model will not push, and saying so at pull time names the constraint while the author is looking at it; the alternative is a push error about a key they never wrote.
- The published aspect description said the strictest consequence among the violated rules is what the action does. It now says that is what the model states, since no component evaluates a constraint today.
- The judgment scan reads quoted text and the expression scan does not. `reference.md` now says which and why: in prose, quotes more often set off a field name for emphasis than delimit a literal, so blanking them would hide the renames the check exists to catch.

A second read found two ways the widened field scan refuses a model it has nothing to say about. Both were reproduced against a loaded model before the fix and confirmed gone after, and both now have a regression test. Fixed in `cc42482`.

- **An entity that declares no fields was scanned as though it declared a complete set.** The map gave it an empty `Set`, which is truthy, so every `orders.total` token became a hard push error. Fields are optional on an entity and a logical model bound to nothing but Knowledge Catalog routinely declares none, so such a model could write no constraint at all. This one is a regression from the widening in this PR: before it, the leading-qualifier scan found no qualifier in `quantity > 0 AND orders.o_totalprice >= 0` and passed. An entity with no fields is now as unknowable as an unrecognized one.
- **A bad `extends` came out of the validation gate as a stack trace.** Building the field map resolves inheritance, which throws on an `extends` naming an undeclared entity, and the map was built for any model carrying a constraint. The call is guarded now, standing the scan down the way a pruned profile does. `validateActions` already builds its concept set lazily for this reason and documents it; this is the same hazard reached by a different path.

Two smaller items from the same read. The provisioning warning said a push "that needs a field it does not carry will fail", which covers only one direction; this PR also makes a template that still *requires* a field the push omits, so the warning names both. And the module-level `text` helper in `kc_constraints.ts` is renamed `aspectText`, since `readEnum` declares a local of the same name — harmless today, a trap for the next caller.

A third read found that the guard above was half a fix, plus one more false rejection. Fixed in `e4521f0`, both reproduced against a loaded model first.

- **Only one of the two call sites that resolve inheritance was guarded.** `validateActions` builds a concept set by the same route whenever an action declares `affects`. A model with a bad `extends` and an action therefore still came out of the gate as a stack trace. The test that shipped with the previous commit passed only because its fixture declared no actions. Both builders now go through one `ifResolvable` helper carrying the reason, and a test covers the action path.
- **A dotted path was read as a field reference.** `Order.lineItems.amount` errored with "entity `Order` declares no field `lineItems`" — a field the author never claimed existed. Nothing in the model defines path syntax, so the scan declines to guess rather than rejecting. A token followed by another dotted segment is skipped, and so is one preceded by a dot, which is how the tail of a path presents. A genuine typo still errors, which was re-checked against the credit model.

Two documentation items with it. A pulled constraint the reader skips is deleted by the next push, because constraint ids are an owned prefix for delete reconciliation — both skip warnings now say so rather than stopping at "the constraint is skipped". And the `actions_place_order` fixture header still described four constraints, a leading-qualifier-only scan, and one constraint stating the routing words; it now describes the model that is actually there.

A fourth read found two more ways the widened scan refuses models it has nothing to say about, and one way it now says nothing at all. Fixed in `69ee36b`, each reproduced against a loaded model first.

- **A two-segment token whose tail is not a field was a hard error.** All three kinds were rejected. `Customer.Order` and `LineItem.BelongsTo` are traversals, and `Order.total_revenue` names a metric, which is model-level and so hangs off the entity rather than being declared by it. The metric case is a regression this branch introduced: such a reference away from position 0 was never scanned before. Traversal has no syntax in the model today, so the scan now settles only the case it can — a tail the model declares under no kind at all, beside an entity it does declare. A misspelling is still caught.
- **Standing the field scan down on an unresolvable `extends` left no one to report it.** The loader accepts such a model, and a Knowledge-Catalog-only push reaches no graph leg that would resolve inheritance. A dangling supertype and a typo beside it therefore both published in silence, where before this branch the push at least stack-traced. The failure is now reported once per model. A profile push that pruned fields stays exempt, because pruning can create the dangling `extends` itself. One test asserted that silence; it now asserts the report.
- **An empty judgment masked a missing `on_violation`,** by returning before the routing check. The two are independent, so both report rather than sending the author back for a second failure over a key they were never told about.

## Tests

793 pass, 0 fail (`npm test`), `npm run compile` clean. 29 new tests covering loader parsing, the exclusivity errors, the required `on_violation` and all three words on a judgment, `Entity.field` resolution in prose, the aspect payload and derived `evaluation`, pull recovery, the push→pull→push fixed point, the OSI round trip (asserts `judgment:` present and `evaluation:` absent), the skipped-entry warnings, and the all-guards-judged warning. Eleven cover the widened expression scan. Four hold the line on what it still catches and what it must leave alone: a bad reference after the leading token, a quoted literal, a fieldless entity, and a dotted path. Four more cover tails that are not fields — a relationship, a metric, another entity, and a name the model declares nowhere, which must still fail. The last three cover an `extends` naming an undeclared entity, reached by each of the two code paths that resolve inheritance and reported rather than swallowed. Goldens regenerated and verified stable.





