### PR TITLE
Add a `proposal` executor kind for writes composed at call time

### DIFF
--- a/toolbox/mdcode/docs/semantic-model/README.md
+++ b/toolbox/mdcode/docs/semantic-model/README.md
@@ -124,7 +124,8 @@ push enforces.
 A model can also declare **actions**: model-level write operations, the
 write-side counterpart to a metric. An action names a business operation, points
 at the executor that carries it out (an MCP tool, a REST endpoint, a gRPC
-method, or DML), and types each parameter against the ontology, so an
+method, DML, or a reviewer for a write composed at call time), and types each
+parameter against the ontology, so an
 entity-typed parameter is an object reference rather than a bare string. The
 executor is a physical binding, so a [binding profile](profiles.md) can supply a
 different one per store. An action also

--- a/toolbox/mdcode/docs/semantic-model/actions.md
+++ b/toolbox/mdcode/docs/semantic-model/actions.md
@@ -81,8 +81,11 @@ a tool already registered in Agent Registry by the server's resource name plus
 the tool's name within it. `rest` (`{endpoint, method}`) and `grpc`
 (`{service, method}`) are the other two remote kinds. A fourth, `sql`, carries
 the write itself rather than a pointer to whoever performs it — see
-[Writing the statements in the model](#writing-the-statements-in-the-model).
-Exactly one kind, where an executor is written at all.
+[Writing the statements in the model](#writing-the-statements-in-the-model). A
+fifth, `proposal`, names neither, because its write does not exist yet — see
+[When the write is composed at call
+time](#when-the-write-is-composed-at-call-time). Exactly one kind, where an
+executor is written at all.
 
 `description` and `ai_context.instructions` are both carried through to the
 catalog. Write the instructions for the agent that will call the action, as
@@ -207,6 +210,56 @@ refer to the generated key as `@new<Concept>Key`:
 Nothing executes a statement yet. `kcmd` validates the statements, publishes
 them to the catalog and reads them back; what runs them is the action runtime,
 which lands separately.
+
+### When the write is composed at call time
+
+The last rule above rules out a whole class of write: the ad hoc correction, the
+cleanup whose shape depends on what is found, the fix an agent works out from the
+data in front of it. Nobody can pre-write those statements, and running one the
+caller supplies would mean running a write no one declared and no gate can check.
+
+A review engine answers that. The caller proposes a statement, a reviewer checks
+it and only then does it run. The `proposal` kind declares that arrangement:
+
+```yaml
+      - name: AdjustPricing
+        description: Change the price on an order, subject to review
+        executor:
+          proposal:
+            reviewer: //dataagents.googleapis.com/projects/acme/locations/us/actionManagers/commerce
+        parameters:
+          - { name: order, type: Order }
+        guards:
+          - discount_within_policy
+        affects:
+          - { concept: Order, operation: modify, fields: [price] }
+```
+
+One coordinate, and it is not a write. The other four kinds answer *what is the
+write*, by carrying it or by naming who holds it. This one answers *who decides*,
+because the write does not exist when the model is authored.
+
+That inverts what the rest of the action is for. Everywhere else, `affects` and
+`guards` describe a write that is already pinned down; here they are the only
+description of it there will ever be before the call, so they are what the
+reviewer checks the proposal against:
+
+- **`affects` is required for this kind, and for no other.** Push rejects a
+  `proposal` executor that declares no blast radius. A `sql` executor's
+  statements say what they touch, and a remote call is performed by a system that
+  knows what it is about to do; a proposal has neither, so an undeclared blast
+  radius leaves the reviewer with nothing to compare against.
+- **`guards` name the rules the proposal is checked against.** The rules live in
+  the model, next to the ontology they are written over, rather than restated in
+  the review engine's own policy language.
+
+What the model does not promise is that the proposed write matches the
+declaration. Nothing can promise that — the statement arrives long after the
+model is published. The declaration is what the reviewer checks the proposal
+*against*, which is the reason it has to exist.
+
+`kcmd` neither reviews nor runs a proposal. It publishes the arrangement: who
+decides, what the call may touch, and which rules apply.
 
 ## 2. Gate it with a constraint
 

--- a/toolbox/mdcode/docs/semantic-model/model_spec.md
+++ b/toolbox/mdcode/docs/semantic-model/model_spec.md
@@ -481,9 +481,9 @@ reads the document ([§6](#6-the-extension-mechanism)).
   withdraws it. An action left with no executor is declared and not performable
   under that binding, which the availability pass reports; it is not an error.
 
-  An executor, where one is written, MUST declare exactly one kind. Three of
-  them — `mcp`, `rest` and `grpc` — name a system that performs the write; the
-  fourth, `sql`, carries the
+  An executor, where one is written, MUST declare exactly one kind. The kinds
+  divide by where the write comes from. Three of them — `mcp`, `rest` and `grpc`
+  — name a system that already holds it; the fourth, `sql`, carries the
   write itself as an ordered list of `statements`. Because that one is the only
   kind whose text the model can read, it is the only one with rules about that
   text: each statement MUST be a single `INSERT`, `UPDATE` or `DELETE`, MUST NOT
@@ -491,6 +491,16 @@ reads the document ([§6](#6-the-extension-mechanism)).
   names the action declares, plus `@new<Concept>Key` for each `affects` entry
   whose `operation` is `create`. Those rules are what let every value be bound
   rather than interpolated, so an argument cannot reach the store as SQL.
+
+  The fifth kind, `proposal`, has no write at all: it declares that the write is
+  composed at call time and reviewed before it runs, and names the `reviewer`
+  that decides. It carries no statement by construction, and the schema rejects
+  one. Because the statement does not exist when the model is published, the
+  declaration is the only description of the call a reviewer can check a proposal
+  against, so a `proposal` executor MUST declare a non-empty `affects` — the one
+  kind for which push requires it. See
+  [Actions → When the write is composed at call
+  time](actions.md#when-the-write-is-composed-at-call-time).
 
 - **`constraints` (extended profile only).** Model-level named invariants over
   the ontology, accepted only under `0.2.0.dev0/google`. Each states exactly one

--- a/toolbox/mdcode/docs/semantic-model/profiles.md
+++ b/toolbox/mdcode/docs/semantic-model/profiles.md
@@ -101,6 +101,12 @@ and column names and each speaks its own dialect. So the `executor` sits with
 `source` and `expression` on the physical side: the same action, the same blast
 radius, performed by whatever mechanism the bound store actually has.
 
+Whether a write is *reviewed* is a property of the environment too, and lands in
+the same place. A profile can bind a `proposal` executor where the store holds
+production data, so the write is composed at call time and passed to a reviewer,
+and leave the staging profile writing DML directly — the same declared action,
+gated in one environment and not the other.
+
 **An executor inherits; a column does not.** A model may declare one default
 executor, and a profile overrides it only for the stores that perform the write
 differently — an action the profile does not mention keeps the default. This is

--- a/toolbox/mdcode/docs/semantic-model/reference.md
+++ b/toolbox/mdcode/docs/semantic-model/reference.md
@@ -372,11 +372,15 @@ and [§4.1](model_spec.md#41-narrowings-stricter-than-ossie).
 * **Every action is well-formed.** Each action parameter's `type` must resolve to
   a known entity (an object reference) or a scalar datatype, and each executor
   must carry its coordinates (an `mcp` server + tool, a `rest` endpoint + method,
-  a `grpc` service + method, or at least one non-blank `sql` statement) with no
+  a `grpc` service + method, at least one non-blank `sql` statement, or a
+  `proposal` reviewer) with no
   blank field. A coordinate omitted altogether is rejected earlier, when the
   model is parsed. An action with *no* executor is not an error at all: the
   executor is a physical binding, so an action no binding performs here is still
-  a declaration worth publishing. Each name in the
+  a declaration worth publishing. A `proposal` executor must additionally declare
+  a non-empty `affects`, and is the only kind that must: its write is composed at
+  call time, so the declared blast radius is the only thing the reviewer can
+  check the proposed statement against. Each name in the
   action's `guards` must resolve to a constraint that the same model declares. A
   guard resolving to nothing leaves the author believing the write is checked
   when nothing checks it. Every `concept` in the action's `affects` must

--- a/toolbox/mdcode/src/libts/semantic/ir.ts
+++ b/toolbox/mdcode/src/libts/semantic/ir.ts
@@ -405,14 +405,52 @@ export interface ActionParameter {
 /**
  * The mechanics of how an action is executed: exactly one kind, tagged so
  * consumers can switch on it. The open format expresses it as an object with a
- * single kind key (`mcp` / `rest` / `grpc`); the loader normalizes that to this
- * discriminated union. Other kinds (SQL DML, CLI, ...) can be added later.
+ * single kind key (`mcp` / `rest` / `grpc` / `sql` / `proposal`); the loader
+ * normalizes that to this discriminated union.
+ *
+ * The kinds divide by WHERE the write comes from. `sql` carries the write in
+ * the model. `mcp`, `rest` and `grpc` name a system that already holds it.
+ * `proposal` says the write does not exist yet: it is composed at call time and
+ * submitted for review before it runs.
  */
 export type Executor =
   | { kind: 'mcp'; mcp: McpExecutor }
   | { kind: 'rest'; rest: RestExecutor }
   | { kind: 'grpc'; grpc: GrpcExecutor }
-  | { kind: 'sql'; sql: SqlExecutor };
+  | { kind: 'sql'; sql: SqlExecutor }
+  | { kind: 'proposal'; proposal: ProposalExecutor };
+
+/**
+ * A PROPOSAL executor: the write is composed at call time and reviewed before
+ * it runs.
+ *
+ * The other four kinds all answer "what is the write?" -- `sql` by carrying it,
+ * the remote three by naming who holds it. This one answers "who decides?"
+ * instead, because the write does not exist when the model is authored. A
+ * caller proposes a statement; the reviewer named here checks it and either
+ * runs it or refuses.
+ *
+ * That is the shape a review-gated write engine already has, and modeling it as
+ * an executor kind puts it inside the model rather than beside it. It is also
+ * the one kind where the rest of the action is not documentation:
+ *
+ *   - `affects` is the only statement of blast radius that exists before the
+ *     call, so it is what a reviewer routes on -- and validate.ts REQUIRES it
+ *     here, unlike every other kind.
+ *   - `guards` are the rules the proposal is checked against, named in the
+ *     model rather than restated in the review engine's own policy language.
+ *
+ * What this kind does NOT promise is that the proposed write matches the
+ * declaration. Nothing here can promise that: the statement arrives after the
+ * model is published. The declaration is what the reviewer checks the proposal
+ * AGAINST, which is the whole point of having one.
+ */
+export interface ProposalExecutor {
+  // Resource name of the service that reviews a proposed write and runs it if
+  // it passes. One coordinate, not two: what is proposed is decided per call,
+  // so there is no operation name to pin here.
+  reviewer: string;
+}
 
 /**
  * A SQL executor: the write itself, declared in the model as an ordered list of

--- a/toolbox/mdcode/src/libts/semantic/kc_actions.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_actions.ts
@@ -225,6 +225,11 @@ function executorData(ex: Executor): Record<string, any> {
         executorKind: 'sql',
         sqlStatements: [...ex.sql.statements],
       };
+    case 'proposal':
+      return {
+        executorKind: 'proposal',
+        proposalReviewer: ex.proposal.reviewer,
+      };
   }
 }
 
@@ -436,6 +441,13 @@ function readExecutor(data: Record<string, any>): Executor|undefined {
       if (statements.length) return {kind: 'sql', sql: {statements}};
       return undefined;
     }
+    case 'proposal':
+      if (str(data.proposalReviewer))
+        return {
+          kind: 'proposal',
+          proposal: {reviewer: data.proposalReviewer}
+        };
+      return undefined;
     default:
       return undefined;
   }

--- a/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
+++ b/toolbox/mdcode/src/libts/semantic/kc_custom_types.ts
@@ -388,6 +388,20 @@ const ACTION_ASPECT_TYPE: Omit<AspectType, 'name'> = {
               'taking it on trust.',
         },
       },
+      {
+        index: 13,
+        name: 'proposalReviewer',
+        type: 'string',
+        annotations: {
+          displayName: 'Proposal Reviewer',
+          description:
+              'For a `proposal` executor: the service that reviews a write ' +
+              'composed at call time and runs it if it passes. The model ' +
+              'carries no statement for this kind, so the declared ' +
+              '`affects` and `guards` are what the proposal is checked ' +
+              'against.',
+        },
+      },
     ],
   },
 };

--- a/toolbox/mdcode/src/libts/semantic/loader.ts
+++ b/toolbox/mdcode/src/libts/semantic/loader.ts
@@ -200,7 +200,7 @@ const metricSchema = z.object({
 // so the schema only checks its shape here. What makes it safe -- one DML verb
 // per statement, and every `@parameter` declared by the action -- is checked in
 // validate.ts, where the action's parameter list is in scope. See SqlExecutor.
-const EXECUTOR_KINDS = ['mcp', 'rest', 'grpc', 'sql'] as const;
+const EXECUTOR_KINDS = ['mcp', 'rest', 'grpc', 'sql', 'proposal'] as const;
 
 const executorSchema =
     z.object({
@@ -214,6 +214,9 @@ const executorSchema =
        sql: z.object({statements: z.array(z.string()).min(1)})
                 .strict()
                 .optional(),
+       // No statement here, by construction: a proposal's write is composed at
+       // call time. What the model pins is who reviews it. See ProposalExecutor.
+       proposal: z.object({reviewer: z.string()}).strict().optional(),
      })
         .strict()
         .superRefine((ex, ctx) => {
@@ -1203,7 +1206,8 @@ function convertExecutor(ex: ExecutorDoc): Executor {
       sql: { statements: ex.sql.statements.map(t => t.trim()) },
     };
   }
-  // The schema's refinement guarantees one of the four kinds is set.
+  if (ex.proposal) return { kind: 'proposal', proposal: { ...ex.proposal } };
+  // The schema's refinement guarantees one of the five kinds is set.
   return { kind: 'grpc', grpc: { ...ex.grpc! } };
 }
 

--- a/toolbox/mdcode/src/libts/semantic/osi_converter.ts
+++ b/toolbox/mdcode/src/libts/semantic/osi_converter.ts
@@ -348,6 +348,8 @@ function executorDoc(ex: Executor): Record<string, any> {
       return {grpc: {service: ex.grpc.service, method: ex.grpc.method}};
     case 'sql':
       return {sql: {statements: [...ex.sql.statements]}};
+    case 'proposal':
+      return {proposal: {reviewer: ex.proposal.reviewer}};
   }
 }
 

--- a/toolbox/mdcode/src/libts/semantic/validate.ts
+++ b/toolbox/mdcode/src/libts/semantic/validate.ts
@@ -212,8 +212,30 @@ function validateActions(
     }
     errors.push(...affectedConceptErrors(action, where, concepts));
     errors.push(...sqlExecutorErrors(action, where));
+    errors.push(...proposalExecutorErrors(action, where));
   }
   return errors;
+}
+
+// The errors in a PROPOSAL executor's declaration.
+//
+// Only one, and it is about `affects` rather than the executor itself: a
+// proposal executor MUST declare a blast radius. Every other kind can fall back
+// on something -- a `sql` executor's statements say what they touch, and a
+// remote call is performed by a system that knows what it is about to do. A
+// proposal has neither. The statement does not exist yet, and the reviewer is
+// being asked to judge one it has never seen against a declaration the model
+// did not make. An undeclared blast radius is not an omission here, it is the
+// missing half of the check.
+function proposalExecutorErrors(action: Action, where: string): string[] {
+  if (action.executor?.kind !== 'proposal') return [];
+  if (action.affects?.length) return [];
+  return [
+    `${where} has a proposal executor but declares no 'affects'. The write is ` +
+        `composed at call time, so the declared blast radius is the only ` +
+        `statement of what the call may touch, and the reviewer has nothing ` +
+        `to check the proposal against without it.`,
+  ];
 }
 
 // The errors in a SQL executor's statements. Nothing here for the other three
@@ -630,6 +652,8 @@ function missingExecutorFields(ex: Executor): string[] {
           .map(([k]) => k);
     case 'sql':
       return ex.sql.statements.every(blank) ? ['statements'] : [];
+    case 'proposal':
+      return blank(ex.proposal.reviewer) ? ['reviewer'] : [];
   }
 }
 

--- a/toolbox/mdcode/tests/libts/semantic/actions.test.ts
+++ b/toolbox/mdcode/tests/libts/semantic/actions.test.ts
@@ -163,6 +163,28 @@ describe('loader parses actions', () => {
     });
   });
 
+  test('a proposal executor normalizes to the tagged union', () => {
+    // No statement, by construction: the write is composed at call time, so
+    // what the model pins is who reviews it.
+    const {models} = withActions([{
+      name: 'A',
+      executor: {proposal: {reviewer: '//x/actionManagers/a'}},
+      affects: [{concept: 'customer', operation: 'modify'}],
+    }]);
+    expect(models[0].actions![0].executor)
+        .toEqual({kind: 'proposal', proposal: {reviewer: '//x/actionManagers/a'}});
+  });
+
+  test('a proposal executor carrying statements is rejected at parse', () => {
+    // The open format is strict per kind, so the shape that would smuggle a
+    // pre-written statement into a reviewed write does not parse.
+    expect(() => withActions([{
+             name: 'A',
+             executor: {proposal: {reviewer: '//x/a', statements: ['DELETE 1']}},
+           }]))
+        .toThrow();
+  });
+
   test('a sql executor normalizes to the tagged union, trimmed', () => {
     // The statements are the write, so whitespace an author wrapped them in is
     // not part of it; trimming here keeps the verb check in validate.ts
@@ -256,6 +278,52 @@ describe('validatePushRequirements gates actions', () => {
     }])]);
     expect(errs.some(e => e.includes('parameter \'x\'') && e.includes('Nope')))
         .toBe(true);
+  });
+
+  test('a proposal executor with no affects is a hard error', () => {
+    // Every other kind can fall back on something -- a sql executor's
+    // statements say what they touch, a remote call is performed by a system
+    // that knows what it is doing. A proposal has neither, so an undeclared
+    // blast radius leaves the reviewer nothing to check against.
+    const errs = validatePushRequirements([loaded([{
+      name: 'A',
+      executor: {kind: 'proposal', proposal: {reviewer: '//x/a'}},
+      parameters: [],
+    }])]);
+    expect(errs.some(e => e.includes('proposal executor') && e.includes('affects')))
+        .toBe(true);
+  });
+
+  test('a proposal executor that declares its blast radius passes', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'A',
+      executor: {kind: 'proposal', proposal: {reviewer: '//x/a'}},
+      parameters: [],
+      affects: [{concept: 'customer', operation: 'modify'}],
+    }])]);
+    expect(errs).toEqual([]);
+  });
+
+  test('a blank proposal reviewer is a hard error', () => {
+    const errs = validatePushRequirements([loaded([{
+      name: 'A',
+      executor: {kind: 'proposal', proposal: {reviewer: '  '}},
+      parameters: [],
+      affects: [{concept: 'customer', operation: 'modify'}],
+    }])]);
+    expect(errs.some(e => e.includes('proposal') && e.includes('reviewer')))
+        .toBe(true);
+  });
+
+  test('the affects rule applies only to the proposal kind', () => {
+    // An mcp call is performed by a system that knows what it touches, so a
+    // missing blast radius there is a gap in the catalog, not a broken gate.
+    const errs = validatePushRequirements([loaded([{
+      name: 'A',
+      executor: {kind: 'mcp', mcp: {server: 's', tool: 't'}},
+      parameters: [],
+    }])]);
+    expect(errs).toEqual([]);
   });
 
   test('a blank executor coordinate is a hard error', () => {
@@ -505,6 +573,7 @@ describe('Knowledge Catalog round trip across executor kinds', () => {
       'commerce.actions.RefundOrder',
       'commerce.actions.CloseBooks',
       'commerce.actions.ReplaceOrder',
+      'commerce.actions.AdjustPricing',
     ]);
     for (const e of actions) expect(e.parentEntry).toBe(entries[0].name);
   });
@@ -530,6 +599,13 @@ describe('Knowledge Catalog round trip across executor kinds', () => {
       grpcService: 'commerce.v1.Ledger',
       grpcMethod: 'CloseBooks',
     });
+    // The one kind that publishes no write at all: what it pins is who decides
+    // whether the write composed at call time may run.
+    expect(dataOf('AdjustPricing')).toMatchObject({
+      executorKind: 'proposal',
+      proposalReviewer:
+          '//dataagents.googleapis.com/projects/p/locations/us/actionManagers/commerce',
+    });
     // The one kind whose coordinate is a list, and whose order is part of the
     // meaning: the insert has to reach the store before the delete.
     expect(dataOf('ReplaceOrder')).toMatchObject({
@@ -543,10 +619,11 @@ describe('Knowledge Catalog round trip across executor kinds', () => {
     // A kind writes nothing belonging to another kind, so the aspect never
     // carries two executors at once.
     for (const [kind, foreign] of [
-             ['PlaceOrder', ['restEndpoint', 'restMethod', 'grpcService', 'grpcMethod', 'sqlStatements']],
-             ['RefundOrder', ['mcpServer', 'mcpTool', 'grpcService', 'grpcMethod', 'sqlStatements']],
-             ['CloseBooks', ['mcpServer', 'mcpTool', 'restEndpoint', 'restMethod', 'sqlStatements']],
-             ['ReplaceOrder', ['mcpServer', 'mcpTool', 'restEndpoint', 'restMethod', 'grpcService', 'grpcMethod']],
+             ['PlaceOrder', ['restEndpoint', 'restMethod', 'grpcService', 'grpcMethod', 'sqlStatements', 'proposalReviewer']],
+             ['RefundOrder', ['mcpServer', 'mcpTool', 'grpcService', 'grpcMethod', 'sqlStatements', 'proposalReviewer']],
+             ['CloseBooks', ['mcpServer', 'mcpTool', 'restEndpoint', 'restMethod', 'sqlStatements', 'proposalReviewer']],
+             ['ReplaceOrder', ['mcpServer', 'mcpTool', 'restEndpoint', 'restMethod', 'grpcService', 'grpcMethod', 'proposalReviewer']],
+             ['AdjustPricing', ['mcpServer', 'mcpTool', 'restEndpoint', 'restMethod', 'grpcService', 'grpcMethod', 'sqlStatements']],
     ] as Array<[string, string[]]>) {
       for (const field of foreign) expect(dataOf(kind)[field]).toBeUndefined();
     }

--- a/toolbox/mdcode/tests/libts/semantic/fixtures/actions_executors.yaml
+++ b/toolbox/mdcode/tests/libts/semantic/fixtures/actions_executors.yaml
@@ -1,15 +1,16 @@
 # Test fixture -- AI-first semantics format (v0.2.0.dev0/google).
 #
-# Four actions covering every executor kind, so the Knowledge Catalog round
+# Five actions covering every executor kind, so the Knowledge Catalog round
 # trip is exercised on each branch of the tagged union rather than on `mcp`
 # alone. It also covers the two shapes an action can be missing pieces in: one
 # with no parameters at all, and one with neither a description nor an
 # ai_context. `actions` is a native extension key, so this document declares the
 # extended profile.
 #
-# The `sql` kind is the odd one out and is here for that reason: the other three
-# publish two scalar coordinates, while this one publishes a list of statements,
-# so it is the only kind whose aspect field is repeated.
+# Two kinds are odd ones out. `sql` publishes a list of statements where the
+# remote three publish two scalar coordinates, so it is the only kind whose
+# aspect field is repeated. `proposal` publishes ONE coordinate and no write at
+# all, because its write is composed at call time.
 
 version: "0.2.0.dev0/google"
 
@@ -84,3 +85,16 @@ semantic_model:
         affects:
           - {concept: orders, operation: create}
           - {concept: orders, operation: delete}
+      # Proposal executor: the write does not exist when the model is authored.
+      # The model names who reviews it, and `affects` is what the reviewer has
+      # to check the proposed statement against -- required for this kind and
+      # for no other.
+      - name: AdjustPricing
+        description: Change the price on an order, subject to review
+        executor:
+          proposal:
+            reviewer: //dataagents.googleapis.com/projects/p/locations/us/actionManagers/commerce
+        parameters:
+          - {name: order, type: orders}
+        affects:
+          - {concept: orders, operation: modify}


### PR DESCRIPTION
Adds a fifth executor kind, `proposal`, for a write that does not exist when the model is authored.

## Why

The four existing kinds all answer *what is the write?* — `sql` by carrying it, `mcp`/`rest`/`grpc` by naming a system that holds it. `sql` push rules say so explicitly: "no statement composed at call time. An action whose body arrives with the call declares nothing, and a gate cannot check what was never declared."

That rules out a real class of write — the ad hoc correction, the cleanup whose shape depends on what is found, the fix an agent works out from the data in front of it. Nobody can pre-write those statements, and running one the caller supplies would mean running a write no one declared.

A review engine is the existing answer: the caller proposes a statement, a reviewer checks it against a policy, and only then does it run. This puts that arrangement inside the model rather than beside it.

## What

```yaml
      - name: AdjustPricing
        description: Change the price on an order, subject to review
        executor:
          proposal:
            reviewer: //dataagents.googleapis.com/projects/acme/locations/us/actionManagers/commerce
        parameters:
          - { name: order, type: Order }
        guards:
          - discount_within_policy
        affects:
          - { concept: Order, operation: modify, fields: [price] }
```

One coordinate, and it is not a write. The kind answers *who decides* instead. No statement by construction — the schema rejects one.

**`affects` is required for this kind, and for no other.** Everywhere else `affects` and `guards` describe a write that is already pinned down; here they are the only description that exists before the call, so they are what the reviewer checks the proposal against. A `sql` executor's statements say what they touch and a remote call is performed by a system that knows what it is about to do; a proposal has neither, so an undeclared blast radius leaves the reviewer nothing to compare against. Push rejects it.

**`guards` name the rules the proposal is checked against**, in the model, next to the ontology they are written over — rather than restated in the review engine's own policy language.

**What this does not promise** is that the proposed write matches the declaration. Nothing can — the statement arrives after the model is published. Being the thing the proposal is checked *against* is the point of having a declaration.

## Profiles

The kind rides the executor binding from #416. A profile can bind `proposal` where the store holds production data and leave staging writing DML directly: whether a write is reviewed is a property of the environment, like everything else in a profile.

## Round trip

- `proposalReviewer` joins the `semantic-action` aspect type at index 13 and reads back to the tagged union.
- A blank reviewer is a hard push error, like every other coordinate.
- The OSI converter emits the kind on the way back out.

`kcmd` neither reviews nor runs a proposal; it publishes the arrangement: who decides, what the call may touch, which rules apply.

## Docs

`actions.md` gains "When the write is composed at call time"; `model_spec.md` §5, `reference.md`, `profiles.md` and the README are updated. The actions.md example was run through the real loader and push gate rather than asserted — it normalizes as written, and removing `affects` produces exactly the documented rejection.

## Tests

`npx tsc --noEmit` clean. `npx bun test`: **799 pass / 0 fail** across 34 files (793 on main). Ten tests added or updated: loader normalization, statements-in-proposal rejected at parse, the no-`affects` hard error, with-`affects` passing, blank reviewer, the rule applying only to this kind, and the Knowledge Catalog round trip including the foreign-field matrix.
